### PR TITLE
Ensure menu button visible on all pages

### DIFF
--- a/src/layouts/FullscreenLayout.vue
+++ b/src/layouts/FullscreenLayout.vue
@@ -1,6 +1,6 @@
 <template>
   <q-layout view="lHh Lpr lFf">
-    <FullscreenHeader />
+    <MainHeader />
     <q-page-container>
       <router-view />
     </q-page-container>
@@ -8,14 +8,14 @@
 </template>
 
 <script>
-import { defineComponent, ref } from "vue";
-import FullscreenHeader from "components/FullscreenHeader.vue";
+import { defineComponent } from "vue";
+import MainHeader from "components/MainHeader.vue";
 
 export default defineComponent({
   name: "FullscreenLayout",
   mixins: [windowMixin],
   components: {
-    FullscreenHeader,
+    MainHeader,
   },
 });
 </script>


### PR DESCRIPTION
## Summary
- use `MainHeader` component in `FullscreenLayout` so navigation menu is always accessible

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683e96801c1c833097e671244cbffa09