### PR TITLE
Add donation type options and flexible schedules

### DIFF
--- a/src/components/DonateDialog.vue
+++ b/src/components/DonateDialog.vue
@@ -1,7 +1,9 @@
 <template>
   <q-dialog v-model="model" persistent>
     <q-card class="q-pa-md qcard" style="min-width: 300px">
-      <q-card-section class="text-h6">{{ $t('FindCreators.actions.donate.label') }}</q-card-section>
+      <q-card-section class="text-h6">{{
+        $t("FindCreators.actions.donate.label")
+      }}</q-card-section>
       <q-card-section>
         <q-select
           v-model="bucketId"
@@ -12,6 +14,24 @@
           dense
           :label="$t('BucketManager.inputs.name')"
         />
+        <q-input
+          v-model.number="amount"
+          type="number"
+          dense
+          outlined
+          :label="$t('DonateDialog.inputs.amount')"
+          class="q-mt-sm"
+        />
+        <q-select
+          v-model="type"
+          :options="typeOptions"
+          emit-value
+          map-options
+          outlined
+          dense
+          class="q-mt-md"
+          :label="$t('DonateDialog.inputs.type')"
+        />
         <q-option-group
           v-model="locked"
           :options="lockOptions"
@@ -19,6 +39,7 @@
           class="q-mt-md"
         />
         <q-select
+          v-if="type !== 'one-time'"
           v-model="preset"
           :options="presetOptions"
           emit-value
@@ -27,31 +48,36 @@
           dense
           class="q-mt-md"
           :label="$t('DonateDialog.inputs.preset')"
+          :hint="$t('DonateDialog.helper.months')"
         />
       </q-card-section>
       <q-card-actions align="right">
-        <q-btn flat color="primary" @click="cancel">{{ $t('global.actions.cancel.label') }}</q-btn>
-        <q-btn flat color="primary" @click="confirm">{{ $t('global.actions.send.label') }}</q-btn>
+        <q-btn flat color="primary" @click="cancel">{{
+          $t("global.actions.cancel.label")
+        }}</q-btn>
+        <q-btn flat color="primary" @click="confirm">{{
+          $t("global.actions.send.label")
+        }}</q-btn>
       </q-card-actions>
     </q-card>
   </q-dialog>
 </template>
 
 <script lang="ts">
-import { defineComponent, computed, ref } from 'vue';
-import { useBucketsStore, DEFAULT_BUCKET_ID } from 'stores/buckets';
-import { useMintsStore } from 'stores/mints';
-import { useUiStore } from 'stores/ui';
-import { storeToRefs } from 'pinia';
-import { useDonationPresetsStore } from 'stores/donationPresets';
+import { defineComponent, computed, ref } from "vue";
+import { useBucketsStore, DEFAULT_BUCKET_ID } from "stores/buckets";
+import { useMintsStore } from "stores/mints";
+import { useUiStore } from "stores/ui";
+import { storeToRefs } from "pinia";
+import { useDonationPresetsStore } from "stores/donationPresets";
 
 export default defineComponent({
-  name: 'DonateDialog',
+  name: "DonateDialog",
   props: {
     modelValue: Boolean,
-    creatorPubkey: { type: String, default: '' }
+    creatorPubkey: { type: String, default: "" },
   },
-  emits: ['update:modelValue', 'confirm'],
+  emits: ["update:modelValue", "confirm"],
   setup(props, { emit }) {
     const bucketsStore = useBucketsStore();
     const mintsStore = useMintsStore();
@@ -61,48 +87,72 @@ export default defineComponent({
     const { activeUnit } = storeToRefs(mintsStore);
 
     const bucketId = ref<string>(DEFAULT_BUCKET_ID);
-    const locked = ref<'normal' | 'locked'>('normal');
-    const preset = ref<number>(donationStore.presets[0]?.months || 3);
+    const locked = ref<"normal" | "locked">("normal");
+    const type = ref<"one-time" | "schedule">("one-time");
+    const amount = ref<number>(0);
+    const preset = ref<number>(donationStore.presets[0]?.months || 0);
 
     const model = computed({
       get: () => props.modelValue,
-      set: (v: boolean) => emit('update:modelValue', v),
+      set: (v: boolean) => emit("update:modelValue", v),
     });
 
     const bucketOptions = computed(() =>
-      bucketList.value.map(b => ({
+      bucketList.value.map((b) => ({
         label: `${b.name} (${uiStore.formatCurrency(
           bucketBalances.value[b.id] ?? 0,
-          activeUnit.value
+          activeUnit.value,
         )})`,
         value: b.id,
-      }))
+      })),
     );
 
+    const typeOptions = [
+      { label: "One-time", value: "one-time" },
+      { label: "Scheduled", value: "schedule" },
+    ];
+
     const lockOptions = [
-      { label: 'Normal', value: 'normal' },
-      { label: 'P2PK Lock', value: 'locked' },
+      { label: "Normal", value: "normal" },
+      { label: "P2PK Lock", value: "locked" },
     ];
 
     const presetOptions = computed(() =>
-      donationStore.presets.map(p => ({ label: `${p.months}m`, value: p.months }))
+      donationStore.presets.map((p) => ({
+        label: `${p.months}m`,
+        value: p.months,
+      })),
     );
 
     const cancel = () => {
-      emit('update:modelValue', false);
+      emit("update:modelValue", false);
     };
 
-    const confirm = async () => {
-      await donationStore.createDonationPreset(
-        preset.value,
-        1,
-        props.creatorPubkey,
-        bucketId.value
-      );
-      emit('update:modelValue', false);
+    const confirm = () => {
+      emit("confirm", {
+        bucketId: bucketId.value,
+        locked: locked.value === "locked",
+        type: type.value,
+        amount: amount.value,
+        months: preset.value,
+      });
+      emit("update:modelValue", false);
     };
 
-    return { model, bucketId, locked, preset, bucketOptions, lockOptions, presetOptions, cancel, confirm };
+    return {
+      model,
+      bucketId,
+      locked,
+      type,
+      amount,
+      preset,
+      bucketOptions,
+      typeOptions,
+      lockOptions,
+      presetOptions,
+      cancel,
+      confirm,
+    };
   },
 });
 </script>

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1352,8 +1352,13 @@ export default {
   },
   DonateDialog: {
     inputs: {
-      preset: "Donation preset"
-    }
+      preset: "Donation months",
+      type: "Donation type",
+      amount: "Amount",
+    },
+    helper: {
+      months: "Number of months (0 = one-time)",
+    },
   },
   BucketManager: {
     actions: {

--- a/src/stores/donationPresets.ts
+++ b/src/stores/donationPresets.ts
@@ -1,65 +1,78 @@
-import { defineStore } from 'pinia'
-import { useLocalStorage } from '@vueuse/core'
-import { useWalletStore } from './wallet'
-import { useMintsStore } from './mints'
-import { useProofsStore } from './proofs'
-import { useLockedTokensStore } from './lockedTokens'
-import { DEFAULT_BUCKET_ID } from './buckets'
+import { defineStore } from "pinia";
+import { useLocalStorage } from "@vueuse/core";
+import { useWalletStore } from "./wallet";
+import { useMintsStore } from "./mints";
+import { useProofsStore } from "./proofs";
+import { useLockedTokensStore } from "./lockedTokens";
+import { DEFAULT_BUCKET_ID } from "./buckets";
 
 export type DonationPreset = {
-  months: number
-}
+  months: number;
+};
 
 const DEFAULT_PRESETS: DonationPreset[] = [
   { months: 3 },
   { months: 6 },
-  { months: 12 }
-]
+  { months: 12 },
+];
 
-export const useDonationPresetsStore = defineStore('donationPresets', {
+export const useDonationPresetsStore = defineStore("donationPresets", {
   state: () => ({
     presets: useLocalStorage<DonationPreset[]>(
-      'cashu.donationPresets',
-      DEFAULT_PRESETS
-    )
+      "cashu.donationPresets",
+      DEFAULT_PRESETS,
+    ),
   }),
   actions: {
     async createDonationPreset(
-      months: number,
+      months: number | undefined,
       amount: number,
       pubkey: string,
-      bucketId: string = DEFAULT_BUCKET_ID
-    ) {
-      const walletStore = useWalletStore()
-      const proofsStore = useProofsStore()
-      const mintsStore = useMintsStore()
-      const lockedStore = useLockedTokensStore()
+      bucketId: string = DEFAULT_BUCKET_ID,
+    ): Promise<string | void> {
+      const walletStore = useWalletStore();
+      const proofsStore = useProofsStore();
+      const mintsStore = useMintsStore();
+      const lockedStore = useLockedTokensStore();
 
-      const wallet = walletStore.wallet
-      const proofs = mintsStore.activeProofs.filter(p => p.bucketId === bucketId)
+      const wallet = walletStore.wallet;
+      const proofs = mintsStore.activeProofs.filter(
+        (p) => p.bucketId === bucketId,
+      );
 
-      for (let i = 0; i < months; i++) {
-        const locktime =
-          Math.floor(Date.now() / 1000) + (i + 1) * 30 * 24 * 60 * 60
+      if (!months || months <= 0) {
         const { sendProofs } = await walletStore.sendToLock(
           proofs,
           wallet,
           amount,
           pubkey,
           bucketId,
-          locktime
-        )
-        const token = proofsStore.serializeProofs(sendProofs)
+        );
+        return proofsStore.serializeProofs(sendProofs);
+      }
+
+      for (let i = 0; i < months; i++) {
+        const locktime =
+          Math.floor(Date.now() / 1000) + (i + 1) * 30 * 24 * 60 * 60;
+        const { sendProofs } = await walletStore.sendToLock(
+          proofs,
+          wallet,
+          amount,
+          pubkey,
+          bucketId,
+          locktime,
+        );
+        const token = proofsStore.serializeProofs(sendProofs);
         lockedStore.addLockedToken({
           amount,
           token,
           pubkey,
           locktime,
-          bucketId
-        })
+          bucketId,
+        });
       }
-    }
-  }
-})
+    },
+  },
+});
 
-export const DEFAULT_DONATION_PRESETS = DEFAULT_PRESETS
+export const DEFAULT_DONATION_PRESETS = DEFAULT_PRESETS;

--- a/test/vitest/__tests__/donationPresets.spec.ts
+++ b/test/vitest/__tests__/donationPresets.spec.ts
@@ -1,57 +1,67 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { useDonationPresetsStore } from '../../../src/stores/donationPresets'
-import { useWalletStore } from '../../../src/stores/wallet'
-import { useProofsStore } from '../../../src/stores/proofs'
-import { useLockedTokensStore } from '../../../src/stores/lockedTokens'
-import { useMintsStore } from '../../../src/stores/mints'
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useDonationPresetsStore } from "../../../src/stores/donationPresets";
+import { useWalletStore } from "../../../src/stores/wallet";
+import { useProofsStore } from "../../../src/stores/proofs";
+import { useLockedTokensStore } from "../../../src/stores/lockedTokens";
+import { useMintsStore } from "../../../src/stores/mints";
 
 beforeEach(() => {
-  localStorage.clear()
-})
+  localStorage.clear();
+});
 
-vi.mock('../../../src/stores/wallet', () => ({
+vi.mock("../../../src/stores/wallet", () => ({
   useWalletStore: () => ({
     wallet: {},
-    sendToLock: vi.fn(async () => ({ sendProofs: [] }))
-  })
-}))
+    sendToLock: vi.fn(async () => ({ sendProofs: [] })),
+  }),
+}));
 
-vi.mock('../../../src/stores/proofs', () => ({
+vi.mock("../../../src/stores/proofs", () => ({
   useProofsStore: () => ({
-    serializeProofs: vi.fn(() => 'tok')
-  })
-}))
+    serializeProofs: vi.fn(() => "tok"),
+  }),
+}));
 
-vi.mock('../../../src/stores/lockedTokens', () => ({
+vi.mock("../../../src/stores/lockedTokens", () => ({
   useLockedTokensStore: () => ({
-    addLockedToken: vi.fn()
-  })
-}))
+    addLockedToken: vi.fn(),
+  }),
+}));
 
-vi.mock('../../../src/stores/mints', () => ({
+vi.mock("../../../src/stores/mints", () => ({
   useMintsStore: () => ({
     activeProofs: [],
-    activeMintUrl: 'm',
-    activeUnit: 'sat'
-  })
-}))
+    activeMintUrl: "m",
+    activeUnit: "sat",
+  }),
+}));
 
-describe('Donation presets', () => {
-  it('has default presets', () => {
-    const store = useDonationPresetsStore()
-    expect(store.presets.length).toBe(3)
-  })
+describe("Donation presets", () => {
+  it("has default presets", () => {
+    const store = useDonationPresetsStore();
+    expect(store.presets.length).toBe(3);
+  });
 
-  it('calls sendToLock with sequential locktimes', async () => {
-    const store = useDonationPresetsStore()
-    const wallet = useWalletStore()
-    const spy = wallet.sendToLock as any
-    await store.createDonationPreset(3, 1, 'pk', 'b')
-    expect(spy).toHaveBeenCalledTimes(3)
-    const first = spy.mock.calls[0][5]
-    const second = spy.mock.calls[1][5]
-    const third = spy.mock.calls[2][5]
-    expect(second).toBeGreaterThan(first)
-    expect(third).toBeGreaterThan(second)
-  })
-})
+  it("calls sendToLock with sequential locktimes", async () => {
+    const store = useDonationPresetsStore();
+    const wallet = useWalletStore();
+    const spy = wallet.sendToLock as any;
+    await store.createDonationPreset(3, 1, "pk", "b");
+    expect(spy).toHaveBeenCalledTimes(3);
+    const first = spy.mock.calls[0][5];
+    const second = spy.mock.calls[1][5];
+    const third = spy.mock.calls[2][5];
+    expect(second).toBeGreaterThan(first);
+    expect(third).toBeGreaterThan(second);
+  });
+
+  it("skips schedule when months is 0 and returns token", async () => {
+    const store = useDonationPresetsStore();
+    const wallet = useWalletStore();
+    const spy = wallet.sendToLock as any;
+    const token = await store.createDonationPreset(0, 5, "pk", "b");
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy.mock.calls[0][2]).toBe(5);
+    expect(token).toBe("tok");
+  });
+});


### PR DESCRIPTION
## Summary
- add donation type and amount fields in DonateDialog
- support one-time donations by skipping schedule logic
- handle new data flow in FindCreatorsView
- update i18n strings
- test donation presets with optional months

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d4504a95883309b9c9bad9d35a4ee