### PR TITLE
Fix extras syntax in quasar config

### DIFF
--- a/quasar.config.js
+++ b/quasar.config.js
@@ -34,17 +34,8 @@ module.exports = configure(function (/* ctx */) {
 
     // https://github.com/quasarframework/quasar/tree/dev/extras
     extras: [
-      // 'ionicons-v4',
-      // 'mdi-v5',
-      // 'fontawesome-v6',
-      // 'eva-icons',
-      // 'themify',
-      // 'line-awesome',
-      // 'roboto-font-latin-ext', // this or either 'roboto-font', NEVER both!
-
-      "roboto-font", // optional, you are not bound to it
-      "material-icons", // optional, you are not bound to it
-      ,
+      "roboto-font",
+      "material-icons",
     ],
 
     // Full list of options: https://v2.quasar.dev/quasar-cli-vite/quasar-config-js#build


### PR DESCRIPTION
## Summary
- fix stray comma entry in `quasar.config.js`

## Testing
- `node --check quasar.config.js`


------
https://chatgpt.com/codex/tasks/task_e_683e0379c4b88330a7ccf7ad8d95e338