### PR TITLE
Improve chat interface layout

### DIFF
--- a/src/pages/ChatView.vue
+++ b/src/pages/ChatView.vue
@@ -1,11 +1,9 @@
 <template>
-  <div
-    :class="[$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark', 'full-height flex column']"
+  <q-page
+    :class="[$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark']"
+    class="flex column full-height"
   >
-    <div
-      class="q-pa-sm row items-center text-h6 border-bottom"
-      style="border-bottom: 1px solid rgba(0,0,0,0.1)"
-    >
+    <q-toolbar class="border-bottom q-pa-sm" style="border-bottom: 1px solid rgba(0,0,0,0.1)">
       <q-btn
         flat
         dense
@@ -16,9 +14,12 @@
         aria-label="Go back"
         class="q-mr-sm"
       />
-      <span>{{ displayName }}</span>
-    </div>
-    <div class="q-pa-md scroll" style="flex: 1; overflow-y: auto" ref="scrollArea">
+      <q-avatar v-if="avatar" size="md" class="q-mr-sm">
+        <img :src="avatar" />
+      </q-avatar>
+      <q-toolbar-title class="text-h6">{{ displayName }}</q-toolbar-title>
+    </q-toolbar>
+    <div class="q-pa-md scroll-area col" ref="scrollArea">
       <q-chat-message
         v-for="msg in messages"
         :key="msg.id"
@@ -30,18 +31,26 @@
       />
       <div ref="bottomMarker"></div>
     </div>
-    <div class="q-pa-sm row items-center">
+    <div class="q-pa-sm row no-wrap items-center">
       <q-input
         v-model="newMessage"
         dense
         outlined
-        class="col-grow q-mr-sm"
+        class="col q-mr-sm"
         placeholder="Type a message"
+        autofocus
         @keyup.enter="sendMessage"
       />
-      <q-btn flat icon="send" color="primary" @click="sendMessage" />
+      <q-btn
+        flat
+        round
+        icon="send"
+        color="primary"
+        @click="sendMessage"
+        :disable="!newMessage.trim()"
+      />
     </div>
-  </div>
+  </q-page>
 </template>
 
 <script lang="ts">
@@ -129,7 +138,7 @@ export default defineComponent({
 </script>
 
 <style scoped>
-.scroll {
+.scroll-area {
   overflow-y: auto;
 }
 .border-bottom {

--- a/src/pages/Chats.vue
+++ b/src/pages/Chats.vue
@@ -1,17 +1,21 @@
 <template>
-  <div :class="[$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark', 'q-pa-md']">
-    <q-list bordered>
+  <q-page :class="[$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark']" class="column full-height">
+    <q-toolbar class="q-pa-sm border-bottom" style="border-bottom: 1px solid rgba(0,0,0,0.1)">
+      <q-toolbar-title class="text-h6">Chats</q-toolbar-title>
+    </q-toolbar>
+    <q-list bordered class="col scroll-area">
       <q-item v-for="pubkey in pubkeys" :key="pubkey" clickable @click="openChat(pubkey)">
         <q-item-section avatar>
           <q-avatar v-if="profiles[pubkey]?.picture" :src="profiles[pubkey].picture" />
         </q-item-section>
         <q-item-section>
           <q-item-label class="text-subtitle1">{{ displayName(pubkey) }}</q-item-label>
-          <q-item-label caption>{{ lastMessageTime(pubkey) }}</q-item-label>
+          <q-item-label caption>{{ lastMessageSnippet(pubkey) }}</q-item-label>
+          <q-item-label caption class="ellipsis">{{ lastMessageTime(pubkey) }}</q-item-label>
         </q-item-section>
       </q-item>
     </q-list>
-  </div>
+  </q-page>
 </template>
 
 <script lang="ts">
@@ -20,6 +24,7 @@ import { useRouter } from 'vue-router';
 import { useDmChatsStore } from 'stores/dmChats';
 import { useNostrStore } from 'stores/nostr';
 import { storeToRefs } from 'pinia';
+import { sanitizeMessage } from 'src/js/message-utils';
 
 export default defineComponent({
   name: 'ChatsPage',
@@ -56,11 +61,31 @@ export default defineComponent({
       return new Date(ts * 1000).toLocaleString();
     };
 
+    const lastMessageSnippet = (pk: string) => {
+      const msgs = chats.value[pk];
+      if (!msgs || !msgs.length) return '';
+      return sanitizeMessage(msgs[msgs.length - 1].content).slice(0, 40);
+    };
+
     const openChat = (pk: string) => {
       router.push(`/chats/${pk}`);
     };
 
-    return { chats, pubkeys, profiles, displayName, lastMessageTime, openChat };
+    return {
+      chats,
+      pubkeys,
+      profiles,
+      displayName,
+      lastMessageTime,
+      lastMessageSnippet,
+      openChat,
+    };
   },
 });
 </script>
+
+<style scoped>
+.scroll-area {
+  overflow-y: auto;
+}
+</style>


### PR DESCRIPTION
## Summary
- adjust chat message layout for readability
- add toolbar with avatar in chat view
- show message previews in chat list
- use q-page layouts for chats

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683deaed9374833097ba76094418fb95