### PR TITLE
Add aria labels for icon-only buttons

### DIFF
--- a/src/components/AndroidPWAPrompt.vue
+++ b/src/components/AndroidPWAPrompt.vue
@@ -20,6 +20,8 @@
           @click="closePrompt"
           size="sm"
           class="close-btn q-px-sm"
+          :aria-label="$t('global.actions.close.label')"
+          :title="$t('global.actions.close.label')"
         />
       </div>
 

--- a/src/components/BucketManager.vue
+++ b/src/components/BucketManager.vue
@@ -58,6 +58,8 @@
                 round
                 size="sm"
                 @click.stop.prevent="openEdit(bucket)"
+                aria-label="Edit"
+                title="Edit"
               />
               <q-btn
                 icon="delete"
@@ -65,6 +67,8 @@
                 round
                 size="sm"
                 @click.stop.prevent="openDelete(bucket.id)"
+                :aria-label="$t('BucketManager.actions.delete')"
+                :title="$t('BucketManager.actions.delete')"
               />
             </q-item-section>
           </q-item>

--- a/src/components/HistoryTable.vue
+++ b/src/components/HistoryTable.vue
@@ -64,6 +64,8 @@
             icon="edit"
             @click.stop="openEditLabel(token)"
             class="cursor-pointer"
+            :aria-label="$t('HistoryTable.actions.edit_label.tooltip_text')"
+            :title="$t('HistoryTable.actions.edit_label.tooltip_text')"
           >
             <q-tooltip>{{
               $t('HistoryTable.actions.edit_label.tooltip_text')
@@ -76,6 +78,8 @@
             @click="checkTokenSpendable(token)"
             class="cursor-pointer"
             v-if="token.status === 'pending' && token.amount < 0"
+            :aria-label="$t('HistoryTable.actions.check_status.tooltip_text')"
+            :title="$t('HistoryTable.actions.check_status.tooltip_text')"
           >
             <q-tooltip>{{
               $t("HistoryTable.actions.check_status.tooltip_text")
@@ -88,6 +92,8 @@
             @click="receiveToken(token.token)"
             class="cursor-pointer"
             v-if="token.status === 'pending' && token.amount > 0"
+            :aria-label="$t('HistoryTable.actions.receive.tooltip_text')"
+            :title="$t('HistoryTable.actions.receive.tooltip_text')"
           >
             <q-tooltip>{{
               $t("HistoryTable.actions.receive.tooltip_text")

--- a/src/components/InvoicesTable.vue
+++ b/src/components/InvoicesTable.vue
@@ -52,6 +52,8 @@
               class="cursor-pointer"
               v-if="invoice.status === 'pending'"
               style="position: absolute; right: 0"
+              :aria-label="$t('InvoiceTable.actions.check_status.tooltip_text')"
+              :title="$t('InvoiceTable.actions.check_status.tooltip_text')"
             >
               <q-tooltip>{{
                 $t("InvoiceTable.actions.check_status.tooltip_text")

--- a/src/components/LockedTokensTable.vue
+++ b/src/components/LockedTokensTable.vue
@@ -42,7 +42,14 @@
           </q-item-label>
         </q-item-section>
         <q-item-section side>
-          <q-btn flat dense icon="content_copy" @click="copyText(token.token)">
+          <q-btn
+            flat
+            dense
+            icon="content_copy"
+            @click="copyText(token.token)"
+            :aria-label="$t('LockedTokensTable.actions.copy.tooltip_text')"
+            :title="$t('LockedTokensTable.actions.copy.tooltip_text')"
+          >
             <q-tooltip>{{
               $t("LockedTokensTable.actions.copy.tooltip_text")
             }}</q-tooltip>

--- a/src/components/ReceiveDialog.vue
+++ b/src/components/ReceiveDialog.vue
@@ -9,7 +9,16 @@
   >
     <q-card :class="[cardClass, 'full-width-card q-pb-lg']">
       <q-card-section class="row items-center q-pb-sm">
-        <q-btn flat round dense v-close-popup class="q-ml-sm" color="primary">
+        <q-btn
+          flat
+          round
+          dense
+          v-close-popup
+          class="q-ml-sm"
+          color="primary"
+          :aria-label="$t('global.actions.close.label')"
+          :title="$t('global.actions.close.label')"
+        >
           <XIcon />
         </q-btn>
         <div class="col text-center">
@@ -22,6 +31,8 @@
           class="q-mr-sm"
           @click="showCamera"
           color="primary"
+          :aria-label="$t('global.actions.scan.label')"
+          :title="$t('global.actions.scan.label')"
         >
           <ScanIcon />
         </q-btn>

--- a/src/components/SendDialog.vue
+++ b/src/components/SendDialog.vue
@@ -9,7 +9,16 @@
   >
     <q-card :class="[cardClass, 'full-width-card q-pb-lg']">
       <q-card-section class="row items-center q-pb-sm">
-        <q-btn flat round dense v-close-popup class="q-ml-sm" color="primary">
+        <q-btn
+          flat
+          round
+          dense
+          v-close-popup
+          class="q-ml-sm"
+          color="primary"
+          :aria-label="$t('global.actions.close.label')"
+          :title="$t('global.actions.close.label')"
+        >
           <XIcon />
         </q-btn>
         <div class="col text-center">
@@ -22,6 +31,8 @@
           class="q-mr-sm"
           @click="showCamera"
           color="primary"
+          :aria-label="$t('global.actions.scan.label')"
+          :title="$t('global.actions.scan.label')"
         >
           <ScanIcon />
         </q-btn>

--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -180,6 +180,8 @@
                   v-if="canPasteFromClipboard && !sendData.p2pkPubkey"
                   icon="content_paste"
                   @click="pasteToP2PKField"
+                  :aria-label="$t('SendTokenDialog.actions.paste_p2pk_pubkey.tooltip_text')"
+                  :title="$t('SendTokenDialog.actions.paste_p2pk_pubkey.tooltip_text')"
                   ><q-tooltip>{{
                     $t("SendTokenDialog.actions.paste_p2pk_pubkey.tooltip_text")
                   }}</q-tooltip></q-btn
@@ -192,6 +194,8 @@
                 color="primary"
                 round
                 @click="showCamera"
+                :aria-label="$t('global.actions.scan.label')"
+                :title="$t('global.actions.scan.label')"
                 ><ScanIcon size="1.5em"
                 /></q-btn>
               </div>
@@ -467,6 +471,8 @@
                     @click="
                       copyText(baseURL + '#token=' + sendData.tokensBase64)
                     "
+                    :aria-label="$t('SendTokenDialog.actions.copy_link.tooltip_text')"
+                    :title="$t('SendTokenDialog.actions.copy_link.tooltip_text')"
                     ><q-tooltip>{{
                       $t("SendTokenDialog.actions.copy_link.tooltip_text")
                     }}</q-tooltip></q-btn
@@ -482,6 +488,8 @@
                       sendData.historyAmount < 0
                     "
                     @click="showCamera"
+                    :aria-label="$t('global.actions.scan.label')"
+                    :title="$t('global.actions.scan.label')"
                   >
                     <ScanIcon />
                   </q-btn>
@@ -499,6 +507,16 @@
                     size="sm"
                     @click="writeTokensToCard"
                     flat
+                    :aria-label="
+                      ndefSupported
+                        ? $t('SendTokenDialog.actions.write_tokens_to_card.tooltips.ndef_supported_text')
+                        : $t('SendTokenDialog.actions.write_tokens_to_card.tooltips.ndef_unsupported_text')
+                    "
+                    :title="
+                      ndefSupported
+                        ? $t('SendTokenDialog.actions.write_tokens_to_card.tooltips.ndef_supported_text')
+                        : $t('SendTokenDialog.actions.write_tokens_to_card.tooltips.ndef_unsupported_text')
+                    "
                   >
                     <NfcIcon />
                     <q-tooltip>{{
@@ -525,6 +543,8 @@
                       closeCardScanner();
                     "
                     flat
+                    :aria-label="$t('SendTokenDialog.actions.delete.tooltip_text')"
+                    :title="$t('SendTokenDialog.actions.delete.tooltip_text')"
                   >
                     <q-tooltip>{{
                       $t("SendTokenDialog.actions.delete.tooltip_text")

--- a/src/components/SettingsView.vue
+++ b/src/components/SettingsView.vue
@@ -39,6 +39,8 @@
                       color="primary"
                       class="cursor-pointer q-mt-md"
                       @click="toggleMnemonicVisibility"
+                      aria-label="Toggle visibility"
+                      title="Toggle visibility"
                     ></q-btn>
                     <q-btn
                       flat
@@ -47,6 +49,8 @@
                       color="primary"
                       class="cursor-pointer q-mt-md"
                       @click="copyText(mnemonic)"
+                      :aria-label="$t('global.actions.copy.label')"
+                      :title="$t('global.actions.copy.label')"
                     ></q-btn>
                   </template>
                 </q-input>
@@ -134,6 +138,8 @@
                       size="xs"
                       color="grey"
                       class="q-mr-sm cursor-pointer"
+                      :aria-label="$t('Settings.lightning_address.address.copy_tooltip')"
+                      :title="$t('Settings.lightning_address.address.copy_tooltip')"
                     >
                       <q-tooltip>{{
                         $t("Settings.lightning_address.address.copy_tooltip")
@@ -464,6 +470,8 @@
                 size="xs"
                 color="grey"
                 class="q-mr-sm cursor-pointer"
+                :aria-label="$t('Settings.nostr_wallet_connect.connection.copy_tooltip')"
+                :title="$t('Settings.nostr_wallet_connect.connection.copy_tooltip')"
                 ><q-tooltip>{{
                   $t("Settings.nostr_wallet_connect.connection.copy_tooltip")
                 }}</q-tooltip></q-icon
@@ -479,6 +487,8 @@
                 size="1.3em"
                 color="grey"
                 class="q-mr-sm cursor-pointer"
+                :aria-label="$t('Settings.nostr_wallet_connect.connection.qr_tooltip')"
+                :title="$t('Settings.nostr_wallet_connect.connection.qr_tooltip')"
               >
                 <q-tooltip>{{
                   $t("Settings.nostr_wallet_connect.connection.qr_tooltip")
@@ -1124,6 +1134,8 @@
                     icon="format_color_fill"
                     color="grey"
                     size="md"
+                    :aria-label="$t('Settings.appearance.theme.tooltips.mono')"
+                    :title="$t('Settings.appearance.theme.tooltips.mono')"
                     ><q-tooltip>{{
                       $t("Settings.appearance.theme.tooltips.mono")
                     }}</q-tooltip>
@@ -1136,6 +1148,8 @@
                     icon="format_color_fill"
                     color="green"
                     size="md"
+                    :aria-label="$t('Settings.appearance.theme.tooltips.cyber')"
+                    :title="$t('Settings.appearance.theme.tooltips.cyber')"
                     ><q-tooltip>{{
                       $t("Settings.appearance.theme.tooltips.cyber")
                     }}</q-tooltip>
@@ -1148,6 +1162,8 @@
                     icon="format_color_fill"
                     color="pink-13"
                     size="md"
+                    :aria-label="$t('Settings.appearance.theme.tooltips.freedom')"
+                    :title="$t('Settings.appearance.theme.tooltips.freedom')"
                     ><q-tooltip>{{
                       $t("Settings.appearance.theme.tooltips.freedom")
                     }}</q-tooltip>
@@ -1160,6 +1176,8 @@
                     icon="format_color_fill"
                     color="deep-purple"
                     size="md"
+                    :aria-label="$t('Settings.appearance.theme.tooltips.nostr')"
+                    :title="$t('Settings.appearance.theme.tooltips.nostr')"
                     ><q-tooltip>{{
                       $t("Settings.appearance.theme.tooltips.nostr")
                     }}</q-tooltip>
@@ -1172,6 +1190,8 @@
                     icon="format_color_fill"
                     color="orange"
                     size="md"
+                    :aria-label="$t('Settings.appearance.theme.tooltips.bitcoin')"
+                    :title="$t('Settings.appearance.theme.tooltips.bitcoin')"
                     ><q-tooltip>{{
                       $t("Settings.appearance.theme.tooltips.bitcoin")
                     }}</q-tooltip>
@@ -1184,6 +1204,10 @@
                     icon="format_color_fill"
                     color="light-green-9"
                     size="md"
+                    :aria-label="$t('Settings.appearance.theme.tooltips.mint')"
+                    :title="$t('Settings.appearance.theme.tooltips.mint')"
+                    :aria-label="$t('Settings.appearance.theme.tooltips.mint')"
+                    :title="$t('Settings.appearance.theme.tooltips.mint')"
                     ><q-tooltip>{{
                       $t("Settings.appearance.theme.tooltips.mint")
                     }}</q-tooltip> </q-btn
@@ -1195,6 +1219,8 @@
                     icon="format_color_fill"
                     color="brown"
                     size="md"
+                    :aria-label="$t('Settings.appearance.theme.tooltips.nut')"
+                    :title="$t('Settings.appearance.theme.tooltips.nut')"
                     ><q-tooltip>{{
                       $t("Settings.appearance.theme.tooltips.nut")
                     }}</q-tooltip>
@@ -1207,6 +1233,8 @@
                     icon="format_color_fill"
                     color="blue-10"
                     size="md"
+                    :aria-label="$t('Settings.appearance.theme.tooltips.blu')"
+                    :title="$t('Settings.appearance.theme.tooltips.blu')"
                     ><q-tooltip>{{
                       $t("Settings.appearance.theme.tooltips.blu")
                     }}</q-tooltip>
@@ -1219,6 +1247,8 @@
                     icon="format_color_fill"
                     color="pink-3"
                     size="md"
+                    :aria-label="$t('Settings.appearance.theme.tooltips.flamingo')"
+                    :title="$t('Settings.appearance.theme.tooltips.flamingo')"
                     ><q-tooltip>{{
                       $t("Settings.appearance.theme.tooltips.flamingo")
                     }}</q-tooltip>

--- a/src/pages/BucketDetail.vue
+++ b/src/pages/BucketDetail.vue
@@ -32,7 +32,14 @@
           </q-item-label>
         </q-item-section>
         <q-item-section side v-if="group.tokens.length">
-          <q-btn flat dense icon="edit" @click.stop="openEditGroup(group)" />
+          <q-btn
+            flat
+            dense
+            icon="edit"
+            @click.stop="openEditGroup(group)"
+            aria-label="Edit"
+            title="Edit"
+          />
         </q-item-section>
       </q-item>
     </q-list>

--- a/src/pages/welcome/WelcomeSlide3.vue
+++ b/src/pages/welcome/WelcomeSlide3.vue
@@ -29,6 +29,8 @@
             icon="visibility"
             class="cursor-pointer q-mt-md"
             @click="toggleMnemonicVisibility"
+            aria-label="Toggle visibility"
+            title="Toggle visibility"
           ></q-btn>
           <q-btn
             flat
@@ -36,6 +38,8 @@
             icon="content_copy"
             class="cursor-pointer q-mt-md"
             @click="copyText(walletStore.mnemonic)"
+            :aria-label="$t('global.actions.copy.label')"
+            :title="$t('global.actions.copy.label')"
           ></q-btn>
         </template>
       </q-input>


### PR DESCRIPTION
## Summary
- improve accessibility by labeling icon-only buttons

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683c9eaa7a5c8330bada7ab9d58054fb