### PR TITLE
Add creator search

### DIFF
--- a/src/components/FindCreatorsView.vue
+++ b/src/components/FindCreatorsView.vue
@@ -1,0 +1,76 @@
+<template>
+  <div style="max-width: 800px; margin: 0 auto">
+    <q-input
+      rounded
+      outlined
+      dense
+      v-model="searchInput"
+      :label="$t('FindCreators.inputs.search.label')"
+      :placeholder="$t('FindCreators.inputs.search.placeholder')"
+      @keydown.enter.prevent="triggerSearch"
+    >
+      <template v-slot:append>
+        <q-icon name="search" class="cursor-pointer" @click="triggerSearch" />
+      </template>
+    </q-input>
+
+    <div v-if="searching" class="q-mt-md flex flex-center">
+      <q-spinner-dots color="primary" />
+    </div>
+
+    <q-list v-if="searchResults.length" class="q-mt-md">
+      <q-item v-for="creator in searchResults" :key="creator.pubkey">
+        <q-item-section avatar v-if="creator.profile?.picture">
+          <q-avatar>
+            <img :src="creator.profile.picture" />
+          </q-avatar>
+        </q-item-section>
+        <q-item-section>
+          <q-item-label>
+            {{ creator.profile?.display_name || creator.profile?.name || creator.pubkey }}
+          </q-item-label>
+          <q-item-label caption>{{ creator.pubkey }}</q-item-label>
+        </q-item-section>
+      </q-item>
+    </q-list>
+  </div>
+</template>
+
+<script>
+import { defineComponent, ref, watch } from "vue";
+import { useCreatorsStore } from "stores/creators";
+import { storeToRefs } from "pinia";
+
+export default defineComponent({
+  name: "FindCreatorsView",
+  setup() {
+    const creatorsStore = useCreatorsStore();
+    const { searchResults, searching } = storeToRefs(creatorsStore);
+    const searchInput = ref("");
+
+    const triggerSearch = () => {
+      if (searchInput.value.trim()) {
+        creatorsStore.searchCreators(searchInput.value.trim());
+      }
+    };
+
+    let debounceTimeout: number | undefined;
+    watch(searchInput, (val) => {
+      if (!val) {
+        return;
+      }
+      clearTimeout(debounceTimeout);
+      debounceTimeout = window.setTimeout(() => {
+        creatorsStore.searchCreators(val);
+      }, 500);
+    });
+
+    return {
+      searchInput,
+      triggerSearch,
+      searchResults,
+      searching,
+    };
+  },
+});
+</script>

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -37,6 +37,9 @@ export default {
       swap: {
         label: "Swap",
       },
+      search: {
+        label: "Search",
+      },
       update: {
         label: "Update",
       },
@@ -1253,6 +1256,14 @@ export default {
       add_mint: {
         label: "@:global.actions.add_mint.label",
         in_progress: "Adding mint",
+      },
+    },
+  },
+  FindCreators: {
+    inputs: {
+      search: {
+        label: "Search creators",
+        placeholder: "npub, hex public key or name",
       },
     },
   },

--- a/src/pages/FindCreators.vue
+++ b/src/pages/FindCreators.vue
@@ -1,13 +1,17 @@
 <template>
   <div class="bg-dark text-white text-center q-pa-md flex flex-center">
-    <div class="text-h5">Find Creators</div>
+    <FindCreatorsView />
   </div>
 </template>
 
 <script>
 import { defineComponent } from "vue";
+import FindCreatorsView from "components/FindCreatorsView.vue";
 
 export default defineComponent({
   name: "FindCreatorsPage",
+  components: {
+    FindCreatorsView,
+  },
 });
 </script>

--- a/src/stores/creators.ts
+++ b/src/stores/creators.ts
@@ -1,0 +1,46 @@
+import { defineStore } from "pinia";
+import { useNostrStore } from "./nostr";
+import { nip19 } from "nostr-tools";
+
+export interface CreatorProfile {
+  pubkey: string;
+  profile: any;
+}
+
+export const useCreatorsStore = defineStore("creators", {
+  state: () => ({
+    searchResults: [] as CreatorProfile[],
+    searching: false,
+  }),
+  actions: {
+    async searchCreators(query: string) {
+      const nostrStore = useNostrStore();
+      this.searchResults = [];
+      if (!query) {
+        return;
+      }
+      this.searching = true;
+      await nostrStore.initNdkReadOnly();
+      let pubkey = query.trim();
+      if (pubkey.startsWith("npub")) {
+        try {
+          const decoded = nip19.decode(pubkey);
+          pubkey = typeof decoded.data === "string" ? (decoded.data as string) : "";
+        } catch (e) {
+          console.error(e);
+          this.searching = false;
+          return;
+        }
+      }
+      try {
+        const user = nostrStore.ndk.getUser({ pubkey });
+        await user.fetchProfile();
+        this.searchResults.push({ pubkey, profile: user.profile });
+      } catch (e) {
+        console.error(e);
+      } finally {
+        this.searching = false;
+      }
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- support searching for creators via Nostr
- add `FindCreatorsView` component with search bar and debounce
- wire new view into FindCreators page
- record search labels in i18n

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint couldn't find eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_683b5778a4108330aa81c20131b1f5dc