### PR TITLE
Fix Vue compilation error

### DIFF
--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -730,7 +730,7 @@ export default {
     } else {
       await this.initSigner();
       this.notifyWarning(
-        this.$t("settings.nostr.signing_extension.not_found") as string
+        this.$t("settings.nostr.signing_extension.not_found")
       );
     }
 


### PR DESCRIPTION
## Summary
- remove TS-only `as string` cast from `WalletPage.vue`

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c073ec4d08330b2d1447d91c29342