### PR TITLE
Add dark mode toggle button

### DIFF
--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -68,6 +68,17 @@
         :disable="uiStore.globalMutexLock && countdown === 0"
       >
       </q-btn>
+      <q-btn
+        flat
+        dense
+        round
+        size="0.8em"
+        :icon="$q.dark.isActive ? 'wb_sunny' : 'brightness_3'"
+        color="primary"
+        aria-label="Toggle Dark Mode"
+        @click="toggleDarkMode"
+        class="q-ml-sm"
+      />
     </q-toolbar>
   </q-header>
 


### PR DESCRIPTION
## Summary
- add a dark mode toggle button to main header

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: vitest not found)*
- `npm run format` *(fails: warnings about npm config)*

------
https://chatgpt.com/codex/tasks/task_e_683bec3e4f4483309ff7b95d671e1ffb