### PR TITLE
Update wallet store to use global i18n

### DIFF
--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -53,7 +53,7 @@ import { generateMnemonic, mnemonicToSeedSync } from "@scure/bip39";
 import { wordlist } from "@scure/bip39/wordlists/english";
 import { useSettingsStore } from "./settings";
 import { usePriceStore } from "./price";
-import { useI18n } from "vue-i18n";
+import { i18n } from "src/boot/i18n";
 // HACK: this is a workaround so that the catch block in the melt function does not throw an error when the user exits the app
 // before the payment is completed. This is necessary because the catch block in the melt function would otherwise remove all
 // quotes from the invoiceHistory and the user would not be able to pay the invoice again after reopening the app.
@@ -89,7 +89,7 @@ const proofsStore = useProofsStore();
 
 export const useWalletStore = defineStore("wallet", {
   state: () => {
-    const { t } = useI18n();
+    const t = i18n.global.t;
     return {
       t: t,
       mnemonic: useLocalStorage("cashu.mnemonic", ""),


### PR DESCRIPTION
## Summary
- use the i18n instance from `src/boot/i18n` in wallet store

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c1cf432c08330ad5e9454d3b5d827