### PR TITLE
Fix missing semicolon error in SendTokenDialog

### DIFF
--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -583,7 +583,7 @@
     </q-card>
   </q-dialog>
 </template>
-<script>
+<script lang="ts">
 import { defineComponent } from "vue";
 import { useSendTokensStore } from "src/stores/sendTokensStore";
 import { useWalletStore } from "src/stores/wallet";


### PR DESCRIPTION
## Summary
- enable TypeScript parsing for SendTokenDialog.vue

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c0d6796e483308e2964cb17202425