### PR TITLE
Add buckets management route and menu entry

### DIFF
--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -89,6 +89,19 @@
           }}</q-item-label>
         </q-item-section>
       </q-item>
+      <q-item clickable to="/buckets">
+        <q-item-section avatar>
+          <q-icon name="inventory_2" />
+        </q-item-section>
+        <q-item-section>
+          <q-item-label>{{
+            $t("MainHeader.menu.buckets.buckets.title")
+          }}</q-item-label>
+          <q-item-label caption>{{
+            $t("MainHeader.menu.buckets.buckets.caption")
+          }}</q-item-label>
+        </q-item-section>
+      </q-item>
       <q-item-label header>{{
         $t("MainHeader.menu.terms.title")
       }}</q-item-label>

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -96,6 +96,13 @@ export default {
           caption: "Wallet configuration",
         },
       },
+      buckets: {
+        title: "Buckets",
+        buckets: {
+          title: "Buckets",
+          caption: "Manage buckets",
+        },
+      },
       terms: {
         title: "Terms",
         terms: {

--- a/src/pages/Buckets.vue
+++ b/src/pages/Buckets.vue
@@ -1,0 +1,17 @@
+<template>
+  <div class="bg-dark text-white text-center q-pa-md flex flex-center">
+    <BucketManager />
+  </div>
+</template>
+
+<script>
+import { defineComponent } from "vue";
+import BucketManager from "components/BucketManager.vue";
+
+export default defineComponent({
+  name: "BucketsPage",
+  components: {
+    BucketManager,
+  },
+});
+</script>

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -12,6 +12,11 @@ const routes = [
     children: [{ path: "", component: () => import("src/pages/Settings.vue") }],
   },
   {
+    path: "/buckets",
+    component: () => import("layouts/FullscreenLayout.vue"),
+    children: [{ path: "", component: () => import("src/pages/Buckets.vue") }],
+  },
+  {
     path: "/restore",
     component: () => import("layouts/FullscreenLayout.vue"),
     children: [{ path: "", component: () => import("src/pages/Restore.vue") }],


### PR DESCRIPTION
## Summary
- add new Buckets page showing the BucketManager component
- route `/buckets` to the new page
- expose Buckets page in the drawer menu
- add English translations for the menu item

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_683a0aacf25883308fa65773e759b214