### PR TITLE
Update Buckets navigation in header

### DIFF
--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -89,7 +89,7 @@
           }}</q-item-label>
         </q-item-section>
       </q-item>
-      <q-item clickable to="/buckets">
+      <q-item clickable @click="gotoBuckets">
         <q-item-section avatar>
           <q-icon name="inventory_2" />
         </q-item-section>
@@ -132,6 +132,7 @@
 
 <script>
 import { defineComponent, ref } from "vue";
+import { useRouter } from "vue-router";
 import EssentialLink from "components/EssentialLink.vue";
 import { useUiStore } from "src/stores/ui";
 import { useI18n } from "vue-i18n";
@@ -146,6 +147,7 @@ export default defineComponent({
     const leftDrawerOpen = ref(false);
     const uiStore = useUiStore();
     const { t } = useI18n();
+    const router = useRouter();
     const countdown = ref(0);
     let countdownInterval;
 
@@ -210,6 +212,11 @@ export default defineComponent({
       }, 1000);
     };
 
+    const gotoBuckets = () => {
+      router.push("/buckets");
+      leftDrawerOpen.value = false;
+    };
+
     return {
       essentialLinks,
       leftDrawerOpen,
@@ -218,6 +225,7 @@ export default defineComponent({
       reload,
       countdown,
       uiStore,
+      gotoBuckets,
     };
   },
 });


### PR DESCRIPTION
## Summary
- use explicit router navigation for Buckets link
- close drawer after navigating to Buckets

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration file)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a0e98fe408330936b259721d4ad46