### PR TITLE
Add notifySuccess on tier save

### DIFF
--- a/src/pages/CreatorDashboardPage.vue
+++ b/src/pages/CreatorDashboardPage.vue
@@ -108,6 +108,7 @@ import {
   onMounted,
   computed,
 } from 'vue';
+import { notifySuccess } from 'src/js/notify';
 import { useCreatorHubStore, Tier } from 'stores/creatorHub';
 import AddTierDialog from 'components/AddTierDialog.vue';
 import { useNostrStore } from 'stores/nostr';
@@ -163,6 +164,7 @@ export default defineComponent({
     const saveNewTier = (tier: Partial<Tier>) => {
       showAddTierDialog.value = false;
       store.addTier(tier);
+      notifySuccess(`Tier '${tier.name}' saved successfully!`);
     };
 
     const saveAllTiers = () => {
@@ -175,6 +177,7 @@ export default defineComponent({
 
     const saveTier = (tier: Tier) => {
       store.updateTier(tier.id, { ...tier });
+      notifySuccess(`Tier '${tier.name}' saved successfully!`);
     };
 
     const bitcoinPrice = computed(() => priceStore.bitcoinPrice);

--- a/src/stores/creatorHub.ts
+++ b/src/stores/creatorHub.ts
@@ -57,11 +57,11 @@ export const useCreatorHubStore = defineStore("creatorHub", {
       this.tiers[id] = newTier;
       this.saveTier(newTier);
     },
-    updateTier(id: string, updates: Partial<Tier>) {
+    async updateTier(id: string, updates: Partial<Tier>) {
       const existing = this.tiers[id];
       if (!existing) return;
       this.tiers[id] = { ...existing, ...updates };
-      this.saveTier(this.tiers[id]);
+      return this.saveTier(this.tiers[id]);
     },
     async saveTier(tier: Tier) {
       const nostr = useNostrStore();


### PR DESCRIPTION
## Summary
- import notifySuccess in CreatorDashboardPage
- show success toast when adding or updating a tier
- return promise from `updateTier` in the creator hub store

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683e88414c308330ae64dd2695c4c684