### PR TITLE
Switch default UI color to primary purple

### DIFF
--- a/src/components/BucketManager.vue
+++ b/src/components/BucketManager.vue
@@ -181,6 +181,7 @@ import { useProofsStore } from "stores/proofs";
 import { storeToRefs } from "pinia";
 import { useUiStore } from "stores/ui";
 import { notifyError } from "src/js/notify";
+import { DEFAULT_COLOR } from "src/js/constants";
 
 export default defineComponent({
   name: "BucketManager",
@@ -195,7 +196,7 @@ export default defineComponent({
     const deleteId = ref(null);
     const form = ref({
       name: "",
-      color: "#1976d2",
+      color: DEFAULT_COLOR,
       description: "",
       goal: null,
       creatorPubkey: "",
@@ -213,7 +214,7 @@ export default defineComponent({
 
     const openAdd = () => {
       editId.value = null;
-      form.value = { name: "", color: "#1976d2", description: "", goal: null, creatorPubkey: "" };
+      form.value = { name: "", color: DEFAULT_COLOR, description: "", goal: null, creatorPubkey: "" };
       showForm.value = true;
     };
 

--- a/src/components/HistoryTable.vue
+++ b/src/components/HistoryTable.vue
@@ -178,6 +178,7 @@ import { useWalletStore } from "src/stores/wallet";
 import { useSendTokensStore } from "src/stores/sendTokensStore";
 import token from "../js/token";
 import { notify } from "src/js/notify";
+import { DEFAULT_COLOR } from "src/js/constants";
 
 export default defineComponent({
   name: "HistoryTable",
@@ -196,7 +197,7 @@ export default defineComponent({
       editDialog: {
         show: false,
         label: '',
-        color: '#1976d2',
+        color: DEFAULT_COLOR,
         token: null,
       },
     };
@@ -277,7 +278,7 @@ export default defineComponent({
     openEditLabel(token) {
       this.editDialog.token = token;
       this.editDialog.label = token.label || '';
-      this.editDialog.color = token.color || '#1976d2';
+      this.editDialog.color = token.color || DEFAULT_COLOR;
       this.editDialog.show = true;
     },
     saveLabel() {

--- a/src/js/constants.ts
+++ b/src/js/constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_COLOR = '#7E22CE';

--- a/src/pages/BucketDetail.vue
+++ b/src/pages/BucketDetail.vue
@@ -132,6 +132,7 @@ import SendTokenDialog from 'components/SendTokenDialog.vue';
 import HistoryTable from 'components/HistoryTable.vue';
 import LockedTokensTable from 'components/LockedTokensTable.vue';
 import { notifyError } from 'src/js/notify';
+import { DEFAULT_COLOR } from 'src/js/constants';
 
 const route = useRoute();
 const bucketsStore = useBucketsStore();
@@ -156,7 +157,7 @@ const targetBucketId = ref<string | null>(null);
 const editDialog = ref({
   show: false,
   label: '',
-  color: '#1976d2',
+  color: DEFAULT_COLOR,
   originalLabel: '',
 });
 
@@ -182,7 +183,7 @@ const groupedProofs = computed<ProofGroup[]>(() => {
   bucketProofs.value.forEach(p => {
     const lbl = p.label ?? '';
     if (!groups[lbl]) {
-      const color = historyByLabel[lbl]?.[0]?.color ?? '#1976d2';
+      const color = historyByLabel[lbl]?.[0]?.color ?? DEFAULT_COLOR;
       groups[lbl] = {
         key: lbl || 'nolabel',
         label: lbl,

--- a/src/stores/tokens.ts
+++ b/src/stores/tokens.ts
@@ -3,6 +3,7 @@ import { date } from "quasar";
 import { defineStore } from "pinia";
 import { PaymentRequest, Proof, Token } from "@cashu/cashu-ts";
 import token from "src/js/token";
+import { DEFAULT_COLOR } from "src/js/constants";
 import { DEFAULT_BUCKET_ID } from "./buckets";
 import { useProofsStore } from "./proofs";
 
@@ -61,7 +62,7 @@ export const useTokensStore = defineStore("tokens", {
         mint,
         unit,
         label,
-        color: color ?? "#1976d2",
+        color: color ?? DEFAULT_COLOR,
         fee,
         paymentRequest,
         bucketId,
@@ -96,7 +97,7 @@ export const useTokensStore = defineStore("tokens", {
         mint,
         unit,
         label,
-        color: color ?? "#1976d2",
+        color: color ?? DEFAULT_COLOR,
         fee,
         paymentRequest,
         bucketId,


### PR DESCRIPTION
## Summary
- add shared constant `DEFAULT_COLOR` with theme purple
- use `DEFAULT_COLOR` for new bucket form defaults
- use `DEFAULT_COLOR` for token history defaults
- update bucket detail page to use shared color constant

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint couldn't find configuration)*


------
https://chatgpt.com/codex/tasks/task_e_683dff485dac8330922d392788449eb2