### PR TITLE
Fix search placeholder

### DIFF
--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1263,7 +1263,7 @@ export default {
     inputs: {
       search: {
         label: "Search creators",
-        placeholder: "npub, hex public key or name",
+        placeholder: "npub or hex public key",
       },
     },
   },


### PR DESCRIPTION
## Summary
- update the English placeholder for creator search

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b5dfdf0888330b32616e5b1448c75