### PR TITLE
Add description tooltip to BucketManager

### DIFF
--- a/src/components/BucketManager.vue
+++ b/src/components/BucketManager.vue
@@ -108,11 +108,20 @@
         <q-input
           v-model="form.description"
           outlined
-          :label="$t('BucketManager.inputs.description')"
           type="textarea"
           autogrow
           class="q-mb-sm"
-        />
+        >
+          <template #label>
+            <div class="row items-center no-wrap">
+              <span>{{ $t('BucketManager.inputs.description') }}</span>
+              <InfoTooltip
+                class="q-ml-xs"
+                :text="$t('BucketManager.tooltips.description')"
+              />
+            </div>
+          </template>
+        </q-input>
         <q-input
           v-model.number="form.goal"
           outlined

--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -1237,6 +1237,11 @@ timelock: {
       },
     },
   },
+  BucketManager: {
+    tooltips: {
+      description: "\u062A\u064F\u0633\u062A\u062E\u062F\u0645 \u0627\u0644\u062D\u0627\u0648\u064A\u0627\u062A \u0644\u062A\u0635\u0646\u064A\u0641 \u0627\u0644\u062A\u0648\u0643\u0646\u0627\u062A",
+    },
+  },
   BucketDetail: {
     move: "Move tokens",
     send: "Send tokens",

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -1249,6 +1249,11 @@ export default {
       },
     },
   },
+  BucketManager: {
+    tooltips: {
+      description: "Buckets dienen zur Kategorisierung von Token",
+    },
+  },
   BucketDetail: {
     move: "Move tokens",
     send: "Send tokens",

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -1247,6 +1247,11 @@ timelock: {
       },
     },
   },
+  BucketManager: {
+    tooltips: {
+      description: "Τα buckets χρησιμοποιούνται για την κατηγοριοποίηση των token",
+    },
+  },
   BucketDetail: {
     move: "Move tokens",
     send: "Send tokens",

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1317,6 +1317,9 @@ export default {
       description: "Description",
       goal: "Goal (sat)",
     },
+    tooltips: {
+      description: "Buckets are for categorizing tokens",
+    },
     validation: {
       name: "Name is required",
       goal: "Goal must be positive",

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -1245,6 +1245,11 @@ timelock: {
       },
     },
   },
+  BucketManager: {
+    tooltips: {
+      description: "Los buckets sirven para categorizar los tokens",
+    },
+  },
   BucketDetail: {
     move: "Move tokens",
     send: "Send tokens",

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -1248,6 +1248,11 @@ timelock: {
       },
     },
   },
+  BucketManager: {
+    tooltips: {
+      description: "Les compartiments servent \u00e0 cat\u00e9goriser les jetons",
+    },
+  },
   BucketDetail: {
     move: "Move tokens",
     send: "Send tokens",

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -1242,6 +1242,11 @@ timelock: {
       },
     },
   },
+  BucketManager: {
+    tooltips: {
+      description: "I bucket servono per categorizzare i token",
+    },
+  },
   BucketDetail: {
     move: "Move tokens",
     send: "Send tokens",

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -1242,6 +1242,11 @@ timelock: {
       },
     },
   },
+  BucketManager: {
+    tooltips: {
+      description: "\u30D0\u30B1\u30C3\u30C8\u306F\u30C8\u30FC\u30AF\u30F3\u3092\u5206\u985E\u3059\u308B\u305F\u3081\u306E\u3082\u306E\u3067\u3059",
+    },
+  },
   BucketDetail: {
     move: "Move tokens",
     send: "Send tokens",

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -1242,6 +1242,11 @@ timelock: {
       },
     },
   },
+  BucketManager: {
+    tooltips: {
+      description: "Buckets anv\u00e4nds f\u00f6r att kategorisera tokens",
+    },
+  },
   BucketDetail: {
     move: "Move tokens",
     send: "Send tokens",

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -1239,6 +1239,11 @@ timelock: {
       },
     },
   },
+  BucketManager: {
+    tooltips: {
+      description: "\u0e1a\u0e31\u0e04\u0e40\u0e01\u0e47\u0e15\u0e43\u0e0a\u0e49\u0e2a\u0e33\u0e2b\u0e23\u0e31\u0e1a\u0e01\u0e32\u0e23\u0e08\u0e31\u0e14\u0e2b\u0e21\u0e27\u0e14\u0e42\u0e17\u0e40\u0e04\u0e19",
+    },
+  },
   BucketDetail: {
     move: "Move tokens",
     send: "Send tokens",

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -1244,6 +1244,11 @@ timelock: {
       },
     },
   },
+  BucketManager: {
+    tooltips: {
+      description: "Bucket'lar tokenleri kategorize etmek i\u00e7in kullan\u0131l\u0131r",
+    },
+  },
   BucketDetail: {
     move: "Move tokens",
     send: "Send tokens",

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -1232,6 +1232,11 @@ timelock: {
       },
     },
   },
+  BucketManager: {
+    tooltips: {
+      description: "\u6876\u7528\u4e8e\u5bf9\u4ee3\u5e01\u8fdb\u884c\u5206\u7c7b",
+    },
+  },
   BucketDetail: {
     move: "Move tokens",
     send: "Send tokens",

--- a/test/vitest/__tests__/bucketManagerForm.spec.ts
+++ b/test/vitest/__tests__/bucketManagerForm.spec.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest'
+import { shallowMount } from '@vue/test-utils'
+import BucketManager from '../../src/components/BucketManager.vue'
+
+vi.mock('../../src/stores/proofs', () => ({
+  useProofsStore: () => ({ moveProofs: vi.fn() })
+}))
+
+vi.mock('../../src/stores/buckets', () => ({
+  useBucketsStore: () => ({
+    bucketList: [],
+    bucketBalances: {},
+    addBucket: vi.fn(),
+    editBucket: vi.fn(),
+    deleteBucket: vi.fn(),
+  }),
+  DEFAULT_BUCKET_ID: 'b1'
+}))
+
+vi.mock('../../src/stores/mints', () => ({
+  useMintsStore: () => ({ activeUnit: 'sat' })
+}))
+
+vi.mock('../../src/stores/ui', () => ({
+  useUiStore: () => ({ formatCurrency: (a: number) => String(a) })
+}))
+
+vi.mock('../../src/js/notify', () => ({
+  notifyError: vi.fn(),
+}))
+
+describe('BucketManager form', () => {
+  it('renders description tooltip', async () => {
+    const wrapper = shallowMount(BucketManager)
+    const vm: any = wrapper.vm
+    vm.openAdd()
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('info-tooltip-stub').exists()).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- show an InfoTooltip for the description field in BucketManager
- translate new tooltip text in all locales
- test that the tooltip renders in the form

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c9447272883309686b1a034fb60fd