### PR TITLE
Add bucketId to proofs database

### DIFF
--- a/src/stores/dexie.ts
+++ b/src/stores/dexie.ts
@@ -23,6 +23,20 @@ export class CashuDexie extends Dexie {
     this.version(1).stores({
       proofs: "secret, id, C, amount, reserved, quote",
     });
+    this.version(2)
+      .stores({
+        proofs: "secret, id, C, amount, reserved, quote, bucketId",
+      })
+      .upgrade(async (tx) => {
+        await tx
+          .table("proofs")
+          .toCollection()
+          .modify((proof: any) => {
+            if (proof.bucketId === undefined) {
+              proof.bucketId = "unassigned";
+            }
+          });
+      });
   }
 }
 

--- a/src/stores/mints.ts
+++ b/src/stores/mints.ts
@@ -83,7 +83,11 @@ export class MintClass {
 }
 
 // type that extends type Proof with reserved boolean
-export type WalletProof = Proof & { reserved: boolean; quote?: string };
+export type WalletProof = Proof & {
+  reserved: boolean;
+  quote?: string;
+  bucketId?: string;
+};
 
 export type Balances = {
   [unit: string]: number;

--- a/src/stores/proofs.ts
+++ b/src/stores/proofs.ts
@@ -84,25 +84,30 @@ export const useProofsStore = defineStore("proofs", {
         }
       });
     },
-    proofsToWalletProofs(proofs: Proof[], quote?: string): WalletProof[] {
+    proofsToWalletProofs(
+      proofs: Proof[],
+      quote?: string,
+      bucketId: string = "unassigned"
+    ): WalletProof[] {
       return proofs.map((p) => {
         return {
           ...p,
           reserved: false,
           quote: quote,
+          bucketId,
         } as WalletProof;
       });
     },
-    async addProofs(proofs: Proof[], quote?: string) {
-      const walletProofs = this.proofsToWalletProofs(proofs);
+    async addProofs(proofs: Proof[], quote?: string, bucketId: string = "unassigned") {
+      const walletProofs = this.proofsToWalletProofs(proofs, quote, bucketId);
       await cashuDb.transaction("rw", cashuDb.proofs, async () => {
         walletProofs.forEach(async (p) => {
           await cashuDb.proofs.add(p);
         });
       });
     },
-    async removeProofs(proofs: Proof[]) {
-      const walletProofs = this.proofsToWalletProofs(proofs);
+    async removeProofs(proofs: Proof[], bucketId: string = "unassigned") {
+      const walletProofs = this.proofsToWalletProofs(proofs, undefined, bucketId);
       await cashuDb.transaction("rw", cashuDb.proofs, async () => {
         walletProofs.forEach(async (p) => {
           await cashuDb.proofs.delete(p.secret);


### PR DESCRIPTION
## Summary
- extend `WalletProof` with optional `bucketId`
- bump Dexie schema version and add upgrade logic for `bucketId`
- assign `bucketId` when creating proofs

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_6839faf0dbf483308a38b9fe0c10955a