### PR TITLE
Refactor FindCreators page

### DIFF
--- a/src/pages/FindCreators.vue
+++ b/src/pages/FindCreators.vue
@@ -1,18 +1,11 @@
 <template>
   <div class="find-creators-wrapper">
-    <iframe
-      src="/find-creators.html"
-      class="find-creators-frame"
-      title="Find Creators"
-    />
+    <FindCreatorsView />
   </div>
 </template>
 
 <script setup lang="ts">
-// The FindCreators page now loads a standalone HTML file that contains the
-// entire implementation for searching and displaying creators. We simply embed
-// that file in an iframe to keep it separate from the Quasar SPA while
-// retaining navigation via the router.
+import FindCreatorsView from "components/FindCreatorsView.vue";
 </script>
 
 <style scoped>
@@ -20,11 +13,5 @@
   height: 100vh;
   padding: 0;
   margin: 0;
-}
-
-.find-creators-frame {
-  border: none;
-  width: 100%;
-  height: 100%;
 }
 </style>


### PR DESCRIPTION
## Summary
- embed `FindCreatorsView` directly in `FindCreators.vue`

## Testing
- `npm test` *(fails: Cannot find module 'vite-jsconfig-paths')*

------
https://chatgpt.com/codex/tasks/task_e_684007179dd48330918d56027f8626b4