### PR TITLE
Watch bucket goal modifications

### DIFF
--- a/src/stores/buckets.ts
+++ b/src/stores/buckets.ts
@@ -52,6 +52,24 @@ export const useBucketsStore = defineStore("buckets", {
       { deep: true }
     );
 
+    watch(
+      buckets,
+      (newBuckets, oldBuckets) => {
+        newBuckets.forEach((bucket) => {
+          if (bucket.goal === undefined || bucket.goal === null) return;
+          const previous = oldBuckets.find((b) => b.id === bucket.id);
+          if (!previous || previous.goal === bucket.goal) return;
+          const sum = proofsStore.proofs
+            .filter((p) => p.bucketId === bucket.id && !p.reserved)
+            .reduce((s, p) => s + p.amount, 0);
+          if (bucket.goal <= sum) {
+            notifiedGoals.value[bucket.id] = false;
+          }
+        });
+      },
+      { deep: true }
+    );
+
     return {
       buckets,
       notifiedGoals,

--- a/test/vitest/__tests__/buckets.spec.ts
+++ b/test/vitest/__tests__/buckets.spec.ts
@@ -116,4 +116,24 @@ describe('Buckets store', () => {
     expect(ht.label).toBe('My label')
     expect(ht.color).toBe('#00ff00')
   })
+
+  it('clears notifiedGoals when goal lowered below balance', async () => {
+    const buckets = useBucketsStore()
+    const proofs = useProofsStore()
+
+    const bucket = buckets.addBucket({ name: 'Goal', goal: 5 })!
+
+    await proofs.addProofs([
+      { id: 'a', amount: 3, C: 'c1', secret: 's1' },
+      { id: 'a', amount: 4, C: 'c2', secret: 's2' },
+    ], undefined, bucket.id)
+
+    await new Promise(r => setTimeout(r, 0))
+    expect(buckets.notifiedGoals[bucket.id]).toBe(true)
+
+    buckets.editBucket(bucket.id, { goal: 2 })
+    await new Promise(r => setTimeout(r, 0))
+
+    expect(buckets.notifiedGoals[bucket.id]).toBe(false)
+  })
 })


### PR DESCRIPTION
## Summary
- watch bucket goal changes and reset notifications when the goal drops below the balance
- cover the new behaviour in buckets.spec

## Testing
- `npx vitest run` *(fails: EHOSTUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_683c906dae208330b98d2c4c06a4f79e