### PR TITLE
Add Creator Hub page

### DIFF
--- a/src/pages/CreatorHubPage.vue
+++ b/src/pages/CreatorHubPage.vue
@@ -1,0 +1,19 @@
+<template>
+  <q-page
+    :class="[
+      $q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark',
+      'q-pa-md',
+    ]"
+  >
+    <div class="text-h5 q-mb-md">Creator Hub</div>
+    <div class="text-subtitle1 q-mb-sm">Core Goals for the Creator Hub</div>
+    <ul>
+      <li>
+        Creator Empowerment: Provide tools for creators to easily showcase their
+        work and set up monetization tiers.
+      </li>
+    </ul>
+  </q-page>
+</template>
+
+<script setup lang="ts"></script>

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -23,6 +23,13 @@ const routes = [
     ],
   },
   {
+    path: "/creator-hub",
+    component: () => import("layouts/FullscreenLayout.vue"),
+    children: [
+      { path: "", component: () => import("src/pages/CreatorHubPage.vue") },
+    ],
+  },
+  {
     path: "/creator/login",
     component: () => import("layouts/FullscreenLayout.vue"),
     children: [


### PR DESCRIPTION
## Summary
- add a simple Creator Hub page
- route /creator-hub points to the new page

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d52a0d61083309a84ad1a1dcf7731