### PR TITLE
Publish event when removing creator tier

### DIFF
--- a/src/stores/creatorHub.ts
+++ b/src/stores/creatorHub.ts
@@ -101,8 +101,17 @@ export const useCreatorHubStore = defineStore("creatorHub", {
         }
       });
     },
-    removeTier(id: string) {
+    async removeTier(id: string) {
       delete this.tiers[id];
+
+      const nostr = useNostrStore();
+      await nostr.initSignerIfNotSet();
+      const ev = new NDKEvent(nostr.ndk);
+      ev.kind = CREATOR_TIER_KIND as unknown as NDKKind;
+      ev.tags = [["d", id]];
+      ev.content = "";
+      await ev.sign(nostr.signer);
+      await ev.publish();
     },
     getTierArray(): Tier[] {
       return Object.values(this.tiers);

--- a/test/vitest/__tests__/creatorHub.spec.ts
+++ b/test/vitest/__tests__/creatorHub.spec.ts
@@ -66,4 +66,19 @@ describe('CreatorHub store', () => {
     expect(signMock).toHaveBeenCalledWith(nostrStoreMock.signer)
     expect(publishMock).toHaveBeenCalled()
   })
+
+  it('removeTier publishes deletion event', async () => {
+    const store = useCreatorHubStore()
+    store.tiers['id1'] = { id: 'id1', name: 'T', price: 1, description: '', welcomeMessage: '' }
+    await store.removeTier('id1')
+    expect(store.tiers['id1']).toBeUndefined()
+    expect(nostrStoreMock.initSignerIfNotSet).toHaveBeenCalled()
+    expect(createdEvents).toHaveLength(1)
+    const ev = createdEvents[0]
+    expect(ev.kind).toBe(38100)
+    expect(ev.tags).toEqual([[ 'd', 'id1' ]])
+    expect(ev.content).toBe('')
+    expect(signMock).toHaveBeenCalledWith(nostrStoreMock.signer)
+    expect(publishMock).toHaveBeenCalled()
+  })
 })


### PR DESCRIPTION
## Summary
- update `removeTier` to publish a replaceable Nostr event when a tier is deleted
- test deletion event publishing

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683deb4359608330ab967c2c1ce71a47