### PR TITLE
Improve DM feedback

### DIFF
--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -625,6 +625,8 @@ import {
   notify,
   notifyWarning,
 } from "src/js/notify.ts";
+import { Dialog } from "quasar";
+import { useDmChatsStore } from "src/stores/dmChats";
 import { getEncodedTokenV3 } from "@cashu/cashu-ts/dist/lib/es5/utils";
 export default defineComponent({
   name: "SendTokenDialog",
@@ -1136,14 +1138,31 @@ export default defineComponent({
         this.sendData.tokensBase64 = this.serializeProofs(sendProofs);
         if (this.sendViaNostr && this.recipientPubkey) {
           try {
-            await useNostrStore().sendNip17DirectMessage(
+            const ev = await useNostrStore().sendNip17DirectMessage(
               this.recipientPubkey,
               this.sendData.tokensBase64,
             );
-            notifySuccess("Sent token via Nostr");
+            if (ev) {
+              useDmChatsStore().addOutgoing(ev);
+              Dialog.create({
+                message: this.$t(
+                  "wallet.notifications.nostr_dm_sent"
+                ) as string,
+              });
+            } else {
+              Dialog.create({
+                message: this.$t(
+                  "wallet.notifications.nostr_dm_failed"
+                ) as string,
+              });
+            }
           } catch (e) {
             console.error(e);
-            notifyError("Failed to send Nostr DM");
+            Dialog.create({
+              message: this.$t(
+                "wallet.notifications.nostr_dm_failed"
+              ) as string,
+            });
           } finally {
             this.recipientPubkey = "";
             this.sendViaNostr = false;
@@ -1235,14 +1254,31 @@ export default defineComponent({
         this.sendData.tokensBase64 = this.serializeProofs(sendProofs);
         if (this.sendViaNostr && this.recipientPubkey) {
           try {
-            await useNostrStore().sendNip17DirectMessage(
+            const ev = await useNostrStore().sendNip17DirectMessage(
               this.recipientPubkey,
               this.sendData.tokensBase64,
             );
-            notifySuccess("Sent token via Nostr");
+            if (ev) {
+              useDmChatsStore().addOutgoing(ev);
+              Dialog.create({
+                message: this.$t(
+                  "wallet.notifications.nostr_dm_sent"
+                ) as string,
+              });
+            } else {
+              Dialog.create({
+                message: this.$t(
+                  "wallet.notifications.nostr_dm_failed"
+                ) as string,
+              });
+            }
           } catch (e) {
             console.error(e);
-            notifyError("Failed to send Nostr DM");
+            Dialog.create({
+              message: this.$t(
+                "wallet.notifications.nostr_dm_failed"
+              ) as string,
+            });
           } finally {
             this.recipientPubkey = "";
             this.sendViaNostr = false;

--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -67,6 +67,8 @@ export default {
       no_lnurl_data: "لا توجد بيانات LNURL",
       no_price_data: "لا توجد بيانات سعرية.",
       please_try_again: "يرجى المحاولة مرة أخرى.",
+      nostr_dm_sent: "تم إرسال رسالة Nostr",
+      nostr_dm_failed: "فشل إرسال رسالة Nostr",
     },
     mint: {
       notifications: {

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -68,6 +68,8 @@ export default {
       no_lnurl_data: "Keine LNURL-Daten",
       no_price_data: "Keine Preisdaten.",
       please_try_again: "Bitte versuchen Sie es erneut.",
+      nostr_dm_sent: "Nostr-DM gesendet",
+      nostr_dm_failed: "Nostr-DM konnte nicht gesendet werden",
     },
     mint: {
       notifications: {

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -68,6 +68,8 @@ export default {
       no_lnurl_data: "Δεν υπάρχουν δεδομένα LNURL",
       no_price_data: "Δεν υπάρχουν δεδομένα τιμής.",
       please_try_again: "Παρακαλώ προσπαθήστε ξανά.",
+      nostr_dm_sent: "Το Nostr DM στάλθηκε",
+      nostr_dm_failed: "Αποτυχία αποστολής Nostr DM",
     },
     mint: {
       notifications: {

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -71,6 +71,8 @@ export default {
       no_price_data: "No price data.",
       please_try_again: "Please try again.",
       lock_not_supported: "Mint does not support locking (NUT-10/11)",
+      nostr_dm_sent: "Nostr DM sent",
+      nostr_dm_failed: "Failed to send Nostr DM",
     },
     mint: {
       notifications: {

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -68,6 +68,8 @@ export default {
       no_lnurl_data: "Sin datos LNURL",
       no_price_data: "Sin datos de precio.",
       please_try_again: "Por favor, inténtelo de nuevo.",
+      nostr_dm_sent: "DM de Nostr enviado",
+      nostr_dm_failed: "Fallo al enviar DM de Nostr",
     },
     mint: {
       notifications: {

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -68,6 +68,8 @@ export default {
       no_lnurl_data: "Pas de données LNURL",
       no_price_data: "Pas de données de prix.",
       please_try_again: "Veuillez réessayer.",
+      nostr_dm_sent: "DM Nostr envoyé",
+      nostr_dm_failed: "Échec de l'envoi du DM Nostr",
     },
     mint: {
       notifications: {

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -68,6 +68,8 @@ export default {
       no_lnurl_data: "Nessun dato LNURL",
       no_price_data: "Nessun dato di prezzo.",
       please_try_again: "Si prega di riprovare.",
+      nostr_dm_sent: "DM Nostr inviato",
+      nostr_dm_failed: "Invio DM Nostr fallito",
     },
     mint: {
       notifications: {

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -68,6 +68,8 @@ export default {
       no_lnurl_data: "LNURLデータがありません",
       no_price_data: "価格データがありません。",
       please_try_again: "もう一度お試しください。",
+      nostr_dm_sent: "Nostr DMを送信しました",
+      nostr_dm_failed: "Nostr DMの送信に失敗しました",
     },
     mint: {
       notifications: {

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -67,6 +67,8 @@ export default {
       no_lnurl_data: "Ingen LNURL-data",
       no_price_data: "Ingen prisdata.",
       please_try_again: "Försök igen.",
+      nostr_dm_sent: "Nostr-DM skickat",
+      nostr_dm_failed: "Kunde inte skicka Nostr-DM",
     },
     mint: {
       notifications: {

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -68,6 +68,8 @@ export default {
       no_lnurl_data: "ไม่มีข้อมูล LNURL",
       no_price_data: "ไม่มีข้อมูลราคา",
       please_try_again: "โปรดลองอีกครั้ง",
+      nostr_dm_sent: "ส่ง Nostr DM แล้ว",
+      nostr_dm_failed: "ส่ง Nostr DM ไม่สำเร็จ",
     },
     mint: {
       notifications: {

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -68,6 +68,8 @@ export default {
       no_lnurl_data: "LNURL verisi yok",
       no_price_data: "Fiyat verisi yok.",
       please_try_again: "Lütfen tekrar deneyin.",
+      nostr_dm_sent: "Nostr DM gönderildi",
+      nostr_dm_failed: "Nostr DM gönderilemedi",
     },
     mint: {
       notifications: {

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -67,6 +67,8 @@ export default {
       no_lnurl_data: "没有LNURL数据",
       no_price_data: "没有价格数据。",
       please_try_again: "请重试。",
+      nostr_dm_sent: "Nostr DM 已发送",
+      nostr_dm_failed: "Nostr DM 发送失败",
     },
     mint: {
       notifications: {


### PR DESCRIPTION
## Summary
- show Nostr DM dialog feedback in SendTokenDialog
- import dialog and chat store when sending DMs
- add translation lines for DM feedback in all locales

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c135f984c8330a238053fe6c12671