### PR TITLE
Add About page and navigation entry

### DIFF
--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -153,6 +153,22 @@
         </q-item-section>
       </q-item>
       <q-item-label header>{{
+        $t("MainHeader.menu.about.title")
+      }}</q-item-label>
+      <q-item clickable to="/about">
+        <q-item-section avatar>
+          <q-icon name="info" />
+        </q-item-section>
+        <q-item-section>
+          <q-item-label>{{
+            $t("MainHeader.menu.about.about.title")
+          }}</q-item-label>
+          <q-item-label caption>{{
+            $t("MainHeader.menu.about.about.caption")
+          }}</q-item-label>
+        </q-item-section>
+      </q-item>
+      <q-item-label header>{{
         $t("MainHeader.menu.links.title")
       }}</q-item-label>
       <EssentialLink

--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -103,6 +103,10 @@ export default {
           caption: "شروط الخدمة",
         },
       },
+      about: {
+        title: "About",
+        about: { title: "About", caption: "About this app" },
+      },
       links: {
         title: "روابط",
         cashuSpace: {
@@ -1251,6 +1255,10 @@ timelock: {
       "التحقق من البراهين من { startIndex } إلى { endIndex } لمجموعة المفاتيح { keysetId }",
     no_proofs_info_text: "لم يتم العثور على براهين للاستعادة",
     restored_amount_success_text: "تم استعادة { amount }",
+  },
+  AboutPage: {
+    title: "About Cashu.me",
+    video_placeholder: "Video coming soon",
   },
   swap: {
     in_progress_warning_text: "التبديل قيد التقدم",

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -104,6 +104,10 @@ export default {
           caption: "Nutzungsbedingungen",
         },
       },
+      about: {
+        title: "About",
+        about: { title: "About", caption: "About this app" },
+      },
       links: {
         title: "Links",
         cashuSpace: {
@@ -1263,6 +1267,10 @@ export default {
       "Prüfe Nachweise { startIndex } bis { endIndex } für Keyset { keysetId }",
     no_proofs_info_text: "Keine Nachweise zum Wiederherstellen gefunden",
     restored_amount_success_text: "{ amount } wiederhergestellt",
+  },
+  AboutPage: {
+    title: "About Cashu.me",
+    video_placeholder: "Video coming soon",
   },
   swap: {
     in_progress_warning_text: "Swap läuft",

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -104,6 +104,10 @@ export default {
           caption: "Όροι Παροχής Υπηρεσιών",
         },
       },
+      about: {
+        title: "About",
+        about: { title: "About", caption: "About this app" },
+      },
       links: {
         title: "Σύνδεσμοι",
         cashuSpace: {
@@ -1261,6 +1265,10 @@ timelock: {
       "Έλεγχος αποδείξεων { startIndex } έως { endIndex } για το keyset { keysetId }",
     no_proofs_info_text: "Δεν βρέθηκαν αποδείξεις για επαναφορά",
     restored_amount_success_text: "Επαναφέρθηκε { amount }",
+  },
+  AboutPage: {
+    title: "About Cashu.me",
+    video_placeholder: "Video coming soon",
   },
   swap: {
     in_progress_warning_text: "Η ανταλλαγή βρίσκεται σε εξέλιξη",

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -120,6 +120,10 @@ export default {
           caption: "Terms of Service",
         },
       },
+      about: {
+        title: "About",
+        about: { title: "About", caption: "About this app" },
+      },
       links: {
         title: "Links",
         cashuSpace: {
@@ -1307,6 +1311,10 @@ export default {
       "Checking proofs { startIndex } to { endIndex } for keyset { keysetId }",
     no_proofs_info_text: "No proofs found to restore",
     restored_amount_success_text: "Restored { amount }",
+  },
+  AboutPage: {
+    title: "About Cashu.me",
+    video_placeholder: "Video coming soon",
   },
   swap: {
     in_progress_warning_text: "Swap in progress",

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -104,6 +104,10 @@ export default {
           caption: "Términos de Servicio",
         },
       },
+      about: {
+        title: "About",
+        about: { title: "About", caption: "About this app" },
+      },
       links: {
         title: "Enlaces",
         cashuSpace: {
@@ -1259,6 +1263,10 @@ timelock: {
       "Verificando pruebas { startIndex } a { endIndex } para el keyset { keysetId }",
     no_proofs_info_text: "No se encontraron pruebas para restaurar",
     restored_amount_success_text: "Restaurado { amount }",
+  },
+  AboutPage: {
+    title: "About Cashu.me",
+    video_placeholder: "Video coming soon",
   },
   swap: {
     in_progress_warning_text: "Intercambio en progreso",

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -104,6 +104,10 @@ export default {
           caption: "Conditions de Service",
         },
       },
+      about: {
+        title: "About",
+        about: { title: "About", caption: "About this app" },
+      },
       links: {
         title: "Liens",
         cashuSpace: {
@@ -1263,6 +1267,10 @@ timelock: {
       "Vérification des preuves { startIndex } à { endIndex } pour le keyset { keysetId }",
     no_proofs_info_text: "Aucune preuve trouvée à restaurer",
     restored_amount_success_text: "{ amount } restauré",
+  },
+  AboutPage: {
+    title: "About Cashu.me",
+    video_placeholder: "Video coming soon",
   },
   swap: {
     in_progress_warning_text: "Échange en cours",

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -104,6 +104,10 @@ export default {
           caption: "Termini di Servizio",
         },
       },
+      about: {
+        title: "About",
+        about: { title: "About", caption: "About this app" },
+      },
       links: {
         title: "Link",
         cashuSpace: {
@@ -1256,6 +1260,10 @@ timelock: {
       "Verifica prove da { startIndex } a { endIndex } per keyset { keysetId }",
     no_proofs_info_text: "Nessuna prova trovata da ripristinare",
     restored_amount_success_text: "Ripristinato { amount }",
+  },
+  AboutPage: {
+    title: "About Cashu.me",
+    video_placeholder: "Video coming soon",
   },
   swap: {
     in_progress_warning_text: "Scambio in corso",

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -104,6 +104,10 @@ export default {
           caption: "利用規約",
         },
       },
+      about: {
+        title: "About",
+        about: { title: "About", caption: "About this app" },
+      },
       links: {
         title: "リンク集",
         cashuSpace: {
@@ -1256,6 +1260,10 @@ timelock: {
       "{ keysetId }キーセットの{ startIndex }から{ endIndex }までの証明書を確認中",
     no_proofs_info_text: "復元する証明書が見つかりませんでした",
     restored_amount_success_text: "{ amount }復元しました",
+  },
+  AboutPage: {
+    title: "About Cashu.me",
+    video_placeholder: "Video coming soon",
   },
   swap: {
     in_progress_warning_text: "スワップ進行中",

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -103,6 +103,10 @@ export default {
           caption: "Användarvillkor",
         },
       },
+      about: {
+        title: "About",
+        about: { title: "About", caption: "About this app" },
+      },
       links: {
         title: "Länkar",
         cashuSpace: {
@@ -1256,6 +1260,10 @@ timelock: {
       "Kontrollerar proofs { startIndex } till { endIndex } för keyset { keysetId }",
     no_proofs_info_text: "Inga proofs hittades att återställa",
     restored_amount_success_text: "Återställde { amount }",
+  },
+  AboutPage: {
+    title: "About Cashu.me",
+    video_placeholder: "Video coming soon",
   },
   swap: {
     in_progress_warning_text: "Byte pågår",

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -104,6 +104,10 @@ export default {
           caption: "ข้อกำหนดในการให้บริการ",
         },
       },
+      about: {
+        title: "About",
+        about: { title: "About", caption: "About this app" },
+      },
       links: {
         title: "ลิงก์",
         cashuSpace: {
@@ -1253,6 +1257,10 @@ timelock: {
       "กำลังตรวจสอบ proofs { startIndex } ถึง { endIndex } สำหรับ keyset { keysetId }",
     no_proofs_info_text: "ไม่พบ proofs ที่จะกู้คืน",
     restored_amount_success_text: "กู้คืน { amount }",
+  },
+  AboutPage: {
+    title: "About Cashu.me",
+    video_placeholder: "Video coming soon",
   },
   swap: {
     in_progress_warning_text: "กำลังดำเนินการแลกเปลี่ยน",

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -104,6 +104,10 @@ export default {
           caption: "Hizmet Şartları",
         },
       },
+      about: {
+        title: "About",
+        about: { title: "About", caption: "About this app" },
+      },
       links: {
         title: "Bağlantılar",
         cashuSpace: {
@@ -1258,6 +1262,10 @@ timelock: {
       "{ keysetId } anahtar kümesi için { startIndex } ila { endIndex } kanıtları kontrol ediliyor",
     no_proofs_info_text: "Geri yüklenecek kanıt bulunamadı",
     restored_amount_success_text: "{ amount } geri yüklendi",
+  },
+  AboutPage: {
+    title: "About Cashu.me",
+    video_placeholder: "Video coming soon",
   },
   swap: {
     in_progress_warning_text: "Takas devam ediyor",

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -103,6 +103,10 @@ export default {
           caption: "服务条款",
         },
       },
+      about: {
+        title: "About",
+        about: { title: "About", caption: "About this app" },
+      },
       links: {
         title: "链接",
         cashuSpace: {
@@ -1246,6 +1250,10 @@ timelock: {
       "正在检查 keyset { keysetId } 的证明 { startIndex } 到 { endIndex }",
     no_proofs_info_text: "未找到要恢复的证明",
     restored_amount_success_text: "已恢复 { amount }",
+  },
+  AboutPage: {
+    title: "About Cashu.me",
+    video_placeholder: "Video coming soon",
   },
   swap: {
     in_progress_warning_text: "兑换进行中",

--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -1,0 +1,29 @@
+<template>
+  <q-page class="bg-dark text-white q-pa-md">
+    <div class="text-h5 q-mb-md">{{ $t('AboutPage.title') }}</div>
+    <p>
+      Cashu.me is a free and open-source Bitcoin wallet built on the Cashu
+      ecash protocol. It aims to provide privacy and ease of use for everyone.
+    </p>
+    <p>
+      The project embraces the values of the Nostr ecosystem: openness,
+      censorship resistance and user empowerment.
+    </p>
+    <div class="video-placeholder q-my-xl flex flex-center">
+      {{ $t('AboutPage.video_placeholder') }}
+    </div>
+  </q-page>
+</template>
+
+<script setup>
+</script>
+
+<style scoped>
+.video-placeholder {
+  height: 200px;
+  border: 1px dashed #ccc;
+  border-radius: 8px;
+  color: #ccc;
+  width: 100%;
+}
+</style>

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -58,6 +58,11 @@ const routes = [
       { path: "", component: () => import("src/pages/TermsPage.vue") },
     ],
   },
+  {
+    path: "/about",
+    component: () => import("layouts/FullscreenLayout.vue"),
+    children: [{ path: "", component: () => import("src/pages/AboutPage.vue") }],
+  },
 
   // Always leave this as last one,
   // but you can also remove it


### PR DESCRIPTION
## Summary
- create AboutPage with placeholder text and video box
- register about route
- add About menu entry
- provide translations for About page and menu across locales

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683bee0a8ad083309c9ce622a3c22fe9