### PR TITLE
Add help popups with '?' icons

### DIFF
--- a/src/boot/global-components.js
+++ b/src/boot/global-components.js
@@ -2,10 +2,12 @@ import { boot } from "quasar/wrappers";
 
 import VueQrcode from "@chenfengyuan/vue-qrcode";
 import InfoTooltip from "components/InfoTooltip.vue";
+import HelpPopup from "components/HelpPopup.vue";
 
 // "async" is optional;
 // more info on params: https://v2.quasar.dev/quasar-cli/boot-files
 export default boot(async ({ app }) => {
   app.component(VueQrcode.name, VueQrcode);
   app.component("InfoTooltip", InfoTooltip);
+  app.component("HelpPopup", HelpPopup);
 });

--- a/src/components/AddMintDialog.vue
+++ b/src/components/AddMintDialog.vue
@@ -5,10 +5,14 @@
     backdrop-filter="blur(2px) brightness(60%)"
   >
     <q-card class="q-pa-lg">
-      <h6 class="q-mt-none q-mb-md">{{ $t("AddMintDialog.title") }}</h6>
-      <p>
-        {{ $t("AddMintDialog.description") }}
-      </p>
+      <h6 class="q-mt-none q-mb-sm">{{ $t("AddMintDialog.title") }}</h6>
+      <div class="row items-center q-mb-md">
+        <p class="q-mr-xs q-mb-none">{{ $t("AddMintDialog.description") }}</p>
+        <HelpPopup
+          text="A mint issues ecash tokens. Only add mints you trust."
+          :close-label="$t('global.actions.close.label')"
+        />
+      </div>
       <q-input
         outlined
         readonly
@@ -28,6 +32,7 @@
           </div>
         </template>
       </q-input>
+      <div class="text-caption text-grey q-mb-sm">Enter the base URL of the mint.</div>
       <div class="row q-mt-lg">
         <div class="col">
           <q-btn

--- a/src/components/AddTierDialog.vue
+++ b/src/components/AddTierDialog.vue
@@ -2,7 +2,13 @@
   <q-dialog v-model="showLocal" persistent backdrop-filter="blur(2px) brightness(60%)">
     <q-card class="q-pa-md" style="min-width:350px">
       <q-card-section>
-        <div class="text-h6">{{ $t('CreatorHub.dashboard.add_tier') }}</div>
+        <div class="row items-center">
+          <div class="text-h6 q-mr-xs">{{ $t('CreatorHub.dashboard.add_tier') }}</div>
+          <HelpPopup
+            text="Create a tier with a price and optional welcome message for your supporters."
+            :close-label="$t('global.actions.close.label')"
+          />
+        </div>
       </q-card-section>
       <q-card-section class="q-pt-none">
         <q-input v-model="localTier.name" label="Title" outlined dense class="q-mb-sm" />
@@ -16,6 +22,7 @@
           dense
           class="q-mb-sm"
         />
+        <div class="text-caption text-grey q-mb-sm">Markdown formatting is supported.</div>
         <q-input
           v-model="localTier.welcomeMessage"
           type="textarea"

--- a/src/components/HelpPopup.vue
+++ b/src/components/HelpPopup.vue
@@ -1,0 +1,30 @@
+<template>
+  <div class="help-popup">
+    <q-icon
+      name="help_outline"
+      color="grey"
+      size="sm"
+      class="cursor-pointer"
+      @click="show = true"
+    />
+    <q-dialog v-model="show">
+      <q-card>
+        <q-card-section>
+          <slot>{{ text }}</slot>
+        </q-card-section>
+        <q-card-actions align="right">
+          <q-btn flat color="primary" v-close-popup>{{ closeLabel }}</q-btn>
+        </q-card-actions>
+      </q-card>
+    </q-dialog>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue';
+const props = defineProps({
+  text: { type: String, default: '' },
+  closeLabel: { type: String, default: 'Close' }
+});
+const show = ref(false);
+</script>


### PR DESCRIPTION
## Summary
- add `HelpPopup` component to show info dialogs
- register `HelpPopup` globally
- show popups on Add Mint and Add Tier dialogs
- include small helper texts near complex form elements

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_683dec1587dc833099d5bf746f70c4a3