### PR TITLE
Add drag-and-drop for bucket tokens

### DIFF
--- a/src/pages/BucketDetail.vue
+++ b/src/pages/BucketDetail.vue
@@ -10,7 +10,12 @@
     </div>
 
     <q-list bordered>
-      <q-item v-for="group in groupedProofs" :key="group.key">
+      <q-item
+        v-for="group in groupedProofs"
+        :key="group.key"
+        draggable="true"
+        @dragstart="onDragStart($event, group)"
+      >
         <q-item-section side>
           <q-checkbox
             :model-value="group.secrets.every(s => selectedSecrets.includes(s))"
@@ -178,6 +183,14 @@ function toggleGroup(group: ProofGroup, val: boolean){
   } else {
     selectedSecrets.value = selectedSecrets.value.filter(s => !group.secrets.includes(s));
   }
+}
+
+function onDragStart(ev: DragEvent, group: ProofGroup){
+  const secrets = selectedSecrets.value.length
+    ? selectedSecrets.value
+    : group.secrets;
+  ev.dataTransfer?.setData('text/plain', JSON.stringify(secrets));
+  ev.dataTransfer?.effectAllowed = 'move';
 }
 
 function openEditGroup(group: ProofGroup){


### PR DESCRIPTION
## Summary
- enable dropping token groups onto buckets in `BucketManager.vue`
- make token groups draggable in `BucketDetail.vue`

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c8f0a6e20833082645cf715e8166d