### PR TITLE
Fix navigation after DM or donation

### DIFF
--- a/src/components/FindCreatorsView.vue
+++ b/src/components/FindCreatorsView.vue
@@ -64,6 +64,7 @@
 
 <script lang="ts">
 import { defineComponent, ref, watch, onMounted } from "vue";
+import { useRouter } from "vue-router";
 import { useCreatorsStore } from "stores/creators";
 import CreatorProfileCard from "components/CreatorProfileCard.vue";
 import DonateDialog from "components/DonateDialog.vue";
@@ -90,6 +91,7 @@ export default defineComponent({
     const { searchResults, searching, error } = storeToRefs(creatorsStore);
     const searchInput = ref("");
     const sendTokensStore = useSendTokensStore();
+    const router = useRouter();
     const { t } = useI18n();
     const showDonateDialog = ref(false);
     const showActionDialog = ref(false);
@@ -202,7 +204,8 @@ export default defineComponent({
           useDmChatsStore().addOutgoing(ev);
           Dialog.create({
             message: t("wallet.notifications.nostr_dm_sent") as string,
-          });
+            ok: { label: t("FindCreators.actions.back_to_search") as string },
+          }).onOk(() => router.push("/find-creators"));
         } else {
           Dialog.create({
             message: t("wallet.notifications.nostr_dm_failed") as string,

--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -1239,6 +1239,15 @@ export default defineComponent({
         };
         this.addPendingToken(historyToken);
         this.sendData.historyToken = historyToken;
+        Dialog.create({
+          message: this.$t(
+            "FindCreators.notifications.donation_sent"
+          ) as string,
+          ok: { label: this.$t("FindCreators.actions.back_to_search") as string },
+        }).onOk(() => {
+          this.showSendTokens = false;
+          this.$router.push("/find-creators");
+        });
 
       if (!this.g.offline) {
         this.onTokenPaid(historyToken);

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1320,11 +1320,18 @@ export default {
       message: {
         label: "Message",
       },
+      back_to_search: {
+        label: "Back to search",
+      },
     },
     choose_action: {
       title: "Select token",
       existing: "Existing Token",
       new: "Create New",
+    },
+    notifications: {
+      donation_sent: "Donation sent",
+      message_sent: "Message sent",
     },
   },
   ChooseExistingTokenDialog: {


### PR DESCRIPTION
## Summary
- add a router link so the user can return to searching after sending a Nostr DM or donation
- show a confirmation dialog after sending a Nostr DM or a donation
- add new i18n strings

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d3d8bcd7c833089bb7f7f11fa06cc