### PR TITLE
Fix TypeScript parsing in FindCreatorsView

### DIFF
--- a/src/components/FindCreatorsView.vue
+++ b/src/components/FindCreatorsView.vue
@@ -36,7 +36,7 @@
   </div>
 </template>
 
-<script>
+<script lang="ts">
 import { defineComponent, ref, watch } from "vue";
 import { useCreatorsStore } from "stores/creators";
 import { storeToRefs } from "pinia";


### PR DESCRIPTION
## Summary
- declare `<script lang="ts">` in FindCreatorsView component so TypeScript syntax parses correctly

## Testing
- `npm test` *(fails: This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.)*

------
https://chatgpt.com/codex/tasks/task_e_683b5995676483309c9d3b49d22f1efa