### PR TITLE
Validate bucket existence before moving proofs

### DIFF
--- a/src/stores/proofs.ts
+++ b/src/stores/proofs.ts
@@ -2,6 +2,7 @@ import { ref } from "vue";
 import { defineStore } from "pinia";
 import { useMintsStore, WalletProof } from "./mints";
 import { cashuDb, CashuDexie, useDexieStore } from "./dexie";
+import { useBucketsStore } from "./buckets";
 import {
   Proof,
   getEncodedToken,
@@ -180,9 +181,17 @@ export const useProofsStore = defineStore("proofs", {
       return mints[0];
     },
     async moveProofs(secrets: string[], bucketId: string) {
+      const bucketsStore = useBucketsStore();
+      const bucketExists = bucketsStore.bucketList.find((b) => b.id === bucketId);
+      if (!bucketExists) {
+        throw new Error(`Bucket not found: ${bucketId}`);
+      }
       await cashuDb.transaction("rw", cashuDb.proofs, async () => {
         for (const secret of secrets) {
-          await cashuDb.proofs.where("secret").equals(secret).modify({ bucketId });
+          await cashuDb.proofs
+            .where("secret")
+            .equals(secret)
+            .modify({ bucketId });
         }
       });
     },


### PR DESCRIPTION
## Summary
- inject `useBucketsStore` into proofs store
- verify bucket exists in `moveProofs`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ab10ee2608330a8c99c0ea7b3378c