### PR TITLE
Add i18n for BucketDetail

### DIFF
--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -1222,6 +1222,16 @@ export default {
       },
     },
   },
+  BucketDetail: {
+    move: "Move tokens",
+    send: "Send tokens",
+    inputs: {
+      target_bucket: {
+        label: "Move to bucket",
+      },
+    },
+    not_found: "Bucket not found.",
+  },
   restore: {
     mnemonic_error_text: "الرجاء إدخال كلمة تذكيرية",
     restore_mint_error_text: "خطأ في استعادة mint: { error }",

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -1234,6 +1234,16 @@ export default {
       },
     },
   },
+  BucketDetail: {
+    move: "Move tokens",
+    send: "Send tokens",
+    inputs: {
+      target_bucket: {
+        label: "Move to bucket",
+      },
+    },
+    not_found: "Bucket not found.",
+  },
   restore: {
     mnemonic_error_text: "Bitte geben Sie ein Mnemonisch ein",
     restore_mint_error_text: "Fehler beim Wiederherstellen der Mint: { error }",

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -1232,6 +1232,16 @@ export default {
       },
     },
   },
+  BucketDetail: {
+    move: "Move tokens",
+    send: "Send tokens",
+    inputs: {
+      target_bucket: {
+        label: "Move to bucket",
+      },
+    },
+    not_found: "Bucket not found.",
+  },
   restore: {
     mnemonic_error_text: "Παρακαλώ εισαγάγετε ένα μνημονικό",
     restore_mint_error_text: "Σφάλμα κατά την επαναφορά του mint: { error }",

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1253,7 +1253,13 @@ export default {
   },
   BucketDetail: {
     move: "Move tokens",
-    send: "Send tokens"
+    send: "Send tokens",
+    inputs: {
+      target_bucket: {
+        label: "Move to bucket",
+      },
+    },
+    not_found: "Bucket not found.",
   },
   restore: {
     mnemonic_error_text: "Please enter a mnemonic",

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -1230,6 +1230,16 @@ export default {
       },
     },
   },
+  BucketDetail: {
+    move: "Move tokens",
+    send: "Send tokens",
+    inputs: {
+      target_bucket: {
+        label: "Move to bucket",
+      },
+    },
+    not_found: "Bucket not found.",
+  },
   restore: {
     mnemonic_error_text: "Por favor, ingresa un mnemónico",
     restore_mint_error_text: "Error restaurando mint: { error }",

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -1233,6 +1233,16 @@ export default {
       },
     },
   },
+  BucketDetail: {
+    move: "Move tokens",
+    send: "Send tokens",
+    inputs: {
+      target_bucket: {
+        label: "Move to bucket",
+      },
+    },
+    not_found: "Bucket not found.",
+  },
   restore: {
     mnemonic_error_text: "Veuillez entrer un mnémonique",
     restore_mint_error_text:

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -1227,6 +1227,16 @@ export default {
       },
     },
   },
+  BucketDetail: {
+    move: "Move tokens",
+    send: "Send tokens",
+    inputs: {
+      target_bucket: {
+        label: "Move to bucket",
+      },
+    },
+    not_found: "Bucket not found.",
+  },
   restore: {
     mnemonic_error_text: "Inserisci un mnemonico",
     restore_mint_error_text: "Errore nel ripristino del mint: { error }",

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -1227,6 +1227,16 @@ export default {
       },
     },
   },
+  BucketDetail: {
+    move: "Move tokens",
+    send: "Send tokens",
+    inputs: {
+      target_bucket: {
+        label: "Move to bucket",
+      },
+    },
+    not_found: "Bucket not found.",
+  },
   restore: {
     mnemonic_error_text: "ニーモニックを入力してください",
     restore_mint_error_text: "ミントの復元エラー: { error }",

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -1227,6 +1227,16 @@ export default {
       },
     },
   },
+  BucketDetail: {
+    move: "Move tokens",
+    send: "Send tokens",
+    inputs: {
+      target_bucket: {
+        label: "Move to bucket",
+      },
+    },
+    not_found: "Bucket not found.",
+  },
   restore: {
     mnemonic_error_text: "Ange en mnemonisk fras",
     restore_mint_error_text: "Fel vid återställning av mint: { error }",

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -1224,6 +1224,16 @@ export default {
       },
     },
   },
+  BucketDetail: {
+    move: "Move tokens",
+    send: "Send tokens",
+    inputs: {
+      target_bucket: {
+        label: "Move to bucket",
+      },
+    },
+    not_found: "Bucket not found.",
+  },
   restore: {
     mnemonic_error_text: "โปรดป้อน mnemonic",
     restore_mint_error_text: "ข้อผิดพลาดในการกู้คืน Mint: { error }",

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -1229,6 +1229,16 @@ export default {
       },
     },
   },
+  BucketDetail: {
+    move: "Move tokens",
+    send: "Send tokens",
+    inputs: {
+      target_bucket: {
+        label: "Move to bucket",
+      },
+    },
+    not_found: "Bucket not found.",
+  },
   restore: {
     mnemonic_error_text: "Lütfen bir anımsatıcı girin",
     restore_mint_error_text: "Nane geri yükleme hatası: { error }",

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -1217,6 +1217,16 @@ export default {
       },
     },
   },
+  BucketDetail: {
+    move: "Move tokens",
+    send: "Send tokens",
+    inputs: {
+      target_bucket: {
+        label: "Move to bucket",
+      },
+    },
+    not_found: "Bucket not found.",
+  },
   restore: {
     mnemonic_error_text: "请输入助记符",
     restore_mint_error_text: "恢复 Mint 错误: { error }",

--- a/src/pages/BucketDetail.vue
+++ b/src/pages/BucketDetail.vue
@@ -26,7 +26,7 @@
         dense outlined
         v-model="targetBucket"
         :options="bucketOptions"
-        :label="bucketSelectLabel"
+        :label="$t('BucketDetail.inputs.target_bucket.label')"
         emit-value map-options
         class="q-mb-md"
       />
@@ -42,7 +42,7 @@
 
     <SendTokenDialog v-model="showSendTokens" />
   </div>
-  <div v-else class="q-pa-md">Bucket not found.</div>
+  <div v-else class="q-pa-md">{{ $t('BucketDetail.not_found') }}</div>
 </template>
 
 <script setup>
@@ -72,7 +72,6 @@ const showSendTokens = storeToRefs(sendTokensStore).showSendTokens;
 
 const selected = ref<string[]>([]);
 const targetBucket = ref(DEFAULT_BUCKET_ID);
-const bucketSelectLabel = 'Move to bucket';
 
 const bucketOptions = computed(() =>
   bucketsStore.bucketList


### PR DESCRIPTION
## Summary
- translate bucket select label and 'bucket not found' message
- add BucketDetail translation entries across all language files

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a9d514b448330bb98f5fe7eedd8e9