### PR TITLE
Enable Nostr token sending

### DIFF
--- a/src/components/FindCreatorsView.vue
+++ b/src/components/FindCreatorsView.vue
@@ -82,6 +82,8 @@ export default defineComponent({
       sendTokensStore.sendData.bucketId = bucketId;
       sendTokensStore.sendData.p2pkPubkey = locked ? donateCreator.value.pubkey : "";
       sendTokensStore.showLockInput = locked;
+      sendTokensStore.recipientPubkey = donateCreator.value.pubkey;
+      sendTokensStore.sendViaNostr = true;
       showDonateDialog.value = false;
       sendTokensStore.showSendTokens = true;
     };

--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -600,6 +600,7 @@ import token from "src/js/token";
 import { Buffer } from "buffer";
 import { useCameraStore } from "src/stores/camera";
 import { useP2PKStore } from "src/stores/p2pk";
+import { useNostrStore } from "src/stores/nostr";
 import TokenInformation from "components/TokenInformation.vue";
 import { getDecodedToken, getEncodedTokenV4 } from "@cashu/cashu-ts";
 import { DEFAULT_BUCKET_ID, useBucketsStore } from "src/stores/buckets";
@@ -669,6 +670,8 @@ export default defineComponent({
       "showSendTokens",
       "showLockInput",
       "sendData",
+      "recipientPubkey",
+      "sendViaNostr",
     ]),
     ...mapWritableState(useCameraStore, ["camera", "hasCamera"]),
     ...mapState(useUiStore, [
@@ -820,6 +823,8 @@ export default defineComponent({
         this.sendData.tokensBase64 = "";
         this.sendData.historyToken = null;
         this.sendData.paymentRequest = null;
+        this.recipientPubkey = "";
+        this.sendViaNostr = false;
       }
     },
     locktimeInput(val) {
@@ -1111,6 +1116,19 @@ export default defineComponent({
         this.sendData.tokens = sendProofs;
 
         this.sendData.tokensBase64 = this.serializeProofs(sendProofs);
+        if (this.sendViaNostr && this.recipientPubkey) {
+          try {
+            await useNostrStore().sendNip17DirectMessage(
+              this.recipientPubkey,
+              this.sendData.tokensBase64
+            );
+            this.recipientPubkey = "";
+            this.sendViaNostr = false;
+          } catch (e) {
+            console.error(e);
+            notifyError("Failed to send token via Nostr");
+          }
+        }
         useLockedTokensStore().addLockedToken({
           amount: sendAmount,
           token: this.sendData.tokensBase64,
@@ -1175,6 +1193,19 @@ export default defineComponent({
         // update UI
         this.sendData.tokens = sendProofs;
         this.sendData.tokensBase64 = this.serializeProofs(sendProofs);
+        if (this.sendViaNostr && this.recipientPubkey) {
+          try {
+            await useNostrStore().sendNip17DirectMessage(
+              this.recipientPubkey,
+              this.sendData.tokensBase64
+            );
+            this.recipientPubkey = "";
+            this.sendViaNostr = false;
+          } catch (e) {
+            console.error(e);
+            notifyError("Failed to send token via Nostr");
+          }
+        }
         this.sendData.historyAmount =
           -this.sendData.amount * this.activeUnitCurrencyMultiplyer;
 

--- a/src/stores/sendTokensStore.ts
+++ b/src/stores/sendTokensStore.ts
@@ -7,6 +7,8 @@ export const useSendTokensStore = defineStore("sendTokensStore", {
   state: () => ({
     showSendTokens: false,
     showLockInput: false,
+    recipientPubkey: "",
+    sendViaNostr: false,
     sendData: {
       amount: null,
       historyAmount: null,
@@ -46,6 +48,8 @@ export const useSendTokensStore = defineStore("sendTokensStore", {
       this.sendData.paymentRequest = undefined;
       this.sendData.historyToken = undefined;
       this.sendData.bucketId = DEFAULT_BUCKET_ID;
+      this.recipientPubkey = "";
+      this.sendViaNostr = false;
     },
   },
 });


### PR DESCRIPTION
## Summary
- extend sendTokensStore with recipientPubkey and sendViaNostr
- set these values when donating to a creator
- send tokens via Nostr in SendTokenDialog when requested
- clear DM details on close or after sending

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration file)*
- `npm run test` *(fails: vitest not found)*


------
https://chatgpt.com/codex/tasks/task_e_683c0010381c83308e4fd53876ab3eaf