### PR TITLE
Switch DM to NIP‑04

### DIFF
--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -1138,8 +1138,20 @@ export default defineComponent({
         this.sendData.tokensBase64 = this.serializeProofs(sendProofs);
         if (this.sendViaNostr && this.recipientPubkey) {
           try {
-            const ev = await useNostrStore().sendNip17DirectMessage(
-              this.recipientPubkey,
+            let recipient = this.recipientPubkey;
+            if (recipient.startsWith("npub") || recipient.startsWith("nprofile")) {
+              try {
+                const decoded = nip19.decode(recipient);
+                recipient =
+                  decoded.type === "npub"
+                    ? (decoded.data as string)
+                    : (decoded.data as ProfilePointer).pubkey;
+              } catch (e) {
+                console.error(e);
+              }
+            }
+            const ev = await useNostrStore().sendNip04DirectMessage(
+              recipient,
               this.sendData.tokensBase64,
             );
             if (ev) {
@@ -1254,8 +1266,20 @@ export default defineComponent({
         this.sendData.tokensBase64 = this.serializeProofs(sendProofs);
         if (this.sendViaNostr && this.recipientPubkey) {
           try {
-            const ev = await useNostrStore().sendNip17DirectMessage(
-              this.recipientPubkey,
+            let recipient = this.recipientPubkey;
+            if (recipient.startsWith("npub") || recipient.startsWith("nprofile")) {
+              try {
+                const decoded = nip19.decode(recipient);
+                recipient =
+                  decoded.type === "npub"
+                    ? (decoded.data as string)
+                    : (decoded.data as ProfilePointer).pubkey;
+              } catch (e) {
+                console.error(e);
+              }
+            }
+            const ev = await useNostrStore().sendNip04DirectMessage(
+              recipient,
               this.sendData.tokensBase64,
             );
             if (ev) {

--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -417,10 +417,8 @@ export default {
     ...mapActions(useNPCStore, ["generateNPCConnection", "claimAllTokens"]),
     ...mapActions(useNostrStore, [
       "sendNip04DirectMessage",
-      "sendNip17DirectMessage",
       "subscribeToNip04DirectMessages",
       "subscribeToNip17DirectMessages",
-      "sendNip17DirectMessageToNprofile",
       "initSigner",
       "checkNip07Signer",
       "initNip07Signer",

--- a/test/vitest/__tests__/nostr.spec.ts
+++ b/test/vitest/__tests__/nostr.spec.ts
@@ -62,7 +62,7 @@ vi.mock("@nostr-dev-kit/ndk", () => {
 const encryptMock = vi.fn((content: string) => content);
 let publishSuccess = true;
 vi.mock("nostr-tools", () => ({
-  nip04: {},
+  nip04: { encrypt: encryptMock },
   nip19: { decode: vi.fn(), nsecEncode: vi.fn(), nprofileEncode: vi.fn() },
   nip44: {
     v2: {
@@ -104,10 +104,10 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
-describe("sendNip17DirectMessage", () => {
+describe("sendNip04DirectMessage", () => {
   it("returns signed event when published", async () => {
     const store = useNostrStore();
-    const promise = store.sendNip17DirectMessage("r", "m");
+    const promise = store.sendNip04DirectMessage("r", "m");
     vi.runAllTimers();
     const ev = await promise;
     expect(ev).not.toBeNull();
@@ -120,7 +120,7 @@ describe("sendNip17DirectMessage", () => {
   it("returns null when publish fails", async () => {
     const store = useNostrStore();
     publishSuccess = false;
-    const promise = store.sendNip17DirectMessage("r", "m");
+    const promise = store.sendNip04DirectMessage("r", "m");
     vi.runAllTimers();
     const ev = await promise;
     expect(ev).toBeNull();


### PR DESCRIPTION
## Summary
- update FindCreatorsView and SendTokenDialog to use `sendNip04DirectMessage`
- decode npub or nprofile before sending the DM
- remove unused NIP‑17 actions from WalletPage
- update tests for NIP‑04 direct messages

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c389e07708330a7d9a4eebd43bc24