### PR TITLE
Add bucket tracking to history

### DIFF
--- a/src/components/HistoryTable.vue
+++ b/src/components/HistoryTable.vue
@@ -134,7 +134,12 @@ import { notify } from "src/js/notify";
 export default defineComponent({
   name: "HistoryTable",
   mixins: [windowMixin],
-  props: {},
+  props: {
+    bucketId: {
+      type: String,
+      default: null,
+    },
+  },
   data: function () {
     return {
       currentPage: 1,
@@ -159,19 +164,26 @@ export default defineComponent({
       "showLockInput",
     ]),
     maxPages() {
-      return Math.ceil(this.historyTokens.length / this.pageSize);
+      let tokens = this.historyTokens;
+      if (this.bucketId) {
+        tokens = tokens.filter((t) => t.bucketId === this.bucketId);
+      }
+      if (this.filterPending) {
+        tokens = tokens.filter((t) => t.status === "pending");
+      }
+      return Math.ceil(tokens.length / this.pageSize);
     },
     paginatedTokens() {
       const start = (this.currentPage - 1) * this.pageSize;
       const end = start + this.pageSize;
-      if (this.filterPending) {
-        return this.historyTokens
-          .filter((historyToken) => historyToken.status === "pending")
-          .slice()
-          .reverse()
-          .slice(start, end);
+      let tokens = this.historyTokens;
+      if (this.bucketId) {
+        tokens = tokens.filter((t) => t.bucketId === this.bucketId);
       }
-      return this.historyTokens.slice().reverse().slice(start, end);
+      if (this.filterPending) {
+        tokens = tokens.filter((historyToken) => historyToken.status === "pending");
+      }
+      return tokens.slice().reverse().slice(start, end);
     },
   },
   methods: {

--- a/src/components/ReceiveTokenDialog.vue
+++ b/src/components/ReceiveTokenDialog.vue
@@ -517,8 +517,9 @@ export default defineComponent({
       tokensStore.addPendingToken({
         amount: amount,
         token: tokenStr,
-        mintInToken: mintInToken,
-        unitInToken: unitInToken,
+        mint: mintInToken,
+        unit: unitInToken,
+        bucketId: DEFAULT_BUCKET_ID,
       });
       this.showReceiveTokens = false;
       // show success notification

--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -575,6 +575,7 @@ import ChooseMint from "components/ChooseMint.vue";
 import { UR, UREncoder } from "@gandlaf21/bc-ur";
 import SendPaymentRequest from "./SendPaymentRequest.vue";
 import NumericKeyboard from "components/NumericKeyboard.vue";
+import { DEFAULT_BUCKET_ID } from "stores/buckets";
 import {
   ChevronLeft as ChevronLeftIcon,
   Clipboard as ClipboardIcon,
@@ -1055,6 +1056,7 @@ export default defineComponent({
           token: this.sendData.tokensBase64,
           unit: this.activeUnit,
           mint: this.activeMintUrl,
+          bucketId: sendProofs[0]?.bucketId || DEFAULT_BUCKET_ID,
         };
         this.addPendingToken(historyToken);
         this.sendData.historyToken = historyToken;
@@ -1109,6 +1111,7 @@ export default defineComponent({
           mint: this.activeMintUrl,
           paymentRequest: this.sendData.paymentRequest,
           status: "pending",
+          bucketId: sendProofs[0]?.bucketId || DEFAULT_BUCKET_ID,
         };
         this.addPendingToken(historyToken);
         this.sendData.historyToken = historyToken;

--- a/src/pages/BucketDetail.vue
+++ b/src/pages/BucketDetail.vue
@@ -1,0 +1,28 @@
+<template>
+  <div class="bg-dark text-white text-center q-pa-md flex flex-center">
+    <div style="max-width: 600px; width: 100%">
+      <h5 class="q-mt-none q-mb-md">{{ bucket?.name }}</h5>
+      <HistoryTable :bucket-id="bucketId" />
+    </div>
+  </div>
+</template>
+<script>
+import { defineComponent, computed } from "vue";
+import { useRoute } from "vue-router";
+import { useBucketsStore } from "stores/buckets";
+import HistoryTable from "components/HistoryTable.vue";
+
+export default defineComponent({
+  name: "BucketDetailPage",
+  components: { HistoryTable },
+  setup() {
+    const route = useRoute();
+    const bucketId = route.params.id as string;
+    const bucketsStore = useBucketsStore();
+    const bucket = computed(() =>
+      bucketsStore.bucketList.find((b) => b.id === bucketId)
+    );
+    return { bucketId, bucket };
+  },
+});
+</script>

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -17,6 +17,11 @@ const routes = [
     children: [{ path: "", component: () => import("src/pages/Buckets.vue") }],
   },
   {
+    path: "/buckets/:id",
+    component: () => import("layouts/FullscreenLayout.vue"),
+    children: [{ path: "", component: () => import("src/pages/BucketDetail.vue") }],
+  },
+  {
     path: "/restore",
     component: () => import("layouts/FullscreenLayout.vue"),
     children: [{ path: "", component: () => import("src/pages/Restore.vue") }],

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -26,6 +26,7 @@ import {
   Token,
 } from "@cashu/cashu-ts";
 import { useTokensStore } from "./tokens";
+import { DEFAULT_BUCKET_ID } from "./buckets";
 import {
   notifyApiError,
   notifyError,
@@ -592,6 +593,7 @@ export const useNostrStore = defineStore("nostr", {
         token: tokenStr,
         mint: token.getMint(decodedToken),
         unit: token.getUnit(decodedToken),
+        bucketId: DEFAULT_BUCKET_ID,
       });
       receiveStore.showReceiveTokens = false;
       // show success notification

--- a/src/stores/npubcash.ts
+++ b/src/stores/npubcash.ts
@@ -18,6 +18,7 @@ import token from "../js/token";
 import { WalletProof, useMintsStore } from "./mints";
 import { useTokensStore } from "../stores/tokens";
 import { useNostrStore } from "../stores/nostr";
+import { DEFAULT_BUCKET_ID } from "./buckets";
 // type NPCConnection = {
 //   walletPublicKey: string,
 //   walletPrivateKey: string,
@@ -217,6 +218,7 @@ export const useNPCStore = defineStore("npc", {
         token: tokenStr,
         mint: mintUrl,
         unit: unit,
+        bucketId: DEFAULT_BUCKET_ID,
       });
       receiveStore.showReceiveTokens = false;
     },

--- a/src/stores/tokens.ts
+++ b/src/stores/tokens.ts
@@ -15,6 +15,7 @@ export type HistoryToken = {
   token: string;
   mint: string;
   unit: string;
+  bucketId: string;
   paymentRequest?: PaymentRequest;
   fee?: number;
 };
@@ -32,6 +33,7 @@ export const useTokensStore = defineStore("tokens", {
       token,
       mint,
       unit,
+      bucketId,
       fee,
       paymentRequest,
     }: {
@@ -39,6 +41,7 @@ export const useTokensStore = defineStore("tokens", {
       token: string;
       mint: string;
       unit: string;
+      bucketId: string;
       fee?: number;
       paymentRequest?: PaymentRequest;
     }) {
@@ -49,6 +52,7 @@ export const useTokensStore = defineStore("tokens", {
         token,
         mint,
         unit,
+        bucketId,
         fee,
         paymentRequest,
       } as HistoryToken);
@@ -58,6 +62,7 @@ export const useTokensStore = defineStore("tokens", {
       token,
       mint,
       unit,
+      bucketId,
       fee,
       paymentRequest,
     }: {
@@ -65,6 +70,7 @@ export const useTokensStore = defineStore("tokens", {
       token: string;
       mint: string;
       unit: string;
+      bucketId: string;
       fee?: number;
       paymentRequest?: PaymentRequest;
     }) {
@@ -75,6 +81,7 @@ export const useTokensStore = defineStore("tokens", {
         token: token,
         mint,
         unit,
+        bucketId,
         fee,
         paymentRequest,
       });
@@ -87,6 +94,7 @@ export const useTokensStore = defineStore("tokens", {
         newStatus?: "paid" | "pending";
         newToken?: string;
         newFee?: number;
+        newBucketId?: string;
       }
     ): HistoryToken | undefined {
       const index = this.historyTokens.findIndex(
@@ -113,6 +121,9 @@ export const useTokensStore = defineStore("tokens", {
           }
           if (options.newFee) {
             this.historyTokens[index].fee = options.newFee;
+          }
+          if (options.newBucketId) {
+            this.historyTokens[index].bucketId = options.newBucketId;
           }
         }
 

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -503,6 +503,7 @@ export const useWalletStore = defineStore("wallet", {
         unit: unitInToken,
         mint: mintInToken,
         fee: fee,
+        bucketId: bucketId,
       } as HistoryToken;
       const mintWallet = this.mintWallet(historyToken.mint, historyToken.unit);
       const mint = mintStore.mints.find((m) => m.url === historyToken.mint);
@@ -677,6 +678,7 @@ export const useWalletStore = defineStore("wallet", {
           token: serializedProofs,
           unit: invoice.unit,
           mint: invoice.mint,
+          bucketId,
         });
         useInvoicesWorkerStore().removeInvoiceFromChecker(invoice.quote);
 
@@ -847,6 +849,7 @@ export const useWalletStore = defineStore("wallet", {
           token: proofsStore.serializeProofs(sendProofs),
           unit: mintWallet.unit,
           mint: mintWallet.mint.mintUrl,
+          bucketId,
         });
 
         this.updateOutgoingInvoiceInHistory(quote, {
@@ -931,6 +934,7 @@ export const useWalletStore = defineStore("wallet", {
               token: serializedProofs,
               unit: wallet.unit,
               mint: wallet.mint.mintUrl,
+              bucketId: spentProofs[0]?.bucketId ?? DEFAULT_BUCKET_ID,
             });
           }
         }
@@ -992,6 +996,7 @@ export const useWalletStore = defineStore("wallet", {
               newAmount: spentAmount,
               newStatus: "paid",
               newToken: serializedSpentProofs,
+              newBucketId: historyToken.bucketId,
             },
           );
           // add all unspent proofs back to the history
@@ -1002,6 +1007,7 @@ export const useWalletStore = defineStore("wallet", {
               token: serializedUnspentProofs,
               unit: historyToken2.unit,
               mint: historyToken2.mint,
+              bucketId: historyToken2.bucketId,
             });
           }
         }


### PR DESCRIPTION
## Summary
- track which bucket each history entry belongs to
- pass bucketId when saving history items in wallet flows
- add bucket filter to `HistoryTable` and create `BucketDetail` page

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a948783d88330805b747b2d4c3d2b