### PR TITLE
Fix NIP-07 init and enable dialog

### DIFF
--- a/quasar.config.js
+++ b/quasar.config.js
@@ -100,7 +100,7 @@ module.exports = configure(function (/* ctx */) {
       // directives: [],
 
       // Quasar plugins
-      plugins: ["LocalStorage", "Notify"],
+      plugins: ["LocalStorage", "Notify", "Dialog"],
     },
 
     animations: "all", // --- includes all animations

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -175,20 +175,17 @@ export const useNostrStore = defineStore("nostr", {
     },
     initNip07Signer: async function () {
       const signer = new NDKNip07Signer();
-      signer.user().then(async (user) => {
-        if (!!user.npub) {
-          console.log(
-            "Permission granted to read their public key:",
-            user.npub
-          );
-          const me = this.ndk.getUser({
-            npub: user.npub,
-          });
-          this.signerType = SignerType.NIP07;
-          await this.setSigner(signer);
-          this.setPubkey(user.pubkey);
-        }
-      });
+      const user = await signer.user();
+      if (user?.npub) {
+        console.log(
+          "Permission granted to read their public key:",
+          user.npub
+        );
+        this.signerType = SignerType.NIP07;
+        await this.setSigner(signer);
+        this.ndk.getUser({ npub: user.npub });
+        this.setPubkey(user.pubkey);
+      }
       await signer.blockUntilReady();
     },
     initNip46Signer: async function (nip46Token?: string) {


### PR DESCRIPTION
## Summary
- fix `initNip07Signer` to set the signer before using the NDK instance
- enable Quasar `Dialog` plugin so calls like `Dialog.create()` work

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_683c1ac07e688330beb5fde50bc402b6