### PR TITLE
Add UI utilities module

### DIFF
--- a/src/components/BucketManager.vue
+++ b/src/components/BucketManager.vue
@@ -180,7 +180,7 @@ import { useMintsStore } from "stores/mints";
 import { useProofsStore } from "stores/proofs";
 import { storeToRefs } from "pinia";
 import { useUiStore } from "stores/ui";
-import { notifyError } from "src/js/notify";
+import { notifyError } from "src/js/ui-utils";
 import { DEFAULT_COLOR } from "src/js/constants";
 
 export default defineComponent({

--- a/src/components/HistoryTable.vue
+++ b/src/components/HistoryTable.vue
@@ -177,7 +177,7 @@ import { useReceiveTokensStore } from "src/stores/receiveTokensStore";
 import { useWalletStore } from "src/stores/wallet";
 import { useSendTokensStore } from "src/stores/sendTokensStore";
 import token from "../js/token";
-import { notify } from "src/js/notify";
+import { notify } from "src/js/ui-utils";
 import { DEFAULT_COLOR } from "src/js/constants";
 
 export default defineComponent({

--- a/src/components/MintSettings.vue
+++ b/src/components/MintSettings.vue
@@ -472,7 +472,7 @@ import { useP2PKStore } from "src/stores/p2pk";
 import { useWorkersStore } from "src/stores/workers";
 import { useSwapStore } from "src/stores/swap";
 import { useUiStore } from "src/stores/ui";
-import { notifyError, notifyWarning } from "src/js/notify";
+import { notifyError, notifyWarning } from "src/js/ui-utils";
 import MintDetailsDialog from "src/components/MintDetailsDialog.vue";
 import { EventBus } from "../js/eventBus";
 import AddMintDialog from "src/components/AddMintDialog.vue";

--- a/src/components/NumericKeyboard.vue
+++ b/src/components/NumericKeyboard.vue
@@ -48,7 +48,7 @@ import { defineComponent } from "vue";
 import { useUiStore } from "../stores/ui";
 import { mapWritableState } from "pinia";
 import { useSettingsStore } from "../stores/settings";
-import { notify } from "src/js/notify";
+import { notify } from "src/js/ui-utils";
 
 export default defineComponent({
   name: "NumericKeyboard",

--- a/src/components/ReceiveDialog.vue
+++ b/src/components/ReceiveDialog.vue
@@ -89,7 +89,7 @@ import {
   notifySuccess,
   notify,
   notifyWarning,
-} from "src/js/notify.ts";
+} from "src/js/ui-utils.ts";
 import {
   X as XIcon,
   Coins as CoinsIcon,

--- a/src/components/ReceiveEcashDrawer.vue
+++ b/src/components/ReceiveEcashDrawer.vue
@@ -146,7 +146,7 @@ import {
 // import ChooseMint from "components/ChooseMint.vue";
 import TokenInformation from "components/TokenInformation.vue";
 import { map } from "underscore";
-import { notifyError, notifySuccess, notify } from "../js/notify";
+import { notifyError, notifySuccess, notify } from "../js/ui-utils";
 
 export default defineComponent({
   name: "ReceiveTokenDialog",

--- a/src/components/ReceiveTokenDialog.vue
+++ b/src/components/ReceiveTokenDialog.vue
@@ -347,7 +347,7 @@ import {
   notifySuccess,
   notifyWarning,
   notify,
-} from "../js/notify";
+} from "../js/ui-utils";
 import MintSettings from "./MintSettings.vue";
 
 export default defineComponent({

--- a/src/components/RestoreView.vue
+++ b/src/components/RestoreView.vue
@@ -172,7 +172,7 @@ import { useMintsStore, MintClass } from "src/stores/mints";
 import { useRestoreStore } from "src/stores/restore";
 import { useWalletStore } from "src/stores/wallet";
 import { useUiStore } from "src/stores/ui";
-import { notifyError, notifySuccess } from "src/js/notify";
+import { notifyError, notifySuccess } from "src/js/ui-utils";
 
 export default defineComponent({
   name: "RestoreView",

--- a/src/components/SendDialog.vue
+++ b/src/components/SendDialog.vue
@@ -88,7 +88,7 @@ import {
   Scan as ScanIcon,
   Coins as CoinsIcon,
 } from "lucide-vue-next";
-import { notifyWarning } from "src/js/notify";
+import { notifyWarning } from "src/js/ui-utils";
 
 export default defineComponent({
   name: "SendDialog",

--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -656,7 +656,7 @@ import {
   notifySuccess,
   notify,
   notifyWarning,
-} from "src/js/notify.ts";
+} from "src/js/ui-utils.ts";
 import { Dialog } from "quasar";
 import { useDmChatsStore } from "src/stores/dmChats";
 import { getEncodedTokenV3 } from "@cashu/cashu-ts/dist/lib/es5/utils";

--- a/src/js/ui-utils.ts
+++ b/src/js/ui-utils.ts
@@ -1,0 +1,75 @@
+import { Notify, copyToClipboard, LocalStorage, Dark, QNotifyCreateOptions } from 'quasar'
+import { Clipboard } from '@capacitor/clipboard'
+import { useUiStore } from 'stores/ui'
+
+function changeColor(newValue: string) {
+  document.body.setAttribute('data-theme', newValue)
+  LocalStorage.set('cashu.theme', newValue)
+}
+
+function changeLanguage(lang: string) {
+  LocalStorage.set('cashu.language', lang)
+}
+
+function toggleDarkMode() {
+  Dark.toggle()
+  LocalStorage.set('cashu.darkMode', Dark.isActive)
+}
+
+function copyText(
+  text: string,
+  message?: string,
+  position: QNotifyCreateOptions['position'] = 'bottom'
+) {
+  copyToClipboard(text).then(() => {
+    Notify.create({
+      message: message || 'Copied to clipboard!',
+      position
+    })
+  })
+}
+
+async function pasteFromClipboard(): Promise<string> {
+  let text = ''
+  if (window?.Capacitor) {
+    const { value } = await Clipboard.read()
+    text = value
+  } else if (navigator.clipboard?.readText) {
+    text = await navigator.clipboard.readText()
+  }
+  return text
+}
+
+function formatSat(value: number) {
+  value = parseInt(String(value))
+  return new Intl.NumberFormat(navigator.language).format(value) + ' sat'
+}
+
+function fromMsat(value: number) {
+  value = parseInt(String(value))
+  return new Intl.NumberFormat(navigator.language).format(value) + ' msat'
+}
+
+function formatCurrency(value: number, currency = 'sat', showBalance = false) {
+  const uiStore = useUiStore()
+  if (uiStore.hideBalance && !showBalance) {
+    return '****'
+  }
+  if (currency === 'sat') return formatSat(value)
+  if (currency === 'msat') return fromMsat(value)
+  if (currency === 'usd' || currency === 'eur') value = value / 100
+  return new Intl.NumberFormat(navigator.language, { style: 'currency', currency }).format(value)
+}
+
+export {
+  changeColor,
+  changeLanguage,
+  toggleDarkMode,
+  copyText,
+  pasteFromClipboard,
+  formatCurrency,
+  formatSat,
+  fromMsat
+}
+
+export * from './notify'

--- a/src/stores/buckets.ts
+++ b/src/stores/buckets.ts
@@ -6,7 +6,7 @@ import { useProofsStore } from "./proofs";
 import { useTokensStore } from "./tokens";
 import { useLockedTokensStore } from "./lockedTokens";
 import { ref, watch } from "vue";
-import { notifySuccess } from "src/js/notify";
+import { notifySuccess } from "src/js/ui-utils";
 
 export type Bucket = {
   id: string;

--- a/src/stores/creatorHub.ts
+++ b/src/stores/creatorHub.ts
@@ -3,7 +3,7 @@ import { useLocalStorage } from "@vueuse/core";
 import { NDKEvent, NDKKind, NDKFilter } from "@nostr-dev-kit/ndk";
 import { useNostrStore } from "./nostr";
 import { v4 as uuidv4 } from "uuid";
-import { notifySuccess } from "src/js/notify";
+import { notifySuccess } from "src/js/ui-utils";
 
 export interface Tier {
   id: string;

--- a/src/stores/dexie.ts
+++ b/src/stores/dexie.ts
@@ -4,7 +4,7 @@ import { useLocalStorage } from "@vueuse/core";
 import { WalletProof } from "./mints";
 import { useStorageStore } from "./storage";
 import { useProofsStore } from "./proofs";
-import { notifyError, notifySuccess } from "../js/notify";
+import { notifyError, notifySuccess } from "../js/ui-utils";
 
 export interface CachedProfileDexie {
   pubkey: string;

--- a/src/stores/migrations.ts
+++ b/src/stores/migrations.ts
@@ -1,7 +1,7 @@
 import { defineStore } from "pinia";
 import { useLocalStorage } from "@vueuse/core";
 import { useMintsStore } from "./mints";
-import { notifySuccess } from "../js/notify";
+import { notifySuccess } from "../js/ui-utils";
 import { useUiStore } from "./ui";
 
 // Define the migration version type

--- a/src/stores/mints.ts
+++ b/src/stores/mints.ts
@@ -6,7 +6,7 @@ import {
   notifyError,
   notifySuccess,
   notifyWarning,
-} from "src/js/notify";
+} from "src/js/ui-utils";
 import {
   CashuMint,
   MintKeys,

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -32,7 +32,7 @@ import {
   notifySuccess,
   notifyWarning,
   notify,
-} from "../js/notify";
+} from "../js/ui-utils";
 import { useSendTokensStore } from "./sendTokensStore";
 import { usePRStore } from "./payment-request";
 import token from "../js/token";

--- a/src/stores/npubcash.ts
+++ b/src/stores/npubcash.ts
@@ -12,7 +12,7 @@ import {
   notifySuccess,
   notifyWarning,
   notify,
-} from "../js/notify";
+} from "../js/ui-utils";
 import { Proof } from "@cashu/cashu-ts";
 import token from "../js/token";
 import { WalletProof, useMintsStore } from "./mints";

--- a/src/stores/nwc.ts
+++ b/src/stores/nwc.ts
@@ -14,7 +14,7 @@ import { nip04, generateSecretKey, getPublicKey } from "nostr-tools";
 import { useMintsStore } from "./mints";
 import { useWalletStore, InvoiceHistory } from "./wallet";
 import { useProofsStore } from "./proofs";
-import { notify, notifyError, notifyWarning } from "../js/notify";
+import { notify, notifyError, notifyWarning } from "../js/ui-utils";
 import { useSettingsStore } from "./settings";
 import { decode as decodeBolt11 } from "light-bolt11-decoder";
 

--- a/src/stores/payment-request.ts
+++ b/src/stores/payment-request.ts
@@ -17,7 +17,7 @@ import {
   notifyError,
   notifySuccess,
   notifyWarning,
-} from "src/js/notify";
+} from "src/js/ui-utils";
 import { useLocalStorage } from "@vueuse/core";
 import { v4 as uuidv4 } from "uuid";
 

--- a/src/stores/price.ts
+++ b/src/stores/price.ts
@@ -7,7 +7,7 @@ import {
   notifySuccess,
   notifyWarning,
   notify,
-} from "../js/notify";
+} from "../js/ui-utils";
 import axios from "axios";
 
 const unitTickerShortMap = {

--- a/src/stores/receiveTokensStore.ts
+++ b/src/stores/receiveTokensStore.ts
@@ -10,7 +10,7 @@ import {
   notifySuccess,
   notify,
   notifyWarning,
-} from "../js/notify";
+} from "../js/ui-utils";
 import { Token } from "@cashu/cashu-ts";
 import { useSwapStore } from "./swap";
 import { Clipboard } from "@capacitor/clipboard";

--- a/src/stores/restore.ts
+++ b/src/stores/restore.ts
@@ -5,7 +5,7 @@ import { bytesToHex } from "@noble/hashes/utils"; // already an installed depend
 import { useWalletStore } from "./wallet";
 import { CashuMint, CashuWallet, CheckStateEnum, Proof } from "@cashu/cashu-ts";
 import { useMintsStore } from "./mints";
-import { notify, notifyError, notifySuccess } from "src/js/notify";
+import { notify, notifyError, notifySuccess } from "src/js/ui-utils";
 import { useUiStore } from "./ui";
 import { useProofsStore } from "./proofs";
 import { i18n } from "../boot/i18n";

--- a/src/stores/storage.ts
+++ b/src/stores/storage.ts
@@ -2,7 +2,7 @@ import { defineStore } from "pinia";
 import { useWalletStore } from "./wallet";
 import { useMintsStore } from "./mints";
 import { useLocalStorage } from "@vueuse/core";
-import { notifyError, notifySuccess } from "../js/notify";
+import { notifyError, notifySuccess } from "../js/ui-utils";
 import { useTokensStore } from "./tokens";
 import { currentDateStr } from "src/js/utils";
 import { useProofsStore } from "./proofs";

--- a/src/stores/swap.ts
+++ b/src/stores/swap.ts
@@ -6,7 +6,7 @@ import { Mint, useMintsStore } from "./mints";
 import { useWalletStore } from "./wallet";
 import { DEFAULT_BUCKET_ID } from "./buckets";
 import { useProofsStore } from "./proofs";
-import { notifyError, notifyWarning } from "../js/notify";
+import { notifyError, notifyWarning } from "../js/ui-utils";
 import token from "src/js/token";
 import { i18n } from "../boot/i18n";
 

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -7,7 +7,7 @@ import {
   notifySuccess,
   notifyWarning,
   notify,
-} from "../js/notify";
+} from "../js/ui-utils";
 import { Clipboard } from "@capacitor/clipboard";
 import { Haptics, ImpactStyle } from "@capacitor/haptics";
 

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -24,7 +24,7 @@ import {
   notifySuccess,
   notifyWarning,
   notify,
-} from "src/js/notify";
+} from "src/js/ui-utils";
 import {
   CashuMint,
   CashuWallet,

--- a/src/stores/wallet/invoices.ts
+++ b/src/stores/wallet/invoices.ts
@@ -5,7 +5,7 @@ import { useUiStore } from '../ui';
 import { useTokensStore } from '../tokens';
 import { DEFAULT_BUCKET_ID } from '../buckets';
 import { currentDateStr } from 'src/js/utils';
-import { notifyApiError, notify, notifySuccess } from 'src/js/notify';
+import { notifyApiError, notify, notifySuccess } from 'src/js/ui-utils';
 import { useInvoicesWorkerStore } from '../invoicesWorker';
 import { HistoryToken } from '../tokens';
 

--- a/src/stores/wallet/p2pk.ts
+++ b/src/stores/wallet/p2pk.ts
@@ -2,7 +2,7 @@ import { CashuWallet, Proof } from '@cashu/cashu-ts';
 import { WalletProof } from '../mints';
 import { useMintsStore } from '../mints';
 import { DEFAULT_BUCKET_ID } from '../buckets';
-import { notifyError } from 'src/js/notify';
+import { notifyError } from 'src/js/ui-utils';
 import { useProofsStore } from '../proofs';
 
 /**


### PR DESCRIPTION
## Summary
- add `ui-utils.ts` with helpers for color, copy, notifications, and more
- reference new helpers from `base.js`
- update stores and components to import utilities from `ui-utils`

## Testing
- `npm test` *(fails: could not resolve some modules and mocks)*

------
https://chatgpt.com/codex/tasks/task_e_683eb2a3d4188330929d0a29efc2e913