### PR TITLE
Rename classic theme

### DIFF
--- a/src/boot/base.js
+++ b/src/boot/base.js
@@ -200,7 +200,7 @@ window.windowMixin = {
     } else {
       this.$q.dark.set(true);
     }
-    this.g.allowedThemes = window.allowedThemes ?? ["classic"];
+    this.g.allowedThemes = window.allowedThemes ?? ["nostr"];
 
     addEventListener("offline", (event) => {
       this.g.offline = true;
@@ -223,7 +223,7 @@ window.windowMixin = {
         this.$q.localStorage.getItem("cashu.theme")
       );
     } else {
-      this.changeColor("classic");
+      this.changeColor("nostr");
     }
 
     const language = this.$q.localStorage.getItem("cashu.language");

--- a/src/components/SettingsView.vue
+++ b/src/components/SettingsView.vue
@@ -1169,10 +1169,10 @@
                     }}</q-tooltip>
                   </q-btn>
                   <q-btn
-                    v-if="themes.includes('classic')"
+                    v-if="themes.includes('nostr')"
                     dense
                     flat
-                    @click="changeColor('classic')"
+                    @click="changeColor('nostr')"
                     icon="format_color_fill"
                     color="deep-purple"
                     size="md"
@@ -1642,7 +1642,7 @@ export default defineComponent({
     return {
       themes: [
         "monochrome",
-        "classic",
+        "nostr",
         "bitcoin",
         "mint",
         "autumn",

--- a/src/css/base.scss
+++ b/src/css/base.scss
@@ -1,5 +1,5 @@
 $themes: (
-  "classic": (
+  "nostr": (
     primary: #7E22CE,
     secondary: #4B5563,
     dark: #1F2937,


### PR DESCRIPTION
## Summary
- rename theme entry from `classic` to `nostr`
- switch default theme references to `nostr`
- update settings view to use the new theme name

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683e0383fd7083308a5658074ef5348a