### PR TITLE
Add close button after sending tokens

### DIFF
--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -563,6 +563,16 @@
                 }}</q-btn
               >
             </div>
+            <div class="row q-mt-lg">
+              <q-btn
+                v-close-popup
+                rounded
+                flat
+                color="grey"
+                class="q-ml-auto"
+                >{{ $t("SendTokenDialog.actions.close.label") }}</q-btn
+              >
+            </div>
           </q-card-section>
         </q-card-section>
       </div>


### PR DESCRIPTION
## Summary
- add button to close SendTokenDialog after sending tokens

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ca3738a60833097dc2acf3163ad32