### PR TITLE
Add message sanitization utility

### DIFF
--- a/src/js/message-utils.ts
+++ b/src/js/message-utils.ts
@@ -1,0 +1,5 @@
+export function sanitizeMessage(message: string, maxLength = 1000): string {
+  if (!message) return "";
+  const sanitized = message.replace(/[^\x09\x0A\x0D\x20-\x7E]/g, "");
+  return sanitized.slice(0, maxLength);
+}

--- a/src/pages/Chats.vue
+++ b/src/pages/Chats.vue
@@ -5,7 +5,7 @@
         <div class="text-h6 q-mb-sm">{{ shorten(pubkey) }}</div>
         <q-item v-for="msg in messages" :key="msg.id">
           <q-item-section>
-            <q-item-label>{{ msg.content }}</q-item-label>
+            <q-item-label>{{ sanitizeMessage(msg.content) }}</q-item-label>
             <q-item-label caption>{{ formatDate(msg.created_at) }} - {{ msg.outgoing ? 'out' : 'in' }}</q-item-label>
           </q-item-section>
         </q-item>
@@ -18,6 +18,7 @@
 import { defineComponent } from 'vue';
 import { useDmChatsStore } from 'src/stores/dmChats';
 import { storeToRefs } from 'pinia';
+import { sanitizeMessage } from 'src/js/message-utils';
 
 export default defineComponent({
   name: 'ChatsPage',
@@ -27,7 +28,7 @@ export default defineComponent({
     const { chats } = storeToRefs(store);
     const shorten = (p) => p.slice(0, 8) + '...' + p.slice(-4);
     const formatDate = (ts) => new Date(ts * 1000).toLocaleString();
-    return { chats, shorten, formatDate };
+    return { chats, shorten, formatDate, sanitizeMessage }; 
   }
 });
 </script>

--- a/src/stores/dmChats.ts
+++ b/src/stores/dmChats.ts
@@ -1,6 +1,7 @@
 import { defineStore } from "pinia";
 import { useLocalStorage } from "@vueuse/core";
 import type { NDKEvent } from "@nostr-dev-kit/ndk";
+import { sanitizeMessage } from "../js/message-utils";
 
 export type DMMessage = {
   id: string;
@@ -30,7 +31,7 @@ export const useDmChatsStore = defineStore("dmChats", {
       const msg: DMMessage = {
         id: event.id,
         pubkey: event.pubkey,
-        content: event.content,
+        content: sanitizeMessage(event.content),
         created_at: event.created_at,
         outgoing: false,
       };
@@ -45,7 +46,7 @@ export const useDmChatsStore = defineStore("dmChats", {
       const msg: DMMessage = {
         id: event.id,
         pubkey: recipient,
-        content: event.content,
+        content: sanitizeMessage(event.content),
         created_at: event.created_at,
         outgoing: true,
       };

--- a/test/vitest/__tests__/message-utils.spec.ts
+++ b/test/vitest/__tests__/message-utils.spec.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { sanitizeMessage } from '../../../src/js/message-utils';
+
+describe('sanitizeMessage', () => {
+  it('removes non printable characters', () => {
+    const result = sanitizeMessage('hi\u0007there');
+    expect(result).toBe('hithere');
+  });
+
+  it('truncates to max length', () => {
+    const result = sanitizeMessage('abcdef', 3);
+    expect(result).toBe('abc');
+  });
+});


### PR DESCRIPTION
## Summary
- add `sanitizeMessage` helper
- sanitize messages when saving DM chats
- sanitize message content during display
- test `sanitizeMessage`

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c978078c88330a6e4385364e001a4