### PR TITLE
Add Creator Hub to nav menu

### DIFF
--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -114,12 +114,25 @@
         <q-item-section avatar>
           <q-icon name="search" />
         </q-item-section>
-        <q-item-section>
+      <q-item-section>
           <q-item-label>{{
             $t("MainHeader.menu.findCreators.findCreators.title")
           }}</q-item-label>
           <q-item-label caption>{{
             $t("MainHeader.menu.findCreators.findCreators.caption")
+          }}</q-item-label>
+        </q-item-section>
+      </q-item>
+      <q-item clickable @click="gotoCreatorHub">
+        <q-item-section avatar>
+          <q-icon name="hub" />
+        </q-item-section>
+        <q-item-section>
+          <q-item-label>{{
+            $t("MainHeader.menu.creatorHub.creatorHub.title")
+          }}</q-item-label>
+          <q-item-label caption>{{
+            $t("MainHeader.menu.creatorHub.creatorHub.caption")
           }}</q-item-label>
         </q-item-section>
       </q-item>
@@ -280,6 +293,11 @@ export default defineComponent({
       leftDrawerOpen.value = false;
     };
 
+    const gotoCreatorHub = () => {
+      router.push("/creator-hub");
+      leftDrawerOpen.value = false;
+    };
+
     const gotoChats = () => {
       router.push("/chats");
       leftDrawerOpen.value = false;
@@ -300,6 +318,7 @@ export default defineComponent({
       uiStore,
       gotoBuckets,
       gotoFindCreators,
+      gotoCreatorHub,
       gotoChats,
       gotoWallet,
     };

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -109,6 +109,13 @@ export default {
           caption: "Discover creators",
         },
       },
+      creatorHub: {
+        title: "Creator Hub",
+        creatorHub: {
+          title: "Creator Hub",
+          caption: "Manage your tiers",
+        },
+      },
       buckets: {
         title: "Buckets",
         buckets: {


### PR DESCRIPTION
## Summary
- add Creator Hub menu item and navigation handler
- update English i18n strings with Creator Hub labels

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_683d5c67b7088330b9235a5f0576a2bd