### PR TITLE
Rename getter in nostr store

### DIFF
--- a/src/components/SettingsView.vue
+++ b/src/components/SettingsView.vue
@@ -210,11 +210,11 @@
               </q-item-label>
               <q-item-label
                 caption
-                v-if="signerType === 'SEED' && seedSignerPrivateKeyNsec"
+                v-if="signerType === 'SEED' && seedSignerPrivateKeyNsecComputed"
               >
                 <q-badge
                   class="cursor-pointer q-mt-xs"
-                  @click="copyText(seedSignerPrivateKeyNsec)"
+                  @click="copyText(seedSignerPrivateKeyNsecComputed)"
                   outline
                   color="grey"
                 >
@@ -1676,7 +1676,7 @@ export default defineComponent({
       "pubkey",
       "mintRecommendations",
       "signerType",
-      "seedSignerPrivateKeyNsec",
+      "seedSignerPrivateKeyNsecComputed",
     ]),
     ...mapState(useWalletStore, ["mnemonic"]),
     ...mapState(useUiStore, ["ndefSupported"]),

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -99,7 +99,7 @@ export const useNostrStore = defineStore("nostr", {
     ),
   }),
   getters: {
-    seedSignerPrivateKeyNsec: (state) => {
+    seedSignerPrivateKeyNsecComputed: (state) => {
       const sk = hexToBytes(state.seedSignerPrivateKey);
       return nip19.nsecEncode(sk);
     },


### PR DESCRIPTION
## Summary
- rename `seedSignerPrivateKeyNsec` getter to `seedSignerPrivateKeyNsecComputed`
- update SettingsView to use the renamed getter

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a9127b8f883309fd9d3aea6df7689