### PR TITLE
Add wallet and nostr tests

### DIFF
--- a/test/vitest/__tests__/nostrMessages.spec.ts
+++ b/test/vitest/__tests__/nostrMessages.spec.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { useNostrStore } from "../../../src/stores/nostr";
+
+let receiveStore: any;
+let sendStore: any;
+let prStore: any;
+let tokensStore: any;
+let dbGet = vi.fn();
+let dbPut = vi.fn();
+const getEncodedTokenV4 = vi.fn(() => "enc");
+
+vi.mock("@cashu/cashu-ts", () => ({
+  getEncodedTokenV4,
+}));
+
+vi.mock("../../../src/stores/receiveTokensStore", () => ({
+  useReceiveTokensStore: () => receiveStore,
+}));
+
+vi.mock("../../../src/stores/sendTokensStore", () => ({
+  useSendTokensStore: () => sendStore,
+}));
+
+vi.mock("../../../src/stores/payment-request", () => ({
+  usePRStore: () => prStore,
+}));
+
+vi.mock("../../../src/stores/tokens", () => ({
+  useTokensStore: () => tokensStore,
+}));
+
+vi.mock("../../../src/stores/dexie", () => ({
+  cashuDb: {
+    profiles: { get: (...args: any[]) => dbGet(...args), put: (...args: any[]) => dbPut(...args) },
+  },
+}));
+
+vi.mock("@nostr-dev-kit/ndk", () => {
+  class NDK {
+    constructor(_opts: any) {}
+    connect() {}
+    getUser() {
+      return {
+        fetchProfile: vi.fn(async () => {}),
+        profile: { name: "alice" },
+      };
+    }
+  }
+  return {
+    default: NDK,
+    NDKEvent: class {},
+    NDKSigner: class {},
+    NDKNip07Signer: class {},
+    NDKNip46Signer: class {},
+    NDKFilter: class {},
+    NDKPrivateKeySigner: class {},
+    NostrEvent: class {},
+    NDKKind: {},
+    NDKRelaySet: class {},
+    NDKRelay: class {},
+    NDKTag: class {},
+    ProfilePointer: class {},
+  };
+});
+
+beforeEach(() => {
+  receiveStore = { receiveData: { tokensBase64: "" }, showReceiveTokens: false, receiveIfDecodes: vi.fn(async () => true) };
+  sendStore = { showSendTokens: true };
+  prStore = { receivePaymentRequestsAutomatically: false, showPRDialog: true };
+  tokensStore = { tokenAlreadyInHistory: vi.fn(() => null) };
+  dbGet.mockReset();
+  dbPut.mockReset();
+});
+
+describe("parseMessageForEcash", () => {
+  it("parses payment request payload", async () => {
+    const store = useNostrStore();
+    vi.spyOn(store, "addPendingTokenToHistory").mockResolvedValue();
+    const msg = JSON.stringify({ proofs: [], mint: "m", unit: "sat" });
+    await store.parseMessageForEcash(msg);
+    expect(getEncodedTokenV4).toHaveBeenCalled();
+    expect(store.addPendingTokenToHistory).toHaveBeenCalledWith("enc", false);
+    expect(sendStore.showSendTokens).toBe(false);
+    expect(prStore.showPRDialog).toBe(false);
+    expect(receiveStore.receiveData.tokensBase64).toBe("enc");
+  });
+
+  it("extracts cashu tokens from text", async () => {
+    const store = useNostrStore();
+    vi.spyOn(store, "addPendingTokenToHistory").mockResolvedValue();
+    await store.parseMessageForEcash("here cashuAaa there cashuBbb");
+    expect(store.addPendingTokenToHistory).toHaveBeenCalledTimes(2);
+    expect(receiveStore.showReceiveTokens).toBe(true);
+  });
+});
+
+describe("getProfile", () => {
+  it("fetches and caches profile", async () => {
+    const store = useNostrStore();
+    dbGet.mockResolvedValue(undefined);
+    const profile = await store.getProfile("pk");
+    expect(profile.name).toBe("alice");
+    expect(dbPut).toHaveBeenCalled();
+    // second call should use cache
+    dbGet.mockResolvedValue({ profile, fetchedAt: Math.floor(Date.now()/1000) });
+    const cached = await store.getProfile("pk");
+    expect(cached).toEqual(profile);
+  });
+});
+

--- a/test/vitest/__tests__/walletInvoices.spec.ts
+++ b/test/vitest/__tests__/walletInvoices.spec.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { useWalletStore } from "../../../src/stores/wallet";
+import { MintQuoteState, MeltQuoteState } from "@cashu/cashu-ts";
+
+// mock dependent stores
+const addProofs = vi.fn();
+const serializeProofs = vi.fn(() => "token-ser");
+const setReserved = vi.fn();
+const removeProofs = vi.fn();
+const sumProofs = vi.fn(() => 0);
+
+vi.mock("../../../src/stores/proofs", () => ({
+  useProofsStore: () => ({
+    addProofs,
+    serializeProofs,
+    setReserved,
+    removeProofs,
+    sumProofs,
+  }),
+}));
+
+const addPaidToken = vi.fn();
+vi.mock("../../../src/stores/tokens", () => ({
+  useTokensStore: () => ({ addPaidToken }),
+}));
+
+vi.mock("../../../src/stores/invoicesWorker", () => ({
+  useInvoicesWorkerStore: () => ({ removeInvoiceFromChecker: vi.fn() }),
+}));
+
+vi.mock("../../../src/js/ui-utils", () => ({
+  notifyApiError: vi.fn(),
+  notify: vi.fn(),
+  notifySuccess: vi.fn(),
+}));
+
+vi.mock("../../../src/stores/mints", () => ({
+  useMintsStore: () => ({
+    mints: [{ url: "m", keysets: [{ id: "kid", active: true }], info: {}, keys: [] }],
+    mintUnitProofs: vi.fn(() => []),
+    activeProofs: [],
+    activeMintUrl: "m",
+    activeUnit: "sat",
+    assertMintError: vi.fn(),
+  }),
+}));
+
+vi.mock("../../../src/stores/ui", () => ({
+  useUiStore: () => ({
+    lockMutex: vi.fn(),
+    unlockMutex: vi.fn(),
+    triggerActivityOrb: vi.fn(),
+    vibrate: vi.fn(),
+    formatCurrency: (a: number) => String(a),
+  }),
+}));
+
+beforeEach(() => {
+  addProofs.mockReset();
+  serializeProofs.mockClear();
+  removeProofs.mockReset();
+  setReserved.mockReset();
+  addPaidToken.mockReset();
+});
+
+describe("wallet mint and melt", () => {
+  it("mints proofs when invoice is paid", async () => {
+    const wallet = useWalletStore();
+    const mintWallet = {
+      checkMintQuote: vi.fn(async () => ({ state: MintQuoteState.PAID })),
+      mintProofs: vi.fn(async () => [{ id: "p1" }]),
+    } as any;
+    wallet.mintWallet = vi.fn(() => mintWallet as any);
+    wallet.getKeyset = vi.fn(() => "kid");
+    wallet.keysetCounter = vi.fn(() => 0);
+    wallet.increaseKeysetCounter = vi.fn();
+    wallet.setInvoicePaid = vi.fn();
+
+    const invoice = {
+      amount: 1,
+      bolt11: "b",
+      quote: "q",
+      memo: "",
+      date: "d",
+      status: "pending",
+      mint: "m",
+      unit: "sat",
+    } as any;
+
+    const proofs = await wallet.mint(invoice);
+    expect(mintWallet.checkMintQuote).toHaveBeenCalledWith("q");
+    expect(addProofs).toHaveBeenCalled();
+    expect(addPaidToken).toHaveBeenCalled();
+    expect(proofs[0].id).toBe("p1");
+  });
+
+  it("throws when invoice not paid", async () => {
+    const wallet = useWalletStore();
+    const mintWallet = {
+      checkMintQuote: vi.fn(async () => ({ state: MintQuoteState.UNPAID })),
+      mintProofs: vi.fn(),
+    } as any;
+    wallet.mintWallet = vi.fn(() => mintWallet as any);
+    wallet.getKeyset = vi.fn(() => "kid");
+    wallet.keysetCounter = vi.fn(() => 0);
+
+    const invoice = {
+      amount: 1,
+      bolt11: "b",
+      quote: "q",
+      memo: "",
+      date: "d",
+      status: "pending",
+      mint: "m",
+      unit: "sat",
+    } as any;
+
+    await expect(wallet.mint(invoice)).rejects.toThrow();
+    expect(addProofs).not.toHaveBeenCalled();
+  });
+
+  it("pays invoice via melt", async () => {
+    const wallet = useWalletStore();
+    const mintWallet = {
+      meltProofs: vi.fn(async () => ({ quote: { state: MeltQuoteState.PAID }, change: [] })),
+      mint: { mintUrl: "m" },
+      unit: "sat",
+    } as any;
+    wallet.getKeyset = vi.fn(() => "kid");
+    wallet.keysetCounter = vi.fn(() => 0);
+    wallet.increaseKeysetCounter = vi.fn();
+    wallet.addOutgoingPendingInvoiceToHistory = vi.fn();
+    wallet.updateOutgoingInvoiceInHistory = vi.fn();
+    wallet.removeOutgoingInvoiceFromHistory = vi.fn();
+    wallet.send = vi.fn(async () => ({ keepProofs: [], sendProofs: [{ id: "p1", amount: 1 }] }));
+
+    const quote = { quote: "q", amount: 1, fee_reserve: 0 } as any;
+    await wallet.melt([{ id: "p1", amount: 1 } as any], quote, mintWallet);
+
+    expect(mintWallet.meltProofs).toHaveBeenCalled();
+    expect(removeProofs).toHaveBeenCalled();
+    expect(addPaidToken).toHaveBeenCalled();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add specs for wallet invoice mint/melt actions
- add specs for parsing DMs and caching profiles in nostr store

## Testing
- `npm test` *(fails: module resolution and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_683eb6ff43e48330aeed5e3d2734f515