### PR TITLE
Validate bucket before moving proofs

### DIFF
--- a/src/pages/BucketDetail.vue
+++ b/src/pages/BucketDetail.vue
@@ -92,6 +92,7 @@ import { useSendTokensStore } from 'stores/sendTokensStore';
 import { useTokensStore, HistoryToken } from 'stores/tokens';
 import SendTokenDialog from 'components/SendTokenDialog.vue';
 import HistoryTable from 'components/HistoryTable.vue';
+import { notifyError } from 'src/js/notify';
 
 const route = useRoute();
 const bucketsStore = useBucketsStore();
@@ -195,6 +196,15 @@ function saveEdit(){
 }
 
 async function moveSelected(){
+  if(!targetBucketId.value){
+    notifyError("Please select a bucket");
+    return;
+  }
+  const exists = bucketsStore.bucketList.some(b => b.id === targetBucketId.value);
+  if(!exists){
+    notifyError("Bucket not found");
+    return;
+  }
   await proofsStore.moveProofs(selectedSecrets.value, targetBucketId.value as string);
   selectedSecrets.value = [];
 }

--- a/src/stores/proofs.ts
+++ b/src/stores/proofs.ts
@@ -2,6 +2,7 @@ import { ref } from "vue";
 import { defineStore } from "pinia";
 import { useMintsStore, WalletProof } from "./mints";
 import { cashuDb, CashuDexie, useDexieStore } from "./dexie";
+import { useBucketsStore } from "./buckets";
 import {
   Proof,
   getEncodedToken,
@@ -180,9 +181,16 @@ export const useProofsStore = defineStore("proofs", {
       return mints[0];
     },
     async moveProofs(secrets: string[], bucketId: string) {
+      const bucketsStore = useBucketsStore();
+      if (!bucketsStore.bucketList.find((b) => b.id === bucketId)) {
+        throw new Error("bucket not found");
+      }
       await cashuDb.transaction("rw", cashuDb.proofs, async () => {
         for (const secret of secrets) {
-          await cashuDb.proofs.where("secret").equals(secret).modify({ bucketId });
+          await cashuDb.proofs
+            .where("secret")
+            .equals(secret)
+            .modify({ bucketId });
         }
       });
     },


### PR DESCRIPTION
## Summary
- validate selected bucket before moving proofs from BucketDetail
- check bucket existence in proofs store

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ab0db6c2c8330a45a8ea325d13021