### PR TITLE
Add bucket validation and tests

### DIFF
--- a/src/components/BucketManager.vue
+++ b/src/components/BucketManager.vue
@@ -77,12 +77,14 @@
   <q-dialog v-model="showForm">
     <q-card class="q-pa-lg" style="max-width: 500px">
       <h6 class="q-mt-none q-mb-md">{{ formTitle }}</h6>
-      <q-input
-        v-model="form.name"
-        outlined
-        :label="$t('BucketManager.inputs.name')"
-        class="q-mb-sm"
-      />
+      <q-form ref="bucketForm">
+        <q-input
+          v-model="form.name"
+          outlined
+          :rules="nameRules"
+          :label="$t('BucketManager.inputs.name')"
+          class="q-mb-sm"
+        />
       <q-input
         v-model="form.color"
         outlined
@@ -98,21 +100,23 @@
         autogrow
         class="q-mb-sm"
       />
-      <q-input
-        v-model.number="form.goal"
-        outlined
-        :label="$t('BucketManager.inputs.goal')"
-        type="number"
-        class="q-mb-sm"
-      />
-      <div class="row q-mt-md">
-        <q-btn color="primary" rounded @click="saveBucket">{{
-          $t("global.actions.update.label")
-        }}</q-btn>
-        <q-btn flat rounded color="grey" class="q-ml-auto" v-close-popup>{{
-          $t("global.actions.cancel.label")
-        }}</q-btn>
-      </div>
+        <q-input
+          v-model.number="form.goal"
+          outlined
+          :rules="goalRules"
+          :label="$t('BucketManager.inputs.goal')"
+          type="number"
+          class="q-mb-sm"
+        />
+        <div class="row q-mt-md">
+          <q-btn color="primary" rounded @click="saveBucket">{{
+            $t("global.actions.update.label")
+          }}</q-btn>
+          <q-btn flat rounded color="grey" class="q-ml-auto" v-close-popup>{{
+            $t("global.actions.cancel.label")
+          }}</q-btn>
+        </div>
+      </q-form>
     </q-card>
   </q-dialog>
 
@@ -138,17 +142,21 @@
 
 <script>
 import { defineComponent, ref, computed } from "vue";
+import { useI18n } from "vue-i18n";
 import { useBucketsStore, DEFAULT_BUCKET_ID } from "stores/buckets";
 import { useMintsStore } from "stores/mints";
 import { storeToRefs } from "pinia";
 import { useUiStore } from "stores/ui";
+import { notifyError } from "src/js/notify";
 
 export default defineComponent({
   name: "BucketManager",
   setup() {
     const bucketsStore = useBucketsStore();
     const uiStore = useUiStore();
+    const { t } = useI18n();
     const showForm = ref(false);
+    const bucketForm = ref(null);
     const showDelete = ref(false);
     const editId = ref(null);
     const deleteId = ref(null);
@@ -186,7 +194,19 @@ export default defineComponent({
       showForm.value = true;
     };
 
-    const saveBucket = () => {
+    const nameRules = [
+      (val) => !!val || t('BucketManager.validation.name'),
+    ];
+
+    const goalRules = [
+      (val) => val === null || val === undefined || val >= 0 || t('BucketManager.validation.goal'),
+    ];
+
+    const saveBucket = async () => {
+      if (!(await bucketForm.value.validate())) {
+        notifyError(t('BucketManager.validation.error'));
+        return;
+      }
       if (editId.value) {
         bucketsStore.editBucket(editId.value, { ...form.value });
       } else {
@@ -213,6 +233,9 @@ export default defineComponent({
       showForm,
       showDelete,
       form,
+      bucketForm,
+      nameRules,
+      goalRules,
       formTitle: computed(() => (editId.value ? "Edit Bucket" : "Add Bucket")),
       openAdd,
       openEdit,

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1251,6 +1251,11 @@ export default {
       description: "Description",
       goal: "Goal (sat)",
     },
+    validation: {
+      name: "Name is required",
+      goal: "Goal must be positive",
+      error: "Please correct the errors before saving",
+    },
     delete_confirm: {
       title: "Delete bucket?",
     },

--- a/src/stores/buckets.ts
+++ b/src/stores/buckets.ts
@@ -76,7 +76,19 @@ export const useBucketsStore = defineStore("buckets", {
     },
   },
   actions: {
-    addBucket(bucket: Omit<Bucket, "id">): Bucket {
+    addBucket(bucket: Omit<Bucket, "id">): Bucket | undefined {
+      // basic validation
+      if (!bucket.name || bucket.name.trim().length === 0) {
+        return;
+      }
+      if (
+        typeof bucket.goal === "number" &&
+        bucket.goal !== null &&
+        bucket.goal < 0
+      ) {
+        return;
+      }
+
       const newBucket: Bucket = { id: uuidv4(), ...bucket };
       this.buckets.push(newBucket);
       return newBucket;

--- a/test/vitest/__tests__/buckets.spec.ts
+++ b/test/vitest/__tests__/buckets.spec.ts
@@ -58,4 +58,17 @@ describe('Buckets store', () => {
     await buckets.deleteBucket(DEFAULT_BUCKET_ID)
     expect(buckets.bucketList.length).toBe(count)
   })
+
+  it('rejects invalid bucket data', () => {
+    const buckets = useBucketsStore()
+    const count = buckets.bucketList.length
+
+    const empty = buckets.addBucket({ name: '' })
+    expect(empty).toBeUndefined()
+    expect(buckets.bucketList.length).toBe(count)
+
+    const negative = buckets.addBucket({ name: 'bad', goal: -5 })
+    expect(negative).toBeUndefined()
+    expect(buckets.bucketList.length).toBe(count)
+  })
 })


### PR DESCRIPTION
## Summary
- add validation logic for buckets in store
- require valid name and non-negative goal in BucketManager form
- show localized error messages
- expand buckets tests

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ab56065848330a023f0c6bcbdd485