### PR TITLE
Add locked token buckets

### DIFF
--- a/src/components/LockedTokensTable.vue
+++ b/src/components/LockedTokensTable.vue
@@ -1,0 +1,84 @@
+<template>
+  <div class="q-pa-xs" style="max-width: 500px; margin: 0 auto">
+    <h6 class="q-mt-none q-mb-md">{{ $t('BucketDetail.locked_tokens_heading') }}</h6>
+    <q-list bordered>
+      <q-item v-for="token in paginatedTokens" :key="token.id">
+        <q-item-section avatar>
+          <q-icon name="lock" />
+        </q-item-section>
+        <q-item-section>
+          <q-item-label class="text-weight-bold">
+            {{ formatCurrency(token.amount, activeUnit) }}
+          </q-item-label>
+          <q-item-label caption>
+            {{ shortenString(token.pubkey, 10, 6) }}
+          </q-item-label>
+          <q-item-label caption v-if="token.locktime">
+            {{ $t('LockedTokensTable.row.unlock_label', { value: formatTs(token.locktime) }) }}
+          </q-item-label>
+          <q-item-label caption>
+            {{ $t('LockedTokensTable.row.date_label', { value: formattedDate(token.date) }) }}
+          </q-item-label>
+        </q-item-section>
+        <q-item-section side>
+          <q-btn flat dense icon="content_copy" @click="copyText(token.token)">
+            <q-tooltip>{{ $t('LockedTokensTable.actions.copy.tooltip_text') }}</q-tooltip>
+          </q-btn>
+        </q-item-section>
+      </q-item>
+    </q-list>
+    <div v-if="paginatedTokens.length === 0" class="text-center q-mt-md">
+      <q-item-label caption>{{ $t('LockedTokensTable.empty_text') }}</q-item-label>
+    </div>
+    <div v-else-if="maxPages > 1" class="text-center q-mt-lg">
+      <div style="display: flex; justify-content: center">
+        <q-pagination v-model="currentPage" :max="maxPages" :max-pages="5" direction-links boundary-links />
+      </div>
+    </div>
+  </div>
+</template>
+<script>
+import { defineComponent } from 'vue';
+import { mapState } from 'pinia';
+import { formatDistanceToNow, parseISO } from 'date-fns';
+import { shortenString } from 'src/js/string-utils';
+import { useLockedTokensStore } from 'stores/lockedTokens';
+import { useMintsStore } from 'stores/mints';
+
+export default defineComponent({
+  name: 'LockedTokensTable',
+  mixins: [windowMixin],
+  props: {
+    bucketId: { type: String, required: true }
+  },
+  data() {
+    return { currentPage: 1, pageSize: 5 };
+  },
+  computed: {
+    ...mapState(useLockedTokensStore, ['lockedTokens']),
+    ...mapState(useMintsStore, ['activeUnit']),
+    filteredTokens() {
+      return this.lockedTokens.filter(t => t.bucketId === this.bucketId);
+    },
+    maxPages() {
+      return Math.ceil(this.filteredTokens.length / this.pageSize);
+    },
+    paginatedTokens() {
+      const start = (this.currentPage - 1) * this.pageSize;
+      const end = start + this.pageSize;
+      return this.filteredTokens.slice().reverse().slice(start, end);
+    }
+  },
+  methods: {
+    shortenString,
+    formattedDate(dateStr) {
+      const date = parseISO(dateStr);
+      return formatDistanceToNow(date, { addSuffix: false });
+    },
+    formatTs(ts) {
+      const d = new Date(ts * 1000);
+      return `${d.getFullYear()}-${('0'+(d.getMonth()+1)).slice(-2)}-${('0'+d.getDate()).slice(-2)} ${('0'+d.getHours()).slice(-2)}:${('0'+d.getMinutes()).slice(-2)}`;
+    }
+  }
+});
+</script>

--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -591,6 +591,7 @@ import { useUiStore } from "src/stores/ui";
 import { useProofsStore } from "src/stores/proofs";
 import { useMintsStore } from "src/stores/mints";
 import { useTokensStore } from "src/stores/tokens";
+import { useLockedTokensStore } from "src/stores/lockedTokens";
 import { getShortUrl } from "src/js/wallet-helpers";
 import { useSettingsStore } from "src/stores/settings";
 import { useWorkersStore } from "src/stores/workers";
@@ -1110,6 +1111,14 @@ export default defineComponent({
         this.sendData.tokens = sendProofs;
 
         this.sendData.tokensBase64 = this.serializeProofs(sendProofs);
+        useLockedTokensStore().addLockedToken({
+          amount: sendAmount,
+          token: this.sendData.tokensBase64,
+          pubkey: this.sendData.p2pkPubkey,
+          locktime: this.sendData.locktime || undefined,
+          refundPubkey: this.sendData.refundPubkey || undefined,
+          bucketId,
+        });
         const historyToken = {
           amount: -this.sendData.amount,
           token: this.sendData.tokensBase64,

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1290,12 +1290,23 @@ export default {
   BucketDetail: {
     move: "Move tokens",
     send: "Send tokens",
+    locked_tokens_heading: "Locked tokens",
     inputs: {
       target_bucket: {
         label: "Move to bucket",
       },
     },
     not_found: "Bucket not found.",
+  },
+  LockedTokensTable: {
+    empty_text: "No locked tokens",
+    row: {
+      date_label: "{ value } ago",
+      unlock_label: "Unlocks { value }",
+    },
+    actions: {
+      copy: { tooltip_text: "Copy" },
+    },
   },
   restore: {
     mnemonic_error_text: "Please enter a mnemonic",

--- a/src/pages/BucketDetail.vue
+++ b/src/pages/BucketDetail.vue
@@ -73,6 +73,7 @@
         </div>
       </q-card>
     </q-dialog>
+    <LockedTokensTable :bucket-id="bucketId" class="q-mt-lg" />
     <div class="q-mt-lg">
       <HistoryTable :bucket-id="bucketId" />
     </div>
@@ -90,8 +91,10 @@ import { useUiStore } from 'stores/ui';
 import { storeToRefs } from 'pinia';
 import { useSendTokensStore } from 'stores/sendTokensStore';
 import { useTokensStore, HistoryToken } from 'stores/tokens';
+import { useLockedTokensStore } from 'stores/lockedTokens';
 import SendTokenDialog from 'components/SendTokenDialog.vue';
 import HistoryTable from 'components/HistoryTable.vue';
+import LockedTokensTable from 'components/LockedTokensTable.vue';
 import { notifyError } from 'src/js/notify';
 
 const route = useRoute();
@@ -101,11 +104,13 @@ const mintsStore = useMintsStore();
 const uiStore = useUiStore();
 const sendTokensStore = useSendTokensStore();
 const tokensStore = useTokensStore();
+const lockedTokensStore = useLockedTokensStore();
 
 const bucketId = route.params.id as string;
 const bucket = computed(() => bucketsStore.bucketList.find(b => b.id === bucketId));
 const bucketProofs = computed(() => proofsStore.proofs.filter(p => p.bucketId === bucketId && !p.reserved));
 const bucketBalance = computed(() => bucketProofs.value.reduce((s,p)=>s+p.amount,0));
+const bucketLockedTokens = computed(() => lockedTokensStore.tokensByBucket(bucketId));
 const { activeUnit } = storeToRefs(mintsStore);
 const showSendTokens = storeToRefs(sendTokensStore).showSendTokens;
 

--- a/src/stores/buckets.ts
+++ b/src/stores/buckets.ts
@@ -4,6 +4,7 @@ import { v4 as uuidv4 } from "uuid";
 import { cashuDb } from "./dexie";
 import { useProofsStore } from "./proofs";
 import { useTokensStore } from "./tokens";
+import { useLockedTokensStore } from "./lockedTokens";
 import { ref, watch } from "vue";
 import { notifySuccess } from "src/js/notify";
 
@@ -72,6 +73,22 @@ export const useBucketsStore = defineStore("buckets", {
         balances[bucket.id] = proofsStore.proofs
           .filter((p) => p.bucketId === bucket.id && !p.reserved)
           .reduce((sum, p) => sum + p.amount, 0);
+      });
+      return balances;
+    },
+    lockedBucketBalance: () => (bucketId: string): number => {
+      const ltStore = useLockedTokensStore();
+      return ltStore.lockedTokens
+        .filter((t) => t.bucketId === bucketId)
+        .reduce((sum, t) => sum + t.amount, 0);
+    },
+    lockedBucketBalances(): Record<string, number> {
+      const ltStore = useLockedTokensStore();
+      const balances: Record<string, number> = {};
+      this.bucketList.forEach((bucket) => {
+        balances[bucket.id] = ltStore.lockedTokens
+          .filter((t) => t.bucketId === bucket.id)
+          .reduce((sum, t) => sum + t.amount, 0);
       });
       return balances;
     },

--- a/src/stores/lockedTokens.ts
+++ b/src/stores/lockedTokens.ts
@@ -1,0 +1,39 @@
+import { defineStore } from "pinia";
+import { useLocalStorage } from "@vueuse/core";
+import { v4 as uuidv4 } from "uuid";
+
+export type LockedToken = {
+  id: string;
+  amount: number;
+  token: string;
+  pubkey: string;
+  locktime?: number;
+  refundPubkey?: string;
+  bucketId: string;
+  date: string;
+};
+
+export const useLockedTokensStore = defineStore("lockedTokens", {
+  state: () => ({
+    lockedTokens: useLocalStorage<LockedToken[]>("cashu.lockedTokens", []),
+  }),
+  getters: {
+    tokensByBucket: (state) => (bucketId: string) =>
+      state.lockedTokens.filter((t) => t.bucketId === bucketId),
+  },
+  actions: {
+    addLockedToken(data: Omit<LockedToken, "id" | "date"> & { date?: string }) {
+      const token: LockedToken = {
+        id: uuidv4(),
+        date: data.date || new Date().toISOString(),
+        ...data,
+      };
+      this.lockedTokens.push(token);
+      return token;
+    },
+    deleteLockedToken(id: string) {
+      const idx = this.lockedTokens.findIndex((t) => t.id === id);
+      if (idx >= 0) this.lockedTokens.splice(idx, 1);
+    },
+  },
+});

--- a/test/vitest/__tests__/lockedTokens.spec.ts
+++ b/test/vitest/__tests__/lockedTokens.spec.ts
@@ -1,0 +1,22 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useLockedTokensStore } from '../../../src/stores/lockedTokens'
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+describe('LockedTokens store', () => {
+  it('adds and retrieves tokens', () => {
+    const store = useLockedTokensStore()
+    const t = store.addLockedToken({ amount: 1, token: 'tok', pubkey: 'pk', bucketId: 'b1' })
+    expect(store.lockedTokens.length).toBe(1)
+    expect(store.tokensByBucket('b1')[0].id).toBe(t.id)
+  })
+
+  it('deletes token', () => {
+    const store = useLockedTokensStore()
+    const t = store.addLockedToken({ amount: 1, token: 'tok', pubkey: 'pk', bucketId: 'b1' })
+    store.deleteLockedToken(t.id)
+    expect(store.lockedTokens.length).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary
- allow creating and storing locked tokens
- separate locked tokens from normal tokens in buckets
- track locked token info (pubkey, time, bucket, etc.)
- show locked tokens on bucket detail page
- add tests for new locked token store

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683beeabed508330a3e959e704c8d963