### PR TITLE
Add creator-specific buckets with send-all option

### DIFF
--- a/src/components/BucketManager.vue
+++ b/src/components/BucketManager.vue
@@ -134,6 +134,12 @@
           type="number"
           class="q-mb-sm"
         />
+        <q-input
+          v-model="form.creatorPubkey"
+          outlined
+          :label="$t('BucketManager.inputs.creator_pubkey')"
+          class="q-mb-sm"
+        />
         <div class="row q-mt-md">
           <q-btn color="primary" rounded @click="saveBucket">{{
             $t("global.actions.update.label")
@@ -192,6 +198,7 @@ export default defineComponent({
       color: "#1976d2",
       description: "",
       goal: null,
+      creatorPubkey: "",
     });
 
     const bucketList = computed(() => bucketsStore.bucketList);
@@ -206,7 +213,7 @@ export default defineComponent({
 
     const openAdd = () => {
       editId.value = null;
-      form.value = { name: "", color: "#1976d2", description: "", goal: null };
+      form.value = { name: "", color: "#1976d2", description: "", goal: null, creatorPubkey: "" };
       showForm.value = true;
     };
 
@@ -217,6 +224,7 @@ export default defineComponent({
         color: bucket.color,
         description: bucket.description,
         goal: bucket.goal,
+        creatorPubkey: bucket.creatorPubkey || "",
       };
       showForm.value = true;
     };

--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -858,6 +858,13 @@ export default defineComponent({
         this.sendData.locktime = null;
       }
     },
+    "sendData.bucketId": function (val) {
+      const bucket = this.bucketList.find((b) => b.id === val);
+      if (bucket && bucket.creatorPubkey) {
+        this.sendData.p2pkPubkey = bucket.creatorPubkey;
+        this.showLockInput = true;
+      }
+    },
   },
   methods: {
     ...mapActions(useWorkersStore, ["clearAllWorkers"]),

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1351,6 +1351,7 @@ export default {
       color: "Color",
       description: "Description",
       goal: "Goal (sat)",
+      creator_pubkey: "Creator pubkey",
     },
     tooltips: {
       description: "Buckets are for categorizing tokens",
@@ -1368,6 +1369,7 @@ export default {
     move: "Move tokens",
     send: "Send tokens",
     export: "Export bucket",
+    send_to_creator: "Send to creator",
     locked_tokens_heading: "Locked tokens",
     inputs: {
       target_bucket: {

--- a/src/pages/BucketDetail.vue
+++ b/src/pages/BucketDetail.vue
@@ -74,6 +74,15 @@
         <q-btn color="primary" outline :disable="!bucketProofs.length" @click="exportBucket">
           {{ $t('BucketDetail.export') }}
         </q-btn>
+        <q-btn
+          v-if="bucket && bucket.creatorPubkey"
+          color="primary"
+          outline
+          :disable="!bucketLockedTokens.length"
+          @click="sendBucketToCreator"
+        >
+          {{ $t('BucketDetail.send_to_creator') }}
+        </q-btn>
       </div>
     </div>
 
@@ -118,6 +127,7 @@ import { storeToRefs } from 'pinia';
 import { useSendTokensStore } from 'stores/sendTokensStore';
 import { useTokensStore, HistoryToken } from 'stores/tokens';
 import { useLockedTokensStore } from 'stores/lockedTokens';
+import { useNostrStore } from 'stores/nostr';
 import SendTokenDialog from 'components/SendTokenDialog.vue';
 import HistoryTable from 'components/HistoryTable.vue';
 import LockedTokensTable from 'components/LockedTokensTable.vue';
@@ -139,6 +149,7 @@ const bucketBalance = computed(() => bucketProofs.value.reduce((s,p)=>s+p.amount
 const bucketLockedTokens = computed(() => lockedTokensStore.tokensByBucket(bucketId));
 const { activeUnit } = storeToRefs(mintsStore);
 const showSendTokens = storeToRefs(sendTokensStore).showSendTokens;
+const nostrStore = useNostrStore();
 
 const selectedSecrets = ref<string[]>([]);
 const targetBucketId = ref<string | null>(null);
@@ -195,6 +206,11 @@ const bucketOptions = computed(() =>
 
 function formatCurrency(amount:number, unit:string){
   return uiStore.formatCurrency(amount, unit);
+}
+
+function formatTs(ts:number){
+  const d = new Date(ts * 1000);
+  return `${d.getFullYear()}-${("0" + (d.getMonth() + 1)).slice(-2)}-${("0" + d.getDate()).slice(-2)} ${("0" + d.getHours()).slice(-2)}:${("0" + d.getMinutes()).slice(-2)}`;
 }
 
 function toggleGroup(group: ProofGroup, val: boolean){
@@ -261,5 +277,16 @@ function exportBucket(){
   sendTokensStore.clearSendData();
   sendTokensStore.sendData.tokensBase64 = token;
   showSendTokens.value = true;
+}
+
+async function sendBucketToCreator(){
+  if(!bucket.value?.creatorPubkey) return;
+  if(!bucketLockedTokens.value.length) return;
+  const messages = bucketLockedTokens.value.map(t => {
+    const unlock = t.locktime ? formatTs(t.locktime) : 'now';
+    return `${formatCurrency(t.amount, activeUnit.value)} unlock ${unlock}\n${t.token}`;
+  });
+  const message = messages.join('\n');
+  await nostrStore.sendNip04DirectMessage(bucket.value.creatorPubkey, message);
 }
 </script>

--- a/src/stores/buckets.ts
+++ b/src/stores/buckets.ts
@@ -14,6 +14,7 @@ export type Bucket = {
   color?: string;
   description?: string;
   goal?: number;
+  creatorPubkey?: string;
 };
 
 export type BucketRule = {

--- a/test/vitest/__tests__/buckets.spec.ts
+++ b/test/vitest/__tests__/buckets.spec.ts
@@ -22,6 +22,13 @@ describe('Buckets store', () => {
     expect(buckets.bucketList.find(b => b.id === bucket.id)?.name).toBe('Test bucket')
   })
 
+  it('stores creator pubkey', () => {
+    const buckets = useBucketsStore()
+    const bucket = buckets.addBucket({ name: 'Creator', creatorPubkey: 'pubkey' })!
+    expect(bucket.creatorPubkey).toBe('pubkey')
+    expect(buckets.bucketList.find(b => b.id === bucket.id)?.creatorPubkey).toBe('pubkey')
+  })
+
   it('edits bucket and protects default', () => {
     const buckets = useBucketsStore()
     const bucket = buckets.addBucket({ name: 'Old' })


### PR DESCRIPTION
## Summary
- allow buckets to hold a `creatorPubkey`
- add form fields for creator key
- auto-fill send dialog with creator locking
- add button to send bucket tokens to creator
- cover creator pubkey in bucket tests

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_683ca36e22b08330b07f98832f47318c