### PR TITLE
Add bucket detail page

### DIFF
--- a/src/components/BalanceView.vue
+++ b/src/components/BalanceView.vue
@@ -129,19 +129,21 @@
     class="row q-mt-xs q-mb-none text-secondary"
   >
     <div class="col-12">
-      <span class="q-my-none q-py-none text-weight-regular">
-        {{ bucket.name }}:
-        <b>{{ formatCurrency(bucketBalances[bucket.id] || 0, activeUnit) }}</b>
-        <span v-if="bucket.goal"
-          >/ {{ formatCurrency(bucket.goal, activeUnit) }}</span
-        >
-      </span>
-      <q-linear-progress
-        v-if="bucket.goal"
-        :value="Math.min(bucketBalances[bucket.id] / bucket.goal, 1)"
-        color="primary"
-        class="q-mt-xs"
-      />
+      <router-link :to="`/buckets/${bucket.id}`" class="text-secondary">
+        <span class="q-my-none q-py-none text-weight-regular">
+          {{ bucket.name }}:
+          <b>{{ formatCurrency(bucketBalances[bucket.id] || 0, activeUnit) }}</b>
+          <span v-if="bucket.goal"
+            >/ {{ formatCurrency(bucket.goal, activeUnit) }}</span
+          >
+        </span>
+        <q-linear-progress
+          v-if="bucket.goal"
+          :value="Math.min(bucketBalances[bucket.id] / bucket.goal, 1)"
+          color="primary"
+          class="q-mt-xs"
+        />
+      </router-link>
     </div>
   </div>
   <!-- pending -->

--- a/src/components/BucketManager.vue
+++ b/src/components/BucketManager.vue
@@ -3,6 +3,8 @@
     <q-list padding>
       <div v-for="bucket in bucketList" :key="bucket.id" class="q-mb-md">
         <q-item
+          clickable
+          :to="`/buckets/${bucket.id}`"
           :style="{
             border: '1px solid rgba(128,128,128,0.2)',
             'border-radius': '10px',
@@ -34,13 +36,13 @@
             />
           </q-item-section>
           <q-item-section side v-if="bucket.id !== DEFAULT_BUCKET_ID">
-            <q-btn icon="edit" flat round size="sm" @click="openEdit(bucket)" />
+            <q-btn icon="edit" flat round size="sm" @click.stop="openEdit(bucket)" />
             <q-btn
               icon="delete"
               flat
               round
               size="sm"
-              @click="openDelete(bucket.id)"
+              @click.stop="openDelete(bucket.id)"
             />
           </q-item-section>
         </q-item>

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1248,9 +1248,14 @@ export default {
       title: "Delete bucket?",
     },
   },
+  BucketDetail: {
+    move: "Move tokens",
+    send: "Send tokens"
+  },
   restore: {
     mnemonic_error_text: "Please enter a mnemonic",
     restore_mint_error_text: "Error restoring mint: { error }",
+  },
     prepare_info_text: "Preparing restore process …",
     restored_proofs_for_keyset_info_text:
       "Restored { restoreCounter } proofs for keyset { keysetId }",

--- a/src/pages/BucketDetail.vue
+++ b/src/pages/BucketDetail.vue
@@ -1,0 +1,99 @@
+<template>
+  <div class="q-pa-md" v-if="bucket">
+    <div class="q-mb-lg">
+      <h5 class="q-my-none">{{ bucket.name }}</h5>
+      <div v-if="bucket.description" class="text-caption q-mt-xs">{{ bucket.description }}</div>
+      <div class="text-secondary q-mt-sm">
+        <span>{{ formatCurrency(bucketBalance, activeUnit) }}</span>
+        <span v-if="bucket.goal"> / {{ formatCurrency(bucket.goal, activeUnit) }}</span>
+      </div>
+    </div>
+
+    <q-list bordered>
+      <q-item v-for="proof in bucketProofs" :key="proof.secret">
+        <q-item-section side>
+          <q-checkbox v-model="selected" :val="proof.secret"/>
+        </q-item-section>
+        <q-item-section>
+          <q-item-label>{{ formatCurrency(proof.amount, activeUnit) }}</q-item-label>
+          <q-item-label caption>{{ proof.secret.slice(0,8) }}...</q-item-label>
+        </q-item-section>
+      </q-item>
+    </q-list>
+
+    <div class="q-mt-lg">
+      <q-select
+        dense outlined
+        v-model="targetBucket"
+        :options="bucketOptions"
+        :label="bucketSelectLabel"
+        emit-value map-options
+        class="q-mb-md"
+      />
+      <div class="row q-gutter-sm">
+        <q-btn color="primary" :disable="!selected.length" @click="moveSelected">
+          {{ $t('BucketDetail.move') }}
+        </q-btn>
+        <q-btn color="primary" outline :disable="!selected.length" @click="sendSelected">
+          {{ $t('BucketDetail.send') }}
+        </q-btn>
+      </div>
+    </div>
+
+    <SendTokenDialog v-model="showSendTokens" />
+  </div>
+  <div v-else class="q-pa-md">Bucket not found.</div>
+</template>
+
+<script setup>
+import { computed, ref } from 'vue';
+import { useRoute } from 'vue-router';
+import { useBucketsStore, DEFAULT_BUCKET_ID } from 'stores/buckets';
+import { useProofsStore } from 'stores/proofs';
+import { useMintsStore } from 'stores/mints';
+import { useUiStore } from 'stores/ui';
+import { storeToRefs } from 'pinia';
+import { useSendTokensStore } from 'stores/sendTokensStore';
+import SendTokenDialog from 'components/SendTokenDialog.vue';
+
+const route = useRoute();
+const bucketsStore = useBucketsStore();
+const proofsStore = useProofsStore();
+const mintsStore = useMintsStore();
+const uiStore = useUiStore();
+const sendTokensStore = useSendTokensStore();
+
+const bucketId = route.params.id as string;
+const bucket = computed(() => bucketsStore.bucketList.find(b => b.id === bucketId));
+const bucketProofs = computed(() => proofsStore.proofs.filter(p => p.bucketId === bucketId && !p.reserved));
+const bucketBalance = computed(() => bucketProofs.value.reduce((s,p)=>s+p.amount,0));
+const { activeUnit } = storeToRefs(mintsStore);
+const showSendTokens = storeToRefs(sendTokensStore).showSendTokens;
+
+const selected = ref<string[]>([]);
+const targetBucket = ref(DEFAULT_BUCKET_ID);
+const bucketSelectLabel = 'Move to bucket';
+
+const bucketOptions = computed(() =>
+  bucketsStore.bucketList
+    .filter(b => b.id !== bucketId)
+    .map(b => ({ label: b.name, value: b.id }))
+);
+
+function formatCurrency(amount:number, unit:string){
+  return uiStore.formatCurrency(amount, unit);
+}
+
+async function moveSelected(){
+  await proofsStore.moveProofs(selected.value, targetBucket.value);
+  selected.value = [];
+}
+
+function sendSelected(){
+  const proofs = bucketProofs.value.filter(p => selected.value.includes(p.secret));
+  const token = proofsStore.serializeProofs(proofs);
+  sendTokensStore.clearSendData();
+  sendTokensStore.sendData.tokensBase64 = token;
+  showSendTokens.value = true;
+}
+</script>

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -17,6 +17,11 @@ const routes = [
     children: [{ path: "", component: () => import("src/pages/Buckets.vue") }],
   },
   {
+    path: "/buckets/:id",
+    component: () => import("layouts/FullscreenLayout.vue"),
+    children: [{ path: "", component: () => import("src/pages/BucketDetail.vue") }],
+  },
+  {
     path: "/restore",
     component: () => import("layouts/FullscreenLayout.vue"),
     children: [{ path: "", component: () => import("src/pages/Restore.vue") }],

--- a/src/stores/proofs.ts
+++ b/src/stores/proofs.ts
@@ -172,5 +172,12 @@ export const useProofsStore = defineStore("proofs", {
       let mints = mints_keysets.map((m) => [{ url: m.url, ids: m.keysets }][0]);
       return mints[0];
     },
+    async moveProofs(secrets: string[], bucketId: string) {
+      await cashuDb.transaction("rw", cashuDb.proofs, async () => {
+        for (const secret of secrets) {
+          await cashuDb.proofs.where("secret").equals(secret).modify({ bucketId });
+        }
+      });
+    },
   },
 });


### PR DESCRIPTION
## Summary
- add `/buckets/:id` route
- implement BucketDetail page using FullscreenLayout
- allow moving proofs between buckets and sending selected tokens
- make bucket lists navigate to detail pages
- add proof moving action
- add translation entries for new page

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a9454bdc48330bdfa52aa30dcc24c