### PR TITLE
Add Wallet page route and menu

### DIFF
--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -76,6 +76,16 @@
       <q-item-label header>{{
         $t("MainHeader.menu.settings.title")
       }}</q-item-label>
+      <q-item clickable @click="gotoWallet">
+        <q-item-section avatar>
+          <q-icon name="account_balance_wallet" />
+        </q-item-section>
+        <q-item-section>
+          <q-item-label>
+            {{ $t("FullscreenHeader.actions.back.label") }}
+          </q-item-label>
+        </q-item-section>
+      </q-item>
       <q-item clickable to="/settings">
         <q-item-section avatar>
           <q-icon name="settings" />
@@ -235,6 +245,11 @@ export default defineComponent({
       leftDrawerOpen.value = false;
     };
 
+    const gotoWallet = () => {
+      router.push("/wallet");
+      leftDrawerOpen.value = false;
+    };
+
     return {
       essentialLinks,
       leftDrawerOpen,
@@ -245,6 +260,7 @@ export default defineComponent({
       uiStore,
       gotoBuckets,
       gotoFindCreators,
+      gotoWallet,
     };
   },
 });

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -1,10 +1,14 @@
 const routes = [
   {
-    path: "/",
+    path: "/wallet",
     component: () => import("layouts/MainLayout.vue"),
     children: [
       { path: "", component: () => import("src/pages/WalletPage.vue") },
     ],
+  },
+  {
+    path: "/",
+    redirect: "/wallet",
   },
   {
     path: "/settings",


### PR DESCRIPTION
## Summary
- route main wallet interface under /wallet and redirect '/' to /wallet
- add Wallet item to navigation drawer

## Testing
- `npx vitest` *(fails: connect EHOSTUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_683b5619fbb48330b6cb26dafafbf2e7