### PR TITLE
Add CreatorCard to search view

### DIFF
--- a/src/components/CreatorCard.vue
+++ b/src/components/CreatorCard.vue
@@ -1,0 +1,36 @@
+<template>
+  <q-card class="q-pa-sm">
+    <q-item>
+      <q-item-section avatar v-if="creator.profile?.picture">
+        <q-avatar>
+          <img :src="creator.profile.picture" />
+        </q-avatar>
+      </q-item-section>
+      <q-item-section>
+        <q-item-label class="text-weight-bold">
+          {{
+            creator.profile?.display_name ||
+            creator.profile?.name ||
+            creator.pubkey
+          }}
+        </q-item-label>
+        <q-item-label caption>{{ creator.pubkey }}</q-item-label>
+      </q-item-section>
+    </q-item>
+  </q-card>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+import type { CreatorProfile } from "stores/creators";
+
+export default defineComponent({
+  name: "CreatorCard",
+  props: {
+    creator: {
+      type: Object as () => CreatorProfile,
+      required: true,
+    },
+  },
+});
+</script>

--- a/src/components/FindCreatorsView.vue
+++ b/src/components/FindCreatorsView.vue
@@ -14,28 +14,35 @@
       </template>
     </q-input>
 
-    <div v-if="searching" class="q-mt-md flex flex-center">
+    <div v-if="searching" class="q-mt-md flex flex-center column items-center">
       <q-spinner-dots color="primary" />
+      <div class="q-mt-sm">{{ $t("FindCreators.messages.loading") }}</div>
     </div>
     <div v-else-if="error" class="q-mt-md text-negative text-bold">
       {{ error }}
     </div>
+    <div
+      v-else-if="!searchResults.length && searchInput"
+      class="q-mt-md text-grey text-center"
+    >
+      {{ $t("FindCreators.messages.no_results") }}
+    </div>
+    <div
+      v-else-if="!searchResults.length"
+      class="q-mt-md text-grey text-center"
+    >
+      {{ $t("FindCreators.messages.empty") }}
+    </div>
 
-    <q-list v-if="searchResults.length" class="q-mt-md">
-      <q-item v-for="creator in searchResults" :key="creator.pubkey">
-        <q-item-section avatar v-if="creator.profile?.picture">
-          <q-avatar>
-            <img :src="creator.profile.picture" />
-          </q-avatar>
-        </q-item-section>
-        <q-item-section>
-          <q-item-label>
-            {{ creator.profile?.display_name || creator.profile?.name || creator.pubkey }}
-          </q-item-label>
-          <q-item-label caption>{{ creator.pubkey }}</q-item-label>
-        </q-item-section>
-      </q-item>
-    </q-list>
+    <div v-if="searchResults.length" class="row q-col-gutter-md q-mt-md">
+      <div
+        v-for="creator in searchResults"
+        :key="creator.pubkey"
+        class="col-12 col-sm-6 col-md-4"
+      >
+        <CreatorCard :creator="creator" />
+      </div>
+    </div>
   </div>
 </template>
 
@@ -43,9 +50,11 @@
 import { defineComponent, ref, watch } from "vue";
 import { useCreatorsStore } from "stores/creators";
 import { storeToRefs } from "pinia";
+import CreatorCard from "./CreatorCard.vue";
 
 export default defineComponent({
   name: "FindCreatorsView",
+  components: { CreatorCard },
   setup() {
     const creatorsStore = useCreatorsStore();
     const { searchResults, searching, error } = storeToRefs(creatorsStore);

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1266,6 +1266,11 @@ export default {
         placeholder: "npub, hex public key or name",
       },
     },
+    messages: {
+      loading: "Searching creators …",
+      no_results: "No creators found.",
+      empty: "Start searching for creators.",
+    },
   },
   BucketManager: {
     actions: {


### PR DESCRIPTION
## Summary
- add CreatorCard component
- update FindCreatorsView to use a grid of CreatorCards
- provide messages for loading, no results and empty state
- add translations for new messages

## Testing
- `npx prettier -w src/components/CreatorCard.vue src/components/FindCreatorsView.vue src/i18n/en-US/index.ts`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b5d1fae6c8330b3a18de3529275bc