### PR TITLE
Implement tier persistence via Nostr

### DIFF
--- a/src/stores/creatorHub.ts
+++ b/src/stores/creatorHub.ts
@@ -1,14 +1,18 @@
 import { defineStore } from "pinia";
 import { useLocalStorage } from "@vueuse/core";
-import { NDKEvent } from "@nostr-dev-kit/ndk";
+import { NDKEvent, NDKKind, NDKFilter } from "@nostr-dev-kit/ndk";
 import { useNostrStore } from "./nostr";
+import { v4 as uuidv4 } from "uuid";
 
 export interface Tier {
   id: string;
   name: string;
   price: number;
   perks: string;
+  welcomeMessage?: string;
 }
+
+const CREATOR_TIER_KIND = 38100;
 
 export const useCreatorHubStore = defineStore("creatorHub", {
   state: () => ({
@@ -39,13 +43,57 @@ export const useCreatorHubStore = defineStore("creatorHub", {
       await ev.publish();
     },
     addTier(tier: Partial<Tier>) {
-      const id = tier.id || Date.now().toString();
-      this.tiers[id] = {
+      let id = tier.id || uuidv4();
+      while (this.tiers[id]) {
+        id = uuidv4();
+      }
+      const newTier: Tier = {
         id,
         name: tier.name || "",
         price: tier.price || 0,
         perks: tier.perks || "",
-      } as Tier;
+        welcomeMessage: tier.welcomeMessage || "",
+      };
+      this.tiers[id] = newTier;
+      this.saveTier(newTier);
+    },
+    updateTier(id: string, updates: Partial<Tier>) {
+      const existing = this.tiers[id];
+      if (!existing) return;
+      this.tiers[id] = { ...existing, ...updates };
+      this.saveTier(this.tiers[id]);
+    },
+    async saveTier(tier: Tier) {
+      const nostr = useNostrStore();
+      await nostr.initSignerIfNotSet();
+      const ev = new NDKEvent(nostr.ndk);
+      ev.kind = CREATOR_TIER_KIND as unknown as NDKKind;
+      ev.tags = [["d", tier.id]];
+      ev.content = JSON.stringify(tier);
+      await ev.sign(nostr.signer);
+      await ev.publish();
+    },
+    async loadTiersFromNostr(pubkey?: string) {
+      const nostr = useNostrStore();
+      await nostr.initNdkReadOnly();
+      const author = pubkey || this.loggedInNpub || nostr.pubkey;
+      if (!author) return;
+      const filter: NDKFilter = {
+        kinds: [CREATOR_TIER_KIND as unknown as NDKKind],
+        authors: [author],
+        limit: 200,
+      };
+      const events = await nostr.ndk.fetchEvents(filter);
+      events.forEach((ev) => {
+        try {
+          const tier = JSON.parse(ev.content) as Tier;
+          const id = tier.id || (ev.tagValue("d") as string) || ev.id;
+          tier.id = id;
+          this.tiers[id] = tier;
+        } catch (e) {
+          console.error(e);
+        }
+      });
     },
     removeTier(id: string) {
       delete this.tiers[id];


### PR DESCRIPTION
## Summary
- extend `Tier` with a `welcomeMessage` field
- ensure unique IDs using `uuid`
- add ability to save/load tiers to/from Nostr
- add mutation for updating tiers and persist them

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d54d205c8833080cb94bc3b7c5c0f