### PR TITLE
Add messenger events support

### DIFF
--- a/src/components/EventLog.vue
+++ b/src/components/EventLog.vue
@@ -2,7 +2,15 @@
   <q-scroll-area style="max-height: 200px">
     <q-list dense>
       <q-item v-for="e in events" :key="e.id">
-        <q-item-section>{{ e.id }}</q-item-section>
+        <q-item-section>
+          <q-icon
+            v-if="e.outgoing !== undefined"
+            :name="e.outgoing ? 'north_east' : 'south_west'"
+            size="xs"
+            class="q-mr-sm"
+          />
+          {{ e.id }}
+        </q-item-section>
         <q-item-section side>{{ formatDate(e.created_at) }}</q-item-section>
       </q-item>
     </q-list>
@@ -13,7 +21,16 @@
 import { computed } from 'vue';
 import { useNostrStore } from 'src/stores/nostr';
 
+interface LogEvent {
+  id: string;
+  created_at: number;
+  outgoing?: boolean;
+}
+
+const props = defineProps<{ events?: LogEvent[] }>();
+
 const nostr = useNostrStore();
-const events = computed(() => nostr.nip17EventIdsWeHaveSeen);
+const defaultEvents = computed(() => nostr.nip17EventIdsWeHaveSeen);
+const events = computed(() => props.events ?? defaultEvents.value);
 const formatDate = (ts: number) => new Date(ts * 1000).toLocaleString();
 </script>

--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -12,7 +12,7 @@
         <MessageInput @send="sendMessage" />
       </div>
     </div>
-    <EventLog class="q-mt-md" />
+    <EventLog class="q-mt-md" :events="eventLog" />
   </q-page>
 </template>
 
@@ -34,6 +34,7 @@ onMounted(() => {
 
 const selected = ref('');
 const messages = computed(() => messenger.conversations[selected.value] || []);
+const eventLog = computed(() => messenger.eventLog);
 
 const selectConversation = (pubkey: string) => {
   selected.value = pubkey;

--- a/src/stores/messenger.ts
+++ b/src/stores/messenger.ts
@@ -28,6 +28,10 @@ export const useMessengerStore = defineStore("messenger", {
       "cashu.messenger.conversations",
       {} as Record<string, MessengerMessage[]>,
     ),
+    eventLog: useLocalStorage<MessengerMessage[]>(
+      "cashu.messenger.eventLog",
+      [] as MessengerMessage[],
+    ),
     started: false,
   }),
   actions: {
@@ -69,6 +73,7 @@ export const useMessengerStore = defineStore("messenger", {
       };
       if (!this.conversations[pubkey]) this.conversations[pubkey] = [];
       this.conversations[pubkey].push(msg);
+      this.eventLog.push(msg);
     },
     async addIncomingMessage(event: NostrEvent) {
       this.loadIdentity();
@@ -89,6 +94,7 @@ export const useMessengerStore = defineStore("messenger", {
         this.conversations[event.pubkey] = [];
       }
       this.conversations[event.pubkey].push(msg);
+      this.eventLog.push(msg);
     },
 
     async start() {


### PR DESCRIPTION
## Summary
- allow `EventLog` component to show messenger events
- add `eventLog` to messenger store and record incoming/outgoing messages
- forward messenger event log to `EventLog` from `NostrMessenger` page

## Testing
- `npm test --silent` *(fails: Cannot find module 'vite-jsconfig-paths')*

------
https://chatgpt.com/codex/tasks/task_e_6840a01d1a2c8330a68d018b6eb8f39b