### PR TITLE
Fix token decoding of inputs with whitespace

### DIFF
--- a/src/stores/receiveTokensStore.ts
+++ b/src/stores/receiveTokensStore.ts
@@ -35,6 +35,7 @@ export const useReceiveTokensStore = defineStore("receiveTokensStore", {
   }),
   actions: {
     decodeToken: function (encodedToken: string) {
+      encodedToken = encodedToken.trim();
       if (!isValidTokenString(encodedToken)) {
         console.error("Invalid token string");
         return undefined;

--- a/test/vitest/__tests__/receiveTokensStore.spec.ts
+++ b/test/vitest/__tests__/receiveTokensStore.spec.ts
@@ -27,4 +27,10 @@ describe("receiveTokensStore.decodeToken", () => {
     const store = useReceiveTokensStore();
     expect(store.decodeToken("cashuAinvalid")).toBeUndefined();
   });
+
+  it("decodes token with surrounding whitespace", () => {
+    const store = useReceiveTokensStore();
+    const decoded = store.decodeToken(`  ${VALID_TOKEN}\n`);
+    expect(decoded?.mint).toBe("https://8333.space:3338");
+  });
 });


### PR DESCRIPTION
## Summary
- trim whitespace before validating token strings
- test decodeToken with surrounding whitespace

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint couldn't find eslint.config)*

------
https://chatgpt.com/codex/tasks/task_e_683caa03ca68833089927ec986710252