### PR TITLE
Wrap mixin boot code

### DIFF
--- a/src/boot/base.js
+++ b/src/boot/base.js
@@ -1,4 +1,5 @@
 import { LocalStorage, Dark } from "quasar";
+import { boot } from "quasar/wrappers";
 import { SafeArea } from "capacitor-plugin-safe-area";
 import {
   changeColor,
@@ -17,10 +18,11 @@ import {
   notify,
 } from "src/js/ui-utils";
 
-window.LOCALE = "en";
-// window.EventHub = new Vue();
+export default boot(() => {
+  window.LOCALE = "en";
+  // window.EventHub = new Vue();
 
-window.windowMixin = {
+  const windowMixin = {
   data: function () {
     return {
       g: {
@@ -113,4 +115,7 @@ window.windowMixin = {
       });
     }
   },
-};
+  };
+
+  window.windowMixin = windowMixin;
+});


### PR DESCRIPTION
## Summary
- integrate Quasar boot wrapper in `src/boot/base.js`
- define `windowMixin` and export via `boot()`

## Testing
- `npm test` *(fails: Cannot access network to install deps)*

------
https://chatgpt.com/codex/tasks/task_e_683ebe45b39c833081489b27785b537c