### PR TITLE
Add basic Nostr messenger components

### DIFF
--- a/src/components/ConversationList.vue
+++ b/src/components/ConversationList.vue
@@ -1,0 +1,26 @@
+<template>
+  <q-drawer v-model="drawer" side="left" bordered :width="260">
+    <q-toolbar>
+      <q-toolbar-title>Conversations</q-toolbar-title>
+    </q-toolbar>
+    <q-list>
+      <q-item v-for="(msgs, pubkey) in conversations" :key="pubkey" clickable @click="select(pubkey)">
+        <q-item-section>{{ pubkey }}</q-item-section>
+      </q-item>
+    </q-list>
+  </q-drawer>
+</template>
+
+<script lang="ts" setup>
+import { computed, ref } from 'vue';
+import { useMessengerStore } from 'src/stores/messenger';
+
+const emit = defineEmits(['select']);
+const drawer = ref(true);
+const messenger = useMessengerStore();
+const conversations = computed(() => messenger.conversations);
+
+const select = (pubkey: string) => {
+  emit('select', pubkey);
+};
+</script>

--- a/src/components/EventLog.vue
+++ b/src/components/EventLog.vue
@@ -1,0 +1,19 @@
+<template>
+  <q-scroll-area style="max-height: 200px">
+    <q-list dense>
+      <q-item v-for="e in events" :key="e.id">
+        <q-item-section>{{ e.id }}</q-item-section>
+        <q-item-section side>{{ formatDate(e.created_at) }}</q-item-section>
+      </q-item>
+    </q-list>
+  </q-scroll-area>
+</template>
+
+<script lang="ts" setup>
+import { computed } from 'vue';
+import { useNostrStore } from 'src/stores/nostr';
+
+const nostr = useNostrStore();
+const events = computed(() => nostr.nip17EventIdsWeHaveSeen);
+const formatDate = (ts: number) => new Date(ts * 1000).toLocaleString();
+</script>

--- a/src/components/MessageInput.vue
+++ b/src/components/MessageInput.vue
@@ -1,0 +1,21 @@
+<template>
+  <div class="row no-wrap items-center q-pa-sm">
+    <q-input v-model="text" class="col" dense outlined @keyup.enter="send" />
+    <q-btn flat round icon="send" color="primary" class="q-ml-sm" :disable="!text.trim()" @click="send" />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue';
+
+const emit = defineEmits(['send']);
+const text = ref('');
+
+const send = () => {
+  const m = text.value.trim();
+  if (m) {
+    emit('send', m);
+    text.value = '';
+  }
+};
+</script>

--- a/src/components/MessageList.vue
+++ b/src/components/MessageList.vue
@@ -1,0 +1,30 @@
+<template>
+  <q-scroll-area class="col column q-pa-md">
+    <q-chat-message
+      v-for="msg in messages"
+      :key="msg.id"
+      :sent="msg.outgoing"
+      :text="[msg.content]"
+      :stamp="formatDate(msg.created_at)"
+    />
+    <div ref="bottom"></div>
+  </q-scroll-area>
+</template>
+
+<script lang="ts" setup>
+import { nextTick, ref, watch } from 'vue';
+import type { MessengerMessage } from 'src/stores/messenger';
+
+const props = defineProps<{ messages: MessengerMessage[] }>();
+const bottom = ref<HTMLElement>();
+
+watch(
+  () => props.messages,
+  () => {
+    nextTick(() => bottom.value?.scrollIntoView({ behavior: 'smooth' }));
+  },
+  { deep: true }
+);
+
+const formatDate = (ts: number) => new Date(ts * 1000).toLocaleString();
+</script>

--- a/src/components/NostrIdentityManager.vue
+++ b/src/components/NostrIdentityManager.vue
@@ -1,0 +1,60 @@
+<template>
+  <div>
+    <q-btn label="Identity / Relays" color="primary" @click="showDialog = true" />
+    <q-dialog v-model="showDialog">
+      <q-card style="min-width: 350px">
+        <q-card-section class="text-h6">Identity &amp; Relays</q-card-section>
+        <q-card-section>
+          <q-input v-model="privKey" label="Private Key" type="text" />
+          <q-input v-model="pubKey" label="Public Key" readonly class="q-mt-md" />
+          <div class="q-mt-md">
+            <q-input v-model="relayInput" label="Add Relay" @keyup.enter="addRelay" />
+            <q-list bordered class="q-mt-sm">
+              <q-item v-for="(r, index) in relays" :key="index">
+                <q-item-section>{{ r }}</q-item-section>
+                <q-item-section side>
+                  <q-btn flat dense icon="delete" @click="removeRelay(index)" />
+                </q-item-section>
+              </q-item>
+            </q-list>
+          </div>
+        </q-card-section>
+        <q-card-actions align="right">
+          <q-btn flat v-close-popup label="Close" />
+          <q-btn flat label="Save" @click="save" />
+        </q-card-actions>
+      </q-card>
+    </q-dialog>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue';
+import { useMessengerStore } from 'src/stores/messenger';
+
+const messenger = useMessengerStore();
+
+const showDialog = ref(false);
+const privKey = ref(messenger.privKey);
+const pubKey = ref(messenger.pubKey);
+const relayInput = ref('');
+const relays = ref<string[]>([...messenger.relays]);
+
+const addRelay = () => {
+  if (relayInput.value.trim()) {
+    relays.value.push(relayInput.value.trim());
+    relayInput.value = '';
+  }
+};
+
+const removeRelay = (index: number) => {
+  relays.value.splice(index, 1);
+};
+
+const save = () => {
+  messenger.privKey = privKey.value;
+  messenger.pubKey = pubKey.value;
+  messenger.relays = relays.value as any;
+  showDialog.value = false;
+};
+</script>

--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -1,13 +1,43 @@
 <template>
   <q-page
-    :class="[
-      $q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark',
-      'q-pa-md'
-    ]"
+    class="column full-height"
+    :class="[$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark', 'q-pa-md']"
   >
-    <div class="text-h5">Nostr Messenger</div>
+    <div class="text-h5 q-mb-md">Nostr Messenger</div>
+    <NostrIdentityManager class="q-mb-md" />
+    <div class="row col-grow">
+      <ConversationList @select="selectConversation" />
+      <div class="col column">
+        <MessageList :messages="messages" class="col" />
+        <MessageInput @send="sendMessage" />
+      </div>
+    </div>
+    <EventLog class="q-mt-md" />
   </q-page>
 </template>
 
-<script setup>
+<script lang="ts" setup>
+import { computed, ref } from 'vue';
+import { useMessengerStore } from 'src/stores/messenger';
+
+import NostrIdentityManager from 'components/NostrIdentityManager.vue';
+import ConversationList from 'components/ConversationList.vue';
+import MessageList from 'components/MessageList.vue';
+import MessageInput from 'components/MessageInput.vue';
+import EventLog from 'components/EventLog.vue';
+
+const messenger = useMessengerStore();
+messenger.loadIdentity();
+
+const selected = ref('');
+const messages = computed(() => messenger.conversations[selected.value] || []);
+
+const selectConversation = (pubkey: string) => {
+  selected.value = pubkey;
+};
+
+const sendMessage = (text: string) => {
+  if (!selected.value) return;
+  messenger.sendDm(selected.value, text);
+};
 </script>


### PR DESCRIPTION
## Summary
- add a manager dialog for identity and relays
- implement conversation list drawer
- implement message list and input helpers
- show nostr event log
- wire new components into `NostrMessenger.vue`

## Testing
- `npm run test` *(fails: Cannot find module 'vite-jsconfig-paths')*

------
https://chatgpt.com/codex/tasks/task_e_684096ea02c48330b71d45358eef43a0