### PR TITLE
Improve locked token display

### DIFF
--- a/src/components/LockedTokensTable.vue
+++ b/src/components/LockedTokensTable.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="q-pa-xs" style="max-width: 500px; margin: 0 auto">
-    <h6 class="q-mt-none q-mb-md">{{ $t('BucketDetail.locked_tokens_heading') }}</h6>
+    <h6 class="q-mt-none q-mb-md">
+      {{ $t("BucketDetail.locked_tokens_heading") }}
+    </h6>
     <q-list bordered>
       <q-item v-for="token in paginatedTokens" :key="token.id">
         <q-item-section avatar>
@@ -11,54 +13,84 @@
             {{ formatCurrency(token.amount, activeUnit) }}
           </q-item-label>
           <q-item-label caption>
-            {{ shortenString(token.pubkey, 10, 6) }}
+            {{
+              $t("LockedTokensTable.row.receiver_label", {
+                value: shortenString(pubkeyNpub(token.pubkey), 15, 6),
+              })
+            }}
+          </q-item-label>
+          <q-item-label caption v-if="token.refundPubkey">
+            {{
+              $t("LockedTokensTable.row.refund_label", {
+                value: shortenString(pubkeyNpub(token.refundPubkey), 15, 6),
+              })
+            }}
           </q-item-label>
           <q-item-label caption v-if="token.locktime">
-            {{ $t('LockedTokensTable.row.unlock_label', { value: formatTs(token.locktime) }) }}
+            {{
+              $t("LockedTokensTable.row.unlock_label", {
+                value: formatTs(token.locktime),
+              })
+            }}
           </q-item-label>
           <q-item-label caption>
-            {{ $t('LockedTokensTable.row.date_label', { value: formattedDate(token.date) }) }}
+            {{
+              $t("LockedTokensTable.row.date_label", {
+                value: formattedDate(token.date),
+              })
+            }}
           </q-item-label>
         </q-item-section>
         <q-item-section side>
           <q-btn flat dense icon="content_copy" @click="copyText(token.token)">
-            <q-tooltip>{{ $t('LockedTokensTable.actions.copy.tooltip_text') }}</q-tooltip>
+            <q-tooltip>{{
+              $t("LockedTokensTable.actions.copy.tooltip_text")
+            }}</q-tooltip>
           </q-btn>
         </q-item-section>
       </q-item>
     </q-list>
     <div v-if="paginatedTokens.length === 0" class="text-center q-mt-md">
-      <q-item-label caption>{{ $t('LockedTokensTable.empty_text') }}</q-item-label>
+      <q-item-label caption>{{
+        $t("LockedTokensTable.empty_text")
+      }}</q-item-label>
     </div>
     <div v-else-if="maxPages > 1" class="text-center q-mt-lg">
       <div style="display: flex; justify-content: center">
-        <q-pagination v-model="currentPage" :max="maxPages" :max-pages="5" direction-links boundary-links />
+        <q-pagination
+          v-model="currentPage"
+          :max="maxPages"
+          :max-pages="5"
+          direction-links
+          boundary-links
+        />
       </div>
     </div>
   </div>
 </template>
 <script>
-import { defineComponent } from 'vue';
-import { mapState } from 'pinia';
-import { formatDistanceToNow, parseISO } from 'date-fns';
-import { shortenString } from 'src/js/string-utils';
-import { useLockedTokensStore } from 'stores/lockedTokens';
-import { useMintsStore } from 'stores/mints';
+import { defineComponent } from "vue";
+import { mapState } from "pinia";
+import { formatDistanceToNow, parseISO } from "date-fns";
+import { shortenString } from "src/js/string-utils";
+import { useLockedTokensStore } from "stores/lockedTokens";
+import { useMintsStore } from "stores/mints";
+import { nip19 } from "nostr-tools";
 
 export default defineComponent({
-  name: 'LockedTokensTable',
+  name: "LockedTokensTable",
   mixins: [windowMixin],
   props: {
-    bucketId: { type: String, required: true }
+    bucketId: { type: String, required: true },
   },
   data() {
     return { currentPage: 1, pageSize: 5 };
   },
   computed: {
-    ...mapState(useLockedTokensStore, ['lockedTokens']),
-    ...mapState(useMintsStore, ['activeUnit']),
+    ...mapState(useLockedTokensStore, ["lockedTokens"]),
+    ...mapState(useMintsStore, ["activeUnit"]),
     filteredTokens() {
-      return this.lockedTokens.filter(t => t.bucketId === this.bucketId);
+      return this.lockedTokens.filter((t) => t.bucketId === this.bucketId);
     },
     maxPages() {
       return Math.ceil(this.filteredTokens.length / this.pageSize);
@@ -67,7 +99,7 @@ export default defineComponent({
       const start = (this.currentPage - 1) * this.pageSize;
       const end = start + this.pageSize;
       return this.filteredTokens.slice().reverse().slice(start, end);
-    }
+    },
   },
   methods: {
     shortenString,
@@ -77,8 +109,16 @@ export default defineComponent({
     },
     formatTs(ts) {
       const d = new Date(ts * 1000);
-      return `${d.getFullYear()}-${('0'+(d.getMonth()+1)).slice(-2)}-${('0'+d.getDate()).slice(-2)} ${('0'+d.getHours()).slice(-2)}:${('0'+d.getMinutes()).slice(-2)}`;
-    }
-  }
+      return `${d.getFullYear()}-${("0" + (d.getMonth() + 1)).slice(-2)}-${("0" + d.getDate()).slice(-2)} ${("0" + d.getHours()).slice(-2)}:${("0" + d.getMinutes()).slice(-2)}`;
+    },
+    pubkeyNpub(hex) {
+      try {
+        if (!hex) return "";
+        return nip19.npubEncode(hex);
+      } catch (e) {
+        return hex;
+      }
+    },
+  },
 });
 </script>

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1312,6 +1312,8 @@ export default {
     row: {
       date_label: "{ value } ago",
       unlock_label: "Unlocks { value }",
+      receiver_label: "Receiver { value }",
+      refund_label: "Refund { value }",
     },
     actions: {
       copy: { tooltip_text: "Copy" },


### PR DESCRIPTION
## Summary
- show receiver and refund public keys in LockedTokensTable
- add translation keys for locked token receiver/refund labels

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683bf3a68ab88330b1c62794381e01dc