### PR TITLE
Add messenger start and mount setup

### DIFF
--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -17,7 +17,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, ref } from 'vue';
+import { computed, ref, onMounted } from 'vue';
 import { useMessengerStore } from 'src/stores/messenger';
 
 import NostrIdentityManager from 'components/NostrIdentityManager.vue';
@@ -28,6 +28,9 @@ import EventLog from 'components/EventLog.vue';
 
 const messenger = useMessengerStore();
 messenger.loadIdentity();
+onMounted(() => {
+  messenger.start();
+});
 
 const selected = ref('');
 const messages = computed(() => messenger.conversations[selected.value] || []);


### PR DESCRIPTION
## Summary
- start messenger relays and subscriptions via new store action
- initialize messenger on NostrMessenger page

## Testing
- `npm run lint`
- `npm run test` *(fails: Cannot find module 'vite-jsconfig-paths')*

------
https://chatgpt.com/codex/tasks/task_e_68409cb68bf883309b1e565193a9756d