### PR TITLE
Fix bucket button label

### DIFF
--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1235,7 +1235,7 @@ export default {
   },
   BucketManager: {
     actions: {
-      add: "Add bucket",
+      add: "Create new Bucket",
       delete: "Delete",
     },
     inputs: {


### PR DESCRIPTION
## Summary
- update bucket manager action label in English translation

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a0e245e4c83308294cff3e0ed9f9d