### PR TITLE
Fix Nostr DM without keypair

### DIFF
--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -340,6 +340,7 @@ export const useNostrStore = defineStore("nostr", {
       recipient: string,
       message: string
     ) {
+      await this.walletSeedGenerateKeyPair();
       const ndk = new NDK({ signer: this.seedSigner });
       const event = new NDKEvent(ndk);
       event.kind = NDKKind.EncryptedDirectMessage;

--- a/test/vitest/__tests__/nostr.spec.ts
+++ b/test/vitest/__tests__/nostr.spec.ts
@@ -117,7 +117,6 @@ afterEach(() => {
 describe("sendNip04DirectMessage", () => {
   it("returns signed event when published", async () => {
     const store = useNostrStore();
-    await store.walletSeedGenerateKeyPair();
     const promise = store.sendNip04DirectMessage("r", "m");
     vi.runAllTimers();
     const ev = await promise;
@@ -130,12 +129,20 @@ describe("sendNip04DirectMessage", () => {
 
   it("constructs event with correct kind and tags", async () => {
     const store = useNostrStore();
-    await store.walletSeedGenerateKeyPair();
     const ev = await store.sendNip04DirectMessage("receiver", "msg");
     vi.runAllTimers();
     expect(ev!.kind).toBe(NDKKind.EncryptedDirectMessage);
     expect(ev!.tags).toContainEqual(["p", "receiver"]);
     expect(ev!.tags).toContainEqual(["p", store.seedSignerPublicKey]);
+  });
+
+  it("generates keypair if not set", async () => {
+    const store = useNostrStore();
+    expect(store.seedSignerPrivateKey).toBe("");
+    const ev = await store.sendNip04DirectMessage("receiver", "msg");
+    vi.runAllTimers();
+    expect(ev).not.toBeNull();
+    expect(store.seedSignerPrivateKey).not.toBe("");
   });
 
   it("returns null when publish fails", async () => {


### PR DESCRIPTION
## Summary
- fix NDK signer initialization for NIP-04 DMs
- test automatic keypair generation

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c3cdc63b883308ccfeb7a33591adf