### PR TITLE
Update tier price labels with monthly info

### DIFF
--- a/src/components/AddTierDialog.vue
+++ b/src/components/AddTierDialog.vue
@@ -18,21 +18,28 @@
           dense
           class="q-mb-sm"
         />
-        <q-input
-          v-model.number="localTier.price"
-          type="number"
-          :label="$t('CreatorHub.dashboard.inputs.price.label')"
-          outlined
-          dense
-          class="q-mb-sm"
-        >
-          <template #hint>
-            <div v-if="bitcoinPrice">
-              ~{{ formatCurrency((bitcoinPrice / 100000000) * localTier.price, 'USD') }} /
-              {{ formatCurrency((bitcoinPrice / 100000000) * localTier.price, 'EUR') }}
-            </div>
-          </template>
-        </q-input>
+        <div class="row items-center q-mb-sm">
+          <q-input
+            v-model.number="localTier.price"
+            type="number"
+            :label="$t('CreatorHub.dashboard.inputs.price.label')"
+            outlined
+            dense
+            class="col"
+          >
+            <template #hint>
+              <div v-if="bitcoinPrice">
+                ~{{ formatCurrency((bitcoinPrice / 100000000) * localTier.price, 'USD') }} /
+                {{ formatCurrency((bitcoinPrice / 100000000) * localTier.price, 'EUR') }}
+              </div>
+            </template>
+          </q-input>
+          <q-icon name="info" color="primary" class="q-ml-xs">
+            <q-tooltip class="text-grey"
+              >This is the monthly amount supporters pledge.</q-tooltip
+            >
+          </q-icon>
+        </div>
         <q-input
           v-model="localTier.description"
           type="textarea"

--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -1315,7 +1315,7 @@ timelock: {
           label: "Title",
         },
         price: {
-          label: "Cost (sats)",
+          label: "Cost (sats/month)",
         },
         description: {
           label: "Description (Markdown)",

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -1322,7 +1322,7 @@ export default {
           label: "Title",
         },
         price: {
-          label: "Cost (sats)",
+          label: "Cost (sats/month)",
         },
         description: {
           label: "Description (Markdown)",

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -1325,7 +1325,7 @@ timelock: {
           label: "Title",
         },
         price: {
-          label: "Cost (sats)",
+          label: "Cost (sats/month)",
         },
         description: {
           label: "Description (Markdown)",

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1464,7 +1464,7 @@ export default {
           label: "Title",
         },
         price: {
-          label: "Cost (sats)",
+          label: "Cost (sats/month)",
         },
         description: {
           label: "Description (Markdown)",

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -1323,7 +1323,7 @@ timelock: {
           label: "Title",
         },
         price: {
-          label: "Cost (sats)",
+          label: "Cost (sats/month)",
         },
         description: {
           label: "Description (Markdown)",

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -1312,7 +1312,7 @@ timelock: {
           label: "Title",
         },
         price: {
-          label: "Cost (sats)",
+          label: "Cost (sats/month)",
         },
         description: {
           label: "Description (Markdown)",

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -1305,7 +1305,7 @@ timelock: {
           label: "Title",
         },
         price: {
-          label: "Cost (sats)",
+          label: "Cost (sats/month)",
         },
         description: {
           label: "Description (Markdown)",

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -1305,7 +1305,7 @@ timelock: {
           label: "Title",
         },
         price: {
-          label: "Cost (sats)",
+          label: "Cost (sats/month)",
         },
         description: {
           label: "Description (Markdown)",

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -1305,7 +1305,7 @@ timelock: {
           label: "Title",
         },
         price: {
-          label: "Cost (sats)",
+          label: "Cost (sats/month)",
         },
         description: {
           label: "Description (Markdown)",

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -1302,7 +1302,7 @@ timelock: {
           label: "Title",
         },
         price: {
-          label: "Cost (sats)",
+          label: "Cost (sats/month)",
         },
         description: {
           label: "Description (Markdown)",

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -1307,7 +1307,7 @@ timelock: {
           label: "Title",
         },
         price: {
-          label: "Cost (sats)",
+          label: "Cost (sats/month)",
         },
         description: {
           label: "Description (Markdown)",

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -1295,7 +1295,7 @@ timelock: {
           label: "Title",
         },
         price: {
-          label: "Cost (sats)",
+          label: "Cost (sats/month)",
         },
         description: {
           label: "Description (Markdown)",

--- a/src/pages/CreatorDashboardPage.vue
+++ b/src/pages/CreatorDashboardPage.vue
@@ -35,22 +35,29 @@
               outlined
               class="q-mt-sm"
             />
-            <q-input
-              v-model.number="tier.price"
-              label="Cost (sats)"
-              type="number"
-              dense
-              outlined
-              class="q-mt-sm"
-            >
-              <template #hint>
-                <div v-if="bitcoinPrice">
-                  ~{{ formatCurrency((bitcoinPrice / 100000000) * tier.price, 'USD') }}
-                  /
-                  {{ formatCurrency((bitcoinPrice / 100000000) * tier.price, 'EUR') }}
-                </div>
-              </template>
-            </q-input>
+            <div class="row items-center q-mt-sm">
+              <q-input
+                v-model.number="tier.price"
+                :label="$t('CreatorHub.dashboard.inputs.price.label')"
+                type="number"
+                dense
+                outlined
+                class="col"
+              >
+                <template #hint>
+                  <div v-if="bitcoinPrice">
+                    ~{{ formatCurrency((bitcoinPrice / 100000000) * tier.price, 'USD') }}
+                    /
+                    {{ formatCurrency((bitcoinPrice / 100000000) * tier.price, 'EUR') }}
+                  </div>
+                </template>
+              </q-input>
+              <q-icon name="info" color="primary" class="q-ml-xs">
+                <q-tooltip class="text-grey"
+                  >This is the monthly amount supporters pledge.</q-tooltip
+                >
+              </q-icon>
+            </div>
             <q-input
               v-model="tier.description"
               label="Description (Markdown)"


### PR DESCRIPTION
## Summary
- update i18n translation label from **Cost (sats)** to **Cost (sats/month)**
- show the translated label in CreatorDashboardPage
- show the translated label in AddTierDialog
- add an info tooltip explaining the price is monthly

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_683e884a2c048330a0905fc64f6ed0f3