### PR TITLE
Add featured creator list

### DIFF
--- a/src/components/FindCreatorsView.vue
+++ b/src/components/FindCreatorsView.vue
@@ -63,7 +63,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, watch } from "vue";
+import { defineComponent, ref, watch, onMounted } from "vue";
 import { useCreatorsStore } from "stores/creators";
 import CreatorProfileCard from "components/CreatorProfileCard.vue";
 import DonateDialog from "components/DonateDialog.vue";
@@ -99,6 +99,10 @@ export default defineComponent({
     const messageCreator = ref<any>(null);
     const selectedBucketId = ref<string>("");
     const selectedLocked = ref(false);
+
+    onMounted(() => {
+      creatorsStore.loadFeaturedCreators();
+    });
 
     const triggerSearch = () => {
       if (searchInput.value.trim()) {

--- a/test/vitest/__tests__/creators.spec.ts
+++ b/test/vitest/__tests__/creators.spec.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { useCreatorsStore } from "../../../src/stores/creators";
+import { useCreatorsStore, FEATURED_CREATORS } from "../../../src/stores/creators";
 
 const fetchProfile = vi.fn();
 const userProfile = { name: "Alice" };
@@ -67,5 +67,13 @@ describe("Creators store", () => {
 
     expect(creators.searchResults.length).toBe(0);
     expect(creators.error).toBe("Invalid pubkey");
+  });
+
+  it("loads featured creators", async () => {
+    const creators = useCreatorsStore();
+    await creators.loadFeaturedCreators();
+
+    expect(creators.error).toBe("");
+    expect(creators.searchResults.length).toBe(FEATURED_CREATORS.length);
   });
 });


### PR DESCRIPTION
## Summary
- show a few featured creators when opening the creator search page
- add action to load featured creators
- test that the featured list populates correctly

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ca25a239483308f0b3251168c9d5a