### PR TITLE
Keep chat headers visible while scrolling

### DIFF
--- a/src/pages/ChatView.vue
+++ b/src/pages/ChatView.vue
@@ -3,12 +3,13 @@
     :class="[$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark']"
     class="flex column full-height"
   >
-    <q-toolbar class="border-bottom q-pa-sm" style="border-bottom: 1px solid rgba(0,0,0,0.1)">
-      <q-btn
-        flat
-        dense
-        round
-        icon="arrow_back"
+    <q-header elevated reveal class="border-bottom" style="border-bottom: 1px solid rgba(0,0,0,0.1)">
+      <q-toolbar class="q-pa-sm">
+        <q-btn
+          flat
+          dense
+          round
+          icon="arrow_back"
         color="primary"
         @click="goBack"
         aria-label="Go back"
@@ -18,7 +19,8 @@
         <img :src="avatar" />
       </q-avatar>
       <q-toolbar-title class="text-h6">{{ displayName }}</q-toolbar-title>
-    </q-toolbar>
+      </q-toolbar>
+    </q-header>
     <div class="q-pa-md scroll-area col" ref="scrollArea">
       <q-chat-message
         v-for="msg in messages"

--- a/src/pages/Chats.vue
+++ b/src/pages/Chats.vue
@@ -1,8 +1,10 @@
 <template>
   <q-page :class="[$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark']" class="column full-height">
-    <q-toolbar class="q-pa-sm border-bottom" style="border-bottom: 1px solid rgba(0,0,0,0.1)">
-      <q-toolbar-title class="text-h6">Chats</q-toolbar-title>
-    </q-toolbar>
+    <q-header elevated reveal class="border-bottom" style="border-bottom: 1px solid rgba(0,0,0,0.1)">
+      <q-toolbar class="q-pa-sm">
+        <q-toolbar-title class="text-h6">Chats</q-toolbar-title>
+      </q-toolbar>
+    </q-header>
     <q-virtual-scroll
       class="col scroll-area"
       :items="pubkeys"


### PR DESCRIPTION
## Summary
- wrap Chats and ChatView toolbars with `<q-header>` using `elevated` + `reveal`
- keep headers visible while scrolling

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683e90a85cf08330a8da9a1dcd34390e