### PR TITLE
Refactor local storage keys

### DIFF
--- a/src/js/storageKeys.ts
+++ b/src/js/storageKeys.ts
@@ -1,0 +1,104 @@
+export const STORAGE_KEYS = {
+  // UI related
+  UI_HIDE_BALANCE: 'cashu.ui.hideBalance',
+  UI_TAB: 'cashu.ui.tab',
+  UI_EXPAND_HISTORY: 'cashu.ui.expandHistory',
+  UI_SHOW_DEBUG_CONSOLE: 'cashu.ui.showDebugConsole',
+  UI_LAST_BALANCE_CACHED: 'cashu.ui.lastBalanceCached',
+  UI_SHOW_NFC_BUTTON_IN_DRAWER: 'cashu.ui.showNfcButtonInDrawer',
+  // NWC
+  NWC_ENABLED: 'cashu.nwc.enabled',
+  NWC_CONNECTIONS: 'cashu.nwc.connections',
+  NWC_SEEN_COMMANDS_UNTIL: 'cashu.nwc.seenCommandsUntil',
+  NWC_RELAYS: 'cashu.nwc.relays',
+  // Buckets
+  BUCKETS: 'cashu.buckets',
+  BUCKET_RULES: 'cashu.bucketRules',
+  // Creator hub
+  CREATOR_HUB_LOGGED_IN_NPUB: 'creatorHub.loggedInNpub',
+  CREATOR_HUB_TIERS: 'creatorHub.tiers',
+  // Storage utilities
+  LAST_LOCAL_STORAGE_CLEANUP: 'cashu.lastLocalStorageCleanUp',
+  DEXIE_PROOFS_BACKUP: 'cashu.dexie.db.proofs',
+  STORAGE_TEST: 'cashu.test',
+  SPENT_PROOFS: 'cashu.spentProofs',
+  // DM chats
+  DM_CHATS: 'cashu.dmChats',
+  DM_CHATS_UNREAD: 'cashu.dmChats.unread',
+  // Dexie
+  DEXIE_MIGRATED: 'cashu.dexie.migrated',
+  PROOFS: 'cashu.proofs',
+  // NPC/Npub.cash
+  NPC_ENABLED: 'cashu.npc.enabled',
+  NPC_AUTOMATIC_CLAIM: 'cashu.npc.automaticClaim',
+  NPC_ADDRESS: 'cashu.npc.address',
+  NPC_DOMAIN: 'cashu.npc.domain',
+  NPC_BASE_URL: 'cashu.npc.baseURL',
+  // Nostr/NDK
+  NDK_PUBKEY: 'cashu.ndk.pubkey',
+  NDK_SIGNER_TYPE: 'cashu.ndk.signerType',
+  NDK_NIP46_TOKEN: 'cashu.ndk.nip46Token',
+  NDK_PRIVATEKEY_SIGNER_PRIVATEKEY: 'cashu.ndk.privateKeySignerPrivateKey',
+  NDK_SEED_SIGNER_PRIVATEKEY: 'cashu.ndk.seedSignerPrivateKey',
+  NDK_SEED_SIGNER_PUBLICKEY: 'cashu.ndk.seedSignerPublicKey',
+  NDK_MINT_RECOMMENDATIONS: 'cashu.ndk.mintRecommendations',
+  NDK_LAST_EVENT_TIMESTAMP: 'cashu.ndk.lastEventTimestamp',
+  NDK_NIP17_EVENT_IDS_WE_HAVE_SEEN: 'cashu.ndk.nip17EventIdsWeHaveSeen',
+  NDK_PROFILES: 'cashu.ndk.profiles',
+  // Mints
+  ACTIVE_UNIT: 'cashu.activeUnit',
+  ACTIVE_MINT_URL: 'cashu.activeMintUrl',
+  MINTS: 'cashu.mints',
+  // Settings
+  SETTINGS_GET_BITCOIN_PRICE: 'cashu.settings.getBitcoinPrice',
+  SETTINGS_CHECK_SENT_TOKENS: 'cashu.settings.checkSentTokens',
+  SETTINGS_CHECK_INCOMING_INVOICES: 'cashu.settings.checkIncomingInvoices',
+  SETTINGS_PERIODICALLY_CHECK_INCOMING_INVOICES:
+    'cashu.settings.periodicallyCheckIncomingInvoices',
+  SETTINGS_CHECK_INVOICES_ON_STARTUP: 'cashu.settings.checkInvoicesOnStartup',
+  SETTINGS_USE_WEBSOCKETS: 'cashu.settings.useWebsockets',
+  SETTINGS_DEFAULT_NOSTR_RELAYS: 'cashu.settings.defaultNostrRelays',
+  SETTINGS_INCLUDE_FEES_IN_SEND_AMOUNT: 'cashu.settings.includeFeesInSendAmount',
+  SETTINGS_NFC_ENCODING: 'cashu.settings.nfcEncoding',
+  SETTINGS_USE_NUMERIC_KEYBOARD: 'cashu.settings.useNumericKeyboard',
+  SETTINGS_ENABLE_RECEIVE_SWAPS: 'cashu.settings.enableReceiveSwaps',
+  SETTINGS_AUTO_PASTE_ECASH_RECEIVE: 'cashu.settings.autoPasteEcashReceive',
+  SETTINGS_AUDITOR_ENABLED: 'cashu.settings.auditorEnabled',
+  SETTINGS_AUDITOR_URL: 'cashu.settings.auditorUrl',
+  SETTINGS_AUDITOR_API_URL: 'cashu.settings.auditorApiUrl',
+  // Migrations
+  MIGRATIONS_VERSION: 'cashu.migrations.version',
+  // Locked tokens
+  LOCKED_TOKENS: 'cashu.lockedTokens',
+  // Wallet
+  MNEMONIC: 'cashu.mnemonic',
+  INVOICE_HISTORY: 'cashu.invoiceHistory',
+  KEYSET_COUNTERS: 'cashu.keysetCounters',
+  OLD_MNEMONIC_COUNTERS: 'cashu.oldMnemonicCounters',
+  // NPC / Npub.cash ??? not exactly: Already above
+  // P2PK
+  P2PK_KEYS: 'cashu.P2PKKeys',
+  P2PK_SHOW_BUTTON_IN_DRAWER: 'cashu.p2pk.showP2PkButtonInDrawer',
+  // Welcome
+  WELCOME_SHOW_WELCOME: 'cashu.welcome.showWelcome',
+  WELCOME_CURRENT_SLIDE: 'cashu.welcome.currentSlide',
+  WELCOME_SEED_PHRASE_VALIDATED: 'cashu.welcome.seedPhraseValidated',
+  WELCOME_TERMS_ACCEPTED: 'cashu.welcome.termsAccepted',
+  // Donation presets
+  DONATION_PRESETS: 'cashu.donationPresets',
+  // Price
+  PRICE_BITCOIN_PRICE: 'cashu.price.bitcoinPrice',
+  PRICE_BITCOIN_PRICE_LAST_UPDATED: 'cashu.price.bitcoinPriceLastUpdated',
+  // Tokens
+  HISTORY_TOKENS: 'cashu.historyTokens',
+  // Invoice worker
+  WORKER_INVOICE_QUOTES_QUEUE: 'cashu.worker.invoices.quotesQueue',
+  WORKER_LAST_PENDING_INVOICE_CHECK: 'cashu.worker.invoices.lastPendingInvoiceCheck',
+  // Restore
+  RESTORE_SHOW_RESTORE_DIALOG: 'cashu.restore.showRestoreDialog',
+  RESTORE_MNEMONIC_TO_RESTORE: 'cashu.restore.mnemonicToRestore',
+  // Payment request
+  PR_ENABLE: 'cashu.pr.enable',
+  PR_RECEIVE: 'cashu.pr.receive',
+};
+export type StorageKey = typeof STORAGE_KEYS[keyof typeof STORAGE_KEYS];

--- a/src/stores/buckets.ts
+++ b/src/stores/buckets.ts
@@ -1,5 +1,6 @@
 import { defineStore } from "pinia";
 import { useLocalStorage } from "@vueuse/core";
+import { STORAGE_KEYS } from "../js/storageKeys";
 import { v4 as uuidv4 } from "uuid";
 import { cashuDb } from "./dexie";
 import { useProofsStore } from "./proofs";
@@ -35,13 +36,13 @@ function ensureDefaultBucket(buckets: { value: Bucket[] }) {
 
 export const useBucketsStore = defineStore("buckets", {
   state: () => {
-    const buckets = useLocalStorage<Bucket[]>("cashu.buckets", [
+    const buckets = useLocalStorage<Bucket[]>(STORAGE_KEYS.BUCKETS, [
       { id: DEFAULT_BUCKET_ID, name: DEFAULT_BUCKET_NAME },
     ]);
     const proofsStore = useProofsStore();
     const notifiedGoals = ref<Record<string, boolean>>({});
     const autoAssignRules = useLocalStorage<BucketRule[]>(
-      "cashu.bucketRules",
+      STORAGE_KEYS.BUCKET_RULES,
       []
     );
 

--- a/src/stores/creatorHub.ts
+++ b/src/stores/creatorHub.ts
@@ -1,5 +1,6 @@
 import { defineStore } from "pinia";
 import { useLocalStorage } from "@vueuse/core";
+import { STORAGE_KEYS } from "../js/storageKeys";
 import { NDKEvent, NDKKind, NDKFilter } from "@nostr-dev-kit/ndk";
 import { useNostrStore } from "./nostr";
 import { v4 as uuidv4 } from "uuid";
@@ -17,8 +18,11 @@ const CREATOR_TIER_KIND = 38100;
 
 export const useCreatorHubStore = defineStore("creatorHub", {
   state: () => ({
-    loggedInNpub: useLocalStorage<string>("creatorHub.loggedInNpub", ""),
-    tiers: useLocalStorage<Record<string, Tier>>("creatorHub.tiers", {}),
+    loggedInNpub: useLocalStorage<string>(
+      STORAGE_KEYS.CREATOR_HUB_LOGGED_IN_NPUB,
+      ""
+    ),
+    tiers: useLocalStorage<Record<string, Tier>>(STORAGE_KEYS.CREATOR_HUB_TIERS, {}),
   }),
   actions: {
     async loginWithNip07() {

--- a/src/stores/dexie.ts
+++ b/src/stores/dexie.ts
@@ -1,6 +1,7 @@
 import { defineStore } from "pinia";
 import Dexie, { Table } from "dexie";
 import { useLocalStorage } from "@vueuse/core";
+import { STORAGE_KEYS } from "../js/storageKeys";
 import { WalletProof } from "./mints";
 import { useStorageStore } from "./storage";
 import { useProofsStore } from "./proofs";
@@ -69,7 +70,7 @@ export const cashuDb = new CashuDexie();
 
 export const useDexieStore = defineStore("dexie", {
   state: () => ({
-    migratedToDexie: useLocalStorage<boolean>("cashu.dexie.migrated", false),
+    migratedToDexie: useLocalStorage<boolean>(STORAGE_KEYS.DEXIE_MIGRATED, false),
   }),
   getters: {},
   actions: {
@@ -79,7 +80,7 @@ export const useDexieStore = defineStore("dexie", {
         return;
       }
       console.log("Migrating to Dexie");
-      const proofs = localStorage.getItem("cashu.proofs");
+      const proofs = localStorage.getItem(STORAGE_KEYS.PROOFS);
       let parsedProofs: WalletProof[] = [];
       if (!proofs) {
         console.log("No cashu.proofs in localStorage to migrate");
@@ -109,7 +110,7 @@ export const useDexieStore = defineStore("dexie", {
       );
       this.migratedToDexie = true;
       // remove proofs from localstorage
-      localStorage.removeItem("cashu.proofs");
+      localStorage.removeItem(STORAGE_KEYS.PROOFS);
     },
     deleteAllTables: function () {
       cashuDb.proofs.clear();

--- a/src/stores/dmChats.ts
+++ b/src/stores/dmChats.ts
@@ -1,5 +1,6 @@
 import { defineStore } from "pinia";
 import { useLocalStorage } from "@vueuse/core";
+import { STORAGE_KEYS } from "../js/storageKeys";
 import type { NDKEvent } from "@nostr-dev-kit/ndk";
 import { sanitizeMessage } from "../js/message-utils";
 
@@ -14,23 +15,23 @@ export type DMMessage = {
 export const useDmChatsStore = defineStore("dmChats", {
   state: () => ({
     chats: useLocalStorage<Record<string, DMMessage[]>>(
-      "cashu.dmChats",
+      STORAGE_KEYS.DM_CHATS,
       {} as Record<string, DMMessage[]>
     ),
     unreadCounts: useLocalStorage<Record<string, number>>(
-      "cashu.dmChats.unread",
+      STORAGE_KEYS.DM_CHATS_UNREAD,
       {} as Record<string, number>
     ),
   }),
   actions: {
     loadChats() {
-      const stored = localStorage.getItem("cashu.dmChats");
+      const stored = localStorage.getItem(STORAGE_KEYS.DM_CHATS);
       if (stored) {
         try {
           this.chats = JSON.parse(stored);
         } catch {}
       }
-      const storedUnread = localStorage.getItem("cashu.dmChats.unread");
+      const storedUnread = localStorage.getItem(STORAGE_KEYS.DM_CHATS_UNREAD);
       if (storedUnread) {
         try {
           this.unreadCounts = JSON.parse(storedUnread);

--- a/src/stores/donationPresets.ts
+++ b/src/stores/donationPresets.ts
@@ -1,5 +1,6 @@
 import { defineStore } from "pinia";
 import { useLocalStorage } from "@vueuse/core";
+import { STORAGE_KEYS } from "../js/storageKeys";
 import { useWalletStore } from "./wallet";
 import { useMintsStore } from "./mints";
 import { useProofsStore } from "./proofs";
@@ -19,7 +20,7 @@ const DEFAULT_PRESETS: DonationPreset[] = [
 export const useDonationPresetsStore = defineStore("donationPresets", {
   state: () => ({
     presets: useLocalStorage<DonationPreset[]>(
-      "cashu.donationPresets",
+      STORAGE_KEYS.DONATION_PRESETS,
       DEFAULT_PRESETS,
     ),
   }),

--- a/src/stores/invoicesWorker.ts
+++ b/src/stores/invoicesWorker.ts
@@ -1,6 +1,7 @@
 import { defineStore } from "pinia";
 import { useWalletStore } from "./wallet";
 import { useLocalStorage } from "@vueuse/core";
+import { STORAGE_KEYS } from "../js/storageKeys";
 import { useSettingsStore } from "./settings";
 interface InvoiceQuote {
   quote: string;
@@ -24,13 +25,13 @@ export const useInvoicesWorkerStore = defineStore("invoicesWorker", {
       invoiceCheckListener: null as NodeJS.Timeout | null,
       invoiceWorkerRunning: false,
       quotes: useLocalStorage<InvoiceQuote[]>(
-        "cashu.worker.invoices.quotesQueue",
+        STORAGE_KEYS.WORKER_INVOICE_QUOTES_QUEUE,
         []
       ),
       lastInvoiceCheckTime: 0,
       maxQuotesToCheckOnStartup: 10,
       lastPendingInvoiceCheck: useLocalStorage<number>(
-        "cashu.worker.invoices.lastPendingInvoiceCheck",
+        STORAGE_KEYS.WORKER_LAST_PENDING_INVOICE_CHECK,
         0
       ),
       checkPendingInvoicesInterval: 1000 * 10, // delay between bulk invoice checks

--- a/src/stores/lockedTokens.ts
+++ b/src/stores/lockedTokens.ts
@@ -1,5 +1,6 @@
 import { defineStore } from "pinia";
 import { useLocalStorage } from "@vueuse/core";
+import { STORAGE_KEYS } from "../js/storageKeys";
 import { v4 as uuidv4 } from "uuid";
 
 export type LockedToken = {
@@ -15,7 +16,7 @@ export type LockedToken = {
 
 export const useLockedTokensStore = defineStore("lockedTokens", {
   state: () => ({
-    lockedTokens: useLocalStorage<LockedToken[]>("cashu.lockedTokens", []),
+    lockedTokens: useLocalStorage<LockedToken[]>(STORAGE_KEYS.LOCKED_TOKENS, []),
   }),
   getters: {
     tokensByBucket: (state) => (bucketId: string) =>

--- a/src/stores/migrations.ts
+++ b/src/stores/migrations.ts
@@ -1,5 +1,6 @@
 import { defineStore } from "pinia";
 import { useLocalStorage } from "@vueuse/core";
+import { STORAGE_KEYS } from "../js/storageKeys";
 import { useMintsStore } from "./mints";
 import { notifySuccess } from "../js/ui-utils";
 import { useUiStore } from "./ui";
@@ -14,7 +15,7 @@ export type Migration = {
 
 export const useMigrationsStore = defineStore("migrations", {
   state: () => ({
-    currentVersion: useLocalStorage<number>("cashu.migrations.version", 0),
+    currentVersion: useLocalStorage<number>(STORAGE_KEYS.MIGRATIONS_VERSION, 0),
     migrations: [] as Migration[],
   }),
   actions: {

--- a/src/stores/mints.ts
+++ b/src/stores/mints.ts
@@ -1,5 +1,6 @@
 import { defineStore, StoreDefinition } from "pinia";
 import { useLocalStorage } from "@vueuse/core";
+import { STORAGE_KEYS } from "../js/storageKeys";
 import { useWorkersStore } from "./workers";
 import {
   notifyApiError,
@@ -111,13 +112,13 @@ export const useMintsStore = defineStore("mints", {
   state: () => {
     const t = i18n.global.t;
     const activeProofs = ref<WalletProof[]>([]);
-    const activeUnit = useLocalStorage<string>("cashu.activeUnit", "sat");
-    const activeMintUrl = useLocalStorage<string>("cashu.activeMintUrl", "");
+    const activeUnit = useLocalStorage<string>(STORAGE_KEYS.ACTIVE_UNIT, "sat");
+    const activeMintUrl = useLocalStorage<string>(STORAGE_KEYS.ACTIVE_MINT_URL, "");
     const addMintData = ref({
       url: "",
       nickname: "",
     });
-    const mints = useLocalStorage("cashu.mints", [] as Mint[]);
+    const mints = useLocalStorage(STORAGE_KEYS.MINTS, [] as Mint[]);
     const showAddMintDialog = ref(false);
     const addMintBlocking = ref(false);
     const showRemoveMintDialog = ref(false);

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -18,6 +18,7 @@ import { bytesToHex, hexToBytes } from "@noble/hashes/utils"; // already an inst
 import { useWalletStore } from "./wallet";
 import { generateSecretKey, getPublicKey } from "nostr-tools";
 import { useLocalStorage } from "@vueuse/core";
+import { STORAGE_KEYS } from "../js/storageKeys";
 import { useSettingsStore } from "./settings";
 import { useReceiveTokensStore } from "./receiveTokensStore";
 import {
@@ -67,26 +68,26 @@ export enum SignerType {
 export const useNostrStore = defineStore("nostr", {
   state: () => ({
     connected: false,
-    pubkey: useLocalStorage<string>("cashu.ndk.pubkey", ""),
+    pubkey: useLocalStorage<string>(STORAGE_KEYS.NDK_PUBKEY, ""),
     relays: useSettingsStore().defaultNostrRelays,
     ndk: {} as NDK,
     signerType: useLocalStorage<SignerType>(
-      "cashu.ndk.signerType",
+      STORAGE_KEYS.NDK_SIGNER_TYPE,
       SignerType.SEED
     ),
     nip07signer: {} as NDKNip07Signer,
-    nip46Token: useLocalStorage<string>("cashu.ndk.nip46Token", ""),
+    nip46Token: useLocalStorage<string>(STORAGE_KEYS.NDK_NIP46_TOKEN, ""),
     nip46signer: {} as NDKNip46Signer,
     privateKeySignerPrivateKey: useLocalStorage<string>(
-      "cashu.ndk.privateKeySignerPrivateKey",
+      STORAGE_KEYS.NDK_PRIVATEKEY_SIGNER_PRIVATEKEY,
       ""
     ),
     seedSignerPrivateKey: useLocalStorage<string>(
-      "cashu.ndk.seedSignerPrivateKey",
+      STORAGE_KEYS.NDK_SEED_SIGNER_PRIVATEKEY,
       ""
     ),
     seedSignerPublicKey: useLocalStorage<string>(
-      "cashu.ndk.seedSignerPublicKey",
+      STORAGE_KEYS.NDK_SEED_SIGNER_PUBLICKEY,
       ""
     ),
     seedSigner: {} as NDKPrivateKeySigner,
@@ -94,19 +95,19 @@ export const useNostrStore = defineStore("nostr", {
     privateKeySigner: {} as NDKPrivateKeySigner,
     signer: {} as NDKSigner,
     mintRecommendations: useLocalStorage<MintRecommendation[]>(
-      "cashu.ndk.mintRecommendations",
+      STORAGE_KEYS.NDK_MINT_RECOMMENDATIONS,
       []
     ),
     initialized: false,
     lastEventTimestamp: useLocalStorage<number>(
-      "cashu.ndk.lastEventTimestamp",
+      STORAGE_KEYS.NDK_LAST_EVENT_TIMESTAMP,
       0
     ),
     nip17EventIdsWeHaveSeen: useLocalStorage<NostrEventLog[]>(
-      "cashu.ndk.nip17EventIdsWeHaveSeen",
+      STORAGE_KEYS.NDK_NIP17_EVENT_IDS_WE_HAVE_SEEN,
       []
     ),
-    profiles: useLocalStorage<Record<string, { profile: any; fetchedAt: number }>>("cashu.ndk.profiles", {}),
+    profiles: useLocalStorage<Record<string, { profile: any; fetchedAt: number }>>(STORAGE_KEYS.NDK_PROFILES, {}),
   }),
   getters: {
     seedSignerPrivateKeyNsecComputed: (state) => {

--- a/src/stores/npubcash.ts
+++ b/src/stores/npubcash.ts
@@ -1,6 +1,7 @@
 import { defineStore } from "pinia";
 import NDK, { NDKEvent, NDKPrivateKeySigner } from "@nostr-dev-kit/ndk";
 import { useLocalStorage } from "@vueuse/core";
+import { STORAGE_KEYS } from "../js/storageKeys";
 import { bytesToHex } from "@noble/hashes/utils"; // already an installed dependency
 import { generateSecretKey, getPublicKey } from "nostr-tools";
 import { nip19 } from "nostr-tools";
@@ -62,12 +63,12 @@ const NIP98Kind = 27235;
 
 export const useNPCStore = defineStore("npc", {
   state: () => ({
-    npcEnabled: useLocalStorage<boolean>("cashu.npc.enabled", false),
-    automaticClaim: useLocalStorage<boolean>("cashu.npc.automaticClaim", true),
+    npcEnabled: useLocalStorage<boolean>(STORAGE_KEYS.NPC_ENABLED, false),
+    automaticClaim: useLocalStorage<boolean>(STORAGE_KEYS.NPC_AUTOMATIC_CLAIM, true),
     // npcConnections: useLocalStorage<NPCConnection[]>("cashu.npc.connections", []),
-    npcAddress: useLocalStorage<string>("cashu.npc.address", ""),
-    npcDomain: useLocalStorage<string>("cashu.npc.domain", "npub.cash"),
-    baseURL: useLocalStorage<string>("cashu.npc.baseURL", "https://npub.cash"),
+    npcAddress: useLocalStorage<string>(STORAGE_KEYS.NPC_ADDRESS, ""),
+    npcDomain: useLocalStorage<string>(STORAGE_KEYS.NPC_DOMAIN, "npub.cash"),
+    baseURL: useLocalStorage<string>(STORAGE_KEYS.NPC_BASE_URL, "https://npub.cash"),
     npcLoading: false,
     // ndk: new NDK(),
     // signer: {} as NDKPrivateKeySigner,

--- a/src/stores/nwc.ts
+++ b/src/stores/nwc.ts
@@ -9,6 +9,7 @@ import NDK, {
   NDKSubscription,
 } from "@nostr-dev-kit/ndk";
 import { useLocalStorage } from "@vueuse/core";
+import { STORAGE_KEYS } from "../js/storageKeys";
 import { bytesToHex } from "@noble/hashes/utils"; // already an installed dependency
 import { nip04, generateSecretKey, getPublicKey } from "nostr-tools";
 import { useMintsStore } from "./mints";
@@ -65,10 +66,10 @@ const NWCKind = {
 
 export const useNWCStore = defineStore("nwc", {
   state: () => ({
-    nwcEnabled: useLocalStorage<boolean>("cashu.nwc.enabled", false),
-    connections: useLocalStorage<NWCConnection[]>("cashu.nwc.connections", []),
+    nwcEnabled: useLocalStorage<boolean>(STORAGE_KEYS.NWC_ENABLED, false),
+    connections: useLocalStorage<NWCConnection[]>(STORAGE_KEYS.NWC_CONNECTIONS, []),
     seenCommandsUntil: useLocalStorage<number>(
-      "cashu.nwc.seenCommandsUntil",
+      STORAGE_KEYS.NWC_SEEN_COMMANDS_UNTIL,
       0
     ),
     supportedMethods: [
@@ -80,7 +81,7 @@ export const useNWCStore = defineStore("nwc", {
       "lookup_invoice",
     ],
     relays: useLocalStorage<string[]>(
-      "cashu.nwc.relays",
+      STORAGE_KEYS.NWC_RELAYS,
       useSettingsStore().defaultNostrRelays
     ),
     blocking: false,

--- a/src/stores/p2pk.ts
+++ b/src/stores/p2pk.ts
@@ -1,5 +1,6 @@
 import { defineStore } from "pinia";
 import { useLocalStorage } from "@vueuse/core";
+import { STORAGE_KEYS } from "../js/storageKeys";
 import { generateSecretKey, getPublicKey, nip19 } from "nostr-tools";
 import { bytesToHex } from "@noble/hashes/utils"; // already an installed dependency
 import { WalletProof } from "stores/mints";
@@ -14,9 +15,9 @@ type P2PKKey = {
 
 export const useP2PKStore = defineStore("p2pk", {
   state: () => ({
-    p2pkKeys: useLocalStorage<P2PKKey[]>("cashu.P2PKKeys", []),
+    p2pkKeys: useLocalStorage<P2PKKey[]>(STORAGE_KEYS.P2PK_KEYS, []),
     showP2PkButtonInDrawer: useLocalStorage<boolean>(
-      "cashu.p2pk.showP2PkButtonInDrawer",
+      STORAGE_KEYS.P2PK_SHOW_BUTTON_IN_DRAWER,
       false
     ),
     showP2PKDialog: false,

--- a/src/stores/payment-request.ts
+++ b/src/stores/payment-request.ts
@@ -19,15 +19,16 @@ import {
   notifyWarning,
 } from "src/js/ui-utils";
 import { useLocalStorage } from "@vueuse/core";
+import { STORAGE_KEYS } from "../js/storageKeys";
 import { v4 as uuidv4 } from "uuid";
 
 export const usePRStore = defineStore("payment-request", {
   state: () => ({
     showPRDialog: false,
     showPRKData: "" as string,
-    enablePaymentRequest: useLocalStorage<boolean>("cashu.pr.enable", false),
+    enablePaymentRequest: useLocalStorage<boolean>(STORAGE_KEYS.PR_ENABLE, false),
     receivePaymentRequestsAutomatically: useLocalStorage<boolean>(
-      "cashu.pr.receive",
+      STORAGE_KEYS.PR_RECEIVE,
       false
     ),
   }),

--- a/src/stores/price.ts
+++ b/src/stores/price.ts
@@ -1,6 +1,7 @@
 import { defineStore } from "pinia";
 import { useSettingsStore } from "./settings";
 import { useLocalStorage } from "@vueuse/core";
+import { STORAGE_KEYS } from "../js/storageKeys";
 import {
   notifyApiError,
   notifyError,
@@ -19,9 +20,9 @@ const unitTickerShortMap = {
 
 export const usePriceStore = defineStore("price", {
   state: () => ({
-    bitcoinPrice: useLocalStorage("cashu.price.bitcoinPrice", 0 as number),
+    bitcoinPrice: useLocalStorage(STORAGE_KEYS.PRICE_BITCOIN_PRICE, 0 as number),
     bitcoinPriceLastUpdated: useLocalStorage(
-      "cashu.price.bitcoinPriceLastUpdated",
+      STORAGE_KEYS.PRICE_BITCOIN_PRICE_LAST_UPDATED,
       0 as number
     ),
     bitcoinPriceMinRefreshInterval: 60_000,

--- a/src/stores/restore.ts
+++ b/src/stores/restore.ts
@@ -1,5 +1,6 @@
 import { defineStore } from "pinia";
 import { useLocalStorage } from "@vueuse/core";
+import { STORAGE_KEYS } from "../js/storageKeys";
 import { generateSecretKey, getPublicKey } from "nostr-tools";
 import { bytesToHex } from "@noble/hashes/utils"; // already an installed dependency
 import { useWalletStore } from "./wallet";
@@ -16,13 +17,13 @@ const MAX_GAP = 2;
 export const useRestoreStore = defineStore("restore", {
   state: () => ({
     showRestoreDialog: useLocalStorage<boolean>(
-      "cashu.restore.showRestoreDialog",
+      STORAGE_KEYS.RESTORE_SHOW_RESTORE_DIALOG,
       false
     ),
     restoringState: false,
     restoringMint: "",
     mnemonicToRestore: useLocalStorage<string>(
-      "cashu.restore.mnemonicToRestore",
+      STORAGE_KEYS.RESTORE_MNEMONIC_TO_RESTORE,
       ""
     ),
     restoreProgress: 0,

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -1,5 +1,6 @@
 import { defineStore } from "pinia";
 import { useLocalStorage } from "@vueuse/core";
+import { STORAGE_KEYS } from "../js/storageKeys";
 
 const defaultNostrRelays = [
   "wss://relay.f7z.io/",
@@ -11,67 +12,67 @@ export const useSettingsStore = defineStore("settings", {
   state: () => {
     return {
       getBitcoinPrice: useLocalStorage<boolean>(
-        "cashu.settings.getBitcoinPrice",
+        STORAGE_KEYS.SETTINGS_GET_BITCOIN_PRICE,
         false
       ),
       checkSentTokens: useLocalStorage<boolean>(
-        "cashu.settings.checkSentTokens",
+        STORAGE_KEYS.SETTINGS_CHECK_SENT_TOKENS,
         true
       ),
       checkIncomingInvoices: useLocalStorage<boolean>(
-        "cashu.settings.checkIncomingInvoices",
+        STORAGE_KEYS.SETTINGS_CHECK_INCOMING_INVOICES,
         true
       ),
       periodicallyCheckIncomingInvoices: useLocalStorage<boolean>(
-        "cashu.settings.periodicallyCheckIncomingInvoices",
+        STORAGE_KEYS.SETTINGS_PERIODICALLY_CHECK_INCOMING_INVOICES,
         true
       ),
       checkInvoicesOnStartup: useLocalStorage<boolean>(
-        "cashu.settings.checkInvoicesOnStartup",
+        STORAGE_KEYS.SETTINGS_CHECK_INVOICES_ON_STARTUP,
         true
       ),
       useWebsockets: useLocalStorage<boolean>(
-        "cashu.settings.useWebsockets",
+        STORAGE_KEYS.SETTINGS_USE_WEBSOCKETS,
         true
       ),
       defaultNostrRelays: useLocalStorage<string[]>(
-        "cashu.settings.defaultNostrRelays",
+        STORAGE_KEYS.SETTINGS_DEFAULT_NOSTR_RELAYS,
         defaultNostrRelays
       ),
       includeFeesInSendAmount: useLocalStorage<boolean>(
-        "cashu.settings.includeFeesInSendAmount",
+        STORAGE_KEYS.SETTINGS_INCLUDE_FEES_IN_SEND_AMOUNT,
         false
       ),
       nfcEncoding: useLocalStorage<string>(
-        "cashu.settings.nfcEncoding",
+        STORAGE_KEYS.SETTINGS_NFC_ENCODING,
         "weburl"
       ),
       useNumericKeyboard: useLocalStorage<boolean>(
-        "cashu.settings.useNumericKeyboard",
+        STORAGE_KEYS.SETTINGS_USE_NUMERIC_KEYBOARD,
         false
       ),
       enableReceiveSwaps: useLocalStorage<boolean>(
-        "cashu.settings.enableReceiveSwaps",
+        STORAGE_KEYS.SETTINGS_ENABLE_RECEIVE_SWAPS,
         false
       ),
       showNfcButtonInDrawer: useLocalStorage(
-        "cashu.ui.showNfcButtonInDrawer",
+        STORAGE_KEYS.UI_SHOW_NFC_BUTTON_IN_DRAWER,
         true
       ),
       autoPasteEcashReceive: useLocalStorage(
-        "cashu.settings.autoPasteEcashReceive",
+        STORAGE_KEYS.SETTINGS_AUTO_PASTE_ECASH_RECEIVE,
         true
       ),
       auditorEnabled: useLocalStorage<boolean>(
-        "cashu.settings.auditorEnabled",
+        STORAGE_KEYS.SETTINGS_AUDITOR_ENABLED,
         false
       ),
       auditorUrl: useLocalStorage<string>(
-        "cashu.settings.auditorUrl",
+        STORAGE_KEYS.SETTINGS_AUDITOR_URL,
         "https://audit.8333.space"
       ),
       auditorApiUrl: useLocalStorage<string>(
-        "cashu.settings.auditorApiUrl",
+        STORAGE_KEYS.SETTINGS_AUDITOR_API_URL,
         "https://api.audit.8333.space"
       ),
     };

--- a/src/stores/storage.ts
+++ b/src/stores/storage.ts
@@ -2,6 +2,7 @@ import { defineStore } from "pinia";
 import { useWalletStore } from "./wallet";
 import { useMintsStore } from "./mints";
 import { useLocalStorage } from "@vueuse/core";
+import { STORAGE_KEYS } from "../js/storageKeys";
 import { notifyError, notifySuccess } from "../js/ui-utils";
 import { useTokensStore } from "./tokens";
 import { currentDateStr } from "src/js/utils";
@@ -11,7 +12,7 @@ import { useBucketsStore } from "./buckets";
 export const useStorageStore = defineStore("storage", {
   state: () => ({
     lastLocalStorageCleanUp: useLocalStorage(
-      "cashu.lastLocalStorageCleanUp",
+      STORAGE_KEYS.LAST_LOCAL_STORAGE_CLEANUP,
       new Date(),
     ),
   }),
@@ -25,10 +26,10 @@ export const useStorageStore = defineStore("storage", {
         const keys = Object.keys(backup);
         for (const key of keys) {
           // we treat some keys differently *magic*
-          if (key === "cashu.dexie.db.proofs") {
+          if (key === STORAGE_KEYS.DEXIE_PROOFS_BACKUP) {
             const proofs = JSON.parse(backup[key]);
             await proofsStore.addProofs(proofs);
-          } else if (key === "cashu.buckets") {
+          } else if (key === STORAGE_KEYS.BUCKETS) {
             bucketsStore.buckets = JSON.parse(backup[key]);
           } else {
             localStorage.setItem(key, backup[key]);
@@ -50,7 +51,7 @@ export const useStorageStore = defineStore("storage", {
       }
       // proofs table *magic*
       const proofs = await useProofsStore().getProofs();
-      jsonToSave["cashu.dexie.db.proofs"] = JSON.stringify(proofs);
+      jsonToSave[STORAGE_KEYS.DEXIE_PROOFS_BACKUP] = JSON.stringify(proofs);
 
       var textToSave = JSON.stringify(jsonToSave);
       var textToSaveAsBlob = new Blob([textToSave], {
@@ -86,8 +87,8 @@ export const useStorageStore = defineStore("storage", {
       console.log(`Local storage size: ${localStorageSize} bytes`);
       let data = new Array(10240).join("x");
       try {
-        localStorage.setItem("cashu.test", data);
-        localStorage.removeItem("cashu.test");
+        localStorage.setItem(STORAGE_KEYS.STORAGE_TEST, data);
+        localStorage.removeItem(STORAGE_KEYS.STORAGE_TEST);
         return false;
       } catch (e) {
         console.log("Local storage quota exceeded");
@@ -115,7 +116,7 @@ export const useStorageStore = defineStore("storage", {
       const localStorageSizeBefore = JSON.stringify(localStorage).length;
 
       // delete cashu.spentProofs from local storage
-      localStorage.removeItem("cashu.spentProofs");
+      localStorage.removeItem(STORAGE_KEYS.SPENT_PROOFS);
 
       // from all paid invoices in this.invoiceHistory, delete the oldest so that only max 100 remain
       const max_history = 200;

--- a/src/stores/tokens.ts
+++ b/src/stores/tokens.ts
@@ -1,4 +1,5 @@
 import { useLocalStorage } from "@vueuse/core";
+import { STORAGE_KEYS } from "../js/storageKeys";
 import { date } from "quasar";
 import { defineStore } from "pinia";
 import { PaymentRequest, Proof, Token } from "@cashu/cashu-ts";
@@ -27,7 +28,10 @@ export type HistoryToken = {
 
 export const useTokensStore = defineStore("tokens", {
   state: () => ({
-    historyTokens: useLocalStorage("cashu.historyTokens", [] as HistoryToken[]),
+    historyTokens: useLocalStorage(
+      STORAGE_KEYS.HISTORY_TOKENS,
+      [] as HistoryToken[]
+    ),
   }),
   actions: {
     /**

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -1,6 +1,7 @@
 import { defineStore } from "pinia";
 import { useMintsStore } from "./mints";
 import { useLocalStorage } from "@vueuse/core";
+import { STORAGE_KEYS } from "../js/storageKeys";
 import {
   notifyApiError,
   notifyError,
@@ -22,7 +23,7 @@ const unitTickerShortMap = {
 
 export const useUiStore = defineStore("ui", {
   state: () => ({
-    hideBalance: useLocalStorage<boolean>("cashu.ui.hideBalance", false),
+    hideBalance: useLocalStorage<boolean>(STORAGE_KEYS.UI_HIDE_BALANCE, false),
     tickerLong: "Satoshis",
     showInvoiceDetails: false,
     showSendDialog: false,
@@ -30,11 +31,11 @@ export const useUiStore = defineStore("ui", {
     showReceiveEcashDrawer: false,
     showNumericKeyboard: false,
     activityOrb: false,
-    tab: useLocalStorage("cashu.ui.tab", "history" as string),
-    expandHistory: useLocalStorage("cashu.ui.expandHistory", true as boolean),
+    tab: useLocalStorage(STORAGE_KEYS.UI_TAB, "history" as string),
+    expandHistory: useLocalStorage(STORAGE_KEYS.UI_EXPAND_HISTORY, true as boolean),
     globalMutexLock: false,
-    showDebugConsole: useLocalStorage("cashu.ui.showDebugConsole", false),
-    lastBalanceCached: useLocalStorage("cashu.ui.lastBalanceCached", 0),
+    showDebugConsole: useLocalStorage(STORAGE_KEYS.UI_SHOW_DEBUG_CONSOLE, false),
+    lastBalanceCached: useLocalStorage(STORAGE_KEYS.UI_LAST_BALANCE_CACHED, 0),
   }),
   actions: {
     closeDialogs() {

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -2,6 +2,7 @@ import { defineStore } from "pinia";
 import { currentDateStr } from "src/js/utils";
 import { useMintsStore, WalletProof, MintClass, Mint } from "./mints";
 import { useLocalStorage } from "@vueuse/core";
+import { STORAGE_KEYS } from "../js/storageKeys";
 import { useProofsStore } from "./proofs";
 import { HistoryToken, useTokensStore } from "./tokens";
 import { useReceiveTokensStore } from "./receiveTokensStore";
@@ -91,17 +92,17 @@ export const useWalletStore = defineStore("wallet", {
     const t = i18n.global.t;
     return {
       t: t,
-      mnemonic: useLocalStorage("cashu.mnemonic", ""),
+      mnemonic: useLocalStorage(STORAGE_KEYS.MNEMONIC, ""),
       invoiceHistory: useLocalStorage(
-        "cashu.invoiceHistory",
+        STORAGE_KEYS.INVOICE_HISTORY,
         [] as InvoiceHistory[],
       ),
       keysetCounters: useLocalStorage(
-        "cashu.keysetCounters",
+        STORAGE_KEYS.KEYSET_COUNTERS,
         [] as KeysetCounter[],
       ),
       oldMnemonicCounters: useLocalStorage(
-        "cashu.oldMnemonicCounters",
+        STORAGE_KEYS.OLD_MNEMONIC_COUNTERS,
         [] as { mnemonic: string; keysetCounters: KeysetCounter[] }[],
       ),
       invoiceData: {} as InvoiceHistory,

--- a/src/stores/welcome.ts
+++ b/src/stores/welcome.ts
@@ -1,6 +1,7 @@
 // src/stores/welcome.ts
 import { defineStore } from "pinia";
 import { useLocalStorage } from "@vueuse/core";
+import { STORAGE_KEYS } from "../js/storageKeys";
 import { computed } from "vue";
 import router from "src/router";
 
@@ -14,14 +15,14 @@ export type WelcomeState = {
 // Define the Pinia store
 export const useWelcomeStore = defineStore("welcome", {
   state: (): WelcomeState => ({
-    showWelcome: useLocalStorage<boolean>("cashu.welcome.showWelcome", true),
-    currentSlide: useLocalStorage<number>("cashu.welcome.currentSlide", 0),
+    showWelcome: useLocalStorage<boolean>(STORAGE_KEYS.WELCOME_SHOW_WELCOME, true),
+    currentSlide: useLocalStorage<number>(STORAGE_KEYS.WELCOME_CURRENT_SLIDE, 0),
     seedPhraseValidated: useLocalStorage<boolean>(
-      "cashu.welcome.seedPhraseValidated",
+      STORAGE_KEYS.WELCOME_SEED_PHRASE_VALIDATED,
       false
     ),
     termsAccepted: useLocalStorage<boolean>(
-      "cashu.welcome.termsAccepted",
+      STORAGE_KEYS.WELCOME_TERMS_ACCEPTED,
       false
     ),
   }),


### PR DESCRIPTION
## Summary
- centralize all localStorage key names in `src/js/storageKeys.ts`
- use the new constants throughout the store modules

## Testing
- `npm test` *(fails: cannot run vitest in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_683eb91b0bf08330b6e9d9e4661c2a7d