### PR TITLE
Fix restore i18n section

### DIFF
--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1264,7 +1264,6 @@ export default {
   restore: {
     mnemonic_error_text: "Please enter a mnemonic",
     restore_mint_error_text: "Error restoring mint: { error }",
-  },
     prepare_info_text: "Preparing restore process …",
     restored_proofs_for_keyset_info_text:
       "Restored { restoreCounter } proofs for keyset { keysetId }",


### PR DESCRIPTION
## Summary
- remove stray closing brace in English i18n file

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run test` *(fails: vitest not found)*
- `npm run build` *(fails: quasar not found)*

------
https://chatgpt.com/codex/tasks/task_e_683aa1c043948330bfd1a4113eb1eef4