### PR TITLE
Fix NIP-04 signing await

### DIFF
--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -353,7 +353,7 @@ export const useNostrStore = defineStore("nostr", {
       event.kind = NDKKind.EncryptedDirectMessage;
       event.content = await nip04.encrypt(randomPrivateKey, recipient, message);
       event.tags = [["p", recipient]];
-      event.sign();
+      await event.sign();
       try {
         await event.publish();
         notifySuccess("NIP-04 event published");


### PR DESCRIPTION
## Summary
- ensure the direct message event signing is awaited in `sendNip04DirectMessage`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c1faacf2c833088f768832b7bd97c