### PR TITLE
Add auto bucket assignment

### DIFF
--- a/src/components/ReceiveTokenDialog.vue
+++ b/src/components/ReceiveTokenDialog.vue
@@ -356,6 +356,12 @@ export default defineComponent({
       },
       deep: true,
     },
+    "receiveData.tokensBase64"() {
+      this.applyBucketRules();
+    },
+    "receiveData.label"() {
+      this.applyBucketRules();
+    },
   },
   computed: {
     ...mapWritableState(useReceiveTokensStore, [
@@ -519,6 +525,20 @@ export default defineComponent({
         tokensStore.historyTokens.find((t) => t.token === tokenStr) !==
         undefined
       );
+    },
+    applyBucketRules() {
+      if (!this.receiveData.tokensBase64) return;
+      if (this.receiveData.bucketId !== DEFAULT_BUCKET_ID) return;
+      const decodedToken = this.decodeToken(this.receiveData.tokensBase64);
+      if (!decodedToken) return;
+      const mint = this.getMint(decodedToken);
+      const bucket = useBucketsStore().autoBucketFor(
+        mint,
+        this.receiveData.label
+      );
+      if (bucket) {
+        this.receiveData.bucketId = bucket;
+      }
     },
     addPendingTokenToHistory: function (tokenStr) {
       if (this.tokenAlreadyInHistory(tokenStr)) {


### PR DESCRIPTION
## Summary
- define auto bucket assignment rules in buckets store
- set bucket based on mint or memo in ReceiveTokenDialog
- apply rules when adding proofs

## Testing
- `npm run test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_683c902c7fcc8330ab42eca087237ce3