### PR TITLE
Modify searchInput watcher to reload featured creators

### DIFF
--- a/src/components/FindCreatorsView.vue
+++ b/src/components/FindCreatorsView.vue
@@ -136,10 +136,12 @@ export default defineComponent({
 
     let debounceTimeout: number | undefined;
     watch(searchInput, (val) => {
-      if (!val) {
+      clearTimeout(debounceTimeout);
+      if (val === "") {
+        creatorsStore.error = "";
+        creatorsStore.loadFeaturedCreators();
         return;
       }
-      clearTimeout(debounceTimeout);
       debounceTimeout = window.setTimeout(() => {
         creatorsStore.searchCreators(val);
       }, 500);


### PR DESCRIPTION
## Summary
- update searchInput watcher logic in `FindCreatorsView`

## Testing
- `npm test` *(fails: Cannot find module 'vite-jsconfig-paths')*

------
https://chatgpt.com/codex/tasks/task_e_683e991770288330b6532846779125d9