### PR TITLE
Improve bucket selection in ReceiveTokenDialog

### DIFF
--- a/src/components/ReceiveTokenDialog.vue
+++ b/src/components/ReceiveTokenDialog.vue
@@ -140,15 +140,15 @@
             />
           </div>
           <div class="row q-pt-sm">
-          <q-select
-              v-model="receiveData.bucketId"
-              :options="bucketOptions"
-              emit-value
-              map-options
-              outlined
-              dense
-              :label="$t('BucketManager.inputs.name')"
-            />
+              <q-select
+                v-model="receiveData.bucketId"
+                :options="bucketOptions"
+                emit-value
+                map-options
+                outlined
+                dense
+                :label="$t('ReceiveTokenDialog.inputs.bucket.label')"
+              />
           <q-input
             v-model="receiveData.label"
             outlined

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -888,7 +888,7 @@ export default {
         label: "Paste Cashu token",
       },
       bucket: {
-        label: "Bucket",
+        label: "Destination bucket",
       },
       label: {
         label: "Label",


### PR DESCRIPTION
## Summary
- clarify bucket selection label in the receive token dialog

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_683b45da71248330bebf30037719dd51