### PR TITLE
Improve timelock info display

### DIFF
--- a/src/components/ReceiveTokenDialog.vue
+++ b/src/components/ReceiveTokenDialog.vue
@@ -150,6 +150,30 @@
                 })
               }}
             </q-chip>
+            <q-chip
+              v-if="receiverPubkey"
+              outline
+              icon="person"
+              class="q-ml-sm"
+            >
+              {{
+                $t('LockedTokensTable.row.receiver_label', {
+                  value: shortenString(pubkeyNpub(receiverPubkey), 15, 6),
+                })
+              }}
+            </q-chip>
+            <q-chip
+              v-if="refundPubkey"
+              outline
+              icon="undo"
+              class="q-ml-sm"
+            >
+              {{
+                $t('LockedTokensTable.row.refund_label', {
+                  value: shortenString(pubkeyNpub(refundPubkey), 15, 6),
+                })
+              }}
+            </q-chip>
           </div>
           <div class="row q-pt-sm">
               <q-select
@@ -299,6 +323,8 @@ import { useSwapStore } from "src/stores/swap";
 import { useSettingsStore } from "src/stores/settings";
 import token from "src/js/token";
 import { date } from "quasar";
+import { shortenString } from "src/js/string-utils";
+import { nip19 } from "nostr-tools";
 
 import ChooseMint from "src/components/ChooseMint.vue";
 import TokenInformation from "components/TokenInformation.vue";
@@ -439,6 +465,18 @@ export default defineComponent({
       const decodedToken = this.decodeToken(this.receiveData.tokensBase64);
       return this.getMint(decodedToken);
     },
+    receiverPubkey: function () {
+      if (!this.tokenDecodesCorrectly) {
+        return "";
+      }
+      return this.getTokenPubkey(this.receiveData.tokensBase64) || "";
+    },
+    refundPubkey: function () {
+      if (!this.tokenDecodesCorrectly) {
+        return "";
+      }
+      return this.getTokenRefundPubkey(this.receiveData.tokensBase64) || "";
+    },
     unlockDate: function () {
       const ts = this.getTokenLocktime(this.receiveData.tokensBase64);
       if (!ts) return "";
@@ -458,6 +496,8 @@ export default defineComponent({
       "generateKeypair",
       "showLastKey",
       "getTokenLocktime",
+      "getTokenPubkey",
+      "getTokenRefundPubkey",
     ]),
     ...mapActions(useMintsStore, ["addMint"]),
     ...mapActions(useReceiveTokensStore, [
@@ -467,6 +507,7 @@ export default defineComponent({
       "toggleScanner",
       "pasteToParseDialog",
     ]),
+    shortenString,
     // TOKEN METHODS
     decodePeanut: function (peanut) {
       try {
@@ -583,6 +624,14 @@ export default defineComponent({
         mint
       );
       this.swapSelected = false;
+    },
+    pubkeyNpub(hex) {
+      try {
+        if (!hex) return "";
+        return nip19.npubEncode(hex);
+      } catch (e) {
+        return hex;
+      }
     },
   },
 });

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -946,6 +946,8 @@ export default {
     },
     timelock: {
       unlock_date_label: "Unlocks { value }",
+      receiver_label: "Receiver { value }",
+      refund_label: "Refund { value }",
     },
     errors: {
       invalid_token: {

--- a/src/stores/p2pk.ts
+++ b/src/stores/p2pk.ts
@@ -96,14 +96,14 @@ export const useP2PKStore = defineStore("p2pk", {
       };
       this.p2pkKeys = this.p2pkKeys.concat(keyPair);
     },
-    getSecretP2PKPubkey: function (
+    getSecretP2PKInfo: function (
       secret: string,
-    ): { pubkey: string; locktime?: number } {
+    ): { pubkey: string; locktime?: number; refundKeys: string[] } {
       try {
         let secretObject = JSON.parse(secret);
         if (secretObject[0] != "P2PK" || secretObject[1]["data"] == undefined) {
           console.log("not p2pk locked");
-          return { pubkey: "", locktime: undefined }; // not p2pk locked
+          return { pubkey: "", locktime: undefined, refundKeys: [] }; // not p2pk locked
         }
         // Get all the p2pk secret data
         const now = Math.floor(Date.now() / 1000); // unix TS
@@ -124,23 +124,31 @@ export const useP2PKStore = defineStore("p2pk", {
           console.log("p2pk token - locktime is active");
           if (n_sigs && n_sigs >= 1) {
             for (const pk of pubkeys) {
-              if (this.haveThisKey(pk)) return { pubkey: pk, locktime };
+              if (this.haveThisKey(pk))
+                return { pubkey: pk, locktime, refundKeys };
             }
           }
-          return { pubkey: data, locktime };
+          return { pubkey: data, locktime, refundKeys };
         }
         // If locktime expired, return first owned 'refund' key match or
         // or just return the first refund key to show token is locked
         if (refundKeys.length > 0) {
           console.log("p2pk token - locked to refund keys");
           for (const pk of refundKeys) {
-            if (this.haveThisKey(pk)) return { pubkey: pk, locktime };
+            if (this.haveThisKey(pk))
+              return { pubkey: pk, locktime, refundKeys };
           }
-          return { pubkey: refundKeys[0], locktime };
+          return { pubkey: refundKeys[0], locktime, refundKeys };
         }
         console.log("p2pk token - lock has expired");
       } catch {}
-      return { pubkey: "", locktime: undefined }; // Token is not locked / secret is not P2PK
+      return { pubkey: "", locktime: undefined, refundKeys: [] }; // Token is not locked / secret is not P2PK
+    },
+    getSecretP2PKPubkey: function (
+      secret: string,
+    ): { pubkey: string; locktime?: number } {
+      const { pubkey, locktime } = this.getSecretP2PKInfo(secret);
+      return { pubkey, locktime };
     },
     isLocked: function (proofs: WalletProof[]) {
       const secrets = proofs.map((p) => p.secret);
@@ -161,6 +169,30 @@ export const useP2PKStore = defineStore("p2pk", {
           return this.haveThisKey(pubkey);
         }
       }
+    },
+    getTokenPubkey: function (encodedToken: string): string | undefined {
+      const decodedToken = token.decode(encodedToken);
+      if (!decodedToken) {
+        return undefined;
+      }
+      const proofs = token.getProofs(decodedToken);
+      for (const p of proofs) {
+        const { pubkey } = this.getSecretP2PKInfo(p.secret);
+        if (pubkey) return pubkey;
+      }
+      return undefined;
+    },
+    getTokenRefundPubkey: function (encodedToken: string): string | undefined {
+      const decodedToken = token.decode(encodedToken);
+      if (!decodedToken) {
+        return undefined;
+      }
+      const proofs = token.getProofs(decodedToken);
+      for (const p of proofs) {
+        const { refundKeys } = this.getSecretP2PKInfo(p.secret);
+        if (refundKeys.length) return refundKeys[0];
+      }
+      return undefined;
     },
     getPrivateKeyForP2PKEncodedToken: function (encodedToken: string): string {
       const decodedToken = token.decode(encodedToken);

--- a/test/vitest/__tests__/p2pk.spec.ts
+++ b/test/vitest/__tests__/p2pk.spec.ts
@@ -50,4 +50,19 @@ describe('P2PK store', () => {
     await walletStore.sendToLock([{ secret: 's', amount: 1, id: 'a', C: 'c' } as any], wallet, 1, 'pk', 'b', 123, 'r')
     expect(wallet.send).toHaveBeenCalledWith(1, [{ secret: 's', amount: 1, id: 'a', C: 'c' }], { keysetId: 'kid', pubkey: 'pk', locktime: 123, refund: 'r' })
   })
+
+  it('extracts pubkeys from encoded token', () => {
+    const p2pk = useP2PKStore()
+    const locktime = Math.floor(Date.now() / 1000) + 1000
+    const secret = JSON.stringify([
+      'P2PK',
+      { data: '02aa', tags: [['locktime', String(locktime)], ['refund', '02bb']] }
+    ])
+    const tokenObj = {
+      token: [{ proofs: [{ id: 'a', amount: 1, C: 'c', secret }], mint: 'm' }]
+    }
+    const encoded = 'cashuA' + Buffer.from(JSON.stringify(tokenObj)).toString('base64')
+    expect(p2pk.getTokenPubkey(encoded)).toBe('02aa')
+    expect(p2pk.getTokenRefundPubkey(encoded)).toBe('02bb')
+  })
 })


### PR DESCRIPTION
## Summary
- expose more details from P2PK secrets
- show locked token receiver and refund keys in Receive dialog
- add translation for new labels
- test pubkey extraction helpers

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d3df1b7a0833084bfac437f18dc03