### PR TITLE
Implement lazy creator profile loading

### DIFF
--- a/src/components/CreatorProfileCard.vue
+++ b/src/components/CreatorProfileCard.vue
@@ -1,72 +1,82 @@
 <template>
   <q-card class="q-pa-md q-mb-md qcard creator-card shadow-2 rounded-borders">
     <q-card-section class="row items-center no-wrap">
-      <q-avatar size="56px" class="creator-avatar">
-        <img
-          v-if="creator.profile?.picture"
-          :src="creator.profile.picture"
-          alt="Creator image"
+      <template v-if="loading">
+        <q-skeleton
+          type="QAvatar"
+          class="creator-avatar"
+          width="56px"
+          height="56px"
         />
-        <div
-          v-else
-          class="placeholder-avatar text-white flex flex-center"
-        >
-          {{ initials }}
+        <div class="q-ml-sm" style="width: 100%">
+          <q-skeleton type="text" width="120px" class="q-mb-xs" />
+          <q-skeleton type="text" width="80px" />
         </div>
-      </q-avatar>
-      <div class="q-ml-sm">
-        <div class="text-subtitle1 ellipsis">
-          {{
-            creator.profile?.display_name ||
-            creator.profile?.name ||
-            shortPubkey
-          }}
+      </template>
+      <template v-else>
+        <q-avatar size="56px" class="creator-avatar">
+          <img
+            v-if="profile?.picture"
+            :src="profile.picture"
+            alt="Creator image"
+          />
+          <div v-else class="placeholder-avatar text-white flex flex-center">
+            {{ initials }}
+          </div>
+        </q-avatar>
+        <div class="q-ml-sm">
+          <div class="text-subtitle1 ellipsis">
+            {{ profile?.display_name || profile?.name || shortPubkey }}
+          </div>
+          <div class="text-caption ellipsis">{{ shortPubkey }}</div>
         </div>
-        <div class="text-caption ellipsis">{{ shortPubkey }}</div>
-      </div>
+      </template>
     </q-card-section>
-    <q-card-section v-if="creator.profile?.about">
+    <q-card-section v-if="loading">
+      <q-skeleton type="text" width="90%" class="q-mb-xs" />
+      <q-skeleton type="text" width="70%" />
+    </q-card-section>
+    <q-card-section v-else-if="profile?.about">
       <div class="truncated-text">{{ truncatedAbout }}</div>
     </q-card-section>
-    <q-card-section v-if="creator.profile?.lud16">
+    <q-card-section v-if="!loading && profile?.lud16">
       <div class="row items-center">
         <q-icon name="bolt" size="xs" class="q-mr-xs" />
-        <span>{{ creator.profile.lud16 }}</span>
+        <span>{{ profile.lud16 }}</span>
       </div>
     </q-card-section>
-    <q-card-section class="text-caption" v-if="creator.followers !== undefined">
-      {{ $t('FindCreators.labels.followers') }}: {{ creator.followers }} |
-      {{ $t('FindCreators.labels.following') }}: {{ creator.following }}
+    <q-card-section class="text-caption" v-if="loading">
+      <q-skeleton type="text" width="60%" />
     </q-card-section>
-    <q-card-section class="text-caption" v-if="joinedDateFormatted">
-      {{ $t('FindCreators.labels.joined') }}: {{ joinedDateFormatted }}
+    <q-card-section class="text-caption" v-else-if="followers !== undefined">
+      {{ $t("FindCreators.labels.followers") }}: {{ followers }} |
+      {{ $t("FindCreators.labels.following") }}: {{ following }}
+    </q-card-section>
+    <q-card-section class="text-caption" v-if="!loading && joinedDateFormatted">
+      {{ $t("FindCreators.labels.joined") }}: {{ joinedDateFormatted }}
     </q-card-section>
     <q-card-actions class="q-mt-sm">
-      <q-btn
-        color="primary"
-        unelevated
-        class="full-width"
-        :to="profileLink"
-      >
+      <q-btn color="primary" unelevated class="full-width" :to="profileLink">
         <q-icon name="chevron_right" size="16px" class="q-mr-xs" />
-        {{ $t('FindCreators.actions.view_profile.label') }}
+        {{ $t("FindCreators.actions.view_profile.label") }}
       </q-btn>
     </q-card-actions>
     <q-card-actions align="right" class="q-gutter-sm">
       <q-btn color="primary" flat @click="$emit('donate', creator)">
-        {{ $t('FindCreators.actions.donate.label') }}
+        {{ $t("FindCreators.actions.donate.label") }}
       </q-btn>
       <q-btn color="primary" flat @click="$emit('message', creator)">
-        {{ $t('FindCreators.actions.message.label') }}
+        {{ $t("FindCreators.actions.message.label") }}
       </q-btn>
     </q-card-actions>
   </q-card>
 </template>
 
 <script lang="ts">
-import { defineComponent, computed } from "vue";
+import { defineComponent, computed, ref, watch } from "vue";
 import { CreatorProfile } from "stores/creators";
 import { date } from "quasar";
+import { useNostrStore } from "stores/nostr";
 
 export default defineComponent({
   name: "CreatorProfileCard",
@@ -75,18 +85,51 @@ export default defineComponent({
       type: Object as () => CreatorProfile,
       required: true,
     },
+    visible: {
+      type: Boolean,
+      default: false,
+    },
   },
   emits: ["donate", "message"],
   setup(props) {
     const MAX_LENGTH = 160;
+    const nostrStore = useNostrStore();
+
+    const profile = ref(props.creator.profile || null);
+    const followers = ref<number | undefined>(props.creator.followers);
+    const following = ref<number | undefined>(props.creator.following);
+    const joined = ref<number | null | undefined>(props.creator.joined);
+    const loading = ref(!profile.value);
+
+    const loadDetails = async () => {
+      if (profile.value || loading.value === false) return;
+      loading.value = true;
+      profile.value = await nostrStore.getProfile(props.creator.pubkey);
+      followers.value = await nostrStore.fetchFollowerCount(
+        props.creator.pubkey,
+      );
+      following.value = await nostrStore.fetchFollowingCount(
+        props.creator.pubkey,
+      );
+      joined.value = await nostrStore.fetchJoinDate(props.creator.pubkey);
+      loading.value = false;
+    };
+
+    watch(
+      () => props.visible,
+      (v) => {
+        if (v) loadDetails();
+      },
+      { immediate: true },
+    );
+
     const shortPubkey = computed(() =>
       props.creator.pubkey.length > 16
         ? `${props.creator.pubkey.slice(0, 8)}…${props.creator.pubkey.slice(-8)}`
         : props.creator.pubkey,
     );
     const initials = computed(() => {
-      const name =
-        props.creator.profile?.display_name || props.creator.profile?.name || "";
+      const name = profile.value?.display_name || profile.value?.name || "";
       if (!name) return "?";
       return name
         .split(" ")
@@ -97,17 +140,14 @@ export default defineComponent({
     });
     const profileLink = computed(() => `/creators/${props.creator.pubkey}`);
     const truncatedAbout = computed(() => {
-      const about = props.creator.profile?.about || "";
+      const about = profile.value?.about || "";
       return about.length > MAX_LENGTH
         ? about.slice(0, MAX_LENGTH) + "…"
         : about;
     });
     const joinedDateFormatted = computed(() => {
-      if (!props.creator.joined) return "";
-      return date.formatDate(
-        new Date(props.creator.joined * 1000),
-        "YYYY-MM-DD"
-      );
+      if (!joined.value) return "";
+      return date.formatDate(new Date(joined.value * 1000), "YYYY-MM-DD");
     });
     return {
       truncatedAbout,
@@ -115,6 +155,11 @@ export default defineComponent({
       shortPubkey,
       profileLink,
       initials,
+      profile,
+      followers,
+      following,
+      joined,
+      loading,
     };
   },
 });


### PR DESCRIPTION
## Summary
- add loading skeletons to `CreatorProfileCard`
- lazily fetch profile details when card becomes visible
- watch scroll position in `FindCreatorsView` to trigger card load

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683e8b45d8648330b211b1e2721a0668