### PR TITLE
Add Creator Hub skeleton

### DIFF
--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1426,6 +1426,27 @@ export default {
     title: "About Cashu.me",
     video_placeholder: "Video coming soon",
   },
+  CreatorHub: {
+    login: {
+      title: "Creator Login",
+      nip07: "Login with Nostr Extension",
+      nsec: "nsec",
+      nsec_button: "Login with nsec",
+      nsec_warning: "Entering your nsec in a web app is dangerous. Use NIP-07 if possible.",
+    },
+    dashboard: {
+      title: "Creator Dashboard",
+      logout: "Logout",
+      edit_profile: "Edit Profile",
+      manage_tiers: "Manage Tiers",
+      add_tier: "Add Tier",
+    },
+    profile: {
+      back: "Back",
+      tiers: "Donation Tiers",
+      support: "Support",
+    },
+  },
   swap: {
     in_progress_warning_text: "Swap in progress",
     invalid_swap_data_error_text: "Invalid swap data",

--- a/src/pages/CreatorDashboardPage.vue
+++ b/src/pages/CreatorDashboardPage.vue
@@ -1,0 +1,76 @@
+<template>
+  <div :class="[$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark', 'q-pa-md']">
+    <div class="row items-center justify-between">
+      <div class="text-h5">{{ $t('CreatorHub.dashboard.title') }}</div>
+      <q-btn flat color="primary" @click="logout">{{ $t('CreatorHub.dashboard.logout') }}</q-btn>
+    </div>
+
+    <div class="q-mt-md">
+      <div class="text-h6">{{ $t('CreatorHub.dashboard.edit_profile') }}</div>
+      <q-input v-model="profile.display_name" label="Display Name" class="q-mt-sm" />
+      <q-input v-model="profile.picture" label="Profile Picture URL" class="q-mt-sm" />
+      <q-input v-model="profile.about" type="textarea" label="Bio" class="q-mt-sm" />
+      <q-btn color="primary" flat class="q-mt-sm" @click="saveProfile">{{ $t('global.actions.update.label') }}</q-btn>
+    </div>
+
+    <div class="q-mt-lg">
+      <div class="text-h6">{{ $t('CreatorHub.dashboard.manage_tiers') }}</div>
+      <div v-for="tier in tiers" :key="tier.id" class="q-mt-md q-pa-sm bg-grey-2">
+        <q-input v-model="tier.name" label="Tier Name" dense class="q-mt-sm" />
+        <q-input v-model.number="tier.price" label="Price (sats)" type="number" dense class="q-mt-sm" />
+        <q-input v-model="tier.perks" label="Perks" type="textarea" dense class="q-mt-sm" />
+        <q-btn color="negative" flat class="q-mt-sm" @click="removeTier(tier.id)">Delete</q-btn>
+      </div>
+      <q-btn color="primary" flat class="q-mt-md" @click="addTier">{{ $t('CreatorHub.dashboard.add_tier') }}</q-btn>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, onMounted } from 'vue';
+import { useCreatorHubStore, Tier } from 'stores/creatorHub';
+import { useNostrStore } from 'stores/nostr';
+import { useRouter } from 'vue-router';
+
+export default defineComponent({
+  name: 'CreatorDashboardPage',
+  setup() {
+    const store = useCreatorHubStore();
+    const nostr = useNostrStore();
+    const router = useRouter();
+    const profile = ref<any>({ display_name: '', picture: '', about: '' });
+    const tiers = ref<Tier[]>([]);
+
+    onMounted(async () => {
+      if (!store.loggedInNpub) {
+        router.push('/creator/login');
+        return;
+      }
+      const p = await nostr.getProfile(store.loggedInNpub);
+      if (p) profile.value = { ...p };
+      tiers.value = store.getTierArray();
+    });
+
+    const logout = () => {
+      store.logout();
+      router.push('/creator/login');
+    };
+
+    const saveProfile = async () => {
+      await store.updateProfile(profile.value);
+    };
+
+    const addTier = () => {
+      store.addTier({ name: '', price: 0, perks: '' });
+      tiers.value = store.getTierArray();
+    };
+
+    const removeTier = (id: string) => {
+      store.removeTier(id);
+      tiers.value = store.getTierArray();
+    };
+
+    return { profile, tiers, logout, saveProfile, addTier, removeTier };
+  }
+});
+</script>

--- a/src/pages/CreatorLoginPage.vue
+++ b/src/pages/CreatorLoginPage.vue
@@ -1,0 +1,42 @@
+<template>
+  <div :class="[$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark', 'q-pa-md flex flex-center']">
+    <q-card class="q-pa-md" style="max-width:400px; width:100%">
+      <q-card-section class="text-h6">{{ $t('CreatorHub.login.title') }}</q-card-section>
+      <q-card-actions vertical>
+        <q-btn color="primary" @click="loginNip07">{{ $t('CreatorHub.login.nip07') }}</q-btn>
+        <q-input v-model="nsec" type="password" :label="$t('CreatorHub.login.nsec')" class="q-mt-md" />
+        <div class="text-negative text-caption q-mt-sm">{{ $t('CreatorHub.login.nsec_warning') }}</div>
+        <q-btn color="primary" flat @click="loginNsec" class="q-mt-md">{{ $t('CreatorHub.login.nsec_button') }}</q-btn>
+      </q-card-actions>
+    </q-card>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref } from 'vue';
+import { useCreatorHubStore } from 'stores/creatorHub';
+import { useRouter } from 'vue-router';
+
+export default defineComponent({
+  name: 'CreatorLoginPage',
+  setup() {
+    const store = useCreatorHubStore();
+    const router = useRouter();
+    const nsec = ref('');
+    const loginNip07 = async () => {
+      await store.loginWithNip07();
+      if (store.loggedInNpub) {
+        router.push('/creator/dashboard');
+      }
+    };
+    const loginNsec = async () => {
+      if (!nsec.value) return;
+      await store.loginWithNsec(nsec.value);
+      if (store.loggedInNpub) {
+        router.push('/creator/dashboard');
+      }
+    };
+    return { nsec, loginNip07, loginNsec };
+  }
+});
+</script>

--- a/src/pages/PublicCreatorProfilePage.vue
+++ b/src/pages/PublicCreatorProfilePage.vue
@@ -1,0 +1,45 @@
+<template>
+  <div :class="[$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark', 'q-pa-md']">
+    <div class="q-mb-md">
+      <q-btn flat color="primary" to="/find-creators">{{ $t('CreatorHub.profile.back') }}</q-btn>
+    </div>
+    <div class="text-h5 q-mb-md">{{ profile.display_name || pubkey }}</div>
+    <div v-if="profile.picture" class="q-mb-md">
+      <img :src="profile.picture" style="max-width:150px" />
+    </div>
+    <div v-if="profile.about" class="q-mb-md">{{ profile.about }}</div>
+
+    <div v-if="tiers.length">
+      <div class="text-h6 q-mb-sm">{{ $t('CreatorHub.profile.tiers') }}</div>
+      <div v-for="tier in tiers" :key="tier.id" class="q-mb-md">
+        <div class="text-subtitle1">{{ tier.name }} - {{ tier.price }} sats</div>
+        <div class="text-caption">{{ tier.perks }}</div>
+        <q-btn color="primary" dense class="q-mt-sm">{{ $t('CreatorHub.profile.support') }}</q-btn>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, onMounted } from 'vue';
+import { useRoute } from 'vue-router';
+import { useNostrStore } from 'stores/nostr';
+import { useCreatorHubStore } from 'stores/creatorHub';
+
+export default defineComponent({
+  name: 'PublicCreatorProfilePage',
+  setup() {
+    const route = useRoute();
+    const nostr = useNostrStore();
+    const hub = useCreatorHubStore();
+    const pubkey = route.params.npubOrVanityName as string;
+    const profile = ref<any>({});
+    const tiers = ref(hub.getTierArray());
+    onMounted(async () => {
+      const p = await nostr.getProfile(pubkey);
+      if (p) profile.value = { ...p };
+    });
+    return { pubkey, profile, tiers };
+  }
+});
+</script>

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -23,6 +23,33 @@ const routes = [
     ],
   },
   {
+    path: "/creator/login",
+    component: () => import("layouts/FullscreenLayout.vue"),
+    children: [
+      { path: "", component: () => import("src/pages/CreatorLoginPage.vue") },
+    ],
+  },
+  {
+    path: "/creator/dashboard",
+    component: () => import("layouts/FullscreenLayout.vue"),
+    children: [
+      {
+        path: "",
+        component: () => import("src/pages/CreatorDashboardPage.vue"),
+      },
+    ],
+  },
+  {
+    path: "/creators/:npubOrVanityName",
+    component: () => import("layouts/FullscreenLayout.vue"),
+    children: [
+      {
+        path: "",
+        component: () => import("src/pages/PublicCreatorProfilePage.vue"),
+      },
+    ],
+  },
+  {
     path: "/buckets",
     component: () => import("layouts/FullscreenLayout.vue"),
     children: [{ path: "", component: () => import("src/pages/Buckets.vue") }],

--- a/src/stores/creatorHub.ts
+++ b/src/stores/creatorHub.ts
@@ -1,0 +1,57 @@
+import { defineStore } from "pinia";
+import { useLocalStorage } from "@vueuse/core";
+import { NDKEvent } from "@nostr-dev-kit/ndk";
+import { useNostrStore } from "./nostr";
+
+export interface Tier {
+  id: string;
+  name: string;
+  price: number;
+  perks: string;
+}
+
+export const useCreatorHubStore = defineStore("creatorHub", {
+  state: () => ({
+    loggedInNpub: useLocalStorage<string>("creatorHub.loggedInNpub", ""),
+    tiers: useLocalStorage<Record<string, Tier>>("creatorHub.tiers", {}),
+  }),
+  actions: {
+    async loginWithNip07() {
+      const nostr = useNostrStore();
+      await nostr.initNip07Signer();
+      this.loggedInNpub = nostr.pubkey;
+    },
+    async loginWithNsec(nsec: string) {
+      const nostr = useNostrStore();
+      await nostr.initPrivateKeySigner(nsec);
+      this.loggedInNpub = nostr.pubkey;
+    },
+    logout() {
+      this.loggedInNpub = "";
+    },
+    async updateProfile(profile: any) {
+      const nostr = useNostrStore();
+      await nostr.initSignerIfNotSet();
+      const ev = new NDKEvent(nostr.ndk);
+      ev.kind = 0;
+      ev.content = JSON.stringify(profile);
+      await ev.sign(nostr.signer);
+      await ev.publish();
+    },
+    addTier(tier: Partial<Tier>) {
+      const id = tier.id || Date.now().toString();
+      this.tiers[id] = {
+        id,
+        name: tier.name || "",
+        price: tier.price || 0,
+        perks: tier.perks || "",
+      } as Tier;
+    },
+    removeTier(id: string) {
+      delete this.tiers[id];
+    },
+    getTierArray(): Tier[] {
+      return Object.values(this.tiers);
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add Creator Hub Pinia store for creator login and tiers
- add pages for Creator Login, Dashboard and public profile
- wire new routes
- add English translations for Creator Hub texts

## Testing
- `npx vitest run` *(fails: connect EHOSTUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_683d426a13fc833090fd1572f82c0591