### PR TITLE
Add welcome dialog closing method

### DIFF
--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -496,6 +496,11 @@ export default {
         this.$router.push("/welcome" + currentQuery + currentHash);
       }
     },
+    setWelcomeDialogSeen: function () {
+      // mark the welcome dialog as seen and close it
+      const welcomeStore = useWelcomeStore();
+      welcomeStore.closeWelcome();
+    },
     setTab: function (to) {
       this.tab = to;
     },


### PR DESCRIPTION
## Summary
- implement `setWelcomeDialogSeen` method in WalletPage

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a10e2b88c8330a8979ef1d049ea9d