### PR TITLE
Ensure NDK connects when signer is initialized

### DIFF
--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -147,6 +147,8 @@ export const useNostrStore = defineStore("nostr", {
     setSigner: async function (signer: NDKSigner) {
       this.signer = signer;
       this.ndk = new NDK({ signer: signer, explicitRelayUrls: this.relays });
+      this.ndk.connect();
+      this.connected = true;
     },
     signDummyEvent: async function (): Promise<NDKEvent> {
       const ndkEvent = new NDKEvent();


### PR DESCRIPTION
## Summary
- connect NDK and update connection status when setting a signer

## Testing
- `npx vitest run` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c171646e0833093e6602004631f48