### PR TITLE
Add tooltips for major inputs

### DIFF
--- a/src/components/AddMintDialog.vue
+++ b/src/components/AddMintDialog.vue
@@ -13,12 +13,21 @@
         outlined
         readonly
         v-model="mintUrl"
-        :label="$t('AddMintDialog.inputs.mint_url.label')"
         type="textarea"
         autogrow
         class="q-mb-xs"
         style="font-family: monospace; font-size: 0.9em"
-      ></q-input>
+      >
+        <template #label>
+          <div class="row items-center no-wrap">
+            <span>{{ $t('AddMintDialog.inputs.mint_url.label') }}</span>
+            <InfoTooltip
+              class="q-ml-xs"
+              :text="$t('AddMintDialog.tooltips.mint_url')"
+            />
+          </div>
+        </template>
+      </q-input>
       <div class="row q-mt-lg">
         <div class="col">
           <q-btn

--- a/src/components/EditMintDialog.vue
+++ b/src/components/EditMintDialog.vue
@@ -8,20 +8,38 @@
       <q-input
         outlined
         v-model="editMintData.url"
-        :label="$t('EditMintDialog.inputs.mint_url.label')"
         type="textarea"
         autogrow
         class="q-mb-xs"
         style="font-family: monospace; font-size: 0.9em"
-      ></q-input>
+      >
+        <template #label>
+          <div class="row items-center no-wrap">
+            <span>{{ $t('EditMintDialog.inputs.mint_url.label') }}</span>
+            <InfoTooltip
+              class="q-ml-xs"
+              :text="$t('EditMintDialog.tooltips.mint_url')"
+            />
+          </div>
+        </template>
+      </q-input>
       <q-input
         outlined
         v-model="editMintData.nickname"
-        :label="$t('EditMintDialog.inputs.nickname.label')"
         type="textarea"
         autogrow
         class="q-mb-xs"
-      ></q-input>
+      >
+        <template #label>
+          <div class="row items-center no-wrap">
+            <span>{{ $t('EditMintDialog.inputs.nickname.label') }}</span>
+            <InfoTooltip
+              class="q-ml-xs"
+              :text="$t('EditMintDialog.tooltips.nickname')"
+            />
+          </div>
+        </template>
+      </q-input>
       <div class="row q-mt-lg">
         <q-btn
           class="float-left"

--- a/src/components/FindCreatorsView.vue
+++ b/src/components/FindCreatorsView.vue
@@ -5,10 +5,18 @@
       outlined
       dense
       v-model="searchInput"
-      :label="$t('FindCreators.inputs.search.label')"
       :placeholder="$t('FindCreators.inputs.search.placeholder')"
       @keydown.enter.prevent="triggerSearch"
     >
+      <template #label>
+        <div class="row items-center no-wrap">
+          <span>{{ $t('FindCreators.inputs.search.label') }}</span>
+          <InfoTooltip
+            class="q-ml-xs"
+            :text="$t('FindCreators.inputs.search.tooltip')"
+          />
+        </div>
+      </template>
       <template v-slot:append>
         <q-icon name="search" class="cursor-pointer" @click="triggerSearch" />
       </template>

--- a/src/components/RestoreView.vue
+++ b/src/components/RestoreView.vue
@@ -16,14 +16,20 @@
                 <q-input
                   outlined
                   v-model="mnemonicToRestore"
-                  :label="
-                    $t('RestoreView.seed_phrase.inputs.seed_phrase.label')
-                  "
                   autogrow
                   type="textarea"
                   :error="mnemonicError !== ''"
                   :error-message="mnemonicError"
                 >
+                  <template #label>
+                    <div class="row items-center no-wrap">
+                      <span>{{ $t('RestoreView.seed_phrase.inputs.seed_phrase.label') }}</span>
+                      <InfoTooltip
+                        class="q-ml-xs"
+                        :text="$t('RestoreView.seed_phrase.inputs.seed_phrase.tooltip')"
+                      />
+                    </div>
+                  </template>
                   <template v-slot:append>
                     <q-btn
                       flat

--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -462,6 +462,9 @@ export default {
       receive: {
         label: "@:global.actions.receive.label",
       },
+      scan: {
+        tooltip: "Scan a QR code",
+      },
     },
     tabs: {
       history: {
@@ -605,6 +608,7 @@ export default {
       seed_phrase: {
         label: "عبارة الاستعادة",
         caption: "يمكنك رؤية عبارة الاستعادة الخاصة بك في الإعدادات.",
+        tooltip: "This phrase restores your wallet. Keep it private",
       },
       checkbox: {
         label: "لقد كتبتها",
@@ -649,6 +653,7 @@ export default {
         seed_phrase: {
           label: "عبارة الاستعادة",
           caption: "يمكنك رؤية عبارة الاستعادة الخاصة بك في الإعدادات.",
+          tooltip: "Enter the 12-word recovery phrase",
         },
       },
     },
@@ -1228,6 +1233,10 @@ timelock: {
         label: "@:global.inputs.mint_url.label",
       },
     },
+    tooltips: {
+      mint_url: "Update the mint's base URL",
+      nickname: "Friendly name for this mint",
+    },
     actions: {
       cancel: {
         label: "@:global.actions.cancel.label",
@@ -1245,6 +1254,9 @@ timelock: {
       mint_url: {
         label: "@:global.inputs.mint_url.label",
       },
+    },
+    tooltips: {
+      mint_url: "URL of the mint you want to add",
     },
     actions: {
       cancel: {
@@ -1268,6 +1280,9 @@ timelock: {
       target_bucket: {
         label: "Move to bucket",
       },
+    },
+    tooltips: {
+      target_bucket: "Choose a bucket to receive the selected tokens",
     },
     not_found: "Bucket not found.",
   },

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -1240,6 +1240,10 @@ export default {
         label: "@:global.inputs.mint_url.label",
       },
     },
+    tooltips: {
+      mint_url: "Basis-URL der Mint",
+      nickname: "Bezeichner für diese Mint",
+    },
     actions: {
       cancel: {
         label: "@:global.actions.cancel.label",
@@ -1257,6 +1261,9 @@ export default {
       mint_url: {
         label: "@:global.inputs.mint_url.label",
       },
+    },
+    tooltips: {
+      mint_url: "URL der hinzuzufügenden Mint",
     },
     actions: {
       cancel: {
@@ -1280,6 +1287,9 @@ export default {
       target_bucket: {
         label: "Move to bucket",
       },
+    },
+    tooltips: {
+      target_bucket: "Wähle einen Bucket für die Tokens",
     },
     not_found: "Bucket not found.",
   },

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -470,6 +470,9 @@ export default {
       receive: {
         label: "@:global.actions.receive.label",
       },
+      scan: {
+        tooltip: "Scan a QR code",
+      },
     },
     tabs: {
       history: {
@@ -613,6 +616,7 @@ export default {
       seed_phrase: {
         label: "Φράση Seed",
         caption: "Μπορείτε να δείτε τη φράση seed σας στις ρυθμίσεις.",
+        tooltip: "This phrase restores your wallet. Keep it private",
       },
       checkbox: {
         label: "Την έχω γράψει",
@@ -657,6 +661,7 @@ export default {
         seed_phrase: {
           label: "Φράση seed",
           caption: "Μπορείτε να δείτε τη φράση seed σας στις ρυθμίσεις.",
+          tooltip: "Enter the 12-word recovery phrase",
         },
       },
     },
@@ -1238,6 +1243,10 @@ timelock: {
         label: "@:global.inputs.mint_url.label",
       },
     },
+    tooltips: {
+      mint_url: "Update the mint's base URL",
+      nickname: "Friendly name for this mint",
+    },
     actions: {
       cancel: {
         label: "@:global.actions.cancel.label",
@@ -1255,6 +1264,9 @@ timelock: {
       mint_url: {
         label: "@:global.inputs.mint_url.label",
       },
+    },
+    tooltips: {
+      mint_url: "URL of the mint you want to add",
     },
     actions: {
       cancel: {
@@ -1278,6 +1290,9 @@ timelock: {
       target_bucket: {
         label: "Move to bucket",
       },
+    },
+    tooltips: {
+      target_bucket: "Choose a bucket to receive the selected tokens",
     },
     not_found: "Bucket not found.",
   },

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -482,6 +482,9 @@ export default {
       receive: {
         label: "@:global.actions.receive.label",
       },
+      scan: {
+        tooltip: "Scan a QR code",
+      },
     },
     tabs: {
       history: {
@@ -628,6 +631,7 @@ export default {
       seed_phrase: {
         label: "Seed Phrase",
         caption: "You can see your seed phrase in the settings.",
+        tooltip: "This phrase restores your wallet. Keep it private",
       },
       checkbox: {
         label: "I have written it down",
@@ -672,6 +676,7 @@ export default {
         seed_phrase: {
           label: "Seed phrase",
           caption: "You can see your seed phrase in the settings.",
+          tooltip: "Enter the 12-word recovery phrase",
         },
       },
     },
@@ -1257,6 +1262,10 @@ export default {
         label: "@:global.inputs.mint_url.label",
       },
     },
+    tooltips: {
+      mint_url: "Update the mint's base URL",
+      nickname: "Friendly name for this mint",
+    },
     actions: {
       cancel: {
         label: "@:global.actions.cancel.label",
@@ -1275,6 +1284,9 @@ export default {
         label: "@:global.inputs.mint_url.label",
       },
     },
+    tooltips: {
+      mint_url: "URL of the mint you want to add",
+    },
     actions: {
       cancel: {
         label: "@:global.actions.cancel.label",
@@ -1290,6 +1302,7 @@ export default {
       search: {
         label: "Search creators",
         placeholder: "npub or hex public key",
+        tooltip: "Search for creators by public key",
       },
     },
     labels: {
@@ -1357,6 +1370,9 @@ export default {
       target_bucket: {
         label: "Move to bucket",
       },
+    },
+    tooltips: {
+      target_bucket: "Choose a bucket to receive the selected tokens",
     },
     not_found: "Bucket not found.",
   },

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -468,6 +468,9 @@ export default {
       receive: {
         label: "@:global.actions.receive.label",
       },
+      scan: {
+        tooltip: "Scan a QR code",
+      },
     },
     tabs: {
       history: {
@@ -611,6 +614,7 @@ export default {
       seed_phrase: {
         label: "Frase Semilla",
         caption: "Puedes ver tu frase semilla en la configuración.",
+        tooltip: "This phrase restores your wallet. Keep it private",
       },
       checkbox: {
         label: "La he anotado",
@@ -655,6 +659,7 @@ export default {
         seed_phrase: {
           label: "Frase semilla",
           caption: "Puedes ver tu frase semilla en la configuración.",
+          tooltip: "Enter the 12-word recovery phrase",
         },
       },
     },
@@ -1236,6 +1241,10 @@ timelock: {
         label: "@:global.inputs.mint_url.label",
       },
     },
+    tooltips: {
+      mint_url: "Update the mint's base URL",
+      nickname: "Friendly name for this mint",
+    },
     actions: {
       cancel: {
         label: "@:global.actions.cancel.label",
@@ -1253,6 +1262,9 @@ timelock: {
       mint_url: {
         label: "@:global.inputs.mint_url.label",
       },
+    },
+    tooltips: {
+      mint_url: "URL of the mint you want to add",
     },
     actions: {
       cancel: {
@@ -1276,6 +1288,9 @@ timelock: {
       target_bucket: {
         label: "Move to bucket",
       },
+    },
+    tooltips: {
+      target_bucket: "Choose a bucket to receive the selected tokens",
     },
     not_found: "Bucket not found.",
   },

--- a/src/pages/BucketDetail.vue
+++ b/src/pages/BucketDetail.vue
@@ -39,13 +39,24 @@
 
     <div class="q-mt-lg">
       <q-select
-        dense outlined
+        dense
+        outlined
         v-model="targetBucketId"
         :options="bucketOptions"
-        :label="$t('BucketDetail.inputs.target_bucket.label')"
-        emit-value map-options
+        emit-value
+        map-options
         class="q-mb-md"
-      />
+      >
+        <template #label>
+          <div class="row items-center no-wrap">
+            <span>{{ $t('BucketDetail.inputs.target_bucket.label') }}</span>
+            <InfoTooltip
+              class="q-ml-xs"
+              :text="$t('BucketDetail.inputs.target_bucket.tooltip')"
+            />
+          </div>
+        </template>
+      </q-select>
       <div class="row q-gutter-sm">
         <q-btn color="primary" :disable="!selectedSecrets.length" @click="moveSelected">
           {{ $t('BucketDetail.move') }}

--- a/src/pages/MoveProofs.vue
+++ b/src/pages/MoveProofs.vue
@@ -6,11 +6,20 @@
       outlined
       v-model="targetBucketId"
       :options="bucketOptions"
-      :label="$t('BucketDetail.inputs.target_bucket.label')"
       emit-value
       map-options
       class="q-mb-md"
-    />
+    >
+      <template #label>
+        <div class="row items-center no-wrap">
+          <span>{{ $t('BucketDetail.inputs.target_bucket.label') }}</span>
+          <InfoTooltip
+            class="q-ml-xs"
+            :text="$t('BucketDetail.inputs.target_bucket.tooltip')"
+          />
+        </div>
+      </template>
+    </q-select>
     <q-btn
       color="primary"
       :disable="!selectedSecrets.length || !targetBucketId"

--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -27,10 +27,14 @@
 
         <transition appear enter-active-class="animated pulse">
           <div class="scan-button-container">
-            <q-btn size="lg" outline color="primary" flat @click="showCamera">
-              <ScanIcon size="2em" />
-            </q-btn>
-          </div>
+          <q-btn size="lg" outline color="primary" flat @click="showCamera">
+            <ScanIcon size="2em" />
+          </q-btn>
+          <InfoTooltip
+            class="q-mt-sm"
+            :text="$t('WalletPage.actions.scan.tooltip')"
+          />
+        </div>
         </transition>
 
         <!-- button to showSendDialog -->

--- a/src/pages/welcome/WelcomeSlide3.vue
+++ b/src/pages/welcome/WelcomeSlide3.vue
@@ -11,9 +11,17 @@
         readonly
         autogrow
         class="q-mt-md q-pa-md seed-phrase"
-        :label="$t('WelcomeSlide3.inputs.seed_phrase.label')"
         dense
       >
+        <template #label>
+          <div class="row items-center no-wrap">
+            <span>{{ $t('WelcomeSlide3.inputs.seed_phrase.label') }}</span>
+            <InfoTooltip
+              class="q-ml-xs"
+              :text="$t('WelcomeSlide3.tooltips.seed_phrase')"
+            />
+          </div>
+        </template>
         <template v-slot:append>
           <q-btn
             flat


### PR DESCRIPTION
## Summary
- add InfoTooltip components near various buttons and inputs
- document tooltip text in translation files

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c9928486c8330a60bb1645a1a220d