### PR TITLE
Add nip07 auto init

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,7 @@ host.com {
     file_server
 }
 ```
+
+### NIP-07 Login
+
+If a NIP-07 compatible signing extension is installed in the browser (for example [nos2x](https://github.com/fiatjaf/nos2x)), the wallet will automatically detect it on startup and log in using that extension.

--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -268,7 +268,7 @@ import { useStorageStore } from "src/stores/storage";
 import ReceiveTokenDialog from "src/components/ReceiveTokenDialog.vue";
 import { useWelcomeStore } from "../stores/welcome";
 import { useInvoicesWorkerStore } from "src/stores/invoicesWorker";
-import { notifyError, notify } from "../js/notify";
+import { notifyError, notify, notifyWarning } from "../js/notify";
 import { DEFAULT_BUCKET_ID } from "src/stores/buckets";
 
 import {
@@ -422,6 +422,8 @@ export default {
       "subscribeToNip17DirectMessages",
       "sendNip17DirectMessageToNprofile",
       "initSigner",
+      "checkNip07Signer",
+      "initNip07Signer",
     ]),
     ...mapActions(useDexieStore, ["migrateToDexie"]),
     ...mapActions(useStorageStore, ["checkLocalStorage"]),
@@ -722,7 +724,15 @@ export default {
     // generate new mnemonic
     this.initializeMnemonic();
 
-    this.initSigner();
+    const hasExt = await this.checkNip07Signer();
+    if (hasExt) {
+      await this.initNip07Signer();
+    } else {
+      await this.initSigner();
+      this.notifyWarning(
+        this.$t("settings.nostr.signing_extension.not_found") as string
+      );
+    }
 
     // show welcome dialog
     this.showWelcomePage();


### PR DESCRIPTION
## Summary
- auto initialize NIP‑07 signer on startup if available
- warn when no NIP‑07 extension is found
- document automatic NIP‑07 login

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683bf95d6f008330a33e00ac7ecccabc