### PR TITLE
Add missing CreatorHub dashboard keys

### DIFF
--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -1303,6 +1303,11 @@ timelock: {
   },
   CreatorHub: {
     dashboard: {
+      title: "Creator Dashboard",
+      logout: "Logout",
+      edit_profile: "Edit Profile",
+      manage_tiers: "Manage Tiers",
+      add_tier: "Add Tier",
       save_tier: "Save Tier",
       delete_tier: "Delete Tier",
       welcome_message: "Welcome Message",

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -1310,6 +1310,11 @@ export default {
   },
   CreatorHub: {
     dashboard: {
+      title: "Creator Dashboard",
+      logout: "Logout",
+      edit_profile: "Edit Profile",
+      manage_tiers: "Manage Tiers",
+      add_tier: "Add Tier",
       save_tier: "Save Tier",
       delete_tier: "Delete Tier",
       welcome_message: "Welcome Message",

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -1313,6 +1313,11 @@ timelock: {
   },
   CreatorHub: {
     dashboard: {
+      title: "Creator Dashboard",
+      logout: "Logout",
+      edit_profile: "Edit Profile",
+      manage_tiers: "Manage Tiers",
+      add_tier: "Add Tier",
       save_tier: "Save Tier",
       delete_tier: "Delete Tier",
       welcome_message: "Welcome Message",

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -1311,6 +1311,11 @@ timelock: {
   },
   CreatorHub: {
     dashboard: {
+      title: "Creator Dashboard",
+      logout: "Logout",
+      edit_profile: "Edit Profile",
+      manage_tiers: "Manage Tiers",
+      add_tier: "Add Tier",
       save_tier: "Save Tier",
       delete_tier: "Delete Tier",
       welcome_message: "Welcome Message",

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -1300,6 +1300,11 @@ timelock: {
   },
   CreatorHub: {
     dashboard: {
+      title: "Creator Dashboard",
+      logout: "Logout",
+      edit_profile: "Edit Profile",
+      manage_tiers: "Manage Tiers",
+      add_tier: "Add Tier",
       save_tier: "Save Tier",
       delete_tier: "Delete Tier",
       welcome_message: "Welcome Message",

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -1293,6 +1293,11 @@ timelock: {
   },
   CreatorHub: {
     dashboard: {
+      title: "Creator Dashboard",
+      logout: "Logout",
+      edit_profile: "Edit Profile",
+      manage_tiers: "Manage Tiers",
+      add_tier: "Add Tier",
       save_tier: "Save Tier",
       delete_tier: "Delete Tier",
       welcome_message: "Welcome Message",

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -1293,6 +1293,11 @@ timelock: {
   },
   CreatorHub: {
     dashboard: {
+      title: "Creator Dashboard",
+      logout: "Logout",
+      edit_profile: "Edit Profile",
+      manage_tiers: "Manage Tiers",
+      add_tier: "Add Tier",
       save_tier: "Save Tier",
       delete_tier: "Delete Tier",
       welcome_message: "Welcome Message",

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -1293,6 +1293,11 @@ timelock: {
   },
   CreatorHub: {
     dashboard: {
+      title: "Creator Dashboard",
+      logout: "Logout",
+      edit_profile: "Edit Profile",
+      manage_tiers: "Manage Tiers",
+      add_tier: "Add Tier",
       save_tier: "Save Tier",
       delete_tier: "Delete Tier",
       welcome_message: "Welcome Message",

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -1290,6 +1290,11 @@ timelock: {
   },
   CreatorHub: {
     dashboard: {
+      title: "Creator Dashboard",
+      logout: "Logout",
+      edit_profile: "Edit Profile",
+      manage_tiers: "Manage Tiers",
+      add_tier: "Add Tier",
       save_tier: "Save Tier",
       delete_tier: "Delete Tier",
       welcome_message: "Welcome Message",

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -1295,6 +1295,11 @@ timelock: {
   },
   CreatorHub: {
     dashboard: {
+      title: "Creator Dashboard",
+      logout: "Logout",
+      edit_profile: "Edit Profile",
+      manage_tiers: "Manage Tiers",
+      add_tier: "Add Tier",
       save_tier: "Save Tier",
       delete_tier: "Delete Tier",
       welcome_message: "Welcome Message",

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -1283,6 +1283,11 @@ timelock: {
   },
   CreatorHub: {
     dashboard: {
+      title: "Creator Dashboard",
+      logout: "Logout",
+      edit_profile: "Edit Profile",
+      manage_tiers: "Manage Tiers",
+      add_tier: "Add Tier",
       save_tier: "Save Tier",
       delete_tier: "Delete Tier",
       welcome_message: "Welcome Message",


### PR DESCRIPTION
## Summary
- fill out `CreatorHub.dashboard` translations for all languages

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683deb1de11c8330b20a63a5a245f562