### PR TITLE
Add bucket management UI

### DIFF
--- a/src/components/BalanceView.vue
+++ b/src/components/BalanceView.vue
@@ -123,6 +123,27 @@
       </div>
     </div>
   </div>
+  <div
+    v-for="bucket in bucketList"
+    :key="bucket.id"
+    class="row q-mt-xs q-mb-none text-secondary"
+  >
+    <div class="col-12">
+      <span class="q-my-none q-py-none text-weight-regular">
+        {{ bucket.name }}:
+        <b>{{ formatCurrency(bucketBalances[bucket.id] || 0, activeUnit) }}</b>
+        <span v-if="bucket.goal"
+          >/ {{ formatCurrency(bucket.goal, activeUnit) }}</span
+        >
+      </span>
+      <q-linear-progress
+        v-if="bucket.goal"
+        :value="Math.min(bucketBalances[bucket.id] / bucket.goal, 1)"
+        color="primary"
+        class="q-mt-xs"
+      />
+    </div>
+  </div>
   <!-- pending -->
   <div class="row q-mt-xs q-mb-none" v-if="pendingBalance > 0">
     <div class="col-12">
@@ -155,6 +176,7 @@ import { useTokensStore } from "stores/tokens";
 import { useUiStore } from "stores/ui";
 import { useWalletStore } from "stores/wallet";
 import { usePriceStore } from "stores/price";
+import { useBucketsStore } from "stores/buckets";
 import ToggleUnit from "components/ToggleUnit.vue";
 import AnimatedNumber from "components/AnimatedNumber.vue";
 import axios from "axios";
@@ -183,6 +205,7 @@ export default defineComponent({
     ...mapState(useTokensStore, ["historyTokens"]),
     ...mapState(useUiStore, ["globalMutexLock"]),
     ...mapState(usePriceStore, ["bitcoinPrice"]),
+    ...mapState(useBucketsStore, ["bucketList", "bucketBalances"]),
     ...mapWritableState(useMintsStore, ["activeUnit"]),
     ...mapWritableState(useUiStore, ["hideBalance", "lastBalanceCached"]),
     pendingBalance: function () {

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -469,6 +469,9 @@ export default {
       mints: {
         label: "Mints",
       },
+      buckets: {
+        label: "Buckets",
+      },
     },
     install: {
       text: "Install",
@@ -1218,6 +1221,21 @@ export default {
         label: "@:global.actions.add_mint.label",
         in_progress: "Adding mint",
       },
+    },
+  },
+  BucketManager: {
+    actions: {
+      add: "Add bucket",
+      delete: "Delete",
+    },
+    inputs: {
+      name: "Name",
+      color: "Color",
+      description: "Description",
+      goal: "Goal (sat)",
+    },
+    delete_confirm: {
+      title: "Delete bucket?",
     },
   },
   restore: {

--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -85,6 +85,11 @@
             class="text-secondary"
             :label="$t('WalletPage.tabs.mints.label')"
           ></q-tab>
+          <q-tab
+            name="buckets"
+            class="text-secondary"
+            :label="$t('WalletPage.tabs.buckets.label')"
+          ></q-tab>
         </q-tabs>
 
         <q-tab-panels
@@ -108,6 +113,9 @@
 
           <q-tab-panel name="mints" class="q-px-sm">
             <MintSettings />
+          </q-tab-panel>
+          <q-tab-panel name="buckets" class="q-px-sm">
+            <BucketManager />
           </q-tab-panel>
         </q-tab-panels>
       </q-expansion-item>
@@ -236,6 +244,7 @@ import QrcodeReader from "components/QrcodeReader.vue";
 import iOSPWAPrompt from "components/iOSPWAPrompt.vue";
 import AndroidPWAPrompt from "components/AndroidPWAPrompt.vue";
 import ActivityOrb from "components/ActivityOrb.vue";
+import BucketManager from "components/BucketManager.vue";
 
 // pinia stores
 import { mapActions, mapState, mapWritableState } from "pinia";
@@ -290,6 +299,7 @@ export default {
     AndroidPWAPrompt,
     ScanIcon,
     ActivityOrb,
+    BucketManager,
   },
   data: function () {
     return {
@@ -535,13 +545,13 @@ export default {
         this.deferredPWAInstallPrompt = e;
         console.log(
           `'beforeinstallprompt' event was fired.`,
-          this.getPwaDisplayMode()
+          this.getPwaDisplayMode(),
         );
       });
     },
     getPwaDisplayMode: function () {
       const isStandalone = window.matchMedia(
-        "(display-mode: standalone)"
+        "(display-mode: standalone)",
       ).matches;
       if (document.referrer.startsWith("android-app://")) {
         return "twa";
@@ -570,7 +580,7 @@ export default {
         sessionStorage.setItem(
           "tabId",
           Math.random().toString(36).substring(2) +
-            new Date().getTime().toString(36)
+            new Date().getTime().toString(36),
         );
       }
       const tabId = sessionStorage.getItem("tabId");


### PR DESCRIPTION
## Summary
- add `BucketManager.vue` component for adding/editing buckets
- show bucket list with balance progress
- integrate bucket manager tab on wallet page
- display per-bucket balances in BalanceView
- provide English i18n strings for buckets

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm run test` *(fails: vitest not found)*
- `npm run checkformat` *(fails: Prettier reports unformatted files)*

------
https://chatgpt.com/codex/tasks/task_e_6839ff0e28708330a5510465d4047c1e