### PR TITLE
Add My Profile page

### DIFF
--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -114,7 +114,7 @@
         <q-item-section avatar>
           <q-icon name="search" />
         </q-item-section>
-      <q-item-section>
+        <q-item-section>
           <q-item-label>{{
             $t("MainHeader.menu.findCreators.findCreators.title")
           }}</q-item-label>
@@ -133,6 +133,19 @@
           }}</q-item-label>
           <q-item-label caption>{{
             $t("MainHeader.menu.creatorHub.creatorHub.caption")
+          }}</q-item-label>
+        </q-item-section>
+      </q-item>
+      <q-item clickable @click="gotoMyProfile">
+        <q-item-section avatar>
+          <q-icon name="person" />
+        </q-item-section>
+        <q-item-section>
+          <q-item-label>{{
+            $t("MainHeader.menu.myProfile.myProfile.title")
+          }}</q-item-label>
+          <q-item-label caption>{{
+            $t("MainHeader.menu.myProfile.myProfile.caption")
           }}</q-item-label>
         </q-item-section>
       </q-item>
@@ -298,6 +311,11 @@ export default defineComponent({
       leftDrawerOpen.value = false;
     };
 
+    const gotoMyProfile = () => {
+      router.push("/my-profile");
+      leftDrawerOpen.value = false;
+    };
+
     const gotoChats = () => {
       router.push("/chats");
       leftDrawerOpen.value = false;
@@ -319,6 +337,7 @@ export default defineComponent({
       gotoBuckets,
       gotoFindCreators,
       gotoCreatorHub,
+      gotoMyProfile,
       gotoChats,
       gotoWallet,
     };

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -116,6 +116,10 @@ export default {
           caption: "Manage your tiers",
         },
       },
+      myProfile: {
+        title: "My Profile",
+        myProfile: { title: "My Profile", caption: "View your profile" },
+      },
       buckets: {
         title: "Buckets",
         buckets: {
@@ -1444,7 +1448,8 @@ export default {
       nip07: "Login with Nostr Extension",
       nsec: "nsec",
       nsec_button: "Login with nsec",
-      nsec_warning: "Entering your nsec in a web app is dangerous. Use NIP-07 if possible.",
+      nsec_warning:
+        "Entering your nsec in a web app is dangerous. Use NIP-07 if possible.",
     },
     dashboard: {
       title: "Creator Dashboard",

--- a/src/pages/MyProfilePage.vue
+++ b/src/pages/MyProfilePage.vue
@@ -1,0 +1,101 @@
+<template>
+  <div
+    :class="[
+      $q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark',
+      'q-pa-md',
+    ]"
+  >
+    <div class="q-mb-md">
+      <q-btn flat color="primary" to="/creator/dashboard">
+        {{ $t("CreatorHub.profile.back") }}
+      </q-btn>
+    </div>
+    <div class="text-h5 q-mb-md">{{ profile.display_name || pubkey }}</div>
+    <div v-if="profile.picture" class="q-mb-md">
+      <img :src="profile.picture" style="max-width: 150px" />
+    </div>
+    <div v-if="profile.about" class="q-mb-md">{{ profile.about }}</div>
+
+    <div v-if="tiers.length">
+      <div class="text-h6 q-mb-sm">{{ $t("CreatorHub.profile.tiers") }}</div>
+      <div v-for="tier in tiers" :key="tier.id" class="q-mb-md">
+        <div class="text-subtitle1">
+          {{ tier.name }} - {{ tier.price }} sats
+          <span v-if="bitcoinPrice" class="text-caption">
+            ({{ formatFiat(tier.price) }})
+          </span>
+        </div>
+        <div class="text-caption" v-html="renderMarkdown(tier.perks)"></div>
+        <q-btn
+          color="primary"
+          dense
+          class="q-mt-sm"
+          @click="supportTier(tier)"
+          >{{ $t("CreatorHub.profile.support") }}</q-btn
+        >
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref, onMounted, computed } from "vue";
+import { useNostrStore } from "stores/nostr";
+import { useCreatorHubStore, Tier } from "stores/creatorHub";
+import { usePriceStore } from "stores/price";
+import { useUiStore } from "stores/ui";
+import { renderMarkdown as renderMarkdownFn } from "src/js/simple-markdown";
+
+export default defineComponent({
+  name: "MyProfilePage",
+  setup() {
+    const nostr = useNostrStore();
+    const hub = useCreatorHubStore();
+    const priceStore = usePriceStore();
+    const uiStore = useUiStore();
+    const bitcoinPrice = computed(() => priceStore.bitcoinPrice);
+    const pubkey = computed(() => hub.loggedInNpub || nostr.pubkey);
+    const profile = ref<any>({});
+    const tiers = ref(hub.getTierArray());
+
+    onMounted(async () => {
+      if (!pubkey.value) return;
+      const p = await nostr.getProfile(pubkey.value);
+      if (p) profile.value = { ...p };
+    });
+
+    function renderMarkdown(text: string): string {
+      return renderMarkdownFn(text || "");
+    }
+
+    function formatFiat(sats: number): string {
+      if (!priceStore.bitcoinPrice) return "";
+      const value = (priceStore.bitcoinPrice / 100000000) * sats;
+      return uiStore.formatCurrency(value, "USD", true);
+    }
+
+    async function supportTier(tier: Tier) {
+      if (tier.welcomeMessage) {
+        try {
+          await useNostrStore().sendNip04DirectMessage(
+            pubkey.value,
+            tier.welcomeMessage,
+          );
+        } catch (e) {
+          console.error(e);
+        }
+      }
+    }
+
+    return {
+      pubkey,
+      profile,
+      tiers,
+      bitcoinPrice,
+      renderMarkdown,
+      formatFiat,
+      supportTier,
+    };
+  },
+});
+</script>

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -47,6 +47,16 @@ const routes = [
     ],
   },
   {
+    path: "/my-profile",
+    component: () => import("layouts/FullscreenLayout.vue"),
+    children: [
+      {
+        path: "",
+        component: () => import("src/pages/MyProfilePage.vue"),
+      },
+    ],
+  },
+  {
     path: "/creators/:npubOrVanityName",
     component: () => import("layouts/FullscreenLayout.vue"),
     children: [


### PR DESCRIPTION
## Summary
- add `MyProfilePage.vue` to show current user profile
- hook new page in router
- link new page from main menu
- add i18n entries for My Profile

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d614ae7e483309eb6af70672e5378