### PR TITLE
Add Nostr messenger page

### DIFF
--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -1,0 +1,13 @@
+<template>
+  <q-page
+    :class="[
+      $q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark',
+      'q-pa-md'
+    ]"
+  >
+    <div class="text-h5">Nostr Messenger</div>
+  </q-page>
+</template>
+
+<script setup>
+</script>

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -89,6 +89,13 @@ const routes = [
     children: [{ path: "", component: () => import("src/pages/ChatView.vue") }],
   },
   {
+    path: "/nostr-messenger",
+    component: () => import("layouts/MainLayout.vue"),
+    children: [
+      { path: "", component: () => import("src/pages/NostrMessenger.vue") },
+    ],
+  },
+  {
     path: "/buckets/:id",
     component: () => import("layouts/FullscreenLayout.vue"),
     children: [


### PR DESCRIPTION
## Summary
- add placeholder NostrMessenger page using MainLayout
- register /nostr-messenger route

## Testing
- `npm test` *(fails: Cannot find module 'vite-jsconfig-paths')*

------
https://chatgpt.com/codex/tasks/task_e_6840945b3c448330b31d0f25044a1a2c