### PR TITLE
Fix Nostr DM donation flow

### DIFF
--- a/src/components/FindCreatorsView.vue
+++ b/src/components/FindCreatorsView.vue
@@ -115,6 +115,8 @@ export default defineComponent({
 
     const chooseNew = () => {
       sendTokensStore.clearSendData();
+      sendTokensStore.recipientPubkey = donateCreator.value.pubkey;
+      sendTokensStore.sendViaNostr = true;
       sendTokensStore.sendData.bucketId = selectedBucketId.value;
       sendTokensStore.sendData.p2pkPubkey = selectedLocked.value ? donateCreator.value.pubkey : "";
       sendTokensStore.showLockInput = selectedLocked.value;
@@ -134,6 +136,8 @@ export default defineComponent({
 
     const handleTokenSelect = (tokenStr: string) => {
       sendTokensStore.clearSendData();
+      sendTokensStore.recipientPubkey = donateCreator.value.pubkey;
+      sendTokensStore.sendViaNostr = true;
       sendTokensStore.sendData.bucketId = selectedBucketId.value;
       sendTokensStore.sendData.p2pkPubkey = selectedLocked.value ? donateCreator.value.pubkey : "";
       sendTokensStore.sendData.tokensBase64 = tokenStr;


### PR DESCRIPTION
## Summary
- ensure Nostr recipient info survives when picking a bucket or token

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c0a0c8f588330be9f8c8f0c3cf9c9