### PR TITLE
Add vitest dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,8 @@
     "workbox-expiration": "^6.6.1",
     "workbox-precaching": "^6.6.1",
     "workbox-routing": "^6.6.1",
-    "workbox-strategies": "^6.6.1"
+    "workbox-strategies": "^6.6.1",
+    "vitest": "^1.5.0"
   },
   "engines": {
     "node": ">=16.11.0",


### PR DESCRIPTION
## Summary
- add vitest dev dependency to package.json

## Testing
- `npm install --loglevel=error` *(fails: Failed to connect to proxy port 8080)*

------
https://chatgpt.com/codex/tasks/task_e_683a984ad4f0833086cada0e21f94842