### PR TITLE
Add InfoTooltip component with tests

### DIFF
--- a/src/boot/global-components.js
+++ b/src/boot/global-components.js
@@ -1,9 +1,11 @@
 import { boot } from "quasar/wrappers";
 
 import VueQrcode from "@chenfengyuan/vue-qrcode";
+import InfoTooltip from "components/InfoTooltip.vue";
 
 // "async" is optional;
 // more info on params: https://v2.quasar.dev/quasar-cli/boot-files
 export default boot(async ({ app }) => {
   app.component(VueQrcode.name, VueQrcode);
+  app.component("InfoTooltip", InfoTooltip);
 });

--- a/src/components/InfoTooltip.vue
+++ b/src/components/InfoTooltip.vue
@@ -1,0 +1,21 @@
+<template>
+  <q-icon name="info_outline" color="grey">
+    <q-tooltip>
+      <slot>{{ text }}</slot>
+    </q-tooltip>
+  </q-icon>
+</template>
+
+<script>
+import { defineComponent } from "vue";
+
+export default defineComponent({
+  name: "InfoTooltip",
+  props: {
+    text: {
+      type: String,
+      default: "",
+    },
+  },
+});
+</script>

--- a/test/vitest/__tests__/infoTooltip.spec.ts
+++ b/test/vitest/__tests__/infoTooltip.spec.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import InfoTooltip from '../../src/components/InfoTooltip.vue'
+
+describe('InfoTooltip', () => {
+  it('shows tooltip on hover', async () => {
+    const wrapper = mount(InfoTooltip, { props: { text: 'Hello' } })
+    const icon = wrapper.find('.q-icon')
+    const tooltip = wrapper.find('.q-tooltip')
+    expect(tooltip.exists()).toBe(true)
+    expect(tooltip.isVisible()).toBe(false)
+    await icon.trigger('mouseenter')
+    await wrapper.vm.$nextTick()
+    expect(tooltip.isVisible()).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- add `InfoTooltip` component to render a `q-icon` with an optional tooltip
- globally register `InfoTooltip` in boot file
- test tooltip visibility on hover

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c93332b8083308255955be10ec91c