### PR TITLE
Allow editing token color

### DIFF
--- a/src/components/HistoryTable.vue
+++ b/src/components/HistoryTable.vue
@@ -8,6 +8,9 @@
         v-ripple
         class="q-px-md"
       >
+        <q-item-section avatar>
+          <q-icon name="circle" :style="{ color: token.color || 'grey' }" />
+        </q-item-section>
         <q-item-section
           side
           @click="showTokenDialog(token)"
@@ -138,6 +141,13 @@
           outlined
           :label="$t('ReceiveTokenDialog.inputs.label.label')"
         />
+        <q-input
+          v-model="editDialog.color"
+          outlined
+          type="color"
+          class="q-mt-md"
+          :label="$t('BucketManager.inputs.color')"
+        />
         <div class="row q-mt-md">
           <q-btn color="primary" rounded @click="saveLabel">{{
             $t('global.actions.update.label')
@@ -180,6 +190,7 @@ export default defineComponent({
       editDialog: {
         show: false,
         label: '',
+        color: '#1976d2',
         token: null,
       },
     };
@@ -260,12 +271,14 @@ export default defineComponent({
     openEditLabel(token) {
       this.editDialog.token = token;
       this.editDialog.label = token.label || '';
+      this.editDialog.color = token.color || '#1976d2';
       this.editDialog.show = true;
     },
     saveLabel() {
       if (!this.editDialog.token) return;
       this.editHistoryToken(this.editDialog.token.token, {
         newLabel: this.editDialog.label,
+        newColor: this.editDialog.color,
       });
       this.editDialog.show = false;
     },

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1090,8 +1090,8 @@ export default {
         label: "Show all",
       },
       edit_label: {
-        tooltip_text: "Edit label",
-        title: "Edit label",
+        tooltip_text: "Edit token",
+        title: "Edit token",
       },
     },
     old_token_not_found_error_text: "Old token not found",

--- a/src/stores/tokens.ts
+++ b/src/stores/tokens.ts
@@ -18,6 +18,7 @@ export type HistoryToken = {
   mint: string;
   unit: string;
   label?: string;
+  color?: string;
   paymentRequest?: PaymentRequest;
   fee?: number;
   bucketId: string;
@@ -39,6 +40,7 @@ export const useTokensStore = defineStore("tokens", {
       fee,
       paymentRequest,
       label,
+      color,
       bucketId = DEFAULT_BUCKET_ID,
     }: {
       amount: number;
@@ -48,6 +50,7 @@ export const useTokensStore = defineStore("tokens", {
       fee?: number;
       paymentRequest?: PaymentRequest;
       label?: string;
+      color?: string;
       bucketId?: string;
     }) {
       this.historyTokens.push({
@@ -58,6 +61,7 @@ export const useTokensStore = defineStore("tokens", {
         mint,
         unit,
         label,
+        color: color ?? "#1976d2",
         fee,
         paymentRequest,
         bucketId,
@@ -71,6 +75,7 @@ export const useTokensStore = defineStore("tokens", {
       fee,
       paymentRequest,
       label,
+      color,
       bucketId = DEFAULT_BUCKET_ID,
     }: {
       amount: number;
@@ -80,6 +85,7 @@ export const useTokensStore = defineStore("tokens", {
       fee?: number;
       paymentRequest?: PaymentRequest;
       label?: string;
+      color?: string;
       bucketId?: string;
     }) {
       this.historyTokens.push({
@@ -90,6 +96,7 @@ export const useTokensStore = defineStore("tokens", {
         mint,
         unit,
         label,
+        color: color ?? "#1976d2",
         fee,
         paymentRequest,
         bucketId,
@@ -104,6 +111,7 @@ export const useTokensStore = defineStore("tokens", {
         newToken?: string;
         newFee?: number;
         newLabel?: string;
+        newColor?: string;
       }
     ): HistoryToken | undefined {
       const index = this.historyTokens.findIndex(
@@ -146,6 +154,9 @@ export const useTokensStore = defineStore("tokens", {
             } catch (e) {
               console.warn("Could not update proof labels", e);
             }
+          }
+          if (options.newColor !== undefined) {
+            this.historyTokens[index].color = options.newColor;
           }
         }
 

--- a/test/vitest/__tests__/tokens.spec.ts
+++ b/test/vitest/__tests__/tokens.spec.ts
@@ -15,4 +15,11 @@ describe('Tokens store', () => {
     store.editHistoryToken('t1', { newLabel: 'new name' })
     expect(store.historyTokens[0].label).toBe('new name')
   })
+
+  it('edits token color', () => {
+    const store = useTokensStore()
+    store.addPaidToken({ amount: 1, token: 't2', mint: 'm1', unit: 'sat' })
+    store.editHistoryToken('t2', { newColor: '#ff0000' })
+    expect(store.historyTokens[0].color).toBe('#ff0000')
+  })
 })


### PR DESCRIPTION
## Summary
- support color field on history tokens
- allow editing token color from history list
- show token color indicator
- test editing token color

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683aa6e9670c833094ae6b35f613b0c6