### PR TITLE
Remove SendTokenDialog v-model usage

### DIFF
--- a/src/pages/BucketDetail.vue
+++ b/src/pages/BucketDetail.vue
@@ -51,7 +51,7 @@
       </div>
     </div>
 
-    <SendTokenDialog v-model="showSendTokens" />
+    <SendTokenDialog />
     <q-dialog v-model="editDialog.show">
       <q-card class="q-pa-md" style="max-width: 400px">
         <h6 class="q-mt-none q-mb-md">Edit token</h6>

--- a/src/pages/FindCreators.vue
+++ b/src/pages/FindCreators.vue
@@ -3,7 +3,7 @@
     :class="[$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark', 'text-center q-pa-md flex flex-center']"
   >
     <FindCreatorsView />
-    <SendTokenDialog v-model="showSendTokens" />
+    <SendTokenDialog />
   </div>
 </template>
 
@@ -11,19 +11,12 @@
 import { defineComponent } from "vue";
 import FindCreatorsView from "components/FindCreatorsView.vue";
 import SendTokenDialog from "components/SendTokenDialog.vue";
-import { useSendTokensStore } from "stores/sendTokensStore";
-import { storeToRefs } from "pinia";
 
 export default defineComponent({
   name: "FindCreatorsPage",
   components: {
     FindCreatorsView,
     SendTokenDialog,
-  },
-  setup() {
-    const sendTokensStore = useSendTokensStore();
-    const { showSendTokens } = storeToRefs(sendTokensStore);
-    return { showSendTokens };
   },
 });
 </script>

--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -171,7 +171,7 @@
     <InvoiceDetailDialog v-model="showInvoiceDetails" />
 
     <!-- SEND TOKENS DIALOG  -->
-    <SendTokenDialog v-model="showSendTokens" />
+    <SendTokenDialog />
 
     <!-- RECEIVE TOKENS DIALOG  -->
     <ReceiveTokenDialog v-model="showReceiveTokens" />


### PR DESCRIPTION
## Summary
- remove obsolete v-model binding on SendTokenDialog component

## Testing
- `npm run lint` *(fails: couldn't find ESLint config)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c1d053d0c8330b9d3f9afe1e5388a