### PR TITLE
Add chat layout utility styles

### DIFF
--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -5,6 +5,7 @@ body {
   font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
     Oxygen, Ubuntu, Cantarell, "Fira Sans", "Droid Sans", "Helvetica Neue",
     sans-serif;
+  overflow: hidden; /* Prevent body scroll, manage scrolling in panes */
 }
 
 // prevent pull to refresh
@@ -100,3 +101,58 @@ body.body--light {
   --custom-btn-bg: var(--custom-btn-light);
   --custom-btn-text: black;
 }
+
+/* Utility heights accounting for a 4rem header */
+.h-screen-minus-header {
+  height: calc(100vh - 4rem);
+}
+
+/* Layout helpers for chat page */
+.sidebar {
+  width: 320px;
+  min-width: 300px;
+}
+
+.main-chat-area {
+  flex-grow: 1;
+}
+
+/* Custom Scrollbars */
+.custom-scrollbar::-webkit-scrollbar {
+  display: initial;
+  width: 6px;
+  height: 6px;
+}
+.custom-scrollbar::-webkit-scrollbar-track {
+  background: #e5e7eb; /* Tailwind gray-200 */
+  border-radius: 10px;
+}
+.custom-scrollbar::-webkit-scrollbar-thumb {
+  background: #9ca3af; /* Tailwind gray-400 */
+  border-radius: 10px;
+}
+.custom-scrollbar::-webkit-scrollbar-thumb:hover {
+  background: #6b7280; /* Tailwind gray-500 */
+}
+
+/* Chat bubble base styles */
+.chat-bubble-sent {
+  background-color: #4f46e5; /* Tailwind indigo-600 */
+  color: white;
+  align-self: flex-end;
+  border-radius: 1.25rem 1.25rem 0.25rem 1.25rem;
+}
+.chat-bubble-received {
+  background-color: #e5e7eb; /* Tailwind gray-200 */
+  color: #1f2937; /* Tailwind gray-800 */
+  align-self: flex-start;
+  border-radius: 1.25rem 1.25rem 1.25rem 0.25rem;
+}
+
+/*
+// For consistent focus on Quasar inputs if needed, though Quasar has its own focus styling
+.q-field--focused .q-field__control:after {
+  // Example: box-shadow: 0 0 0 2px #a78bfa;
+  // border-color: #8b5cf6;
+}
+*/

--- a/src/css/base.scss
+++ b/src/css/base.scss
@@ -263,3 +263,8 @@ video {
 ::-webkit-scrollbar {
   display: none;
 }
+
+/* Allow scrollbars when explicitly requested */
+.custom-scrollbar::-webkit-scrollbar {
+  display: initial;
+}


### PR DESCRIPTION
## Summary
- prevent scrolling on body
- add utilities for chat layout and scrollbar styling
- ensure custom scrollbars override default hidden style

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68408cfd6bc88330af740b365398dfcc