### PR TITLE
Fix token parsing of strings with spaces

### DIFF
--- a/src/stores/receiveTokensStore.ts
+++ b/src/stores/receiveTokensStore.ts
@@ -17,8 +17,9 @@ import { Clipboard } from "@capacitor/clipboard";
 import { DEFAULT_BUCKET_ID } from "./buckets";
 
 function isValidTokenString(tokenStr: string): boolean {
+  const sanitized = tokenStr.replace(/\s+/g, "");
   const prefixRegex = /^cashu[A-B][0-9A-Za-z]+$/;
-  return prefixRegex.test(tokenStr);
+  return prefixRegex.test(sanitized);
 }
 
 export const useReceiveTokensStore = defineStore("receiveTokensStore", {
@@ -35,6 +36,7 @@ export const useReceiveTokensStore = defineStore("receiveTokensStore", {
   }),
   actions: {
     decodeToken: function (encodedToken: string) {
+      encodedToken = encodedToken.replace(/\s+/g, "");
       if (!isValidTokenString(encodedToken)) {
         console.error("Invalid token string");
         return undefined;

--- a/test/vitest/__tests__/receiveTokensStore.spec.ts
+++ b/test/vitest/__tests__/receiveTokensStore.spec.ts
@@ -27,4 +27,17 @@ describe("receiveTokensStore.decodeToken", () => {
     const store = useReceiveTokensStore();
     expect(store.decodeToken("cashuAinvalid")).toBeUndefined();
   });
+
+  it("decodes token with surrounding whitespace", () => {
+    const store = useReceiveTokensStore();
+    const decoded = store.decodeToken(`  ${VALID_TOKEN}\n`);
+    expect(decoded?.mint).toBe("https://8333.space:3338");
+  });
+
+  it("decodes token with internal whitespace", () => {
+    const store = useReceiveTokensStore();
+    const spaced = `${VALID_TOKEN.slice(0, 5)} \n${VALID_TOKEN.slice(5)}`;
+    const decoded = store.decodeToken(spaced);
+    expect(decoded?.mint).toBe("https://8333.space:3338");
+  });
 });


### PR DESCRIPTION
## Summary
- sanitize token input by stripping all whitespace before validation
- allow decoding tokens that include spaces inside the string
- add test for internal whitespace tokens

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint couldn't find eslint.config)*

------
https://chatgpt.com/codex/tasks/task_e_683caa03ca68833089927ec986710252