### PR TITLE
Improve light mode visuals

### DIFF
--- a/src/components/ReceiveDialog.vue
+++ b/src/components/ReceiveDialog.vue
@@ -7,7 +7,7 @@
     transition-hide="slide-down"
     backdrop-filter="blur(2px) brightness(60%)"
   >
-    <q-card class="bg-grey-10 text-white full-width-card q-pb-lg">
+    <q-card :class="[cardClass, 'full-width-card q-pb-lg']">
       <q-card-section class="row items-center q-pb-sm">
         <q-btn flat round dense v-close-popup class="q-ml-sm" color="primary">
           <XIcon />
@@ -34,7 +34,7 @@
             @click="toggleReceiveEcashDrawer"
           >
             <div class="row items-center full-width">
-              <div class="icon-background q-mr-md">
+              <div class="icon-background q-mr-md" :style="{ backgroundColor: iconBgColor }">
                 <CoinsIcon />
               </div>
               <div class="text-left">
@@ -47,7 +47,7 @@
 
           <q-btn class="full-width custom-btn" @click="showInvoiceCreateDialog">
             <div class="row items-center full-width">
-              <div class="icon-background q-mr-md">
+              <div class="icon-background q-mr-md" :style="{ backgroundColor: iconBgColor }">
                 <ZapIcon />
               </div>
               <div class="text-left">
@@ -122,6 +122,16 @@ export default defineComponent({
         return true;
       }
     },
+    cardClass: function () {
+      return this.$q.dark.isActive
+        ? "bg-grey-10 text-white"
+        : "bg-white text-dark";
+    },
+    iconBgColor: function () {
+      return this.$q.dark.isActive
+        ? 'var(--q-color-grey-10)'
+        : 'var(--q-color-grey-2)';
+    },
   },
   methods: {
     toggleReceiveEcashDrawer: function () {
@@ -165,7 +175,7 @@ export default defineComponent({
 }
 
 .icon-background {
-  background-color: $grey-10;
+  background-color: var(--icon-bg-color);
   border-radius: 8px;
   padding: 8px;
   display: flex;

--- a/src/components/ReceiveEcashDrawer.vue
+++ b/src/components/ReceiveEcashDrawer.vue
@@ -7,7 +7,7 @@
     transition-hide="slide-down"
     backdrop-filter="blur(2px) brightness(60%)"
   >
-    <q-card class="bg-grey-10 text-white full-width-card q-pb-lg">
+    <q-card :class="[cardClass, 'full-width-card q-pb-lg']">
       <q-card-section class="row items-center q-pb-sm">
         <q-btn flat round dense @click="goBack" class="q-ml-sm" color="primary">
           <ChevronLeftIcon />
@@ -31,7 +31,7 @@
         <div class="q-gutter-y-md">
           <q-btn class="full-width custom-btn" @click="handlePasteBtn">
             <div class="row items-center full-width">
-              <div class="icon-background q-mr-md">
+              <div class="icon-background q-mr-md" :style="{ backgroundColor: iconBgColor }">
                 <ClipboardIcon />
               </div>
               <div class="text-left">
@@ -44,7 +44,7 @@
 
           <q-btn class="full-width custom-btn" @click="showCamera">
             <div class="row items-center full-width">
-              <div class="icon-background q-mr-md">
+              <div class="icon-background q-mr-md" :style="{ backgroundColor: iconBgColor }">
                 <ScanIcon />
               </div>
               <div class="text-left">
@@ -61,7 +61,7 @@
             @click="handlePaymentRequestBtn"
           >
             <div class="row items-center full-width">
-              <div class="icon-background q-mr-md">
+              <div class="icon-background q-mr-md" :style="{ backgroundColor: iconBgColor }">
                 <FileTextIcon />
               </div>
               <div class="text-left">
@@ -78,7 +78,7 @@
             @click="handleLockBtn"
           >
             <div class="row items-center full-width">
-              <div class="icon-background q-mr-md">
+              <div class="icon-background q-mr-md" :style="{ backgroundColor: iconBgColor }">
                 <LockIcon />
               </div>
               <div class="text-left">
@@ -95,7 +95,7 @@
             @click="handleNFCBtn"
           >
             <div class="row items-center full-width">
-              <div class="icon-background q-mr-md">
+              <div class="icon-background q-mr-md" :style="{ backgroundColor: iconBgColor }">
                 <q-spinner v-if="scanningCard" size="sm" />
                 <NfcIcon v-else />
               </div>
@@ -191,6 +191,16 @@ export default defineComponent({
     ...mapState(usePRStore, ["enablePaymentRequest"]),
     ...mapWritableState(useUiStore, ["showReceiveDialog"]),
     ...mapState(useCameraStore, ["lastScannedResult"]),
+    cardClass: function () {
+      return this.$q.dark.isActive
+        ? "bg-grey-10 text-white"
+        : "bg-white text-dark";
+    },
+    iconBgColor: function () {
+      return this.$q.dark.isActive
+        ? 'var(--q-color-grey-10)'
+        : 'var(--q-color-grey-2)';
+    },
   },
   methods: {
     ...mapActions(useWalletStore, ["redeem"]),
@@ -271,7 +281,7 @@ export default defineComponent({
 }
 
 .icon-background {
-  background-color: $grey-10;
+  background-color: var(--icon-bg-color);
   border-radius: 8px;
   padding: 8px;
   display: flex;

--- a/src/components/ReceiveTokenDialog.vue
+++ b/src/components/ReceiveTokenDialog.vue
@@ -570,8 +570,8 @@ export default defineComponent({
 
 <style lang="scss" scoped>
 .custom-btn {
-  background: $grey-9;
-  color: white;
+  background: var(--custom-btn-bg);
+  color: var(--custom-btn-text);
   border-radius: 8px;
   height: 60px;
   box-shadow: none;
@@ -590,7 +590,7 @@ export default defineComponent({
 }
 
 .icon-background {
-  background-color: $grey-10;
+  background-color: var(--icon-bg-color);
   border-radius: 8px;
   padding: 8px;
   display: flex;

--- a/src/components/SendDialog.vue
+++ b/src/components/SendDialog.vue
@@ -7,7 +7,7 @@
     transition-hide="slide-down"
     backdrop-filter="blur(2px) brightness(60%)"
   >
-    <q-card class="bg-grey-10 text-white full-width-card q-pb-lg">
+    <q-card :class="[cardClass, 'full-width-card q-pb-lg']">
       <q-card-section class="row items-center q-pb-sm">
         <q-btn flat round dense v-close-popup class="q-ml-sm" color="primary">
           <XIcon />
@@ -31,7 +31,7 @@
         <div class="q-gutter-y-md">
           <q-btn class="full-width custom-btn" @click="showSendTokensDialog">
             <div class="row items-center full-width">
-              <div class="icon-background q-mr-md">
+              <div class="icon-background q-mr-md" :style="{ backgroundColor: iconBgColor }">
                 <CoinsIcon />
               </div>
               <div class="text-left">
@@ -44,7 +44,7 @@
 
           <q-btn class="full-width custom-btn" @click="showParseDialog">
             <div class="row items-center full-width">
-              <div class="icon-background q-mr-md">
+              <div class="icon-background q-mr-md" :style="{ backgroundColor: iconBgColor }">
                 <ZapIcon />
               </div>
               <div class="text-left">
@@ -121,6 +121,16 @@ export default defineComponent({
         return true;
       }
     },
+    cardClass: function () {
+      return this.$q.dark.isActive
+        ? "bg-grey-10 text-white"
+        : "bg-white text-dark";
+    },
+    iconBgColor: function () {
+      return this.$q.dark.isActive
+        ? 'var(--q-color-grey-10)'
+        : 'var(--q-color-grey-2)';
+    },
   },
   methods: {
     ...mapActions(useCameraStore, ["closeCamera", "showCamera"]),
@@ -174,7 +184,7 @@ export default defineComponent({
 }
 
 .icon-background {
-  background-color: $grey-10;
+  background-color: var(--icon-bg-color);
   border-radius: 8px;
   padding: 8px;
   display: flex;

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -45,8 +45,8 @@ body,
 }
 
 .custom-btn {
-  background: $grey-9;
-  color: white;
+  background: var(--custom-btn-bg);
+  color: var(--custom-btn-text);
   border-radius: 8px;
   height: 80px;
   box-shadow: none;
@@ -59,7 +59,7 @@ body,
 
 .custom-btn-text {
   font-size: 18px !important;
-  color: white;
+  color: var(--custom-btn-text);
   padding-top: 2px;
 }
 
@@ -81,4 +81,24 @@ body,
 
 .q-checkbox__svg {
   color: var(--q-dark);
+}
+
+/* theme-based variables */
+:root {
+  --icon-bg-dark: var(--q-color-grey-10);
+  --icon-bg-light: var(--q-color-grey-3);
+  --custom-btn-dark: var(--q-color-grey-9);
+  --custom-btn-light: var(--q-color-grey-2);
+}
+
+body.body--dark {
+  --icon-bg-color: var(--icon-bg-dark);
+  --custom-btn-bg: var(--custom-btn-dark);
+  --custom-btn-text: white;
+}
+
+body.body--light {
+  --icon-bg-color: var(--icon-bg-light);
+  --custom-btn-bg: var(--custom-btn-light);
+  --custom-btn-text: black;
 }

--- a/src/css/base.scss
+++ b/src/css/base.scss
@@ -160,6 +160,18 @@ body.body--dark .q-field--error {
   }
 }
 
+body.body--light {
+  .bg-dark {
+    background: white !important;
+  }
+  .text-white {
+    color: black !important;
+  }
+  .bg-grey-10 {
+    background: var(--q-color-grey-3) !important;
+  }
+}
+
 .qcard {
   width: 500px;
 }

--- a/src/pages/AlreadyRunning.vue
+++ b/src/pages/AlreadyRunning.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="fullscreen bg-dark text-white text-center q-pa-md flex flex-center"
+    :class="[$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark', 'fullscreen text-center q-pa-md flex flex-center']"
   >
     <div>
       <div class="text-h3">{{ $t("AlreadyRunning.title") }}</div>

--- a/src/pages/Buckets.vue
+++ b/src/pages/Buckets.vue
@@ -1,5 +1,7 @@
 <template>
-  <div class="bg-dark text-white text-center q-pa-md flex flex-center">
+  <div
+    :class="[$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark', 'text-center q-pa-md flex flex-center']"
+  >
     <BucketManager />
   </div>
 </template>

--- a/src/pages/ErrorNotFound.vue
+++ b/src/pages/ErrorNotFound.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="fullscreen bg-dark text-white text-center q-pa-md flex flex-center"
+    :class="[$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark', 'fullscreen text-center q-pa-md flex flex-center']"
   >
     <div>
       <div style="font-size: 30vh">{{ $t("ErrorNotFound.title") }}</div>

--- a/src/pages/FindCreators.vue
+++ b/src/pages/FindCreators.vue
@@ -1,5 +1,7 @@
 <template>
-  <div class="bg-dark text-white text-center q-pa-md flex flex-center">
+  <div
+    :class="[$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark', 'text-center q-pa-md flex flex-center']"
+  >
     <FindCreatorsView />
   </div>
 </template>

--- a/src/pages/Restore.vue
+++ b/src/pages/Restore.vue
@@ -1,5 +1,7 @@
 <template>
-  <div class="bg-dark text-white text-center q-pa-md flex flex-center">
+  <div
+    :class="[$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark', 'text-center q-pa-md flex flex-center']"
+  >
     <RestoreView />
   </div>
 </template>

--- a/src/pages/Settings.vue
+++ b/src/pages/Settings.vue
@@ -1,5 +1,7 @@
 <template>
-  <div class="bg-dark text-white text-center q-pa-md flex flex-center">
+  <div
+    :class="[$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark', 'text-center q-pa-md flex flex-center']"
+  >
     <SettingsView />
   </div>
 </template>

--- a/src/pages/TermsPage.vue
+++ b/src/pages/TermsPage.vue
@@ -1,6 +1,6 @@
 <!-- src/components/WelcomePage.vue -->
 <template>
-  <q-card class="bg-dark q-pa-none" style="height: 100%">
+  <q-card :class="$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark'" class="q-pa-none" style="height: 100%">
     <WelcomeSlide4 />
   </q-card>
   <q-dialog persistent transition-show="slide-up" transition-hide="fadeOut">


### PR DESCRIPTION
## Summary
- allow custom button and icon backgrounds to adapt to dark/light mode
- tweak global styles for better light mode contrast
- update dialogs to use reactive card classes and icon styles
- adjust page wrappers for light mode support

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683bef43ac7483309d73dfc7c78d8758