### PR TITLE
Add label support for wallet tokens

### DIFF
--- a/src/components/HistoryTable.vue
+++ b/src/components/HistoryTable.vue
@@ -47,8 +47,11 @@
               $t("HistoryTable.row.date_label", {
                 value: formattedDate(token.date),
               })
-            }}</q-item-label
-          >
+            }}
+          </q-item-label>
+          <q-item-label caption v-if="token.label">
+            {{ token.label }}
+          </q-item-label>
         </q-item-section>
 
         <q-item-section side top>

--- a/src/components/ReceiveTokenDialog.vue
+++ b/src/components/ReceiveTokenDialog.vue
@@ -140,7 +140,7 @@
             />
           </div>
           <div class="row q-pt-sm">
-            <q-select
+          <q-select
               v-model="receiveData.bucketId"
               :options="bucketOptions"
               emit-value
@@ -149,6 +149,13 @@
               dense
               :label="$t('BucketManager.inputs.name')"
             />
+          <q-input
+            v-model="receiveData.label"
+            outlined
+            dense
+            class="q-mt-sm"
+            :label="$t('ReceiveTokenDialog.inputs.label.label')"
+          />
           </div>
           <div class="row q-pt-md" v-if="!swapSelected">
             <q-btn
@@ -517,8 +524,9 @@ export default defineComponent({
       tokensStore.addPendingToken({
         amount: amount,
         token: tokenStr,
-        mintInToken: mintInToken,
-        unitInToken: unitInToken,
+        mint: mintInToken,
+        unit: unitInToken,
+        label: this.receiveData.label,
       });
       this.showReceiveTokens = false;
       // show success notification

--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -1055,6 +1055,7 @@ export default defineComponent({
           token: this.sendData.tokensBase64,
           unit: this.activeUnit,
           mint: this.activeMintUrl,
+          label: "",
         };
         this.addPendingToken(historyToken);
         this.sendData.historyToken = historyToken;
@@ -1109,6 +1110,7 @@ export default defineComponent({
           mint: this.activeMintUrl,
           paymentRequest: this.sendData.paymentRequest,
           status: "pending",
+          label: "",
         };
         this.addPendingToken(historyToken);
         this.sendData.historyToken = historyToken;

--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -877,6 +877,9 @@ export default {
       bucket: {
         label: "Bucket",
       },
+      label: {
+        label: "Label",
+      },
     },
     errors: {
       invalid_token: {

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -888,6 +888,9 @@ export default {
       bucket: {
         label: "Bucket",
       },
+      label: {
+        label: "Label",
+      },
     },
     errors: {
       invalid_token: {

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -886,6 +886,9 @@ export default {
       bucket: {
         label: "Bucket",
       },
+      label: {
+        label: "Label",
+      },
     },
     errors: {
       invalid_token: {

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -890,6 +890,9 @@ export default {
       bucket: {
         label: "Bucket",
       },
+      label: {
+        label: "Label",
+      },
     },
     errors: {
       invalid_token: {

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -884,6 +884,9 @@ export default {
       bucket: {
         label: "Bucket",
       },
+      label: {
+        label: "Label",
+      },
     },
     errors: {
       invalid_token: {

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -887,6 +887,9 @@ export default {
       bucket: {
         label: "Bucket",
       },
+      label: {
+        label: "Label",
+      },
     },
     errors: {
       invalid_token: {

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -881,6 +881,9 @@ export default {
       bucket: {
         label: "Bucket",
       },
+      label: {
+        label: "Label",
+      },
     },
     errors: {
       invalid_token: {

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -880,6 +880,9 @@ export default {
       bucket: {
         label: "Bucket",
       },
+      label: {
+        label: "Label",
+      },
     },
     errors: {
       invalid_token: {

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -881,6 +881,9 @@ export default {
       bucket: {
         label: "Bucket",
       },
+      label: {
+        label: "Label",
+      },
     },
     errors: {
       invalid_token: {

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -878,6 +878,9 @@ export default {
       bucket: {
         label: "Bucket",
       },
+      label: {
+        label: "Label",
+      },
     },
     errors: {
       invalid_token: {

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -883,6 +883,9 @@ export default {
       bucket: {
         label: "Bucket",
       },
+      label: {
+        label: "Label",
+      },
     },
     errors: {
       invalid_token: {

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -872,6 +872,9 @@ export default {
       bucket: {
         label: "Bucket",
       },
+      label: {
+        label: "Label",
+      },
     },
     errors: {
       invalid_token: {

--- a/src/js/token.ts
+++ b/src/js/token.ts
@@ -19,7 +19,7 @@ function getProofs(decoded_token: Token): WalletProof[] {
     throw new Error("Token format wrong");
   }
   const proofs = decoded_token.proofs.flat();
-  return useProofsStore().proofsToWalletProofs(proofs);
+  return useProofsStore().proofsToWalletProofs(proofs, undefined, "unassigned", "");
 }
 
 function getMint(decoded_token: Token) {

--- a/src/stores/dexie.ts
+++ b/src/stores/dexie.ts
@@ -37,6 +37,20 @@ export class CashuDexie extends Dexie {
             }
           });
       });
+    this.version(3)
+      .stores({
+        proofs: "secret, id, C, amount, reserved, quote, bucketId, label",
+      })
+      .upgrade(async (tx) => {
+        await tx
+          .table("proofs")
+          .toCollection()
+          .modify((proof: any) => {
+            if (proof.label === undefined) {
+              proof.label = "";
+            }
+          });
+      });
   }
 }
 

--- a/src/stores/mints.ts
+++ b/src/stores/mints.ts
@@ -87,6 +87,7 @@ export type WalletProof = Proof & {
   reserved: boolean;
   quote?: string;
   bucketId?: string;
+  label?: string;
 };
 
 export type Balances = {

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -592,6 +592,7 @@ export const useNostrStore = defineStore("nostr", {
         token: tokenStr,
         mint: token.getMint(decodedToken),
         unit: token.getUnit(decodedToken),
+        label: "",
       });
       receiveStore.showReceiveTokens = false;
       // show success notification

--- a/src/stores/npubcash.ts
+++ b/src/stores/npubcash.ts
@@ -217,6 +217,7 @@ export const useNPCStore = defineStore("npc", {
         token: tokenStr,
         mint: mintUrl,
         unit: unit,
+        label: "",
       });
       receiveStore.showReceiveTokens = false;
     },

--- a/src/stores/proofs.ts
+++ b/src/stores/proofs.ts
@@ -87,7 +87,8 @@ export const useProofsStore = defineStore("proofs", {
     proofsToWalletProofs(
       proofs: Proof[],
       quote?: string,
-      bucketId: string = "unassigned"
+      bucketId: string = "unassigned",
+      label: string = ""
     ): WalletProof[] {
       return proofs.map((p) => {
         return {
@@ -95,11 +96,17 @@ export const useProofsStore = defineStore("proofs", {
           reserved: false,
           quote: quote,
           bucketId,
+          label,
         } as WalletProof;
       });
     },
-    async addProofs(proofs: Proof[], quote?: string, bucketId: string = "unassigned") {
-      const walletProofs = this.proofsToWalletProofs(proofs, quote, bucketId);
+    async addProofs(
+      proofs: Proof[],
+      quote?: string,
+      bucketId: string = "unassigned",
+      label: string = ""
+    ) {
+      const walletProofs = this.proofsToWalletProofs(proofs, quote, bucketId, label);
       await cashuDb.transaction("rw", cashuDb.proofs, async () => {
         walletProofs.forEach(async (p) => {
           await cashuDb.proofs.add(p);

--- a/src/stores/receiveTokensStore.ts
+++ b/src/stores/receiveTokensStore.ts
@@ -24,6 +24,7 @@ export const useReceiveTokensStore = defineStore("receiveTokensStore", {
       tokensBase64: "",
       p2pkPrivateKey: "",
       bucketId: DEFAULT_BUCKET_ID,
+      label: "",
     },
     scanningCard: false,
   }),

--- a/src/stores/swap.ts
+++ b/src/stores/swap.ts
@@ -27,6 +27,7 @@ export type HistoryToken = {
   token?: string;
   mint: string;
   unit: string;
+  label?: string;
   paymentRequest?: PaymentRequest;
   fee?: number;
 };

--- a/src/stores/tokens.ts
+++ b/src/stores/tokens.ts
@@ -15,6 +15,7 @@ export type HistoryToken = {
   token: string;
   mint: string;
   unit: string;
+  label?: string;
   paymentRequest?: PaymentRequest;
   fee?: number;
 };
@@ -34,6 +35,7 @@ export const useTokensStore = defineStore("tokens", {
       unit,
       fee,
       paymentRequest,
+      label,
     }: {
       amount: number;
       token: string;
@@ -41,6 +43,7 @@ export const useTokensStore = defineStore("tokens", {
       unit: string;
       fee?: number;
       paymentRequest?: PaymentRequest;
+      label?: string;
     }) {
       this.historyTokens.push({
         status: "paid",
@@ -49,6 +52,7 @@ export const useTokensStore = defineStore("tokens", {
         token,
         mint,
         unit,
+        label,
         fee,
         paymentRequest,
       } as HistoryToken);
@@ -60,6 +64,7 @@ export const useTokensStore = defineStore("tokens", {
       unit,
       fee,
       paymentRequest,
+      label,
     }: {
       amount: number;
       token: string;
@@ -67,6 +72,7 @@ export const useTokensStore = defineStore("tokens", {
       unit: string;
       fee?: number;
       paymentRequest?: PaymentRequest;
+      label?: string;
     }) {
       this.historyTokens.push({
         status: "pending",
@@ -75,6 +81,7 @@ export const useTokensStore = defineStore("tokens", {
         token: token,
         mint,
         unit,
+        label,
         fee,
         paymentRequest,
       });

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -380,7 +380,7 @@ export const useWalletStore = defineStore("wallet", {
       await proofsStore.removeProofs(proofsToSend);
       // note: we do not store sendProofs in the proofs store but
       // expect from the caller to store it in the history
-      await proofsStore.addProofs(keepProofs, undefined, bucketId);
+      await proofsStore.addProofs(keepProofs, undefined, bucketId, "");
       return { keepProofs, sendProofs };
     },
     send: async function (
@@ -436,8 +436,8 @@ export const useWalletStore = defineStore("wallet", {
             keysetId,
             keepProofs.length + sendProofs.length,
           );
-          await proofsStore.addProofs(keepProofs, undefined, bucketId);
-          await proofsStore.addProofs(sendProofs, undefined, bucketId);
+          await proofsStore.addProofs(keepProofs, undefined, bucketId, "");
+          await proofsStore.addProofs(sendProofs, undefined, bucketId, "");
 
           // make sure we don't delete any proofs that were returned
           const proofsToSendNotReturned = proofsToSend
@@ -502,6 +502,7 @@ export const useWalletStore = defineStore("wallet", {
         token: receiveStore.receiveData.tokensBase64,
         unit: unitInToken,
         mint: mintInToken,
+        label: receiveStore.receiveData.label ?? "",
         fee: fee,
       } as HistoryToken;
       const mintWallet = this.mintWallet(historyToken.mint, historyToken.unit);
@@ -525,7 +526,7 @@ export const useWalletStore = defineStore("wallet", {
               proofsWeHave: mintStore.mintUnitProofs(mint, historyToken.unit),
             },
           );
-          await proofsStore.addProofs(proofs, undefined, bucketId);
+          await proofsStore.addProofs(proofs, undefined, bucketId, receiveStore.receiveData.label ?? "");
           this.increaseKeysetCounter(keysetId, proofs.length);
         } catch (error: any) {
           console.error(error);
@@ -667,7 +668,7 @@ export const useWalletStore = defineStore("wallet", {
           },
         );
         this.increaseKeysetCounter(keysetId, proofs.length);
-        await proofsStore.addProofs(proofs, undefined, bucketId);
+        await proofsStore.addProofs(proofs, undefined, bucketId, "");
 
         // update UI
         await this.setInvoicePaid(invoice.quote);
@@ -677,6 +678,7 @@ export const useWalletStore = defineStore("wallet", {
           token: serializedProofs,
           unit: invoice.unit,
           mint: invoice.mint,
+          label: "",
         });
         useInvoicesWorkerStore().removeInvoiceFromChecker(invoice.quote);
 
@@ -828,7 +830,7 @@ export const useWalletStore = defineStore("wallet", {
           console.log(
             "## Received change: " + proofsStore.sumProofs(changeProofs),
           );
-          await proofsStore.addProofs(changeProofs, undefined, bucketId);
+          await proofsStore.addProofs(changeProofs, undefined, bucketId, "");
         }
 
         // delete spent tokens from db
@@ -847,6 +849,7 @@ export const useWalletStore = defineStore("wallet", {
           token: proofsStore.serializeProofs(sendProofs),
           unit: mintWallet.unit,
           mint: mintWallet.mint.mintUrl,
+          label: "",
         });
 
         this.updateOutgoingInvoiceInHistory(quote, {
@@ -931,6 +934,7 @@ export const useWalletStore = defineStore("wallet", {
               token: serializedProofs,
               unit: wallet.unit,
               mint: wallet.mint.mintUrl,
+              label: "",
             });
           }
         }
@@ -1002,6 +1006,7 @@ export const useWalletStore = defineStore("wallet", {
               token: serializedUnspentProofs,
               unit: historyToken2.unit,
               mint: historyToken2.mint,
+              label: historyToken2.label ?? "",
             });
           }
         }


### PR DESCRIPTION
## Summary
- extend `WalletProof` with optional `label`
- migrate Dexie DB to add a `label` column
- allow setting labels when receiving tokens
- persist labels in history and show them in the history table

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a9466a96c8330a61bbdf17b64d614