### PR TITLE
Handle malformed NWC commands

### DIFF
--- a/src/stores/nwc.ts
+++ b/src/stores/nwc.ts
@@ -362,8 +362,19 @@ export const useNWCStore = defineStore("nwc", {
       conn: NWCConnection
     ) {
       // parse command to JSON object {method: 'pay_invoice', params: {invoice: '1234'}}
-      let nwcCommand: NWCCommand = JSON.parse(command);
+      let nwcCommand: NWCCommand;
       let result: NWCResult | NWCError;
+      try {
+        nwcCommand = JSON.parse(command);
+      } catch (e) {
+        console.log("### failed to parse NWC command", command);
+        result = {
+          result_type: "parse_error",
+          error: { code: "OTHER", message: "Failed to parse command" },
+        } as NWCError;
+        await this.replyNWC(result, event, conn);
+        return;
+      }
       console.log("### nwcCommand", nwcCommand);
       // parse "get_info" without params
       if (nwcCommand.method == "get_info") {


### PR DESCRIPTION
## Summary
- handle invalid JSON in `parseNWCCommand`

## Testing
- `npm run test:ci` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c9778d3a083309e4238dc15af50ef