### PR TITLE
Fix icons import

### DIFF
--- a/src/icons.js
+++ b/src/icons.js
@@ -1,4 +1,3 @@
-import { createApp } from "vue";
 import {
   LucideX,
   LucideQrCode,


### PR DESCRIPTION
## Summary
- remove unused `createApp` import in icons

## Testing
- `npm test` *(fails: Cannot find module 'vite-jsconfig-paths')*

------
https://chatgpt.com/codex/tasks/task_e_683ed7ace39c8330ab16193174bc3144