### PR TITLE
Fix token parsing

### DIFF
--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -624,7 +624,7 @@ export const useNostrStore = defineStore("nostr", {
       const receiveStore = useReceiveTokensStore();
       const words = message.split(" ");
       const tokens = words.filter((word) => {
-        return word.startsWith("cashuA") || word.startsWith("cashuB");
+        return word.startsWith("cashu");
       });
       for (const tokenStr of tokens) {
         receiveStore.receiveData.tokensBase64 = tokenStr;

--- a/src/stores/receiveTokensStore.ts
+++ b/src/stores/receiveTokensStore.ts
@@ -17,7 +17,9 @@ import { Clipboard } from "@capacitor/clipboard";
 import { DEFAULT_BUCKET_ID } from "./buckets";
 
 function isValidTokenString(tokenStr: string): boolean {
-  const prefixRegex = /^cashu[A-B][0-9A-Za-z]+$/;
+  // allow any Cashu token prefix (e.g. cashuA, cashuB, ...)
+  // and accept base64/base64url characters in the body
+  const prefixRegex = /^cashu[A-Za-z0-9][A-Za-z0-9_\-+=\/]*$/;
   return prefixRegex.test(tokenStr);
 }
 

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -1508,7 +1508,7 @@ export const useWalletStore = defineStore("wallet", {
       ) {
         this.payInvoiceData.input.request = req;
         await this.lnurlPayFirst(this.payInvoiceData.input.request);
-      } else if (req.startsWith("cashuA") || req.startsWith("cashuB")) {
+      } else if (req.startsWith("cashu")) {
         // parse cashu tokens from a pasted token
         receiveStore.receiveData.tokensBase64 = req;
         this.handleCashuToken();


### PR DESCRIPTION
## Summary
- relax token string validation in `receiveTokensStore`
- treat any `cashu` prefix as token in wallet input handler
- pick up `cashu` tokens in Nostr messages

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683cad36d1948330b25dbcd0b004fd2f