### PR TITLE
Add bucket ID to history tokens

### DIFF
--- a/src/components/HistoryTable.vue
+++ b/src/components/HistoryTable.vue
@@ -137,7 +137,12 @@ import { notify } from "src/js/notify";
 export default defineComponent({
   name: "HistoryTable",
   mixins: [windowMixin],
-  props: {},
+  props: {
+    bucketId: {
+      type: String,
+      default: null,
+    },
+  },
   data: function () {
     return {
       currentPage: 1,
@@ -147,6 +152,9 @@ export default defineComponent({
   },
   watch: {
     filterPending: function () {
+      this.currentPage = 1;
+    },
+    bucketId() {
       this.currentPage = 1;
     },
   },
@@ -161,20 +169,26 @@ export default defineComponent({
       "sendData",
       "showLockInput",
     ]),
+    filteredTokens() {
+      if (this.bucketId) {
+        return this.historyTokens.filter((t) => t.bucketId === this.bucketId);
+      }
+      return this.historyTokens;
+    },
     maxPages() {
-      return Math.ceil(this.historyTokens.length / this.pageSize);
+      return Math.ceil(this.filteredTokens.length / this.pageSize);
     },
     paginatedTokens() {
       const start = (this.currentPage - 1) * this.pageSize;
       const end = start + this.pageSize;
       if (this.filterPending) {
-        return this.historyTokens
+        return this.filteredTokens
           .filter((historyToken) => historyToken.status === "pending")
           .slice()
           .reverse()
           .slice(start, end);
       }
-      return this.historyTokens.slice().reverse().slice(start, end);
+      return this.filteredTokens.slice().reverse().slice(start, end);
     },
   },
   methods: {

--- a/src/components/ReceiveTokenDialog.vue
+++ b/src/components/ReceiveTokenDialog.vue
@@ -527,6 +527,7 @@ export default defineComponent({
         mint: mintInToken,
         unit: unitInToken,
         label: this.receiveData.label,
+        bucketId: this.receiveData.bucketId,
       });
       this.showReceiveTokens = false;
       // show success notification

--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -569,6 +569,7 @@ import { useCameraStore } from "src/stores/camera";
 import { useP2PKStore } from "src/stores/p2pk";
 import TokenInformation from "components/TokenInformation.vue";
 import { getDecodedToken, getEncodedTokenV4 } from "@cashu/cashu-ts";
+import { DEFAULT_BUCKET_ID } from "src/stores/buckets";
 
 import { mapActions, mapState, mapWritableState } from "pinia";
 import ChooseMint from "components/ChooseMint.vue";
@@ -1050,12 +1051,14 @@ export default defineComponent({
         this.sendData.tokens = sendProofs;
 
         this.sendData.tokensBase64 = this.serializeProofs(sendProofs);
+        const bucketId = sendProofs[0]?.bucketId ?? DEFAULT_BUCKET_ID;
         const historyToken = {
           amount: -this.sendData.amount,
           token: this.sendData.tokensBase64,
           unit: this.activeUnit,
           mint: this.activeMintUrl,
           label: "",
+          bucketId,
         };
         this.addPendingToken(historyToken);
         this.sendData.historyToken = historyToken;
@@ -1103,6 +1106,7 @@ export default defineComponent({
         this.sendData.historyAmount =
           -this.sendData.amount * this.activeUnitCurrencyMultiplyer;
 
+        const bucketId = sendProofs[0]?.bucketId ?? DEFAULT_BUCKET_ID;
         const historyToken = {
           amount: -sendAmount,
           token: this.sendData.tokensBase64,
@@ -1111,6 +1115,7 @@ export default defineComponent({
           paymentRequest: this.sendData.paymentRequest,
           status: "pending",
           label: "",
+          bucketId,
         };
         this.addPendingToken(historyToken);
         this.sendData.historyToken = historyToken;

--- a/src/pages/BucketDetail.vue
+++ b/src/pages/BucketDetail.vue
@@ -41,6 +41,9 @@
     </div>
 
     <SendTokenDialog v-model="showSendTokens" />
+    <div class="q-mt-lg">
+      <HistoryTable :bucket-id="bucketId" />
+    </div>
   </div>
   <div v-else class="q-pa-md">{{ $t('BucketDetail.not_found') }}</div>
 </template>
@@ -55,6 +58,7 @@ import { useUiStore } from 'stores/ui';
 import { storeToRefs } from 'pinia';
 import { useSendTokensStore } from 'stores/sendTokensStore';
 import SendTokenDialog from 'components/SendTokenDialog.vue';
+import HistoryTable from 'components/HistoryTable.vue';
 
 const route = useRoute();
 const bucketsStore = useBucketsStore();

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -37,6 +37,7 @@ import { useSendTokensStore } from "./sendTokensStore";
 import { usePRStore } from "./payment-request";
 import token from "../js/token";
 import { HistoryToken } from "./tokens";
+import { DEFAULT_BUCKET_ID } from "./buckets";
 
 type MintRecommendation = {
   url: string;
@@ -593,6 +594,7 @@ export const useNostrStore = defineStore("nostr", {
         mint: token.getMint(decodedToken),
         unit: token.getUnit(decodedToken),
         label: "",
+        bucketId: DEFAULT_BUCKET_ID,
       });
       receiveStore.showReceiveTokens = false;
       // show success notification

--- a/src/stores/npubcash.ts
+++ b/src/stores/npubcash.ts
@@ -18,6 +18,7 @@ import token from "../js/token";
 import { WalletProof, useMintsStore } from "./mints";
 import { useTokensStore } from "../stores/tokens";
 import { useNostrStore } from "../stores/nostr";
+import { DEFAULT_BUCKET_ID } from "./buckets";
 // type NPCConnection = {
 //   walletPublicKey: string,
 //   walletPrivateKey: string,
@@ -218,6 +219,7 @@ export const useNPCStore = defineStore("npc", {
         mint: mintUrl,
         unit: unit,
         label: "",
+        bucketId: DEFAULT_BUCKET_ID,
       });
       receiveStore.showReceiveTokens = false;
     },

--- a/src/stores/tokens.ts
+++ b/src/stores/tokens.ts
@@ -3,6 +3,7 @@ import { date } from "quasar";
 import { defineStore } from "pinia";
 import { PaymentRequest, Proof, Token } from "@cashu/cashu-ts";
 import token from "src/js/token";
+import { DEFAULT_BUCKET_ID } from "./buckets";
 
 /**
  * The tokens store handles everything related to tokens and proofs
@@ -18,6 +19,7 @@ export type HistoryToken = {
   label?: string;
   paymentRequest?: PaymentRequest;
   fee?: number;
+  bucketId: string;
 };
 
 export const useTokensStore = defineStore("tokens", {
@@ -36,6 +38,7 @@ export const useTokensStore = defineStore("tokens", {
       fee,
       paymentRequest,
       label,
+      bucketId = DEFAULT_BUCKET_ID,
     }: {
       amount: number;
       token: string;
@@ -44,6 +47,7 @@ export const useTokensStore = defineStore("tokens", {
       fee?: number;
       paymentRequest?: PaymentRequest;
       label?: string;
+      bucketId?: string;
     }) {
       this.historyTokens.push({
         status: "paid",
@@ -55,6 +59,7 @@ export const useTokensStore = defineStore("tokens", {
         label,
         fee,
         paymentRequest,
+        bucketId,
       } as HistoryToken);
     },
     addPendingToken({
@@ -65,6 +70,7 @@ export const useTokensStore = defineStore("tokens", {
       fee,
       paymentRequest,
       label,
+      bucketId = DEFAULT_BUCKET_ID,
     }: {
       amount: number;
       token: string;
@@ -73,6 +79,7 @@ export const useTokensStore = defineStore("tokens", {
       fee?: number;
       paymentRequest?: PaymentRequest;
       label?: string;
+      bucketId?: string;
     }) {
       this.historyTokens.push({
         status: "pending",
@@ -84,6 +91,7 @@ export const useTokensStore = defineStore("tokens", {
         label,
         fee,
         paymentRequest,
+        bucketId,
       });
     },
     editHistoryToken(

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -504,6 +504,7 @@ export const useWalletStore = defineStore("wallet", {
         mint: mintInToken,
         label: receiveStore.receiveData.label ?? "",
         fee: fee,
+        bucketId,
       } as HistoryToken;
       const mintWallet = this.mintWallet(historyToken.mint, historyToken.unit);
       const mint = mintStore.mints.find((m) => m.url === historyToken.mint);
@@ -679,6 +680,7 @@ export const useWalletStore = defineStore("wallet", {
           unit: invoice.unit,
           mint: invoice.mint,
           label: "",
+          bucketId,
         });
         useInvoicesWorkerStore().removeInvoiceFromChecker(invoice.quote);
 
@@ -850,6 +852,7 @@ export const useWalletStore = defineStore("wallet", {
           unit: mintWallet.unit,
           mint: mintWallet.mint.mintUrl,
           label: "",
+          bucketId,
         });
 
         this.updateOutgoingInvoiceInHistory(quote, {
@@ -916,16 +919,17 @@ export const useWalletStore = defineStore("wallet", {
         const spentProofsStates = proofStates.filter(
           (p) => p.state == CheckStateEnum.SPENT,
         );
-        const spentProofs = proofs.filter((p) =>
-          spentProofsStates.find(
-            (s) => s.Y == hashToCurve(enc.encode(p.secret)).toHex(true),
-          ),
-        );
-        if (spentProofs.length) {
-          await proofsStore.removeProofs(spentProofs);
-          // update UI
-          const serializedProofs = proofsStore.serializeProofs(spentProofs);
-          if (serializedProofs == null) {
+      const spentProofs = proofs.filter((p) =>
+        spentProofsStates.find(
+          (s) => s.Y == hashToCurve(enc.encode(p.secret)).toHex(true),
+        ),
+      );
+      const bucketId = (proofs[0] as any)?.bucketId ?? DEFAULT_BUCKET_ID;
+      if (spentProofs.length) {
+        await proofsStore.removeProofs(spentProofs);
+        // update UI
+        const serializedProofs = proofsStore.serializeProofs(spentProofs);
+        if (serializedProofs == null) {
             throw new Error("could not serialize proofs.");
           }
           if (update_history) {
@@ -935,6 +939,7 @@ export const useWalletStore = defineStore("wallet", {
               unit: wallet.unit,
               mint: wallet.mint.mintUrl,
               label: "",
+              bucketId,
             });
           }
         }
@@ -1007,6 +1012,7 @@ export const useWalletStore = defineStore("wallet", {
               unit: historyToken2.unit,
               mint: historyToken2.mint,
               label: historyToken2.label ?? "",
+              bucketId: historyToken2.bucketId,
             });
           }
         }


### PR DESCRIPTION
## Summary
- extend `HistoryToken` with `bucketId`
- pass `bucketId` to history actions when sending or receiving tokens
- allow history view to filter by bucket
- display bucket-specific history in bucket detail view

## Testing
- `npm test` *(fails: vitest not installed)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_683aa1025cc8833089afc2d57bb1cbd9