### PR TITLE
Add bucket selection for receiving tokens

### DIFF
--- a/src/components/ReceiveTokenDialog.vue
+++ b/src/components/ReceiveTokenDialog.vue
@@ -139,6 +139,17 @@
               :showP2PKCheck="true"
             />
           </div>
+          <div class="row q-pt-sm">
+            <q-select
+              v-model="receiveData.bucketId"
+              :options="bucketOptions"
+              emit-value
+              map-options
+              outlined
+              dense
+              :label="$t('BucketManager.inputs.name')"
+            />
+          </div>
           <div class="row q-pt-md" v-if="!swapSelected">
             <q-btn
               @click="receiveIfDecodes"
@@ -272,6 +283,8 @@ import token from "src/js/token";
 import ChooseMint from "src/components/ChooseMint.vue";
 import TokenInformation from "components/TokenInformation.vue";
 
+import { useBucketsStore, DEFAULT_BUCKET_ID } from "src/stores/buckets";
+
 import { mapActions, mapState, mapWritableState } from "pinia";
 import {
   ChevronLeft as ChevronLeftIcon,
@@ -315,6 +328,14 @@ export default defineComponent({
         });
       }
     },
+    bucketList: {
+      handler(newList) {
+        if (!newList.find((b) => b.id === this.receiveData.bucketId)) {
+          this.receiveData.bucketId = DEFAULT_BUCKET_ID;
+        }
+      },
+      deep: true,
+    },
   },
   computed: {
     ...mapWritableState(useReceiveTokensStore, [
@@ -341,6 +362,10 @@ export default defineComponent({
     ...mapState(useSwapStore, ["swapBlocking"]),
     ...mapWritableState(useUiStore, ["showReceiveDialog"]),
     ...mapState(useCameraStore, ["lastScannedResult"]),
+    ...mapState(useBucketsStore, ["bucketList"]),
+    bucketOptions() {
+      return this.bucketList.map((b) => ({ label: b.name, value: b.id }));
+    },
     canPasteFromClipboard: function () {
       return (
         window.isSecureContext &&

--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -874,6 +874,9 @@ export default {
       tokens_base64: {
         label: "لصق رمز Cashu",
       },
+      bucket: {
+        label: "Bucket",
+      },
     },
     errors: {
       invalid_token: {

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -885,6 +885,9 @@ export default {
       tokens_base64: {
         label: "Cashu Token einfügen",
       },
+      bucket: {
+        label: "Bucket",
+      },
     },
     errors: {
       invalid_token: {

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -883,6 +883,9 @@ export default {
       tokens_base64: {
         label: "Επικολλήστε το token Cashu",
       },
+      bucket: {
+        label: "Bucket",
+      },
     },
     errors: {
       invalid_token: {

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -880,6 +880,9 @@ export default {
       tokens_base64: {
         label: "Paste Cashu token",
       },
+      bucket: {
+        label: "Bucket",
+      },
     },
     errors: {
       invalid_token: {

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -881,6 +881,9 @@ export default {
       tokens_base64: {
         label: "Pegar token Cashu",
       },
+      bucket: {
+        label: "Bucket",
+      },
     },
     errors: {
       invalid_token: {

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -884,6 +884,9 @@ export default {
       tokens_base64: {
         label: "Coller le jeton Cashu",
       },
+      bucket: {
+        label: "Bucket",
+      },
     },
     errors: {
       invalid_token: {

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -878,6 +878,9 @@ export default {
       tokens_base64: {
         label: "Incolla token Cashu",
       },
+      bucket: {
+        label: "Bucket",
+      },
     },
     errors: {
       invalid_token: {

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -877,6 +877,9 @@ export default {
       tokens_base64: {
         label: "Cashuトークンを貼り付け",
       },
+      bucket: {
+        label: "Bucket",
+      },
     },
     errors: {
       invalid_token: {

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -878,6 +878,9 @@ export default {
       tokens_base64: {
         label: "Klistra in Cashu token",
       },
+      bucket: {
+        label: "Bucket",
+      },
     },
     errors: {
       invalid_token: {

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -875,6 +875,9 @@ export default {
       tokens_base64: {
         label: "วางโทเค็น Cashu",
       },
+      bucket: {
+        label: "Bucket",
+      },
     },
     errors: {
       invalid_token: {

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -880,6 +880,9 @@ export default {
       tokens_base64: {
         label: "Cashu token'ını yapıştır",
       },
+      bucket: {
+        label: "Bucket",
+      },
     },
     errors: {
       invalid_token: {

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -869,6 +869,9 @@ export default {
       tokens_base64: {
         label: "粘贴 Cashu token",
       },
+      bucket: {
+        label: "Bucket",
+      },
     },
     errors: {
       invalid_token: {


### PR DESCRIPTION
## Summary
- add bucket dropdown when receiving tokens
- update selected bucket if deleted
- add translations for bucket label in all locales

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a009ab9148330b2a9aa5b2e2ec655