### PR TITLE
Add onDialogShown method

### DIFF
--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -803,6 +803,17 @@ export default defineComponent({
     ...mapActions(useP2PKStore, ["isValidPubkey", "maybeConvertNpub"]),
     ...mapActions(useCameraStore, ["closeCamera", "showCamera"]),
     ...mapActions(useMintsStore, ["toggleUnit"]),
+    onDialogShown() {
+      this.$nextTick(() => {
+        const input = this.$el.querySelector('input');
+        if (input) {
+          input.focus();
+        }
+        if (this.useNumericKeyboard && !this.sendData.tokensBase64.length) {
+          this.showNumericKeyboard = true;
+        }
+      });
+    },
     // decodeP2PKQR: function (res) {
     //   console.log("### SendToken qr", res);
     //   this.camera.data = res;


### PR DESCRIPTION
## Summary
- focus the amount input and optionally open the numeric keyboard when SendTokenDialog opens

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a91a3d4cc833089fdc25c3b418f16