### PR TITLE
Improve creator tier management UI

### DIFF
--- a/src/pages/CreatorDashboardPage.vue
+++ b/src/pages/CreatorDashboardPage.vue
@@ -15,22 +15,95 @@
 
     <div class="q-mt-lg">
       <div class="text-h6">{{ $t('CreatorHub.dashboard.manage_tiers') }}</div>
-      <div v-for="tier in tiers" :key="tier.id" class="q-mt-md q-pa-sm bg-grey-2">
-        <q-input v-model="tier.name" label="Tier Name" dense class="q-mt-sm" />
-        <q-input v-model.number="tier.price" label="Price (sats)" type="number" dense class="q-mt-sm" />
-        <q-input v-model="tier.perks" label="Perks" type="textarea" dense class="q-mt-sm" />
-        <q-btn color="negative" flat class="q-mt-sm" @click="removeTier(tier.id)">Delete</q-btn>
+      <div
+        v-for="tier in tiers"
+        :key="tier.id"
+        class="q-mt-md q-pa-sm bg-grey-2"
+      >
+        <q-input
+          :id="`tier-name-${tier.id}`"
+          v-model="tier.name"
+          label="Tier Name"
+          dense
+          class="q-mt-sm"
+        />
+        <q-input
+          v-model.number="tier.price"
+          label="Price (sats)"
+          type="number"
+          dense
+          class="q-mt-sm"
+        >
+          <template #hint>
+            <div v-if="bitcoinPrice">
+              ~{{ formatCurrency((bitcoinPrice / 100000000) * tier.price, 'USD') }}
+              /
+              {{ formatCurrency((bitcoinPrice / 100000000) * tier.price, 'EUR') }}
+            </div>
+          </template>
+        </q-input>
+        <q-input
+          v-model="tier.perks"
+          label="Perks (Markdown)"
+          type="textarea"
+          autogrow
+          dense
+          class="q-mt-sm"
+        />
+        <q-input
+          v-model="tier.welcomeMessage"
+          label="Welcome Message"
+          type="textarea"
+          autogrow
+          dense
+          class="q-mt-sm"
+        />
+        <q-input
+          v-model="tier.id"
+          label="ID (optional)"
+          dense
+          class="q-mt-sm"
+        />
+        <div class="row q-gutter-sm q-mt-sm">
+          <q-btn
+            color="primary"
+            flat
+            @click="saveTier(tier)"
+            >Save Tier</q-btn
+          >
+          <q-btn
+            color="negative"
+            flat
+            @click="removeTier(tier.id)"
+            >Delete Tier</q-btn
+          >
+        </div>
       </div>
-      <q-btn color="primary" flat class="q-mt-md" @click="addTier">{{ $t('CreatorHub.dashboard.add_tier') }}</q-btn>
+      <q-btn
+        color="primary"
+        flat
+        class="q-mt-md"
+        @click="addTier"
+        >{{ $t('CreatorHub.dashboard.add_tier') }}</q-btn
+      >
     </div>
   </div>
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, onMounted } from 'vue';
+import {
+  defineComponent,
+  ref,
+  onMounted,
+  computed,
+  nextTick,
+} from 'vue';
 import { useCreatorHubStore, Tier } from 'stores/creatorHub';
 import { useNostrStore } from 'stores/nostr';
 import { useRouter } from 'vue-router';
+import { usePriceStore } from 'stores/price';
+import { useUiStore } from 'stores/ui';
+import { v4 as uuidv4 } from 'uuid';
 
 export default defineComponent({
   name: 'CreatorDashboardPage',
@@ -38,8 +111,10 @@ export default defineComponent({
     const store = useCreatorHubStore();
     const nostr = useNostrStore();
     const router = useRouter();
+    const priceStore = usePriceStore();
+    const uiStore = useUiStore();
     const profile = ref<any>({ display_name: '', picture: '', about: '' });
-    const tiers = ref<Tier[]>([]);
+    const tiers = computed<Tier[]>(() => store.getTierArray());
 
     onMounted(async () => {
       if (!store.loggedInNpub) {
@@ -48,7 +123,6 @@ export default defineComponent({
       }
       const p = await nostr.getProfile(store.loggedInNpub);
       if (p) profile.value = { ...p };
-      tiers.value = store.getTierArray();
     });
 
     const logout = () => {
@@ -60,17 +134,39 @@ export default defineComponent({
       await store.updateProfile(profile.value);
     };
 
-    const addTier = () => {
-      store.addTier({ name: '', price: 0, perks: '' });
-      tiers.value = store.getTierArray();
+    const addTier = async () => {
+      const id = uuidv4();
+      store.addTier({ id, name: '', price: 0, perks: '', welcomeMessage: '' });
+      await nextTick(() => {
+        const el = document.getElementById(`tier-name-${id}`);
+        if (el) (el as HTMLInputElement).focus();
+      });
     };
 
     const removeTier = (id: string) => {
       store.removeTier(id);
-      tiers.value = store.getTierArray();
     };
 
-    return { profile, tiers, logout, saveProfile, addTier, removeTier };
+    const saveTier = (tier: Tier) => {
+      store.updateTier(tier.id, { ...tier });
+    };
+
+    const bitcoinPrice = computed(() => priceStore.bitcoinPrice);
+
+    const formatCurrency = (amount: number, unit: string) =>
+      uiStore.formatCurrency(amount, unit);
+
+    return {
+      profile,
+      tiers,
+      bitcoinPrice,
+      formatCurrency,
+      logout,
+      saveProfile,
+      addTier,
+      removeTier,
+      saveTier,
+    };
   }
 });
 </script>


### PR DESCRIPTION
## Summary
- expand creator dashboard tier editor
- compute fiat prices from bitcoin price
- allow saving and deleting tiers
- autofocus new tier's name when added

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d559be1148330ae08a2e950c8b15f