### PR TITLE
Add InfoTooltip components

### DIFF
--- a/src/components/BalanceView.vue
+++ b/src/components/BalanceView.vue
@@ -163,6 +163,10 @@
         {{ formatCurrency(pendingBalance, this.activeUnit) }}
         <q-tooltip>{{ $t("BalanceView.pending.tooltip") }}</q-tooltip>
       </q-btn>
+      <InfoTooltip
+        class="q-ml-xs"
+        :text="$t('BalanceView.pending.infoTooltip')"
+      />
     </div>
   </div>
   <!-- </q-card-section>
@@ -181,6 +185,7 @@ import { usePriceStore } from "stores/price";
 import { useBucketsStore } from "stores/buckets";
 import ToggleUnit from "components/ToggleUnit.vue";
 import AnimatedNumber from "components/AnimatedNumber.vue";
+import InfoTooltip from "./InfoTooltip.vue";
 import axios from "axios";
 import { map } from "underscore";
 
@@ -190,6 +195,7 @@ export default defineComponent({
   components: {
     ToggleUnit,
     AnimatedNumber,
+    InfoTooltip,
   },
   props: {
     setTab: Function,

--- a/src/components/BucketManager.vue
+++ b/src/components/BucketManager.vue
@@ -89,7 +89,10 @@
 
   <q-dialog v-model="showForm">
     <q-card class="q-pa-lg" style="max-width: 500px">
-      <h6 class="q-mt-none q-mb-md">{{ formTitle }}</h6>
+      <h6 class="q-mt-none q-mb-md">
+        {{ formTitle }}
+        <InfoTooltip :text="$t('BucketManager.info.tooltip')" />
+      </h6>
       <q-form ref="bucketForm">
         <q-input
           v-model="form.name"
@@ -162,6 +165,7 @@ import { useProofsStore } from "stores/proofs";
 import { storeToRefs } from "pinia";
 import { useUiStore } from "stores/ui";
 import { notifyError } from "src/js/notify";
+import InfoTooltip from "./InfoTooltip.vue";
 
 export default defineComponent({
   name: "BucketManager",
@@ -277,6 +281,7 @@ export default defineComponent({
       deleteBucket,
       formatCurrency,
       handleDrop,
+      InfoTooltip,
     };
   },
 });

--- a/src/components/InfoTooltip.vue
+++ b/src/components/InfoTooltip.vue
@@ -1,0 +1,19 @@
+<template>
+  <q-icon name="info" size="1rem" color="grey" class="q-ml-xs">
+    <q-tooltip>{{ text }}</q-tooltip>
+  </q-icon>
+</template>
+
+<script>
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+  name: 'InfoTooltip',
+  props: {
+    text: {
+      type: String,
+      required: true
+    }
+  }
+})
+</script>

--- a/src/components/SettingsView.vue
+++ b/src/components/SettingsView.vue
@@ -1354,9 +1354,13 @@
                       @click="checkActiveProofsSpendable"
                       >{{
                         $t("Settings.advanced.developer.remove_spent.button")
-                      }}</q-btn
-                    ></row
-                  ><row>
+                      }}</q-btn>
+                    <InfoTooltip
+                      class="q-ml-xs"
+                      :text="$t('Settings.tooltips.proofs')"
+                    />
+                  </row>
+                  <row>
                     <q-item-label class="q-px-sm" caption
                       >{{
                         $t(
@@ -1393,8 +1397,13 @@
                       {{
                         $t("Settings.advanced.developer.export_proofs.button")
                       }}
-                    </q-btn></row
-                  ><row>
+                    </q-btn>
+                    <InfoTooltip
+                      class="q-ml-xs"
+                      :text="$t('Settings.tooltips.proofs')"
+                    />
+                  </row>
+                  <row>
                     <q-item-label class="q-px-sm" caption
                       >{{
                         $t(
@@ -1601,6 +1610,7 @@ import { useReceiveTokensStore } from "../stores/receiveTokensStore";
 import { useWelcomeStore } from "src/stores/welcome";
 import { useStorageStore } from "src/stores/storage";
 import { useI18n } from "vue-i18n";
+import InfoTooltip from "./InfoTooltip.vue";
 
 export default defineComponent({
   name: "SettingsView",
@@ -1608,6 +1618,7 @@ export default defineComponent({
   components: {
     P2PKDialog,
     NWCDialog,
+    InfoTooltip,
   },
   props: {},
   data: function () {

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -191,6 +191,9 @@ export default {
       experimental: "EXPERIMENTAL",
       appearance: "APPEARANCE",
     },
+    tooltips: {
+      proofs: "Proofs are blinded signatures representing your ecash",
+    },
     backup_restore: {
       backup_seed: {
         title: "Backup seed phrase",
@@ -492,6 +495,7 @@ export default {
       },
       mints: {
         label: "Mints",
+        tooltip: "A mint issues ecash; choose which one you are using",
       },
       buckets: {
         label: "Buckets",
@@ -533,6 +537,7 @@ export default {
     pending: {
       label: "Pending",
       tooltip: "Check all pending tokens",
+      infoTooltip: "Pending tokens are reserved until the transaction settles",
     },
   },
   WelcomePage: {
@@ -1317,6 +1322,9 @@ export default {
       description: "Description",
       goal: "Goal (sat)",
     },
+    info: {
+      tooltip: "Buckets group tokens by purpose or goal",
+    },
     validation: {
       name: "Name is required",
       goal: "Goal must be positive",
@@ -1331,6 +1339,9 @@ export default {
     send: "Send tokens",
     export: "Export bucket",
     locked_tokens_heading: "Locked tokens",
+    info: {
+      tooltip: "Buckets group tokens by purpose or goal",
+    },
     inputs: {
       target_bucket: {
         label: "Move to bucket",

--- a/src/pages/BucketDetail.vue
+++ b/src/pages/BucketDetail.vue
@@ -1,7 +1,10 @@
 <template>
   <div class="q-pa-md" v-if="bucket">
     <div class="q-mb-lg">
-      <h5 class="q-my-none">{{ bucket.name }}</h5>
+      <h5 class="q-my-none">
+        {{ bucket.name }}
+        <InfoTooltip :text="$t('BucketDetail.info.tooltip')" />
+      </h5>
       <div v-if="bucket.description" class="text-caption q-mt-xs">{{ bucket.description }}</div>
       <div class="text-secondary q-mt-sm">
         <span>{{ formatCurrency(bucketBalance, activeUnit) }}</span>
@@ -104,6 +107,7 @@ import SendTokenDialog from 'components/SendTokenDialog.vue';
 import HistoryTable from 'components/HistoryTable.vue';
 import LockedTokensTable from 'components/LockedTokensTable.vue';
 import { notifyError } from 'src/js/notify';
+import InfoTooltip from 'components/InfoTooltip.vue';
 
 const route = useRoute();
 const bucketsStore = useBucketsStore();

--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -80,11 +80,10 @@
             :label="$t('WalletPage.tabs.invoices.label')"
           ></q-tab>
           <!-- <q-tab name="tokens" label="Tokens"></q-tab> -->
-          <q-tab
-            name="mints"
-            class="text-secondary"
-            :label="$t('WalletPage.tabs.mints.label')"
-          ></q-tab>
+          <q-tab name="mints" class="text-secondary">
+            <span>{{ $t('WalletPage.tabs.mints.label') }}</span>
+            <InfoTooltip :text="$t('WalletPage.tabs.mints.tooltip')" />
+          </q-tab>
           <q-tab
             name="buckets"
             class="text-secondary"
@@ -245,6 +244,7 @@ import iOSPWAPrompt from "components/iOSPWAPrompt.vue";
 import AndroidPWAPrompt from "components/AndroidPWAPrompt.vue";
 import ActivityOrb from "components/ActivityOrb.vue";
 import BucketManager from "components/BucketManager.vue";
+import InfoTooltip from "components/InfoTooltip.vue";
 
 // pinia stores
 import { mapActions, mapState, mapWritableState } from "pinia";
@@ -301,6 +301,7 @@ export default {
     ScanIcon,
     ActivityOrb,
     BucketManager,
+    InfoTooltip,
   },
   data: function () {
     return {


### PR DESCRIPTION
## Summary
- create `InfoTooltip` component for standard info icons
- add tooltip on "Mints" tab
- explain pending balance with tooltip
- describe what proofs are in Settings
- clarify bucket usage with tooltips
- document tooltips in English locale

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c93b3a8048330a4006eafb8b1e8fe