### PR TITLE
Fix join date sanity check

### DIFF
--- a/src/components/CreatorProfileCard.vue
+++ b/src/components/CreatorProfileCard.vue
@@ -103,7 +103,9 @@ export default defineComponent({
         : about;
     });
     const joinedDateFormatted = computed(() => {
-      if (!props.creator.joined) return "";
+      if (props.creator.joined === null || props.creator.joined === undefined) {
+        return "";
+      }
       return date.formatDate(
         new Date(props.creator.joined * 1000),
         "YYYY-MM-DD"

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -350,6 +350,12 @@ export const useNostrStore = defineStore("nostr", {
           earliest = ev.created_at;
         }
       });
+      if (earliest !== null) {
+        const now = Math.floor(Date.now() / 1000);
+        if (earliest > now) {
+          earliest = null;
+        }
+      }
       return earliest;
     },
     fetchMints: async function () {


### PR DESCRIPTION
## Summary
- avoid join date in the future in fetchJoinDate
- handle null join dates in CreatorProfileCard

## Testing
- `npx vitest run` *(fails: connect EHOSTUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_683e8c4ff0a483309eda1e54835b8851