### PR TITLE
Improve featured creators view

### DIFF
--- a/src/components/CreatorProfileCard.vue
+++ b/src/components/CreatorProfileCard.vue
@@ -9,18 +9,18 @@
         <img :src="creator.profile.picture" alt="Creator image" />
       </q-avatar>
       <div class="q-ml-sm">
-        <div class="text-subtitle1">
+        <div class="text-subtitle1 name-line">
           {{
             creator.profile?.display_name ||
             creator.profile?.name ||
-            creator.pubkey
+            shortPubkey
           }}
         </div>
-        <div class="text-caption">{{ creator.pubkey }}</div>
+        <div class="text-caption pubkey-line">{{ shortPubkey }}</div>
       </div>
     </q-card-section>
     <q-card-section v-if="creator.profile?.about">
-      <div>{{ truncatedAbout }}</div>
+      <div class="about-text">{{ truncatedAbout }}</div>
     </q-card-section>
     <q-card-section v-if="creator.profile?.lud16">
       <div class="row items-center">
@@ -68,6 +68,10 @@ export default defineComponent({
         ? about.slice(0, MAX_LENGTH) + "…"
         : about;
     });
+    const shortPubkey = computed(() => {
+      const key = props.creator.pubkey;
+      return key.slice(0, 8) + "…" + key.slice(-8);
+    });
     const joinedDateFormatted = computed(() => {
       if (!props.creator.joined) return "";
       return date.formatDate(
@@ -77,6 +81,7 @@ export default defineComponent({
     });
     return {
       truncatedAbout,
+      shortPubkey,
       joinedDateFormatted,
     };
   },
@@ -94,5 +99,15 @@ export default defineComponent({
 .creator-card.qcard {
   width: 100%;
   max-width: 280px;
+}
+.name-line,
+.pubkey-line {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.about-text {
+  max-height: 4.5em;
+  overflow: hidden;
 }
 </style>

--- a/src/components/FindCreatorsView.vue
+++ b/src/components/FindCreatorsView.vue
@@ -1,5 +1,5 @@
 <template>
-  <div style="max-width: 1200px; margin: 0 auto">
+  <div class="creators-container">
     <q-input
       rounded
       outlined
@@ -37,6 +37,12 @@
         @donate="openDonateDialog(creator)"
         @message="openMessageDialog(creator)"
       />
+    </div>
+    <div
+      v-else-if="!searching && !error"
+      class="q-mt-md text-grey text-center"
+    >
+      {{ $t('FindCreators.labels.no_results') }}
     </div>
     <DonateDialog v-model="showDonateDialog" @confirm="handleDonate" />
     <q-dialog v-model="showActionDialog" persistent>
@@ -126,7 +132,14 @@ export default defineComponent({
       }
       clearTimeout(debounceTimeout);
       debounceTimeout = window.setTimeout(() => {
-        creatorsStore.searchCreators(val);
+        const trimmed = val.trim();
+        if (
+          trimmed.startsWith("npub") ||
+          trimmed.startsWith("nprofile") ||
+          /^[0-9a-fA-F]{64}$/.test(trimmed)
+        ) {
+          creatorsStore.searchCreators(trimmed);
+        }
       }, 500);
     });
 
@@ -282,6 +295,11 @@ export default defineComponent({
 </script>
 
 <style scoped>
+.creators-container {
+  max-width: 1400px;
+  margin: 0 auto;
+  width: 100%;
+}
 .creators-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));

--- a/src/components/MintSettings.vue
+++ b/src/components/MintSettings.vue
@@ -656,7 +656,7 @@ export default defineComponent({
     },
     fetchMintsFromNdk: async function () {
       this.discoveringMints = true;
-      await this.initNdkReadOnly();
+      this.initNdkReadOnly();
       console.log("### fetch mints");
       let maxTries = 5;
       let tries = 0;

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1314,6 +1314,7 @@ export default {
       followers: "Followers",
       following: "Following",
       joined: "Joined",
+      no_results: "No creators found",
     },
     actions: {
       donate: {

--- a/src/stores/creators.ts
+++ b/src/stores/creators.ts
@@ -3,15 +3,16 @@ import { useNostrStore } from "./nostr";
 import { nip19 } from "nostr-tools";
 
 export const FEATURED_CREATORS = [
-  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-  "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-  "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
-  "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
-  "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
-  "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-  "1111111111111111111111111111111111111111111111111111111111111111",
-  "2222222222222222222222222222222222222222222222222222222222222222",
-  "3333333333333333333333333333333333333333333333333333333333333333",
+  "npub1aljmhjp5tqrw3m60ra7t3u8uqq223d6rdg9q0h76a8djd9m4hmvsmlj82m",
+  "npub1sg6plzptd64u62a878hep2kev88swjh3tw00gjsfl8f237lmu63q0uf63m",
+  "npub1qny3tkh0acurzla8x3zy4nhrjz5zd8l9sy9jys09umwng00manysew95gx",
+  "npub1cj8znuztfqkvq89pl8hceph0svvvqk0qay6nydgk9uyq7fhpfsgsqwrz4u",
+  "npub1a2cww4kn9wqte4ry70vyfwqyqvpswksna27rtxd8vty6c74era8sdcw83a",
+  "npub1s05p3ha7en49dv8429tkk07nnfa9pcwczkf5x5qrdraqshxdje9sq6eyhe",
+  "npub180cvv07tjdrrgpa0j7j7tmnyl2yr6yr7l8j4s3evf6u64th6gkwsyjh6w6",
+  "npub1dergggklka99wwrs92yz8wdjs952h2ux2ha2ed598ngwu9w7a6fsh9xzpc",
+  "npub1s5yq6wadwrxde4lhfs56gn64hwzuhnfa6r9mj476r5s4hkunzgzqrs6q7z",
+  "npub1spdnfacgsd7lk0nlqkq443tkq4jx9z6c6ksvaquuewmw7d3qltpslcq6j7",
 ];
 
 export interface CreatorProfile {
@@ -37,12 +38,16 @@ export const useCreatorsStore = defineStore("creators", {
         return;
       }
       this.searching = true;
-      await nostrStore.initNdkReadOnly();
+      nostrStore.initNdkReadOnly();
       let pubkey = query.trim();
-      if (pubkey.startsWith("npub")) {
+      if (pubkey.startsWith("npub") || pubkey.startsWith("nprofile")) {
         try {
           const decoded = nip19.decode(pubkey);
-          pubkey = typeof decoded.data === "string" ? (decoded.data as string) : "";
+          if (typeof decoded.data === "string") {
+            pubkey = decoded.data as string;
+          } else if (typeof decoded.data === "object" && (decoded.data as any).pubkey) {
+            pubkey = (decoded.data as any).pubkey as string;
+          }
         } catch (e) {
           console.error(e);
           this.error = "Invalid npub";
@@ -55,14 +60,15 @@ export const useCreatorsStore = defineStore("creators", {
         return;
       }
       try {
-        const user = nostrStore.ndk.getUser({ pubkey });
-        await user.fetchProfile();
-        const followers = await nostrStore.fetchFollowerCount(pubkey);
-        const following = await nostrStore.fetchFollowingCount(pubkey);
-        const joined = await nostrStore.fetchJoinDate(pubkey);
+        const profile = await nostrStore.getProfile(pubkey);
+        const [followers, following, joined] = await Promise.all([
+          nostrStore.fetchFollowerCount(pubkey),
+          nostrStore.fetchFollowingCount(pubkey),
+          nostrStore.fetchJoinDate(pubkey),
+        ]);
         this.searchResults.push({
           pubkey,
-          profile: user.profile,
+          profile,
           followers,
           following,
           joined,
@@ -79,25 +85,39 @@ export const useCreatorsStore = defineStore("creators", {
       this.searchResults = [];
       this.error = "";
       this.searching = true;
-      await nostrStore.initNdkReadOnly();
-      for (const pubkey of FEATURED_CREATORS) {
+      nostrStore.initNdkReadOnly();
+
+      const promises = FEATURED_CREATORS.map(async (entry) => {
+        let pubkey = entry;
+        if (entry.startsWith("npub") || entry.startsWith("nprofile")) {
+          try {
+            const decoded = nip19.decode(entry);
+            if (typeof decoded.data === "string") {
+              pubkey = decoded.data as string;
+            } else if (typeof decoded.data === "object" && (decoded.data as any).pubkey) {
+              pubkey = (decoded.data as any).pubkey as string;
+            }
+          } catch (e) {
+            console.error("Failed to decode", entry, e);
+            return null;
+          }
+        }
         try {
-          const user = nostrStore.ndk.getUser({ pubkey });
-          await user.fetchProfile();
-          const followers = await nostrStore.fetchFollowerCount(pubkey);
-          const following = await nostrStore.fetchFollowingCount(pubkey);
-          const joined = await nostrStore.fetchJoinDate(pubkey);
-          this.searchResults.push({
-            pubkey,
-            profile: user.profile,
-            followers,
-            following,
-            joined,
-          });
+          const profile = await nostrStore.getProfile(pubkey);
+          const [followers, following, joined] = await Promise.all([
+            nostrStore.fetchFollowerCount(pubkey),
+            nostrStore.fetchFollowingCount(pubkey),
+            nostrStore.fetchJoinDate(pubkey),
+          ]);
+          return { pubkey, profile, followers, following, joined } as CreatorProfile;
         } catch (e) {
           console.error(e);
+          return null;
         }
-      }
+      });
+
+      const results = await Promise.all(promises);
+      this.searchResults = results.filter((r): r is CreatorProfile => !!r);
       this.searching = false;
     },
   },

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -124,6 +124,9 @@ export const useNostrStore = defineStore("nostr", {
   },
   actions: {
     initNdkReadOnly: function () {
+      if (this.connected && this.ndk) {
+        return;
+      }
       this.ndk = new NDK({ explicitRelayUrls: this.relays });
       this.ndk.connect();
       this.connected = true;
@@ -169,7 +172,7 @@ export const useNostrStore = defineStore("nostr", {
       if (this.profiles[pubkey]) {
         return this.profiles[pubkey];
       }
-      await this.initNdkReadOnly();
+      this.initNdkReadOnly();
       try {
         const user = this.ndk.getUser({ pubkey });
         await user.fetchProfile();
@@ -286,7 +289,7 @@ export const useNostrStore = defineStore("nostr", {
     },
 
     fetchFollowerCount: async function (pubkey: string): Promise<number> {
-      await this.initNdkReadOnly();
+      this.initNdkReadOnly();
       const filter: NDKFilter = { kinds: [3], "#p": [pubkey] };
       const events = await this.ndk.fetchEvents(filter);
       const authors = new Set<string>();
@@ -295,7 +298,7 @@ export const useNostrStore = defineStore("nostr", {
     },
 
     fetchFollowingCount: async function (pubkey: string): Promise<number> {
-      await this.initNdkReadOnly();
+      this.initNdkReadOnly();
       const filter: NDKFilter = { kinds: [3], authors: [pubkey] };
       const events = await this.ndk.fetchEvents(filter);
       let latest: NDKEvent | undefined;
@@ -315,7 +318,7 @@ export const useNostrStore = defineStore("nostr", {
     },
 
     fetchJoinDate: async function (pubkey: string): Promise<number | null> {
-      await this.initNdkReadOnly();
+      this.initNdkReadOnly();
       const filter: NDKFilter = { kinds: [0, 1], authors: [pubkey] };
       const events = await this.ndk.fetchEvents(filter);
       let earliest: number | null = null;
@@ -385,7 +388,7 @@ export const useNostrStore = defineStore("nostr", {
     },
     subscribeToNip04DirectMessages: async function () {
       await this.walletSeedGenerateKeyPair();
-      await this.initNdkReadOnly();
+      this.initNdkReadOnly();
       let nip04DirectMessageEvents: Set<NDKEvent> = new Set();
       const fetchEventsPromise = new Promise<Set<NDKEvent>>((resolve) => {
         if (!this.lastEventTimestamp) {
@@ -511,7 +514,7 @@ export const useNostrStore = defineStore("nostr", {
     },
     subscribeToNip17DirectMessages: async function () {
       await this.walletSeedGenerateKeyPair();
-      await this.initNdkReadOnly();
+      this.initNdkReadOnly();
       let nip17DirectMessageEvents: Set<NDKEvent> = new Set();
       const fetchEventsPromise = new Promise<Set<NDKEvent>>((resolve) => {
         if (!this.lastEventTimestamp) {

--- a/test/vitest/__tests__/creators.spec.ts
+++ b/test/vitest/__tests__/creators.spec.ts
@@ -7,6 +7,7 @@ const getUserMock = vi.fn(() => ({ fetchProfile, profile: userProfile }));
 const nostrStoreMock = {
   initNdkReadOnly: vi.fn(),
   ndk: { getUser: getUserMock },
+  getProfile: vi.fn().mockResolvedValue(userProfile),
   fetchFollowerCount: vi.fn().mockResolvedValue(10),
   fetchFollowingCount: vi.fn().mockResolvedValue(5),
   fetchJoinDate: vi.fn().mockResolvedValue(123456),
@@ -41,6 +42,16 @@ describe("Creators store", () => {
     expect(creators.searchResults[0].joined).toBe(123456);
   });
 
+  it("populates searchResults for valid nprofile", async () => {
+    (nip19.decode as any).mockReturnValue({ data: { pubkey: "e".repeat(64) } });
+    const creators = useCreatorsStore();
+    await creators.searchCreators("nprofile1xyz");
+
+    expect(creators.error).toBe("");
+    expect(creators.searchResults.length).toBe(1);
+    expect(creators.searchResults[0].pubkey).toBe("e".repeat(64));
+  });
+
   it("populates searchResults for hex pubkey", async () => {
     const creators = useCreatorsStore();
     await creators.searchCreators("a".repeat(64));
@@ -70,6 +81,7 @@ describe("Creators store", () => {
   });
 
   it("loads featured creators", async () => {
+    (nip19.decode as any).mockReturnValue({ data: "f".repeat(64) });
     const creators = useCreatorsStore();
     await creators.loadFeaturedCreators();
 


### PR DESCRIPTION
## Summary
- support `nprofile` search in creators store
- run NDK initialization only once
- fetch featured creators concurrently and use cached profiles
- truncate displayed pubkeys and bios in creator cards
- show message when no creators are found and validate search input
- add translation for no results
- update tests for new behaviour

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d464e2b5483309e3dc866e113a401