### PR TITLE
Add Inter font via Google Fonts

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,12 @@
       content="initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width<% if (ctx.mode.cordova || ctx.mode.capacitor) { %>, viewport-fit=cover<% } %>"
     />
 
+    <!-- Load Inter font from Google Fonts -->
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter&display=swap"
+      rel="stylesheet"
+    />
+
     <link
       rel="icon"
       type="image/png"


### PR DESCRIPTION
## Summary
- include Inter font from Google Fonts in the head section

## Testing
- `npm test` *(fails: `vitest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683dff3b9ea88330a62d219aef43270e