### PR TITLE
Add creators store vitest

### DIFF
--- a/test/vitest/__tests__/creators.spec.ts
+++ b/test/vitest/__tests__/creators.spec.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useCreatorsStore } from "../../../src/stores/creators";
+
+const fetchProfile = vi.fn();
+const userProfile = { name: "Alice" };
+const getUserMock = vi.fn(() => ({ fetchProfile, profile: userProfile }));
+const nostrStoreMock = {
+  initNdkReadOnly: vi.fn(),
+  ndk: { getUser: getUserMock },
+};
+
+vi.mock("../../../src/stores/nostr", () => ({
+  useNostrStore: () => nostrStoreMock,
+}));
+
+vi.mock("nostr-tools", () => ({
+  nip19: { decode: vi.fn() },
+}));
+
+const { nip19 } = require("nostr-tools");
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("Creators store", () => {
+  it("populates searchResults for valid npub", async () => {
+    (nip19.decode as any).mockReturnValue({ data: "f".repeat(64) });
+    const creators = useCreatorsStore();
+    await creators.searchCreators("npub123");
+
+    expect(creators.error).toBe("");
+    expect(creators.searchResults.length).toBe(1);
+    expect(creators.searchResults[0].pubkey).toBe("f".repeat(64));
+    expect(creators.searchResults[0].profile).toEqual(userProfile);
+  });
+
+  it("populates searchResults for hex pubkey", async () => {
+    const creators = useCreatorsStore();
+    await creators.searchCreators("a".repeat(64));
+
+    expect(creators.error).toBe("");
+    expect(creators.searchResults.length).toBe(1);
+    expect(creators.searchResults[0].pubkey).toBe("a".repeat(64));
+  });
+
+  it("handles invalid npub", async () => {
+    (nip19.decode as any).mockImplementation(() => {
+      throw new Error("bad");
+    });
+    const creators = useCreatorsStore();
+    await creators.searchCreators("npubbad");
+
+    expect(creators.searchResults.length).toBe(0);
+    expect(creators.error).toBe("Invalid npub");
+  });
+
+  it("handles invalid hex", async () => {
+    const creators = useCreatorsStore();
+    await creators.searchCreators("badhex");
+
+    expect(creators.searchResults.length).toBe(0);
+    expect(creators.error).toBe("Invalid pubkey");
+  });
+});


### PR DESCRIPTION
## Summary
- add creators store vitest covering profile search validation

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b5ec2b6c08330adfd2fd4ec3e46b4