### PR TITLE
Add token validation helper

### DIFF
--- a/test/vitest/__tests__/receiveTokensStore.spec.ts
+++ b/test/vitest/__tests__/receiveTokensStore.spec.ts
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { useReceiveTokensStore } from "../../../src/stores/receiveTokensStore";
+import { cashuDb } from "../../../src/stores/dexie";
+
+const VALID_TOKEN =
+  "cashuAeyJ0b2tlbiI6W3sicHJvb2ZzIjpbeyJpZCI6IkkyeU4raVJZZmt6VCIsImFtb3VudCI6MSwiQyI6IjAyZTRkYmJmMGZmNDI4YTU4ZDZjNjZjMTljNjI0YWRlY2MxNzg0YzdlNTU5ODZhNGVmNDQ4NDM5MzZhM2M4ZjM1OSIsInNlY3JldCI6ImZHWVpzSlVjME1mU1orVlhGandEZXNsNkJScW5wNmRSblZpUGQ2L00yQ0k9In1dLCJtaW50IjoiaHR0cHM6Ly84MzMzLnNwYWNlOjMzMzgifV19";
+
+beforeEach(async () => {
+  localStorage.clear();
+  await cashuDb.delete();
+  await cashuDb.open();
+});
+
+describe("receiveTokensStore.decodeToken", () => {
+  it("decodes valid token", () => {
+    const store = useReceiveTokensStore();
+    const decoded = store.decodeToken(VALID_TOKEN);
+    expect(decoded?.mint).toBe("https://8333.space:3338");
+  });
+
+  it("rejects invalid prefix", () => {
+    const store = useReceiveTokensStore();
+    expect(store.decodeToken("bad")).toBeUndefined();
+  });
+
+  it("rejects malformed token", () => {
+    const store = useReceiveTokensStore();
+    expect(store.decodeToken("cashuAinvalid")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- improve token decoding with pre-validation
- extend receiveTokensStore tests for new decodeToken behavior

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c963982e883308d8e2685b4824375