### PR TITLE
Fix Transition wrapper in SendTokenDialog

### DIFF
--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -152,7 +152,7 @@
             enter-active-class="animated fadeIn"
             leave-active-class="animated fadeOut"
           >
-            <template v-if="showLockInput">
+            <div v-if="showLockInput">
               <div class="row items-center no-wrap">
                 <div :class="!sendData.p2pkPubkey ? 'col-8' : 'col-12'">
                   <q-input
@@ -211,7 +211,7 @@
               class="col-12"
             />
             </div>
-            </template>
+            </div>
           </transition>
           <div v-if="activeBalance >= sendData.amount" class="row q-mt-lg">
             <q-btn


### PR DESCRIPTION
## Summary
- fix `SendTokenDialog` `<transition>` to have a single root element

## Testing
- `vitest` *(fails: This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.)*

------
https://chatgpt.com/codex/tasks/task_e_683b549c51848330933c3a377ac5b052