### PR TITLE
Fix header z-index for menu

### DIFF
--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -346,8 +346,8 @@ export default defineComponent({
 </script>
 <style scoped>
 .q-header {
-  position: relative;
-  z-index: auto;
+  position: sticky; /* or fixed */
+  z-index: 1000; /* ensures header stays above page content */
   overflow-x: hidden;
 }
 


### PR DESCRIPTION
## Summary
- ensure `.q-header` stays above page content in `MainHeader.vue`

## Testing
- `npm test` *(fails: Cannot find module 'vite-jsconfig-paths')*

------
https://chatgpt.com/codex/tasks/task_e_683ed175bc848330872d03bc8c32e1c9