### PR TITLE
Add bucket token count getters and display

### DIFF
--- a/src/components/BucketManager.vue
+++ b/src/components/BucketManager.vue
@@ -43,6 +43,7 @@
                 <span v-if="bucket.goal"
                   >/ {{ formatCurrency(bucket.goal, activeUnit.value) }}</span
                 >
+                <span class="q-ml-sm">({{ bucketTokenCounts[bucket.id] ?? 0 }})</span>
               </q-item-label>
               <q-linear-progress
                 v-if="bucket.goal"
@@ -183,6 +184,7 @@ export default defineComponent({
 
     const bucketList = computed(() => bucketsStore.bucketList);
     const bucketBalances = computed(() => bucketsStore.bucketBalances);
+    const bucketTokenCounts = computed(() => bucketsStore.bucketTokenCounts);
 
     const formatCurrency = (amount, unit) => {
       return uiStore.formatCurrency(amount, unit);
@@ -262,6 +264,7 @@ export default defineComponent({
       DEFAULT_BUCKET_ID,
       bucketList,
       bucketBalances,
+      bucketTokenCounts,
       activeUnit,
       showForm,
       showDelete,

--- a/src/pages/BucketDetail.vue
+++ b/src/pages/BucketDetail.vue
@@ -7,6 +7,7 @@
         <span>{{ formatCurrency(bucketBalance, activeUnit) }}</span>
         <span v-if="bucket.goal"> / {{ formatCurrency(bucket.goal, activeUnit) }}</span>
       </div>
+      <div class="text-caption q-mt-xs">{{ bucketTokenCount }} tokens</div>
     </div>
 
     <q-list bordered>
@@ -113,9 +114,16 @@ const lockedTokensStore = useLockedTokensStore();
 
 const bucketId = route.params.id as string;
 const bucket = computed(() => bucketsStore.bucketList.find(b => b.id === bucketId));
-const bucketProofs = computed(() => proofsStore.proofs.filter(p => p.bucketId === bucketId && !p.reserved));
-const bucketBalance = computed(() => bucketProofs.value.reduce((s,p)=>s+p.amount,0));
-const bucketLockedTokens = computed(() => lockedTokensStore.tokensByBucket(bucketId));
+const bucketProofs = computed(() =>
+  proofsStore.proofs.filter(p => p.bucketId === bucketId && !p.reserved)
+);
+const bucketBalance = computed(() =>
+  bucketProofs.value.reduce((s, p) => s + p.amount, 0)
+);
+const bucketTokenCount = computed(() => bucketsStore.bucketTokenCount(bucketId));
+const bucketLockedTokens = computed(() =>
+  lockedTokensStore.tokensByBucket(bucketId)
+);
 const { activeUnit } = storeToRefs(mintsStore);
 const showSendTokens = storeToRefs(sendTokensStore).showSendTokens;
 

--- a/src/stores/buckets.ts
+++ b/src/stores/buckets.ts
@@ -77,6 +77,22 @@ export const useBucketsStore = defineStore("buckets", {
       });
       return balances;
     },
+    bucketTokenCount: () => (bucketId: string): number => {
+      const proofsStore = useProofsStore();
+      return proofsStore.proofs.filter(
+        (p) => p.bucketId === bucketId && !p.reserved
+      ).length;
+    },
+    bucketTokenCounts(): Record<string, number> {
+      const proofsStore = useProofsStore();
+      const counts: Record<string, number> = {};
+      this.bucketList.forEach((bucket) => {
+        counts[bucket.id] = proofsStore.proofs.filter(
+          (p) => p.bucketId === bucket.id && !p.reserved
+        ).length;
+      });
+      return counts;
+    },
     lockedBucketBalance: () => (bucketId: string): number => {
       const ltStore = useLockedTokensStore();
       return ltStore.lockedTokens

--- a/test/vitest/__tests__/buckets.spec.ts
+++ b/test/vitest/__tests__/buckets.spec.ts
@@ -116,4 +116,26 @@ describe('Buckets store', () => {
     expect(ht.label).toBe('My label')
     expect(ht.color).toBe('#00ff00')
   })
+
+  it('computes token counts per bucket', async () => {
+    const buckets = useBucketsStore()
+    const proofsStore = useProofsStore()
+
+    const b1 = buckets.addBucket({ name: 'B1' })!
+    await proofsStore.addProofs([
+      { id: 'a', amount: 1, C: 'c1', secret: 's1' },
+      { id: 'a', amount: 2, C: 'c2', secret: 's2' }
+    ], undefined, b1.id)
+
+    await proofsStore.addProofs([
+      { id: 'a', amount: 1, C: 'c3', secret: 's3' }
+    ], undefined, DEFAULT_BUCKET_ID)
+
+    await proofsStore.setReserved([{ id: 'a', amount: 2, C: 'c2', secret: 's2' }])
+
+    expect(buckets.bucketTokenCount(b1.id)).toBe(1)
+    const counts = buckets.bucketTokenCounts()
+    expect(counts[b1.id]).toBe(1)
+    expect(counts[DEFAULT_BUCKET_ID]).toBe(1)
+  })
 })


### PR DESCRIPTION
## Summary
- add `bucketTokenCount` and `bucketTokenCounts` getters in buckets store
- show token count for each bucket in BucketManager
- show token count in BucketDetail view
- test bucket token count calculations

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c90c958a88330b5301ca65b387ff2