### PR TITLE
Fix optional chaining assignment causing parser error

### DIFF
--- a/src/pages/BucketDetail.vue
+++ b/src/pages/BucketDetail.vue
@@ -226,8 +226,10 @@ function onDragStart(ev: DragEvent, group: ProofGroup){
   const secrets = selectedSecrets.value.length
     ? selectedSecrets.value
     : group.secrets;
-  ev.dataTransfer?.setData('text/plain', JSON.stringify(secrets));
-  ev.dataTransfer?.effectAllowed = 'move';
+  if (ev.dataTransfer) {
+    ev.dataTransfer.setData('text/plain', JSON.stringify(secrets));
+    ev.dataTransfer.effectAllowed = 'move';
+  }
 }
 
 function openEditGroup(group: ProofGroup){


### PR DESCRIPTION
## Summary
- avoid optional chaining assignment for `DragEvent`

## Testing
- `npm run test:ci` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ca7e10d248330827393729fe2b7c4