### PR TITLE
Fix search timer cleanup in FindCreatorsView

### DIFF
--- a/src/components/FindCreatorsView.vue
+++ b/src/components/FindCreatorsView.vue
@@ -83,7 +83,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, watch, onMounted } from "vue";
+import { defineComponent, ref, watch, onMounted, onBeforeUnmount } from "vue";
 import { useRouter } from "vue-router";
 import { useCreatorsStore } from "stores/creators";
 import CreatorProfileCard from "components/CreatorProfileCard.vue";
@@ -146,6 +146,8 @@ export default defineComponent({
         creatorsStore.searchCreators(val);
       }, 500);
     });
+
+    onBeforeUnmount(() => clearTimeout(debounceTimeout));
 
     const openDonateDialog = (creator: any) => {
       donateCreator.value = creator;


### PR DESCRIPTION
## Summary
- import `onBeforeUnmount` in `FindCreatorsView.vue`
- clear search debounce when leaving the component

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot find module 'vite-jsconfig-paths')*

------
https://chatgpt.com/codex/tasks/task_e_683ed2aa701483308910cfdec19eeb06