### PR TITLE
Add bucket export

### DIFF
--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1329,6 +1329,7 @@ export default {
   BucketDetail: {
     move: "Move tokens",
     send: "Send tokens",
+    export: "Export bucket",
     locked_tokens_heading: "Locked tokens",
     inputs: {
       target_bucket: {

--- a/src/pages/BucketDetail.vue
+++ b/src/pages/BucketDetail.vue
@@ -53,6 +53,9 @@
         <q-btn color="primary" outline :disable="!selectedSecrets.length" @click="sendSelected">
           {{ $t('BucketDetail.send') }}
         </q-btn>
+        <q-btn color="primary" outline :disable="!bucketProofs.length" @click="exportBucket">
+          {{ $t('BucketDetail.export') }}
+        </q-btn>
       </div>
     </div>
 
@@ -230,6 +233,13 @@ async function moveSelected(){
 function sendSelected(){
   const proofs = bucketProofs.value.filter(p => selectedSecrets.value.includes(p.secret));
   const token = proofsStore.serializeProofs(proofs);
+  sendTokensStore.clearSendData();
+  sendTokensStore.sendData.tokensBase64 = token;
+  showSendTokens.value = true;
+}
+
+function exportBucket(){
+  const token = proofsStore.serializeProofs(bucketProofs.value);
   sendTokensStore.clearSendData();
   sendTokensStore.sendData.tokensBase64 = token;
   showSendTokens.value = true;


### PR DESCRIPTION
## Summary
- add option to export all proofs in a bucket
- show exported token in the standard SendTokenDialog
- translate new button text

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c92b63ac48330b1f1b0f3e9cdfcf4