### PR TITLE
Update Find Creators page

### DIFF
--- a/src/pages/FindCreators.vue
+++ b/src/pages/FindCreators.vue
@@ -1,7 +1,30 @@
 <template>
-  <FindCreatorsView />
+  <div class="find-creators-wrapper">
+    <iframe
+      src="/find-creators.html"
+      class="find-creators-frame"
+      title="Find Creators"
+    />
+  </div>
 </template>
 
 <script setup lang="ts">
-import FindCreatorsView from 'components/FindCreatorsView.vue'
+// The FindCreators page now loads a standalone HTML file that contains the
+// entire implementation for searching and displaying creators. We simply embed
+// that file in an iframe to keep it separate from the Quasar SPA while
+// retaining navigation via the router.
 </script>
+
+<style scoped>
+.find-creators-wrapper {
+  height: 100vh;
+  padding: 0;
+  margin: 0;
+}
+
+.find-creators-frame {
+  border: none;
+  width: 100%;
+  height: 100%;
+}
+</style>


### PR DESCRIPTION
## Summary
- replace the `FindCreators` view with an iframe pointing to the standalone `find-creators.html`

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840013465cc8330b3b8e1c00e4f8340