### PR TITLE
Enable markdown perks and welcome DMs

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "underscore": "^1.13.6",
     "vue": "^3.4.27",
     "vue-i18n": "^11.1.3",
-    "vue-router": "^4.3.2"
+    "vue-router": "^4.3.2",
+    "marked": "^9.1.2"
   },
   "devDependencies": {
     "@capacitor/assets": "^3.0.5",


### PR DESCRIPTION
## Summary
- render tier perks using markdown
- display estimated fiat price for each tier
- DM tier welcome message when a supporter selects a tier
- add `marked` dependency

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d55a7f91c83308023357df5a6cc1a