### PR TITLE
Fix repeated NDK initialization

### DIFF
--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -124,6 +124,9 @@ export const useNostrStore = defineStore("nostr", {
   },
   actions: {
     initNdkReadOnly: function () {
+      if (this.connected) {
+        return;
+      }
       this.ndk = new NDK({ explicitRelayUrls: this.relays });
       this.ndk.connect();
       this.connected = true;


### PR DESCRIPTION
## Summary
- prevent repeated NDK setup by checking `this.connected` in `initNdkReadOnly`
- `fetchFollowerCount`, `fetchFollowingCount` and `fetchJoinDate` rely on the updated helper

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683e8a627f98833082ddf147fbf43f07