### PR TITLE
Move follower stats to dedicated page

### DIFF
--- a/src/components/CreatorProfileCard.vue
+++ b/src/components/CreatorProfileCard.vue
@@ -7,10 +7,7 @@
           :src="creator.profile.picture"
           alt="Creator image"
         />
-        <div
-          v-else
-          class="placeholder-avatar text-white flex flex-center"
-        >
+        <div v-else class="placeholder-avatar text-white flex flex-center">
           {{ initials }}
         </div>
       </q-avatar>
@@ -34,30 +31,24 @@
         <span>{{ creator.profile.lud16 }}</span>
       </div>
     </q-card-section>
-    <q-card-section class="text-caption" v-if="creator.followers !== undefined">
-      {{ $t('FindCreators.labels.followers') }}: {{ creator.followers }} |
-      {{ $t('FindCreators.labels.following') }}: {{ creator.following }}
+    <q-card-section class="text-caption">
+      {{ $t("FindCreators.labels.view_profile_stats") }}
     </q-card-section>
     <q-card-section class="text-caption" v-if="joinedDateFormatted">
-      {{ $t('FindCreators.labels.joined') }}: {{ joinedDateFormatted }}
+      {{ $t("FindCreators.labels.joined") }}: {{ joinedDateFormatted }}
     </q-card-section>
     <q-card-actions class="q-mt-sm">
-      <q-btn
-        color="primary"
-        unelevated
-        class="full-width"
-        :to="profileLink"
-      >
+      <q-btn color="primary" unelevated class="full-width" :to="profileLink">
         <q-icon name="chevron_right" size="16px" class="q-mr-xs" />
-        {{ $t('FindCreators.actions.view_profile.label') }}
+        {{ $t("FindCreators.actions.view_profile.label") }}
       </q-btn>
     </q-card-actions>
     <q-card-actions align="right" class="q-gutter-sm">
       <q-btn color="primary" flat @click="$emit('donate', creator)">
-        {{ $t('FindCreators.actions.donate.label') }}
+        {{ $t("FindCreators.actions.donate.label") }}
       </q-btn>
       <q-btn color="primary" flat @click="$emit('message', creator)">
-        {{ $t('FindCreators.actions.message.label') }}
+        {{ $t("FindCreators.actions.message.label") }}
       </q-btn>
     </q-card-actions>
   </q-card>
@@ -86,7 +77,9 @@ export default defineComponent({
     );
     const initials = computed(() => {
       const name =
-        props.creator.profile?.display_name || props.creator.profile?.name || "";
+        props.creator.profile?.display_name ||
+        props.creator.profile?.name ||
+        "";
       if (!name) return "?";
       return name
         .split(" ")
@@ -106,7 +99,7 @@ export default defineComponent({
       if (!props.creator.joined) return "";
       return date.formatDate(
         new Date(props.creator.joined * 1000),
-        "YYYY-MM-DD"
+        "YYYY-MM-DD",
       );
     });
     return {

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1325,6 +1325,7 @@ export default {
       followers: "Followers",
       following: "Following",
       joined: "Joined",
+      view_profile_stats: "View profile for stats",
     },
     actions: {
       donate: {

--- a/src/pages/PublicCreatorProfilePage.vue
+++ b/src/pages/PublicCreatorProfilePage.vue
@@ -15,6 +15,10 @@
       <img :src="profile.picture" style="max-width: 150px" />
     </div>
     <div v-if="profile.about" class="q-mb-md">{{ profile.about }}</div>
+    <div v-if="followers !== null" class="text-caption q-mb-md">
+      {{ $t("FindCreators.labels.followers") }}: {{ followers }} |
+      {{ $t("FindCreators.labels.following") }}: {{ following }}
+    </div>
 
     <div v-if="tiers.length">
       <div class="text-h6 q-mb-sm">{{ $t("CreatorHub.profile.tiers") }}</div>
@@ -25,7 +29,10 @@
             ({{ formatFiat(tier.price) }})
           </span>
         </div>
-        <div class="text-caption" v-html="renderMarkdown(tier.description)"></div>
+        <div
+          class="text-caption"
+          v-html="renderMarkdown(tier.description)"
+        ></div>
         <q-btn
           color="primary"
           dense
@@ -59,9 +66,13 @@ export default defineComponent({
     const pubkey = route.params.npubOrVanityName as string;
     const profile = ref<any>({});
     const tiers = ref(hub.getTierArray());
+    const followers = ref<number | null>(null);
+    const following = ref<number | null>(null);
     onMounted(async () => {
       const p = await nostr.getProfile(pubkey);
       if (p) profile.value = { ...p };
+      followers.value = await nostr.fetchFollowerCount(pubkey);
+      following.value = await nostr.fetchFollowingCount(pubkey);
     });
     function renderMarkdown(text: string): string {
       return renderMarkdownFn(text || "");
@@ -90,6 +101,8 @@ export default defineComponent({
       pubkey,
       profile,
       tiers,
+      followers,
+      following,
       bitcoinPrice,
       renderMarkdown,
       formatFiat,


### PR DESCRIPTION
## Summary
- show note in CreatorProfileCard telling users to view profile for stats
- fetch and display follower numbers in PublicCreatorProfilePage
- add i18n entry for the new message

## Testing
- `npm run test:ci` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683e8c449b548330bd482da8644e6496