### PR TITLE
Improve tier editor UI

### DIFF
--- a/src/components/AddTierDialog.vue
+++ b/src/components/AddTierDialog.vue
@@ -1,0 +1,61 @@
+<template>
+  <q-dialog v-model="showLocal" persistent backdrop-filter="blur(2px) brightness(60%)">
+    <q-card class="q-pa-md" style="min-width:350px">
+      <q-card-section>
+        <div class="text-h6">{{ $t('CreatorHub.dashboard.add_tier') }}</div>
+      </q-card-section>
+      <q-card-section class="q-pt-none">
+        <q-input v-model="localTier.name" label="Title" outlined dense class="q-mb-sm" />
+        <q-input v-model.number="localTier.price" type="number" label="Cost (sats)" outlined dense class="q-mb-sm" />
+        <q-input v-model="localTier.description" type="textarea" autogrow label="Description (Markdown)" outlined dense class="q-mb-sm" />
+        <q-input v-model="localTier.welcomeMessage" type="textarea" autogrow label="Welcome Message" outlined dense class="q-mb-sm" />
+      </q-card-section>
+      <q-card-actions align="between" class="q-pt-none">
+        <q-btn flat color="primary" @click="save">{{ $t('CreatorHub.dashboard.save_tier') }}</q-btn>
+        <q-btn flat color="grey" v-close-popup>{{ $t('global.actions.cancel.label') }}</q-btn>
+      </q-card-actions>
+    </q-card>
+  </q-dialog>
+</template>
+
+<script lang="ts">
+import { defineComponent, computed, reactive, watch } from 'vue';
+import { Tier } from 'stores/creatorHub';
+
+export default defineComponent({
+  name: 'AddTierDialog',
+  props: {
+    modelValue: {
+      type: Boolean,
+      required: true,
+    },
+    tier: {
+      type: Object as () => Partial<Tier>,
+      required: true,
+    },
+  },
+  emits: ['update:modelValue', 'save'],
+  setup(props, { emit }) {
+    const showLocal = computed({
+      get: () => props.modelValue,
+      set: (val) => emit('update:modelValue', val),
+    });
+
+    const localTier = reactive({ ...props.tier });
+
+    watch(
+      () => props.tier,
+      (val) => {
+        Object.assign(localTier, val);
+      },
+      { deep: true, immediate: true }
+    );
+
+    const save = () => {
+      emit('save', { ...localTier });
+    };
+
+    return { showLocal, localTier, save };
+  },
+});
+</script>

--- a/src/pages/CreatorHubPage.vue
+++ b/src/pages/CreatorHubPage.vue
@@ -18,7 +18,7 @@
             <div class="text-subtitle1">
               {{ tier.name }} - {{ tier.price }} sats
             </div>
-            <div class="text-caption" v-html="renderMarkdown(tier.perks)"></div>
+            <div class="text-caption" v-html="renderMarkdown(tier.description)"></div>
           </q-card-section>
         </q-card>
       </div>

--- a/src/pages/MyProfilePage.vue
+++ b/src/pages/MyProfilePage.vue
@@ -25,7 +25,7 @@
             ({{ formatFiat(tier.price) }})
           </span>
         </div>
-        <div class="text-caption" v-html="renderMarkdown(tier.perks)"></div>
+        <div class="text-caption" v-html="renderMarkdown(tier.description)"></div>
         <q-btn
           color="primary"
           dense

--- a/src/pages/PublicCreatorProfilePage.vue
+++ b/src/pages/PublicCreatorProfilePage.vue
@@ -25,7 +25,7 @@
             ({{ formatFiat(tier.price) }})
           </span>
         </div>
-        <div class="text-caption" v-html="renderMarkdown(tier.perks)"></div>
+        <div class="text-caption" v-html="renderMarkdown(tier.description)"></div>
         <q-btn
           color="primary"
           dense

--- a/src/stores/creatorHub.ts
+++ b/src/stores/creatorHub.ts
@@ -8,7 +8,7 @@ export interface Tier {
   id: string;
   name: string;
   price: number;
-  perks: string;
+  description: string;
   welcomeMessage?: string;
 }
 
@@ -51,7 +51,7 @@ export const useCreatorHubStore = defineStore("creatorHub", {
         id,
         name: tier.name || "",
         price: tier.price || 0,
-        perks: tier.perks || "",
+        description: (tier as any).description || (tier as any).perks || "",
         welcomeMessage: tier.welcomeMessage || "",
       };
       this.tiers[id] = newTier;
@@ -86,9 +86,15 @@ export const useCreatorHubStore = defineStore("creatorHub", {
       const events = await nostr.ndk.fetchEvents(filter);
       events.forEach((ev) => {
         try {
-          const tier = JSON.parse(ev.content) as Tier;
-          const id = tier.id || (ev.tagValue("d") as string) || ev.id;
-          tier.id = id;
+          const data = JSON.parse(ev.content) as any;
+          const id = data.id || (ev.tagValue("d") as string) || ev.id;
+          const tier: Tier = {
+            id,
+            name: data.name || "",
+            price: data.price || 0,
+            description: data.description || data.perks || "",
+            welcomeMessage: data.welcomeMessage || "",
+          };
           this.tiers[id] = tier;
         } catch (e) {
           console.error(e);

--- a/test/vitest/__tests__/creatorHub.spec.ts
+++ b/test/vitest/__tests__/creatorHub.spec.ts
@@ -47,7 +47,7 @@ describe('CreatorHub store', () => {
   it('addTier stores tier and calls saveTier', () => {
     const store = useCreatorHubStore()
     const spy = vi.spyOn(store, 'saveTier').mockResolvedValue()
-    store.addTier({ name: 'Tier 1', price: 5, perks: 'p' })
+    store.addTier({ name: 'Tier 1', price: 5, description: 'p' })
     const tier = store.getTierArray()[0]
     expect(tier.name).toBe('Tier 1')
     expect(spy).toHaveBeenCalledWith(tier)
@@ -55,7 +55,7 @@ describe('CreatorHub store', () => {
 
   it('saveTier creates proper nostr event', async () => {
     const store = useCreatorHubStore()
-    const tier = { id: 'id1', name: 'T', price: 1, perks: 'p', welcomeMessage: 'w' }
+    const tier = { id: 'id1', name: 'T', price: 1, description: 'p', welcomeMessage: 'w' }
     await store.saveTier(tier)
     expect(nostrStoreMock.initSignerIfNotSet).toHaveBeenCalled()
     expect(createdEvents).toHaveLength(1)


### PR DESCRIPTION
## Summary
- create AddTierDialog for cleaner tier creation
- enhance CreatorDashboardPage UI with cards
- allow tier descriptions in creatorHub store
- show tier descriptions in profile pages
- fix prop mutation in AddTierDialog
- update tests for description field

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d6352e5c08330bc69a1cf5ec3dedd