### PR TITLE
Add CreatorHub dashboard locale keys

### DIFF
--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -1301,6 +1301,17 @@ timelock: {
     title: "About Cashu.me",
     video_placeholder: "Video coming soon",
   },
+  CreatorHub: {
+    dashboard: {
+      save_tier: "Save Tier",
+      delete_tier: "Delete Tier",
+      welcome_message: "Welcome Message",
+      currency_labels: {
+        usd: "USD",
+        eur: "EUR",
+      },
+    },
+  },
   swap: {
     in_progress_warning_text: "التبديل قيد التقدم",
     invalid_swap_data_error_text: "بيانات تبديل غير صالحة",

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -1308,6 +1308,17 @@ export default {
     title: "About Cashu.me",
     video_placeholder: "Video coming soon",
   },
+  CreatorHub: {
+    dashboard: {
+      save_tier: "Save Tier",
+      delete_tier: "Delete Tier",
+      welcome_message: "Welcome Message",
+      currency_labels: {
+        usd: "USD",
+        eur: "EUR",
+      },
+    },
+  },
   swap: {
     in_progress_warning_text: "Swap läuft",
     invalid_swap_data_error_text: "Ungültige Swap-Daten",

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -1311,6 +1311,17 @@ timelock: {
     title: "About Cashu.me",
     video_placeholder: "Video coming soon",
   },
+  CreatorHub: {
+    dashboard: {
+      save_tier: "Save Tier",
+      delete_tier: "Delete Tier",
+      welcome_message: "Welcome Message",
+      currency_labels: {
+        usd: "USD",
+        eur: "EUR",
+      },
+    },
+  },
   swap: {
     in_progress_warning_text: "Η ανταλλαγή βρίσκεται σε εξέλιξη",
     invalid_swap_data_error_text: "Μη έγκυρα δεδομένα ανταλλαγής",

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1445,6 +1445,13 @@ export default {
       edit_profile: "Edit Profile",
       manage_tiers: "Manage Tiers",
       add_tier: "Add Tier",
+      save_tier: "Save Tier",
+      delete_tier: "Delete Tier",
+      welcome_message: "Welcome Message",
+      currency_labels: {
+        usd: "USD",
+        eur: "EUR",
+      },
     },
     profile: {
       back: "Back",

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -1309,6 +1309,17 @@ timelock: {
     title: "About Cashu.me",
     video_placeholder: "Video coming soon",
   },
+  CreatorHub: {
+    dashboard: {
+      save_tier: "Save Tier",
+      delete_tier: "Delete Tier",
+      welcome_message: "Welcome Message",
+      currency_labels: {
+        usd: "USD",
+        eur: "EUR",
+      },
+    },
+  },
   swap: {
     in_progress_warning_text: "Intercambio en progreso",
     invalid_swap_data_error_text: "Datos de intercambio inválidos",

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -1298,6 +1298,17 @@ timelock: {
     title: "About Cashu.me",
     video_placeholder: "Video coming soon",
   },
+  CreatorHub: {
+    dashboard: {
+      save_tier: "Save Tier",
+      delete_tier: "Delete Tier",
+      welcome_message: "Welcome Message",
+      currency_labels: {
+        usd: "USD",
+        eur: "EUR",
+      },
+    },
+  },
   swap: {
     in_progress_warning_text: "Échange en cours",
     invalid_swap_data_error_text: "Données d'échange invalides",

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -1291,6 +1291,17 @@ timelock: {
     title: "About Cashu.me",
     video_placeholder: "Video coming soon",
   },
+  CreatorHub: {
+    dashboard: {
+      save_tier: "Save Tier",
+      delete_tier: "Delete Tier",
+      welcome_message: "Welcome Message",
+      currency_labels: {
+        usd: "USD",
+        eur: "EUR",
+      },
+    },
+  },
   swap: {
     in_progress_warning_text: "Scambio in corso",
     invalid_swap_data_error_text: "Dati di scambio non validi",

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -1291,6 +1291,17 @@ timelock: {
     title: "About Cashu.me",
     video_placeholder: "Video coming soon",
   },
+  CreatorHub: {
+    dashboard: {
+      save_tier: "Save Tier",
+      delete_tier: "Delete Tier",
+      welcome_message: "Welcome Message",
+      currency_labels: {
+        usd: "USD",
+        eur: "EUR",
+      },
+    },
+  },
   swap: {
     in_progress_warning_text: "スワップ進行中",
     invalid_swap_data_error_text: "無効なスワップデータ",

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -1291,6 +1291,17 @@ timelock: {
     title: "About Cashu.me",
     video_placeholder: "Video coming soon",
   },
+  CreatorHub: {
+    dashboard: {
+      save_tier: "Save Tier",
+      delete_tier: "Delete Tier",
+      welcome_message: "Welcome Message",
+      currency_labels: {
+        usd: "USD",
+        eur: "EUR",
+      },
+    },
+  },
   swap: {
     in_progress_warning_text: "Byte pågår",
     invalid_swap_data_error_text: "Ogiltig bytesdata",

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -1288,6 +1288,17 @@ timelock: {
     title: "About Cashu.me",
     video_placeholder: "Video coming soon",
   },
+  CreatorHub: {
+    dashboard: {
+      save_tier: "Save Tier",
+      delete_tier: "Delete Tier",
+      welcome_message: "Welcome Message",
+      currency_labels: {
+        usd: "USD",
+        eur: "EUR",
+      },
+    },
+  },
   swap: {
     in_progress_warning_text: "กำลังดำเนินการแลกเปลี่ยน",
     invalid_swap_data_error_text: "ข้อมูลการแลกเปลี่ยนไม่ถูกต้อง",

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -1293,6 +1293,17 @@ timelock: {
     title: "About Cashu.me",
     video_placeholder: "Video coming soon",
   },
+  CreatorHub: {
+    dashboard: {
+      save_tier: "Save Tier",
+      delete_tier: "Delete Tier",
+      welcome_message: "Welcome Message",
+      currency_labels: {
+        usd: "USD",
+        eur: "EUR",
+      },
+    },
+  },
   swap: {
     in_progress_warning_text: "Takas devam ediyor",
     invalid_swap_data_error_text: "Geçersiz takas verisi",

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -1281,6 +1281,17 @@ timelock: {
     title: "About Cashu.me",
     video_placeholder: "Video coming soon",
   },
+  CreatorHub: {
+    dashboard: {
+      save_tier: "Save Tier",
+      delete_tier: "Delete Tier",
+      welcome_message: "Welcome Message",
+      currency_labels: {
+        usd: "USD",
+        eur: "EUR",
+      },
+    },
+  },
   swap: {
     in_progress_warning_text: "兑换进行中",
     invalid_swap_data_error_text: "无效的兑换数据",


### PR DESCRIPTION
## Summary
- add CreatorHub dashboard locale keys for new features
- add placeholders for all other locales

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_683d56f574c08330aab3e6c6c3234a05