### PR TITLE
Improve find creators UI

### DIFF
--- a/src/components/CreatorProfileCard.vue
+++ b/src/components/CreatorProfileCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <q-card class="q-pa-md q-mb-md qcard">
+  <q-card class="q-pa-md q-mb-md qcard creator-card">
     <q-card-section class="row items-center no-wrap">
       <q-avatar
         v-if="creator.profile?.picture"
@@ -90,5 +90,9 @@ export default defineComponent({
 }
 .creator-avatar img {
   object-fit: cover;
+}
+.creator-card.qcard {
+  width: 100%;
+  max-width: 280px;
 }
 </style>

--- a/src/components/FindCreatorsView.vue
+++ b/src/components/FindCreatorsView.vue
@@ -1,5 +1,5 @@
 <template>
-  <div style="max-width: 800px; margin: 0 auto">
+  <div style="max-width: 1200px; margin: 0 auto">
     <q-input
       rounded
       outlined
@@ -29,7 +29,7 @@
       {{ error }}
     </div>
 
-    <div v-if="searchResults.length" class="q-mt-md">
+    <div v-if="searchResults.length" class="q-mt-md creators-grid">
       <creator-profile-card
         v-for="creator in searchResults"
         :key="creator.pubkey"
@@ -240,3 +240,12 @@ export default defineComponent({
   },
 });
 </script>
+
+<style scoped>
+.creators-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 16px;
+  justify-items: center;
+}
+</style>

--- a/src/stores/creators.ts
+++ b/src/stores/creators.ts
@@ -6,6 +6,12 @@ export const FEATURED_CREATORS = [
   "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
   "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
   "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+  "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "1111111111111111111111111111111111111111111111111111111111111111",
+  "2222222222222222222222222222222222222222222222222222222222222222",
+  "3333333333333333333333333333333333333333333333333333333333333333",
 ];
 
 export interface CreatorProfile {


### PR DESCRIPTION
## Summary
- show more featured creators
- allow multiple profile cards in a grid
- resize creator card for grid layout

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d3b7229b483309697274ee8dd0ea3