### PR TITLE
Add bucket-specific token import

### DIFF
--- a/src/components/BucketManager.vue
+++ b/src/components/BucketManager.vue
@@ -66,6 +66,13 @@
                 size="sm"
                 @click.stop.prevent="openDelete(bucket.id)"
               />
+              <q-btn
+                icon="arrow_circle_down"
+                flat
+                round
+                size="sm"
+                @click.stop.prevent="importTokens(bucket.id)"
+              />
             </q-item-section>
           </q-item>
         </router-link>
@@ -151,6 +158,8 @@
       </q-card-actions>
     </q-card>
   </q-dialog>
+
+  <ReceiveTokenDialog v-model="showReceiveTokens" />
 </template>
 
 <script>
@@ -162,6 +171,8 @@ import { useProofsStore } from "stores/proofs";
 import { storeToRefs } from "pinia";
 import { useUiStore } from "stores/ui";
 import { notifyError } from "src/js/notify";
+import ReceiveTokenDialog from "./ReceiveTokenDialog.vue";
+import { useReceiveTokensStore } from "stores/receiveTokensStore";
 
 export default defineComponent({
   name: "BucketManager",
@@ -172,6 +183,8 @@ export default defineComponent({
     const showForm = ref(false);
     const bucketForm = ref(null);
     const showDelete = ref(false);
+    const receiveTokensStore = useReceiveTokensStore();
+    const showReceiveTokens = storeToRefs(receiveTokensStore).showReceiveTokens;
     const editId = ref(null);
     const deleteId = ref(null);
     const form = ref({
@@ -253,6 +266,12 @@ export default defineComponent({
       showDelete.value = true;
     };
 
+    const importTokens = (id) => {
+      receiveTokensStore.receiveData.bucketId = id;
+      receiveTokensStore.receiveData.tokensBase64 = "";
+      showReceiveTokens.value = true;
+    };
+
     const deleteBucket = () => {
       bucketsStore.deleteBucket(deleteId.value);
       showDelete.value = false;
@@ -277,6 +296,8 @@ export default defineComponent({
       deleteBucket,
       formatCurrency,
       handleDrop,
+      importTokens,
+      showReceiveTokens,
     };
   },
 });

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1329,6 +1329,7 @@ export default {
   BucketDetail: {
     move: "Move tokens",
     send: "Send tokens",
+    import: "Import tokens",
     locked_tokens_heading: "Locked tokens",
     inputs: {
       target_bucket: {

--- a/src/pages/BucketDetail.vue
+++ b/src/pages/BucketDetail.vue
@@ -53,10 +53,14 @@
         <q-btn color="primary" outline :disable="!selectedSecrets.length" @click="sendSelected">
           {{ $t('BucketDetail.send') }}
         </q-btn>
+        <q-btn color="primary" outline @click="importTokens">
+          {{ $t('BucketDetail.import') }}
+        </q-btn>
       </div>
     </div>
 
     <SendTokenDialog />
+    <ReceiveTokenDialog v-model="showReceiveTokens" />
     <q-dialog v-model="editDialog.show">
       <q-card class="q-pa-md" style="max-width: 400px">
         <h6 class="q-mt-none q-mb-md">Edit token</h6>
@@ -98,9 +102,11 @@ import { useSendTokensStore } from 'stores/sendTokensStore';
 import { useTokensStore, HistoryToken } from 'stores/tokens';
 import { useLockedTokensStore } from 'stores/lockedTokens';
 import SendTokenDialog from 'components/SendTokenDialog.vue';
+import ReceiveTokenDialog from 'components/ReceiveTokenDialog.vue';
 import HistoryTable from 'components/HistoryTable.vue';
 import LockedTokensTable from 'components/LockedTokensTable.vue';
 import { notifyError } from 'src/js/notify';
+import { useReceiveTokensStore } from 'stores/receiveTokensStore';
 
 const route = useRoute();
 const bucketsStore = useBucketsStore();
@@ -110,6 +116,7 @@ const uiStore = useUiStore();
 const sendTokensStore = useSendTokensStore();
 const tokensStore = useTokensStore();
 const lockedTokensStore = useLockedTokensStore();
+const receiveTokensStore = useReceiveTokensStore();
 
 const bucketId = route.params.id as string;
 const bucket = computed(() => bucketsStore.bucketList.find(b => b.id === bucketId));
@@ -118,6 +125,7 @@ const bucketBalance = computed(() => bucketProofs.value.reduce((s,p)=>s+p.amount
 const bucketLockedTokens = computed(() => lockedTokensStore.tokensByBucket(bucketId));
 const { activeUnit } = storeToRefs(mintsStore);
 const showSendTokens = storeToRefs(sendTokensStore).showSendTokens;
+const showReceiveTokens = storeToRefs(receiveTokensStore).showReceiveTokens;
 
 const selectedSecrets = ref<string[]>([]);
 const targetBucketId = ref<string | null>(null);
@@ -233,5 +241,11 @@ function sendSelected(){
   sendTokensStore.clearSendData();
   sendTokensStore.sendData.tokensBase64 = token;
   showSendTokens.value = true;
+}
+
+function importTokens(){
+  receiveTokensStore.receiveData.bucketId = bucketId;
+  receiveTokensStore.receiveData.tokensBase64 = '';
+  showReceiveTokens.value = true;
 }
 </script>


### PR DESCRIPTION
## Summary
- enable importing tokens directly into a bucket
- support ReceiveTokenDialog in BucketManager and BucketDetail
- expose new i18n string for bucket token import

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_683c92bece7883308006161b4e5b767a