### PR TITLE
Add bulk proof move screen

### DIFF
--- a/src/components/BucketManager.vue
+++ b/src/components/BucketManager.vue
@@ -71,6 +71,13 @@
           }}</q-btn>
         </q-item-section>
       </q-item>
+      <q-item>
+        <q-item-section>
+          <router-link to="/move-proofs" style="text-decoration: none">
+            <q-btn color="primary" outline>{{ $t("BucketDetail.move") }}</q-btn>
+          </router-link>
+        </q-item-section>
+      </q-item>
     </q-list>
   </div>
 
@@ -85,21 +92,21 @@
           :label="$t('BucketManager.inputs.name')"
           class="q-mb-sm"
         />
-      <q-input
-        v-model="form.color"
-        outlined
-        :label="$t('BucketManager.inputs.color')"
-        class="q-mb-sm"
-        type="color"
-      />
-      <q-input
-        v-model="form.description"
-        outlined
-        :label="$t('BucketManager.inputs.description')"
-        type="textarea"
-        autogrow
-        class="q-mb-sm"
-      />
+        <q-input
+          v-model="form.color"
+          outlined
+          :label="$t('BucketManager.inputs.color')"
+          class="q-mb-sm"
+          type="color"
+        />
+        <q-input
+          v-model="form.description"
+          outlined
+          :label="$t('BucketManager.inputs.description')"
+          type="textarea"
+          autogrow
+          class="q-mb-sm"
+        />
         <q-input
           v-model.number="form.goal"
           outlined
@@ -194,17 +201,19 @@ export default defineComponent({
       showForm.value = true;
     };
 
-    const nameRules = [
-      (val) => !!val || t('BucketManager.validation.name'),
-    ];
+    const nameRules = [(val) => !!val || t("BucketManager.validation.name")];
 
     const goalRules = [
-      (val) => val === null || val === undefined || val >= 0 || t('BucketManager.validation.goal'),
+      (val) =>
+        val === null ||
+        val === undefined ||
+        val >= 0 ||
+        t("BucketManager.validation.goal"),
     ];
 
     const saveBucket = async () => {
       if (!(await bucketForm.value.validate())) {
-        notifyError(t('BucketManager.validation.error'));
+        notifyError(t("BucketManager.validation.error"));
         return;
       }
       if (editId.value) {

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1337,6 +1337,10 @@ export default {
     },
     not_found: "Bucket not found.",
   },
+  MoveProofs: {
+    title: "Move tokens",
+    empty: "No tokens",
+  },
   LockedTokensTable: {
     empty_text: "No locked tokens",
     row: {

--- a/src/pages/MoveProofs.vue
+++ b/src/pages/MoveProofs.vue
@@ -1,0 +1,115 @@
+<template>
+  <div class="q-pa-md">
+    <h5 class="q-my-none q-mb-md">{{ $t("MoveProofs.title") }}</h5>
+    <q-select
+      dense
+      outlined
+      v-model="targetBucketId"
+      :options="bucketOptions"
+      :label="$t('BucketDetail.inputs.target_bucket.label')"
+      emit-value
+      map-options
+      class="q-mb-md"
+    />
+    <q-btn
+      color="primary"
+      :disable="!selectedSecrets.length || !targetBucketId"
+      @click="moveSelected"
+      class="q-mb-lg"
+    >
+      {{ $t("BucketDetail.move") }}
+    </q-btn>
+    <div v-for="bucket in bucketList" :key="bucket.id" class="q-mb-md">
+      <q-expansion-item :label="bucket.name">
+        <q-list bordered>
+          <q-item
+            v-for="proof in proofsByBucket[bucket.id]"
+            :key="proof.secret"
+          >
+            <q-item-section side>
+              <q-checkbox
+                :model-value="selectedSecrets.includes(proof.secret)"
+                @update:model-value="(val) => toggleProof(proof.secret, val)"
+              />
+            </q-item-section>
+            <q-item-section>
+              <q-item-label>{{
+                formatCurrency(proof.amount, activeUnit)
+              }}</q-item-label>
+              <q-item-label caption v-if="proof.label">{{
+                proof.label
+              }}</q-item-label>
+            </q-item-section>
+          </q-item>
+          <q-item v-if="!proofsByBucket[bucket.id].length">
+            <q-item-section>{{ $t("MoveProofs.empty") }}</q-item-section>
+          </q-item>
+        </q-list>
+      </q-expansion-item>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { useBucketsStore } from "stores/buckets";
+import { useProofsStore } from "stores/proofs";
+import { useMintsStore, WalletProof } from "stores/mints";
+import { useUiStore } from "stores/ui";
+import { storeToRefs } from "pinia";
+import { notifyError } from "src/js/notify";
+
+const bucketsStore = useBucketsStore();
+const proofsStore = useProofsStore();
+const mintsStore = useMintsStore();
+const uiStore = useUiStore();
+const { activeUnit } = storeToRefs(mintsStore);
+
+const bucketList = computed(() => bucketsStore.bucketList);
+
+const proofsByBucket = computed<Record<string, WalletProof[]>>(() => {
+  const map: Record<string, WalletProof[]> = {};
+  bucketList.value.forEach((b) => {
+    map[b.id] = proofsStore.proofs.filter(
+      (p) => p.bucketId === b.id && !p.reserved,
+    );
+  });
+  return map;
+});
+
+const selectedSecrets = ref<string[]>([]);
+const targetBucketId = ref<string | null>(null);
+
+function toggleProof(secret: string, val: boolean) {
+  if (val) {
+    if (!selectedSecrets.value.includes(secret))
+      selectedSecrets.value.push(secret);
+  } else {
+    selectedSecrets.value = selectedSecrets.value.filter((s) => s !== secret);
+  }
+}
+
+const bucketOptions = computed(() =>
+  bucketsStore.bucketList.map((b) => ({ label: b.name, value: b.id })),
+);
+
+function formatCurrency(amount: number, unit: string) {
+  return uiStore.formatCurrency(amount, unit);
+}
+
+async function moveSelected() {
+  if (!targetBucketId.value) {
+    notifyError("Please select a bucket");
+    return;
+  }
+  const bucketExists = bucketsStore.bucketList.find(
+    (b) => b.id === targetBucketId.value,
+  );
+  if (!bucketExists) {
+    notifyError(`Bucket not found: ${targetBucketId.value}`);
+    return;
+  }
+  await proofsStore.moveProofs(selectedSecrets.value, targetBucketId.value);
+  selectedSecrets.value = [];
+}
+</script>

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -28,6 +28,13 @@ const routes = [
     children: [{ path: "", component: () => import("src/pages/Buckets.vue") }],
   },
   {
+    path: "/move-proofs",
+    component: () => import("layouts/FullscreenLayout.vue"),
+    children: [
+      { path: "", component: () => import("src/pages/MoveProofs.vue") },
+    ],
+  },
+  {
     path: "/chats",
     component: () => import("layouts/MainLayout.vue"),
     children: [{ path: "", component: () => import("src/pages/Chats.vue") }],
@@ -35,7 +42,9 @@ const routes = [
   {
     path: "/buckets/:id",
     component: () => import("layouts/FullscreenLayout.vue"),
-    children: [{ path: "", component: () => import("src/pages/BucketDetail.vue") }],
+    children: [
+      { path: "", component: () => import("src/pages/BucketDetail.vue") },
+    ],
   },
   {
     path: "/restore",
@@ -66,7 +75,9 @@ const routes = [
   {
     path: "/about",
     component: () => import("layouts/FullscreenLayout.vue"),
-    children: [{ path: "", component: () => import("src/pages/AboutPage.vue") }],
+    children: [
+      { path: "", component: () => import("src/pages/AboutPage.vue") },
+    ],
   },
 
   // Always leave this as last one,


### PR DESCRIPTION
## Summary
- allow moving proofs across buckets with new `MoveProofs` page
- link to new page from Bucket Manager
- route `/move-proofs`
- add i18n strings

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c8e819df88330ade1cdea52b333db