### PR TITLE
Add shared Nostr types

### DIFF
--- a/src/stores/types.ts
+++ b/src/stores/types.ts
@@ -1,0 +1,48 @@
+export interface NostrRelay {
+  url: string;
+  socket: WebSocket | null;
+  status: 'idle' | 'connecting' | 'connected' | 'error' | 'disconnected' | 'disconnecting';
+  subscriptionId?: string;
+  sub?: any; // nostr-tools Sub object
+  error?: string; // To store error messages
+  eoseReceived?: boolean; // To track EOSE for initial sync
+  notice?: string; // To store last notice from relay
+}
+
+export interface NostrEvent {
+  id?: string;
+  kind: number;
+  pubkey: string;
+  created_at: number;
+  tags: string[][];
+  content: string;
+  sig?: string;
+}
+
+export interface SignerInfo {
+  remoteSignerPubkey?: string;
+  relays?: string[];
+  secret?: string; // NIP-46 secret
+  canSign?: boolean;
+  canDecrypt?: boolean;
+}
+
+export interface Message {
+  id: string; // Nostr event ID
+  content: string;
+  isOutgoing: boolean;
+  timestamp: number; // Milliseconds
+  senderPkHex: string; // Pubkey of the sender
+  recipientPkHex: string; // Pubkey of the recipient (for context in conversation)
+  status?: 'sending' | 'sent' | 'failed'; // Optional: for optimistic updates
+}
+
+export interface Conversation {
+  recipientPkHex: string;
+  messages: Message[];
+  lastMessageTimestamp: number; // Milliseconds, for sorting
+  unreadCount: number;
+  displayName: string; // npub1... or fetched profile name
+}
+
+export type ConversationsRecord = Record<string, Conversation>;


### PR DESCRIPTION
## Summary
- add shared `NostrRelay`, `NostrEvent`, `SignerInfo`, `Message`, `Conversation`, and `ConversationsRecord` interfaces

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68408dc2d70883308b1fc4b954a5744c