### PR TITLE
Add bucket component tests

### DIFF
--- a/test/vitest/__tests__/bucketManagerDrag.spec.ts
+++ b/test/vitest/__tests__/bucketManagerDrag.spec.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { shallowMount } from '@vue/test-utils'
+import BucketManager from '../../src/components/BucketManager.vue'
+
+const moveProofsMock = vi.fn()
+
+vi.mock('../../src/stores/proofs', () => ({
+  useProofsStore: () => ({ moveProofs: moveProofsMock })
+}))
+
+vi.mock('../../src/stores/buckets', () => ({
+  useBucketsStore: () => ({
+    bucketList: [{ id: 'b1', name: 'Bucket 1' }],
+    bucketBalances: {},
+    addBucket: vi.fn(),
+    editBucket: vi.fn(),
+    deleteBucket: vi.fn(),
+  }),
+  DEFAULT_BUCKET_ID: 'b1'
+}))
+
+vi.mock('../../src/stores/mints', () => ({
+  useMintsStore: () => ({ activeUnit: 'sat' })
+}))
+
+vi.mock('../../src/stores/ui', () => ({
+  useUiStore: () => ({ formatCurrency: (a: number) => String(a) })
+}))
+
+vi.mock('../../src/js/notify', () => ({
+  notifyError: vi.fn(),
+}))
+
+beforeEach(() => {
+  moveProofsMock.mockReset()
+})
+
+describe('BucketManager drag and drop', () => {
+  it('moves proofs on drop with JSON data', async () => {
+    const wrapper = shallowMount(BucketManager)
+    const vm: any = wrapper.vm
+    const event = {
+      preventDefault: vi.fn(),
+      dataTransfer: { getData: vi.fn(() => '["s1","s2"]') }
+    } as any
+    await vm.handleDrop(event, 'b1')
+    expect(moveProofsMock).toHaveBeenCalledWith(['s1','s2'], 'b1')
+  })
+
+  it('moves proofs on drop with comma string', async () => {
+    const wrapper = shallowMount(BucketManager)
+    const vm: any = wrapper.vm
+    const event = {
+      preventDefault: vi.fn(),
+      dataTransfer: { getData: vi.fn(() => 's3,s4') }
+    } as any
+    await vm.handleDrop(event, 'b1')
+    expect(moveProofsMock).toHaveBeenCalledWith(['s3','s4'], 'b1')
+  })
+})

--- a/test/vitest/__tests__/moveProofs.spec.ts
+++ b/test/vitest/__tests__/moveProofs.spec.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { shallowMount } from '@vue/test-utils'
+import MoveProofs from '../../src/pages/MoveProofs.vue'
+
+const moveProofsMock = vi.fn()
+
+vi.mock('../../src/stores/proofs', () => ({
+  useProofsStore: () => ({ proofs: [], moveProofs: moveProofsMock })
+}))
+
+vi.mock('../../src/stores/buckets', () => ({
+  useBucketsStore: () => ({
+    bucketList: [
+      { id: 'b1', name: 'Bucket 1' },
+      { id: 'b2', name: 'Bucket 2' },
+    ],
+  }),
+}))
+
+vi.mock('../../src/stores/mints', () => ({
+  useMintsStore: () => ({ activeUnit: 'sat' })
+}))
+
+vi.mock('../../src/stores/ui', () => ({
+  useUiStore: () => ({ formatCurrency: (a: number) => String(a) })
+}))
+
+vi.mock('../../src/js/notify', () => ({
+  notifyError: vi.fn(),
+}))
+
+beforeEach(() => {
+  moveProofsMock.mockReset()
+})
+
+describe('MoveProofs component', () => {
+  it('toggles token selection', () => {
+    const wrapper = shallowMount(MoveProofs)
+    const vm: any = wrapper.vm
+
+    vm.toggleProof('s1', true)
+    expect(vm.selectedSecrets).toContain('s1')
+
+    vm.toggleProof('s1', false)
+    expect(vm.selectedSecrets).not.toContain('s1')
+  })
+
+  it('moves selected tokens', async () => {
+    const wrapper = shallowMount(MoveProofs)
+    const vm: any = wrapper.vm
+    vm.selectedSecrets = ['a', 'b']
+    vm.targetBucketId = 'b2'
+
+    await vm.moveSelected()
+
+    expect(moveProofsMock).toHaveBeenCalledWith(['a', 'b'], 'b2')
+    expect(vm.selectedSecrets.length).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary
- add tests for MoveProofs page selecting and moving tokens
- add tests for BucketManager drag-and-drop token moving

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c90acb0a08330a738fdccb7832168