### PR TITLE
refactor: async VueQrcode per component

### DIFF
--- a/src/boot/global-components.js
+++ b/src/boot/global-components.js
@@ -1,13 +1,11 @@
 import { boot } from "quasar/wrappers";
 
-import VueQrcode from "@chenfengyuan/vue-qrcode";
 import InfoTooltip from "components/InfoTooltip.vue";
 import HelpPopup from "components/HelpPopup.vue";
 
 // "async" is optional;
 // more info on params: https://v2.quasar.dev/quasar-cli/boot-files
 export default boot(async ({ app }) => {
-  app.component(VueQrcode.name, VueQrcode);
   app.component("InfoTooltip", InfoTooltip);
   app.component("HelpPopup", HelpPopup);
 });

--- a/src/components/InvoiceDetailDialog.vue
+++ b/src/components/InvoiceDetailDialog.vue
@@ -170,7 +170,10 @@
 <script>
 import { defineComponent } from "vue";
 import { mapActions, mapState, mapWritableState } from "pinia";
-import VueQrcode from "@chenfengyuan/vue-qrcode";
+import { defineAsyncComponent } from "vue";
+const VueQrcode = defineAsyncComponent(() =>
+  import("@chenfengyuan/vue-qrcode")
+);
 
 import { useWalletStore } from "src/stores/wallet";
 import ChooseMint from "src/components/ChooseMint.vue";

--- a/src/components/MintDetailsDialog.vue
+++ b/src/components/MintDetailsDialog.vue
@@ -340,7 +340,10 @@
 <script>
 import { defineComponent } from "vue";
 import { mapActions, mapState, mapWritableState } from "pinia";
-import VueQrcode from "@chenfengyuan/vue-qrcode";
+import { defineAsyncComponent } from "vue";
+const VueQrcode = defineAsyncComponent(() =>
+  import("@chenfengyuan/vue-qrcode")
+);
 import { useMintsStore, MintClass } from "src/stores/mints";
 import { useSettingsStore } from "src/stores/settings";
 import EditMintDialog from "src/components/EditMintDialog.vue";

--- a/src/components/NWCDialog.vue
+++ b/src/components/NWCDialog.vue
@@ -62,7 +62,10 @@
 <script>
 import { defineComponent } from "vue";
 import { mapActions, mapState, mapWritableState } from "pinia";
-import VueQrcode from "@chenfengyuan/vue-qrcode";
+import { defineAsyncComponent } from "vue";
+const VueQrcode = defineAsyncComponent(() =>
+  import("@chenfengyuan/vue-qrcode")
+);
 
 import { useNWCStore } from "src/stores/nwc";
 

--- a/src/components/P2PKDialog.vue
+++ b/src/components/P2PKDialog.vue
@@ -70,7 +70,10 @@
 <script>
 import { defineComponent } from "vue";
 import { mapActions, mapState, mapWritableState } from "pinia";
-import VueQrcode from "@chenfengyuan/vue-qrcode";
+import { defineAsyncComponent } from "vue";
+const VueQrcode = defineAsyncComponent(() =>
+  import("@chenfengyuan/vue-qrcode")
+);
 
 import { useP2PKStore } from "src/stores/p2pk";
 

--- a/src/components/PaymentRequestDialog.vue
+++ b/src/components/PaymentRequestDialog.vue
@@ -117,7 +117,10 @@
 <script>
 import { defineComponent } from "vue";
 import { mapActions, mapState, mapWritableState } from "pinia";
-import VueQrcode from "@chenfengyuan/vue-qrcode";
+import { defineAsyncComponent } from "vue";
+const VueQrcode = defineAsyncComponent(() =>
+  import("@chenfengyuan/vue-qrcode")
+);
 
 import { usePRStore } from "src/stores/payment-request";
 import { useMintsStore } from "../stores/mints";


### PR DESCRIPTION
## Summary
- stop registering VueQrcode globally
- load VueQrcode lazily inside components

## Testing
- `npm test` *(fails: Cannot find module 'vite-jsconfig-paths')*

------
https://chatgpt.com/codex/tasks/task_e_683ed38beb8483309d7d0e12de2d2f32