### PR TITLE
Update AddTierDialog with price hints and translations

### DIFF
--- a/src/components/AddTierDialog.vue
+++ b/src/components/AddTierDialog.vue
@@ -5,13 +5,33 @@
         <div class="text-h6">{{ $t('CreatorHub.dashboard.add_tier') }}</div>
       </q-card-section>
       <q-card-section class="q-pt-none">
-        <q-input v-model="localTier.name" label="Title" outlined dense class="q-mb-sm" />
-        <q-input v-model.number="localTier.price" type="number" label="Cost (sats)" outlined dense class="q-mb-sm" />
+        <q-input
+          v-model="localTier.name"
+          :label="$t('CreatorHub.dashboard.inputs.title.label')"
+          outlined
+          dense
+          class="q-mb-sm"
+        />
+        <q-input
+          v-model.number="localTier.price"
+          type="number"
+          :label="$t('CreatorHub.dashboard.inputs.price.label')"
+          outlined
+          dense
+          class="q-mb-sm"
+        >
+          <template #hint>
+            <div v-if="bitcoinPrice">
+              ~{{ formatCurrency((bitcoinPrice / 100000000) * localTier.price, 'USD') }} /
+              {{ formatCurrency((bitcoinPrice / 100000000) * localTier.price, 'EUR') }}
+            </div>
+          </template>
+        </q-input>
         <q-input
           v-model="localTier.description"
           type="textarea"
           autogrow
-          label="Description (Markdown)"
+          :label="$t('CreatorHub.dashboard.inputs.description.label')"
           outlined
           dense
           class="q-mb-sm"
@@ -20,7 +40,7 @@
           v-model="localTier.welcomeMessage"
           type="textarea"
           autogrow
-          label="Welcome Message"
+          :label="$t('CreatorHub.dashboard.welcome_message')"
           outlined
           dense
           class="q-mb-sm"
@@ -37,6 +57,8 @@
 <script lang="ts">
 import { defineComponent, computed, reactive, watch } from 'vue';
 import { Tier } from 'stores/creatorHub';
+import { usePriceStore } from 'stores/price';
+import { useUiStore } from 'stores/ui';
 
 export default defineComponent({
   name: 'AddTierDialog',
@@ -52,6 +74,9 @@ export default defineComponent({
   },
   emits: ['update:modelValue', 'save'],
   setup(props, { emit }) {
+    const priceStore = usePriceStore();
+    const uiStore = useUiStore();
+
     const showLocal = computed({
       get: () => props.modelValue,
       set: (val) => emit('update:modelValue', val),
@@ -71,7 +96,12 @@ export default defineComponent({
       emit('save', { ...localTier });
     };
 
-    return { showLocal, localTier, save };
+    const bitcoinPrice = computed(() => priceStore.bitcoinPrice);
+
+    const formatCurrency = (amount: number, unit: string) =>
+      uiStore.formatCurrency(amount, unit);
+
+    return { showLocal, localTier, save, bitcoinPrice, formatCurrency };
   },
 });
 </script>

--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -1305,6 +1305,17 @@ timelock: {
     dashboard: {
       save_tier: "Save Tier",
       delete_tier: "Delete Tier",
+      inputs: {
+        title: {
+          label: "Title",
+        },
+        price: {
+          label: "Cost (sats)",
+        },
+        description: {
+          label: "Description (Markdown)",
+        },
+      },
       welcome_message: "Welcome Message",
       currency_labels: {
         usd: "USD",

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -1312,6 +1312,17 @@ export default {
     dashboard: {
       save_tier: "Save Tier",
       delete_tier: "Delete Tier",
+      inputs: {
+        title: {
+          label: "Title",
+        },
+        price: {
+          label: "Cost (sats)",
+        },
+        description: {
+          label: "Description (Markdown)",
+        },
+      },
       welcome_message: "Welcome Message",
       currency_labels: {
         usd: "USD",

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -1315,6 +1315,17 @@ timelock: {
     dashboard: {
       save_tier: "Save Tier",
       delete_tier: "Delete Tier",
+      inputs: {
+        title: {
+          label: "Title",
+        },
+        price: {
+          label: "Cost (sats)",
+        },
+        description: {
+          label: "Description (Markdown)",
+        },
+      },
       welcome_message: "Welcome Message",
       currency_labels: {
         usd: "USD",

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1459,6 +1459,17 @@ export default {
       add_tier: "Add Tier",
       save_tier: "Save Tier",
       delete_tier: "Delete Tier",
+      inputs: {
+        title: {
+          label: "Title",
+        },
+        price: {
+          label: "Cost (sats)",
+        },
+        description: {
+          label: "Description (Markdown)",
+        },
+      },
       welcome_message: "Welcome Message",
       currency_labels: {
         usd: "USD",

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -1313,6 +1313,17 @@ timelock: {
     dashboard: {
       save_tier: "Save Tier",
       delete_tier: "Delete Tier",
+      inputs: {
+        title: {
+          label: "Title",
+        },
+        price: {
+          label: "Cost (sats)",
+        },
+        description: {
+          label: "Description (Markdown)",
+        },
+      },
       welcome_message: "Welcome Message",
       currency_labels: {
         usd: "USD",

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -1302,6 +1302,17 @@ timelock: {
     dashboard: {
       save_tier: "Save Tier",
       delete_tier: "Delete Tier",
+      inputs: {
+        title: {
+          label: "Title",
+        },
+        price: {
+          label: "Cost (sats)",
+        },
+        description: {
+          label: "Description (Markdown)",
+        },
+      },
       welcome_message: "Welcome Message",
       currency_labels: {
         usd: "USD",

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -1295,6 +1295,17 @@ timelock: {
     dashboard: {
       save_tier: "Save Tier",
       delete_tier: "Delete Tier",
+      inputs: {
+        title: {
+          label: "Title",
+        },
+        price: {
+          label: "Cost (sats)",
+        },
+        description: {
+          label: "Description (Markdown)",
+        },
+      },
       welcome_message: "Welcome Message",
       currency_labels: {
         usd: "USD",

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -1295,6 +1295,17 @@ timelock: {
     dashboard: {
       save_tier: "Save Tier",
       delete_tier: "Delete Tier",
+      inputs: {
+        title: {
+          label: "Title",
+        },
+        price: {
+          label: "Cost (sats)",
+        },
+        description: {
+          label: "Description (Markdown)",
+        },
+      },
       welcome_message: "Welcome Message",
       currency_labels: {
         usd: "USD",

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -1295,6 +1295,17 @@ timelock: {
     dashboard: {
       save_tier: "Save Tier",
       delete_tier: "Delete Tier",
+      inputs: {
+        title: {
+          label: "Title",
+        },
+        price: {
+          label: "Cost (sats)",
+        },
+        description: {
+          label: "Description (Markdown)",
+        },
+      },
       welcome_message: "Welcome Message",
       currency_labels: {
         usd: "USD",

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -1292,6 +1292,17 @@ timelock: {
     dashboard: {
       save_tier: "Save Tier",
       delete_tier: "Delete Tier",
+      inputs: {
+        title: {
+          label: "Title",
+        },
+        price: {
+          label: "Cost (sats)",
+        },
+        description: {
+          label: "Description (Markdown)",
+        },
+      },
       welcome_message: "Welcome Message",
       currency_labels: {
         usd: "USD",

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -1297,6 +1297,17 @@ timelock: {
     dashboard: {
       save_tier: "Save Tier",
       delete_tier: "Delete Tier",
+      inputs: {
+        title: {
+          label: "Title",
+        },
+        price: {
+          label: "Cost (sats)",
+        },
+        description: {
+          label: "Description (Markdown)",
+        },
+      },
       welcome_message: "Welcome Message",
       currency_labels: {
         usd: "USD",

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -1285,6 +1285,17 @@ timelock: {
     dashboard: {
       save_tier: "Save Tier",
       delete_tier: "Delete Tier",
+      inputs: {
+        title: {
+          label: "Title",
+        },
+        price: {
+          label: "Cost (sats)",
+        },
+        description: {
+          label: "Description (Markdown)",
+        },
+      },
       welcome_message: "Welcome Message",
       currency_labels: {
         usd: "USD",


### PR DESCRIPTION
## Summary
- show fiat price hints in AddTierDialog just like the dashboard
- internationalize tier input labels

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683deb386374833090e09a717e3ba163