### PR TITLE
Load i18n locale dynamically

### DIFF
--- a/src/boot/i18n.js
+++ b/src/boot/i18n.js
@@ -1,10 +1,14 @@
 import { boot } from "quasar/wrappers";
 import { createI18n } from "vue-i18n";
-import messages from "src/i18n";
+import { loadMessages } from "src/i18n";
 
 // Get stored locale from localStorage or fallback to browser language or en-US
 const storedLocale =
   localStorage.getItem("cashu.language") || navigator.language || "en-US";
+const messages = { "en-US": await loadMessages("en-US") };
+if (storedLocale !== "en-US") {
+  messages[storedLocale] = await loadMessages(storedLocale);
+}
 
 export const i18n = createI18n({
   locale: storedLocale,

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,27 +1,3 @@
-import enUS from "./en-US";
-import esES from "./es-ES";
-import itIT from "./it-IT";
-import deDE from "./de-DE";
-import frFR from "./fr-FR";
-import svSE from "./sv-SE";
-import elGR from "./el-GR";
-import trTR from "./tr-TR";
-import thTH from "./th-TH";
-import arSA from "./ar-SA";
-import zhCN from "./zh-CN";
-import jaJP from "./ja-JP";
-
-export default {
-  "en-US": enUS,
-  "es-ES": esES,
-  "it-IT": itIT,
-  "de-DE": deDE,
-  "fr-FR": frFR,
-  "sv-SE": svSE,
-  "el-GR": elGR,
-  "tr-TR": trTR,
-  "th-TH": thTH,
-  "ar-SA": arSA,
-  "zh-CN": zhCN,
-  "ja-JP": jaJP,
-};
+export async function loadMessages(locale: string) {
+  return (await import(`./${locale}`)).default
+}


### PR DESCRIPTION
## Summary
- import only needed locale in `boot/i18n.js`
- expose `loadMessages` helper in i18n module

## Testing
- `npm test` *(fails: Cannot find module 'vite-jsconfig-paths')*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_683ed6b2141483309d13c047631bb487