### PR TITLE
Integrate success notification when saving tiers

### DIFF
--- a/src/stores/creatorHub.ts
+++ b/src/stores/creatorHub.ts
@@ -3,6 +3,7 @@ import { useLocalStorage } from "@vueuse/core";
 import { NDKEvent, NDKKind, NDKFilter } from "@nostr-dev-kit/ndk";
 import { useNostrStore } from "./nostr";
 import { v4 as uuidv4 } from "uuid";
+import { notifySuccess } from "src/js/notify";
 
 export interface Tier {
   id: string;
@@ -72,6 +73,7 @@ export const useCreatorHubStore = defineStore("creatorHub", {
       ev.content = JSON.stringify(tier);
       await ev.sign(nostr.signer);
       await ev.publish();
+      notifySuccess("Tier saved");
     },
     async loadTiersFromNostr(pubkey?: string) {
       const nostr = useNostrStore();


### PR DESCRIPTION
## Summary
- notify user when tiers are saved

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683e895f101c8330bcbbdb2b6ce76cd4