### PR TITLE
Show follower stats in creator card

### DIFF
--- a/src/components/CreatorProfileCard.vue
+++ b/src/components/CreatorProfileCard.vue
@@ -51,19 +51,35 @@
       </div>
     </q-card-section>
     <q-card-section class="text-caption">
-      <template v-if="loaded">
-        {{ $t("FindCreators.labels.view_profile_stats") }}
-      </template>
-      <template v-else-if="loading">
-        <q-skeleton type="text" width="60%" />
-      </template>
-    </q-card-section>
-    <q-card-section class="text-caption">
       <template v-if="loaded && joinedDateFormatted">
         {{ $t("FindCreators.labels.joined") }}: {{ joinedDateFormatted }}
       </template>
       <template v-else-if="loading">
         <q-skeleton type="text" width="40%" />
+      </template>
+    </q-card-section>
+    <q-card-section class="text-caption">
+      <template v-if="loaded">
+        {{ $t('FindCreators.labels.followers') }}: {{ followers }}
+      </template>
+      <template v-else-if="loading">
+        <q-skeleton type="text" width="40%" />
+      </template>
+    </q-card-section>
+    <q-card-section class="text-caption">
+      <template v-if="loaded">
+        {{ $t('FindCreators.labels.following') }}: {{ following }}
+      </template>
+      <template v-else-if="loading">
+        <q-skeleton type="text" width="40%" />
+      </template>
+    </q-card-section>
+    <q-card-section class="text-caption">
+      <template v-if="loaded">
+        {{ $t("FindCreators.labels.view_profile_stats") }}
+      </template>
+      <template v-else-if="loading">
+        <q-skeleton type="text" width="60%" />
       </template>
     </q-card-section>
     <q-card-actions class="q-mt-sm">


### PR DESCRIPTION
## Summary
- display creator follower stats in the profile card
- keep lazy-load logic using `IntersectionObserver`

## Testing
- `npm test` *(fails: Cannot find module 'vite-jsconfig-paths')*

------
https://chatgpt.com/codex/tasks/task_e_683edc847e888330966e1f44b4bc8440