### PR TITLE
Add connection status badge

### DIFF
--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -3,7 +3,15 @@
     class="column full-height"
     :class="[$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark', 'q-pa-md']"
   >
-    <div class="text-h5 q-mb-md">Nostr Messenger</div>
+    <div class="text-h5 q-mb-md">
+      Nostr Messenger
+      <q-badge
+        :color="messenger.connected ? 'positive' : 'negative'"
+        class="q-ml-sm"
+      >
+        {{ messenger.connected ? 'Online' : 'Offline' }}
+      </q-badge>
+    </div>
     <NostrIdentityManager class="q-mb-md" />
     <div class="row col-grow">
       <ConversationList @select="selectConversation" />

--- a/src/stores/messenger.ts
+++ b/src/stores/messenger.ts
@@ -34,6 +34,12 @@ export const useMessengerStore = defineStore("messenger", {
     ),
     started: false,
   }),
+  getters: {
+    connected(): boolean {
+      const nostr = useNostrStore();
+      return nostr.connected;
+    },
+  },
   actions: {
     loadIdentity() {
       if (!this.privKey) {


### PR DESCRIPTION
## Summary
- add a `connected` getter on messenger store that mirrors the Nostr connection
- show a badge in NostrMessenger page indicating if the connection is online or offline

## Testing
- `npm test` *(fails: Cannot find module 'vite-jsconfig-paths')*
- `npm run lint`
- `npm run checkformat` *(fails: Code style issues found in 91 files)*

------
https://chatgpt.com/codex/tasks/task_e_6840a1be56a88330a6d2cd1899e9a4c4