### PR TITLE
Fix duplicate attribute in SettingsView

### DIFF
--- a/src/components/SettingsView.vue
+++ b/src/components/SettingsView.vue
@@ -1206,8 +1206,6 @@
                     size="md"
                     :aria-label="$t('Settings.appearance.theme.tooltips.mint')"
                     :title="$t('Settings.appearance.theme.tooltips.mint')"
-                    :aria-label="$t('Settings.appearance.theme.tooltips.mint')"
-                    :title="$t('Settings.appearance.theme.tooltips.mint')"
                     ><q-tooltip>{{
                       $t("Settings.appearance.theme.tooltips.mint")
                     }}</q-tooltip> </q-btn


### PR DESCRIPTION
## Summary
- remove duplicate `:aria-label` and `:title` on the mint theme button

## Testing
- `npm run test` *(fails: This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.)*

------
https://chatgpt.com/codex/tasks/task_e_683dfd9f99248330b7ef55479970941e