### PR TITLE
Add NIP17 chat store and page

### DIFF
--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -136,6 +136,14 @@
           }}</q-item-label>
         </q-item-section>
       </q-item>
+      <q-item clickable @click="gotoChats">
+        <q-item-section avatar>
+          <q-icon name="chat" />
+        </q-item-section>
+        <q-item-section>
+          <q-item-label>Chats</q-item-label>
+        </q-item-section>
+      </q-item>
       <q-item-label header>{{
         $t("MainHeader.menu.terms.title")
       }}</q-item-label>
@@ -272,6 +280,11 @@ export default defineComponent({
       leftDrawerOpen.value = false;
     };
 
+    const gotoChats = () => {
+      router.push("/chats");
+      leftDrawerOpen.value = false;
+    };
+
     const gotoWallet = () => {
       router.push("/wallet");
       leftDrawerOpen.value = false;
@@ -287,6 +300,7 @@ export default defineComponent({
       uiStore,
       gotoBuckets,
       gotoFindCreators,
+      gotoChats,
       gotoWallet,
     };
   },

--- a/src/pages/Chats.vue
+++ b/src/pages/Chats.vue
@@ -1,0 +1,33 @@
+<template>
+  <div :class="[$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark', 'q-pa-md']">
+    <q-list bordered>
+      <div v-for="(messages, pubkey) in chats" :key="pubkey" class="q-mb-md">
+        <div class="text-h6 q-mb-sm">{{ shorten(pubkey) }}</div>
+        <q-item v-for="msg in messages" :key="msg.id">
+          <q-item-section>
+            <q-item-label>{{ msg.content }}</q-item-label>
+            <q-item-label caption>{{ formatDate(msg.created_at) }} - {{ msg.outgoing ? 'out' : 'in' }}</q-item-label>
+          </q-item-section>
+        </q-item>
+      </div>
+    </q-list>
+  </div>
+</template>
+
+<script>
+import { defineComponent } from 'vue';
+import { useDmChatsStore } from 'src/stores/dmChats';
+import { storeToRefs } from 'pinia';
+
+export default defineComponent({
+  name: 'ChatsPage',
+  setup() {
+    const store = useDmChatsStore();
+    store.loadChats();
+    const { chats } = storeToRefs(store);
+    const shorten = (p) => p.slice(0, 8) + '...' + p.slice(-4);
+    const formatDate = (ts) => new Date(ts * 1000).toLocaleString();
+    return { chats, shorten, formatDate };
+  }
+});
+</script>

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -28,6 +28,11 @@ const routes = [
     children: [{ path: "", component: () => import("src/pages/Buckets.vue") }],
   },
   {
+    path: "/chats",
+    component: () => import("layouts/MainLayout.vue"),
+    children: [{ path: "", component: () => import("src/pages/Chats.vue") }],
+  },
+  {
     path: "/buckets/:id",
     component: () => import("layouts/FullscreenLayout.vue"),
     children: [{ path: "", component: () => import("src/pages/BucketDetail.vue") }],

--- a/src/stores/dmChats.ts
+++ b/src/stores/dmChats.ts
@@ -1,0 +1,58 @@
+import { defineStore } from "pinia";
+import { useLocalStorage } from "@vueuse/core";
+import type { NDKEvent } from "@nostr-dev-kit/ndk";
+
+export type DMMessage = {
+  id: string;
+  pubkey: string;
+  content: string;
+  created_at: number;
+  outgoing: boolean;
+};
+
+export const useDmChatsStore = defineStore("dmChats", {
+  state: () => ({
+    chats: useLocalStorage<Record<string, DMMessage[]>>(
+      "cashu.dmChats",
+      {} as Record<string, DMMessage[]>
+    ),
+  }),
+  actions: {
+    loadChats() {
+      const stored = localStorage.getItem("cashu.dmChats");
+      if (stored) {
+        try {
+          this.chats = JSON.parse(stored);
+        } catch {}
+      }
+    },
+    addIncoming(event: NDKEvent) {
+      const msg: DMMessage = {
+        id: event.id,
+        pubkey: event.pubkey,
+        content: event.content,
+        created_at: event.created_at,
+        outgoing: false,
+      };
+      if (!this.chats[event.pubkey]) {
+        this.chats[event.pubkey] = [];
+      }
+      this.chats[event.pubkey].push(msg);
+    },
+    addOutgoing(event: NDKEvent) {
+      const recipientTag = event.tags?.find((t) => t[0] === "p");
+      const recipient = recipientTag ? (recipientTag[1] as string) : "";
+      const msg: DMMessage = {
+        id: event.id,
+        pubkey: recipient,
+        content: event.content,
+        created_at: event.created_at,
+        outgoing: true,
+      };
+      if (!this.chats[recipient]) {
+        this.chats[recipient] = [];
+      }
+      this.chats[recipient].push(msg);
+    },
+  },
+});

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -38,6 +38,8 @@ import { usePRStore } from "./payment-request";
 import token from "../js/token";
 import { HistoryToken } from "./tokens";
 import { DEFAULT_BUCKET_ID } from "./buckets";
+import { useDmChatsStore } from "./dmChats";
+import { useRouter } from "vue-router";
 
 type MintRecommendation = {
   url: string;
@@ -473,6 +475,12 @@ export const useNostrStore = defineStore("nostr", {
       try {
         randomNdk.connect();
         await wrapEvent.publish();
+        try {
+          const chatStore = useDmChatsStore();
+          chatStore.addOutgoing(dmEvent);
+          const router = useRouter();
+          router.push("/chats");
+        } catch {}
       } catch (e) {
         console.error(e);
         notifyError("Could not publish NIP-17 event");
@@ -547,6 +555,10 @@ export const useNostrStore = defineStore("nostr", {
           nip17DirectMessageEvents.add(dmEvent);
           this.lastEventTimestamp = Math.floor(Date.now() / 1000);
           this.parseMessageForEcash(content);
+          try {
+            const chatStore = useDmChatsStore();
+            chatStore.addIncoming(dmEvent);
+          } catch {}
         });
       });
       try {


### PR DESCRIPTION
## Summary
- add new Pinia store for DM chats
- show chats in new page
- hook chats into Nostr store for incoming/outgoing DMs
- route `/chats` and link in main menu

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c1220e70483309a7534200d478507