### PR TITLE
Improve chat UI

### DIFF
--- a/src/pages/ChatView.vue
+++ b/src/pages/ChatView.vue
@@ -1,0 +1,120 @@
+<template>
+  <div
+    :class="[$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark', 'full-height flex column']"
+  >
+    <div class="q-pa-sm text-h6 border-bottom" style="border-bottom: 1px solid rgba(0,0,0,0.1)">
+      {{ displayName }}
+    </div>
+    <div class="q-pa-md scroll" style="flex: 1; overflow-y: auto" ref="scrollArea">
+      <q-chat-message
+        v-for="msg in messages"
+        :key="msg.id"
+        :sent="msg.outgoing"
+        :name="msg.outgoing ? 'You' : displayName"
+        :avatar="msg.outgoing ? '' : avatar"
+        :text="[sanitizeMessage(msg.content)]"
+        :stamp="formatDate(msg.created_at)"
+      />
+      <div ref="bottomMarker"></div>
+    </div>
+    <div class="q-pa-sm row items-center">
+      <q-input
+        v-model="newMessage"
+        dense
+        outlined
+        class="col-grow q-mr-sm"
+        placeholder="Type a message"
+        @keyup.enter="sendMessage"
+      />
+      <q-btn flat icon="send" color="primary" @click="sendMessage" />
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, computed, watch, onMounted, nextTick } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import { useDmChatsStore } from 'stores/dmChats';
+import { storeToRefs } from 'pinia';
+import { useNostrStore } from 'stores/nostr';
+import { sanitizeMessage } from 'src/js/message-utils';
+
+export default defineComponent({
+  name: 'ChatView',
+  setup() {
+    const route = useRoute();
+    const router = useRouter();
+    const pubkey = route.params.pubkey as string;
+    const dmStore = useDmChatsStore();
+    dmStore.loadChats();
+    const { chats } = storeToRefs(dmStore);
+    const nostrStore = useNostrStore();
+    const profile = ref<any>(null);
+    const newMessage = ref('');
+    const bottomMarker = ref<HTMLElement | null>(null);
+
+    const messages = computed(() => chats.value[pubkey] || []);
+
+    const loadProfile = async () => {
+      profile.value = await nostrStore.getProfile(pubkey);
+    };
+
+    const scrollToBottom = () => {
+      nextTick(() => {
+        if (bottomMarker.value) {
+          bottomMarker.value.scrollIntoView({ behavior: 'smooth' });
+        }
+      });
+    };
+
+    watch(messages, scrollToBottom);
+
+    onMounted(async () => {
+      await loadProfile();
+      scrollToBottom();
+    });
+
+    const sendMessage = async () => {
+      const content = newMessage.value.trim();
+      if (!content) return;
+      const ev = await nostrStore.sendNip04DirectMessage(pubkey, content);
+      if (ev) {
+        dmStore.addOutgoing(ev);
+        newMessage.value = '';
+      }
+    };
+
+    const displayName = computed(() => {
+      return (
+        profile.value?.display_name ||
+        profile.value?.name ||
+        pubkey.slice(0, 8) + '...' + pubkey.slice(-4)
+      );
+    });
+
+    const avatar = computed(() => profile.value?.picture || '');
+
+    const formatDate = (ts: number) => new Date(ts * 1000).toLocaleString();
+
+    return {
+      messages,
+      displayName,
+      avatar,
+      newMessage,
+      sendMessage,
+      sanitizeMessage,
+      formatDate,
+      bottomMarker,
+    };
+  },
+});
+</script>
+
+<style scoped>
+.scroll {
+  overflow-y: auto;
+}
+.border-bottom {
+  border-color: rgba(0, 0, 0, 0.1);
+}
+</style>

--- a/src/pages/Chats.vue
+++ b/src/pages/Chats.vue
@@ -1,24 +1,25 @@
 <template>
   <div :class="[$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark', 'q-pa-md']">
     <q-list bordered>
-      <div v-for="(messages, pubkey) in chats" :key="pubkey" class="q-mb-md">
-        <div class="text-h6 q-mb-sm">{{ shorten(pubkey) }}</div>
-        <q-item v-for="msg in messages" :key="msg.id">
-          <q-item-section>
-            <q-item-label>{{ sanitizeMessage(msg.content) }}</q-item-label>
-            <q-item-label caption>{{ formatDate(msg.created_at) }} - {{ msg.outgoing ? 'out' : 'in' }}</q-item-label>
-          </q-item-section>
-        </q-item>
-      </div>
+      <q-item v-for="pubkey in pubkeys" :key="pubkey" clickable @click="openChat(pubkey)">
+        <q-item-section avatar>
+          <q-avatar v-if="profiles[pubkey]?.picture" :src="profiles[pubkey].picture" />
+        </q-item-section>
+        <q-item-section>
+          <q-item-label class="text-subtitle1">{{ displayName(pubkey) }}</q-item-label>
+          <q-item-label caption>{{ lastMessageTime(pubkey) }}</q-item-label>
+        </q-item-section>
+      </q-item>
     </q-list>
   </div>
 </template>
 
-<script>
-import { defineComponent } from 'vue';
-import { useDmChatsStore } from 'src/stores/dmChats';
+<script lang="ts">
+import { defineComponent, ref, onMounted, watch, computed } from 'vue';
+import { useRouter } from 'vue-router';
+import { useDmChatsStore } from 'stores/dmChats';
+import { useNostrStore } from 'stores/nostr';
 import { storeToRefs } from 'pinia';
-import { sanitizeMessage } from 'src/js/message-utils';
 
 export default defineComponent({
   name: 'ChatsPage',
@@ -26,9 +27,40 @@ export default defineComponent({
     const store = useDmChatsStore();
     store.loadChats();
     const { chats } = storeToRefs(store);
-    const shorten = (p) => p.slice(0, 8) + '...' + p.slice(-4);
-    const formatDate = (ts) => new Date(ts * 1000).toLocaleString();
-    return { chats, shorten, formatDate, sanitizeMessage }; 
-  }
+    const router = useRouter();
+    const nostrStore = useNostrStore();
+    const profiles = ref<Record<string, any>>({});
+
+    const loadProfiles = async () => {
+      for (const pk of Object.keys(chats.value)) {
+        if (!profiles.value[pk]) {
+          profiles.value[pk] = await nostrStore.getProfile(pk);
+        }
+      }
+    };
+
+    onMounted(loadProfiles);
+    watch(chats, loadProfiles, { deep: true });
+
+    const pubkeys = computed(() => Object.keys(chats.value));
+
+    const displayName = (pk: string) =>
+      profiles.value[pk]?.display_name ||
+      profiles.value[pk]?.name ||
+      pk.slice(0, 8) + '...' + pk.slice(-4);
+
+    const lastMessageTime = (pk: string) => {
+      const msgs = chats.value[pk];
+      if (!msgs || !msgs.length) return '';
+      const ts = msgs[msgs.length - 1].created_at;
+      return new Date(ts * 1000).toLocaleString();
+    };
+
+    const openChat = (pk: string) => {
+      router.push(`/chats/${pk}`);
+    };
+
+    return { chats, pubkeys, profiles, displayName, lastMessageTime, openChat };
+  },
 });
 </script>

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -40,6 +40,11 @@ const routes = [
     children: [{ path: "", component: () => import("src/pages/Chats.vue") }],
   },
   {
+    path: "/chats/:pubkey",
+    component: () => import("layouts/MainLayout.vue"),
+    children: [{ path: "", component: () => import("src/pages/ChatView.vue") }],
+  },
+  {
     path: "/buckets/:id",
     component: () => import("layouts/FullscreenLayout.vue"),
     children: [

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -100,6 +100,7 @@ export const useNostrStore = defineStore("nostr", {
       "cashu.ndk.nip17EventIdsWeHaveSeen",
       []
     ),
+    profiles: useLocalStorage<Record<string, any>>("cashu.ndk.profiles", {}),
   }),
   getters: {
     seedSignerPrivateKeyNsecComputed: (state) => {
@@ -163,6 +164,21 @@ export const useNostrStore = defineStore("nostr", {
     setPubkey: function (pubkey: string) {
       console.log("Setting pubkey to", pubkey);
       this.pubkey = pubkey;
+    },
+    getProfile: async function (pubkey: string): Promise<any> {
+      if (this.profiles[pubkey]) {
+        return this.profiles[pubkey];
+      }
+      await this.initNdkReadOnly();
+      try {
+        const user = this.ndk.getUser({ pubkey });
+        await user.fetchProfile();
+        this.profiles[pubkey] = user.profile;
+        return user.profile;
+      } catch (e) {
+        console.error(e);
+        return null;
+      }
     },
     checkNip07Signer: async function (): Promise<boolean> {
       const signer = new NDKNip07Signer();


### PR DESCRIPTION
## Summary
- fetch and cache profiles in `useNostrStore`
- redesign Chats page to list conversations with names
- add dynamic ChatView page for a single conversation
- route `/chats/:pubkey` for chat navigation

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d3f8d1a188330b99e0eccd358be72