### PR TITLE
Fix TypeScript parsing in BucketDetail

### DIFF
--- a/src/pages/BucketDetail.vue
+++ b/src/pages/BucketDetail.vue
@@ -45,7 +45,7 @@
   <div v-else class="q-pa-md">{{ $t('BucketDetail.not_found') }}</div>
 </template>
 
-<script setup>
+<script setup lang="ts">
 import { computed, ref } from 'vue';
 import { useRoute } from 'vue-router';
 import { useBucketsStore, DEFAULT_BUCKET_ID } from 'stores/buckets';


### PR DESCRIPTION
## Summary
- enable TypeScript support in `BucketDetail.vue`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683aa2c06b888330b3f782f7f56c7778