### PR TITLE
Add Creator profile card component

### DIFF
--- a/src/components/CreatorProfileCard.vue
+++ b/src/components/CreatorProfileCard.vue
@@ -1,0 +1,39 @@
+<template>
+  <q-card class="q-pa-md q-mb-md qcard">
+    <q-card-section class="row items-center no-wrap">
+      <q-avatar v-if="creator.profile?.picture">
+        <img :src="creator.profile.picture" />
+      </q-avatar>
+      <div class="q-ml-sm">
+        <div class="text-subtitle1">
+          {{ creator.profile?.display_name || creator.profile?.name || creator.pubkey }}
+        </div>
+        <div class="text-caption">{{ creator.pubkey }}</div>
+      </div>
+    </q-card-section>
+    <q-card-section v-if="creator.profile?.about">
+      <div>{{ creator.profile.about }}</div>
+    </q-card-section>
+    <q-card-section v-if="creator.profile?.lud16">
+      <div class="row items-center">
+        <q-icon name="bolt" size="xs" class="q-mr-xs" />
+        <span>{{ creator.profile.lud16 }}</span>
+      </div>
+    </q-card-section>
+  </q-card>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+import { CreatorProfile } from "stores/creators";
+
+export default defineComponent({
+  name: "CreatorProfileCard",
+  props: {
+    creator: {
+      type: Object as () => CreatorProfile,
+      required: true,
+    },
+  },
+});
+</script>

--- a/src/components/FindCreatorsView.vue
+++ b/src/components/FindCreatorsView.vue
@@ -21,31 +21,27 @@
       {{ error }}
     </div>
 
-    <q-list v-if="searchResults.length" class="q-mt-md">
-      <q-item v-for="creator in searchResults" :key="creator.pubkey">
-        <q-item-section avatar v-if="creator.profile?.picture">
-          <q-avatar>
-            <img :src="creator.profile.picture" />
-          </q-avatar>
-        </q-item-section>
-        <q-item-section>
-          <q-item-label>
-            {{ creator.profile?.display_name || creator.profile?.name || creator.pubkey }}
-          </q-item-label>
-          <q-item-label caption>{{ creator.pubkey }}</q-item-label>
-        </q-item-section>
-      </q-item>
-    </q-list>
+    <div v-if="searchResults.length" class="q-mt-md">
+      <creator-profile-card
+        v-for="creator in searchResults"
+        :key="creator.pubkey"
+        :creator="creator"
+      />
+    </div>
   </div>
 </template>
 
 <script lang="ts">
 import { defineComponent, ref, watch } from "vue";
 import { useCreatorsStore } from "stores/creators";
+import CreatorProfileCard from "components/CreatorProfileCard.vue";
 import { storeToRefs } from "pinia";
 
 export default defineComponent({
   name: "FindCreatorsView",
+  components: {
+    CreatorProfileCard,
+  },
   setup() {
     const creatorsStore = useCreatorsStore();
     const { searchResults, searching, error } = storeToRefs(creatorsStore);


### PR DESCRIPTION
## Summary
- add `CreatorProfileCard` component using Quasar's `q-card`
- show profile cards in `FindCreatorsView`

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run test:ci` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b5d14e1f083309076fba5e84d95c1