### PR TITLE
Add Find Creators page

### DIFF
--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -89,6 +89,19 @@
           }}</q-item-label>
         </q-item-section>
       </q-item>
+      <q-item clickable @click="gotoFindCreators">
+        <q-item-section avatar>
+          <q-icon name="search" />
+        </q-item-section>
+        <q-item-section>
+          <q-item-label>{{
+            $t("MainHeader.menu.findCreators.findCreators.title")
+          }}</q-item-label>
+          <q-item-label caption>{{
+            $t("MainHeader.menu.findCreators.findCreators.caption")
+          }}</q-item-label>
+        </q-item-section>
+      </q-item>
       <q-item clickable @click="gotoBuckets">
         <q-item-section avatar>
           <q-icon name="inventory_2" />
@@ -217,6 +230,11 @@ export default defineComponent({
       leftDrawerOpen.value = false;
     };
 
+    const gotoFindCreators = () => {
+      router.push("/find-creators");
+      leftDrawerOpen.value = false;
+    };
+
     return {
       essentialLinks,
       leftDrawerOpen,
@@ -226,6 +244,7 @@ export default defineComponent({
       countdown,
       uiStore,
       gotoBuckets,
+      gotoFindCreators,
     };
   },
 });

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -96,6 +96,13 @@ export default {
           caption: "Wallet configuration",
         },
       },
+      findCreators: {
+        title: "Find Creators",
+        findCreators: {
+          title: "Find Creators",
+          caption: "Discover creators",
+        },
+      },
       buckets: {
         title: "Buckets",
         buckets: {

--- a/src/pages/FindCreators.vue
+++ b/src/pages/FindCreators.vue
@@ -1,0 +1,13 @@
+<template>
+  <div class="bg-dark text-white text-center q-pa-md flex flex-center">
+    <div class="text-h5">Find Creators</div>
+  </div>
+</template>
+
+<script>
+import { defineComponent } from "vue";
+
+export default defineComponent({
+  name: "FindCreatorsPage",
+});
+</script>

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -12,6 +12,13 @@ const routes = [
     children: [{ path: "", component: () => import("src/pages/Settings.vue") }],
   },
   {
+    path: "/find-creators",
+    component: () => import("layouts/FullscreenLayout.vue"),
+    children: [
+      { path: "", component: () => import("src/pages/FindCreators.vue") },
+    ],
+  },
+  {
     path: "/buckets",
     component: () => import("layouts/FullscreenLayout.vue"),
     children: [{ path: "", component: () => import("src/pages/Buckets.vue") }],


### PR DESCRIPTION
## Summary
- add a minimal `FindCreators` page
- link new page in routes
- add new navigation item in `MainHeader`
- include i18n entries for Find Creators

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b53008004833090cc3845d426f3b7