### PR TITLE
Add bucket support on token operations

### DIFF
--- a/src/stores/storage.ts
+++ b/src/stores/storage.ts
@@ -6,17 +6,19 @@ import { notifyError, notifySuccess } from "../js/notify";
 import { useTokensStore } from "./tokens";
 import { currentDateStr } from "src/js/utils";
 import { useProofsStore } from "./proofs";
+import { useBucketsStore } from "./buckets";
 
 export const useStorageStore = defineStore("storage", {
   state: () => ({
     lastLocalStorageCleanUp: useLocalStorage(
       "cashu.lastLocalStorageCleanUp",
-      new Date()
+      new Date(),
     ),
   }),
   actions: {
     restoreFromBackup: async function (backup: any) {
       const proofsStore = useProofsStore();
+      const bucketsStore = useBucketsStore();
       if (!backup) {
         notifyError("Unrecognized Backup Format!");
       } else {
@@ -26,6 +28,8 @@ export const useStorageStore = defineStore("storage", {
           if (key === "cashu.dexie.db.proofs") {
             const proofs = JSON.parse(backup[key]);
             await proofsStore.addProofs(proofs);
+          } else if (key === "cashu.buckets") {
+            bucketsStore.buckets = JSON.parse(backup[key]);
           } else {
             localStorage.setItem(key, backup[key]);
           }
@@ -88,7 +92,7 @@ export const useStorageStore = defineStore("storage", {
       } catch (e) {
         console.log("Local storage quota exceeded");
         notifyError(
-          "Local storage quota exceeded. Clean up your local storage."
+          "Local storage quota exceeded. Clean up your local storage.",
         );
         return true;
       }
@@ -116,7 +120,7 @@ export const useStorageStore = defineStore("storage", {
       // from all paid invoices in this.invoiceHistory, delete the oldest so that only max 100 remain
       const max_history = 200;
       let paidInvoices = walletStore.invoiceHistory.filter(
-        (i) => i.status == "paid"
+        (i) => i.status == "paid",
       );
 
       if (paidInvoices.length > max_history) {
@@ -125,16 +129,16 @@ export const useStorageStore = defineStore("storage", {
         });
         const deleteInvoices = sortedInvoices.slice(
           0,
-          sortedInvoices.length - max_history
+          sortedInvoices.length - max_history,
         );
         walletStore.invoiceHistory = walletStore.invoiceHistory.filter(
-          (i) => !deleteInvoices.includes(i)
+          (i) => !deleteInvoices.includes(i),
         );
       }
 
       // walk through the oldest paid tokenStore.historyTokens and delete the token
       let paidTokens = tokenStore.historyTokens.filter(
-        (t) => t.status == "paid"
+        (t) => t.status == "paid",
       );
 
       if (paidTokens.length > max_history) {
@@ -143,7 +147,7 @@ export const useStorageStore = defineStore("storage", {
         });
         const deleteTokens = sortedTokens.slice(
           0,
-          sortedTokens.length - max_history
+          sortedTokens.length - max_history,
         );
         for (var i = 0; i < deleteTokens.length; i++) {
           deleteTokens[i].token = undefined;


### PR DESCRIPTION
## Summary
- allow assigning bucket IDs when receiving tokens
- preserve bucket info when sending or swapping
- handle buckets on restore

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint config missing)*
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_6839fcd602c88330861977c5e3ee75d1