### PR TITLE
Implement bucket proof moving

### DIFF
--- a/src/pages/BucketDetail.vue
+++ b/src/pages/BucketDetail.vue
@@ -1,0 +1,96 @@
+<template>
+  <div class="q-pa-md">
+    <div v-if="bucket">
+      <h5 class="q-mb-md">{{ bucket.name }}</h5>
+      <q-select
+        v-model="targetBucketId"
+        :options="bucketOptions"
+        emit-value
+        map-options
+        outlined
+        dense
+        label="Move to bucket"
+        class="q-mb-md"
+      />
+      <q-btn
+        color="primary"
+        class="q-mb-md"
+        :disable="!selectedSecrets.length || !targetBucketId"
+        @click="moveSelected"
+      >
+        Move
+      </q-btn>
+      <q-list bordered>
+        <q-item v-for="proof in bucketProofs" :key="proof.secret">
+          <q-item-section side>
+            <q-checkbox v-model="selectedSecrets" :val="proof.secret" />
+          </q-item-section>
+          <q-item-section>
+            <q-item-label>{{ formatCurrency(proof.amount, activeUnit) }}</q-item-label>
+          </q-item-section>
+        </q-item>
+      </q-list>
+    </div>
+    <div v-else>
+      <q-item-label>Bucket not found</q-item-label>
+    </div>
+  </div>
+</template>
+
+<script>
+import { defineComponent, ref, computed } from 'vue';
+import { useRoute } from 'vue-router';
+import { useBucketsStore } from 'stores/buckets';
+import { useProofsStore } from 'stores/proofs';
+import { useMintsStore } from 'stores/mints';
+import { useUiStore } from 'stores/ui';
+
+export default defineComponent({
+  name: 'BucketDetail',
+  setup() {
+    const route = useRoute();
+    const bucketId = route.params.id;
+    const bucketsStore = useBucketsStore();
+    const proofsStore = useProofsStore();
+    const mintsStore = useMintsStore();
+    const uiStore = useUiStore();
+
+    const targetBucketId = ref(null);
+    const selectedSecrets = ref([]);
+
+    const bucket = computed(() =>
+      bucketsStore.bucketList.find((b) => b.id === bucketId)
+    );
+    const bucketProofs = computed(() =>
+      proofsStore.proofs.filter((p) => p.bucketId === bucketId)
+    );
+    const bucketOptions = computed(() =>
+      bucketsStore.bucketList
+        .filter((b) => b.id !== bucketId)
+        .map((b) => ({ label: b.name, value: b.id }))
+    );
+
+    const formatCurrency = (val, unit) => uiStore.formatCurrency(val, unit);
+
+    const moveSelected = async () => {
+      const proofs = bucketProofs.value.filter((p) =>
+        selectedSecrets.value.includes(p.secret)
+      );
+      if (!proofs.length || !targetBucketId.value) return;
+      await proofsStore.moveProofs(proofs, targetBucketId.value);
+      selectedSecrets.value = [];
+    };
+
+    return {
+      bucket,
+      bucketProofs,
+      bucketOptions,
+      targetBucketId,
+      selectedSecrets,
+      moveSelected,
+      formatCurrency,
+      activeUnit: computed(() => mintsStore.activeUnit),
+    };
+  },
+});
+</script>

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -17,6 +17,13 @@ const routes = [
     children: [{ path: "", component: () => import("src/pages/Buckets.vue") }],
   },
   {
+    path: "/buckets/:id",
+    component: () => import("layouts/FullscreenLayout.vue"),
+    children: [
+      { path: "", component: () => import("src/pages/BucketDetail.vue") },
+    ],
+  },
+  {
     path: "/restore",
     component: () => import("layouts/FullscreenLayout.vue"),
     children: [{ path: "", component: () => import("src/pages/Restore.vue") }],

--- a/src/stores/proofs.ts
+++ b/src/stores/proofs.ts
@@ -114,6 +114,16 @@ export const useProofsStore = defineStore("proofs", {
         });
       });
     },
+    async updateProofBucket(secret: string, newBucketId: string) {
+      await cashuDb.proofs.update(secret, { bucketId: newBucketId });
+    },
+    async moveProofs(proofs: WalletProof[], newBucketId: string) {
+      await cashuDb.transaction("rw", cashuDb.proofs, async () => {
+        for (const proof of proofs) {
+          await cashuDb.proofs.update(proof.secret, { bucketId: newBucketId });
+        }
+      });
+    },
     async getProofsForQuote(quote: string): Promise<WalletProof[]> {
       return await cashuDb.proofs.where("quote").equals(quote).toArray();
     },

--- a/test/vitest/__tests__/proofs.spec.ts
+++ b/test/vitest/__tests__/proofs.spec.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useProofsStore } from '../../../src/stores/proofs'
+import { cashuDb } from '../../../src/stores/dexie'
+
+beforeEach(async () => {
+  await cashuDb.delete()
+  await cashuDb.open()
+})
+
+describe('Proofs store', () => {
+  it('updateProofBucket updates proof bucket', async () => {
+    const proofs = useProofsStore()
+    await proofs.addProofs([{ id: 'a', amount: 1, C: 'c1', secret: 's1' }], undefined, 'b1')
+    await proofs.updateProofBucket('s1', 'b2')
+    const stored = await cashuDb.proofs.get('s1')
+    expect(stored?.bucketId).toBe('b2')
+  })
+
+  it('moveProofs updates multiple proofs', async () => {
+    const store = useProofsStore()
+    const sample = [
+      { id: 'a', amount: 1, C: 'c1', secret: 's1' },
+      { id: 'a', amount: 2, C: 'c2', secret: 's2' }
+    ]
+    await store.addProofs(sample)
+    const toMove = await cashuDb.proofs.toArray()
+    await store.moveProofs(toMove, 'b3')
+    const updated = await cashuDb.proofs.toArray()
+    expect(updated.every(p => p.bucketId === 'b3')).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- support updating a proof's bucket
- allow moving a list of proofs in the proofs store
- create BucketDetail view with token selection and move controls
- wire new bucket page into routes
- add tests for bucket moving

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a947f068483308461b52ba92f5497