### PR TITLE
Update messenger navigation

### DIFF
--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -336,7 +336,7 @@ export default defineComponent({
     };
 
     const gotoChats = () => {
-      router.push("/chats");
+      router.push("/nostr-messenger");
       leftDrawerOpen.value = false;
     };
 


### PR DESCRIPTION
## Summary
- update `gotoChats()` route to `/nostr-messenger`

## Testing
- `npm test` *(fails: Cannot find module 'vite-jsconfig-paths')*

------
https://chatgpt.com/codex/tasks/task_e_6840a730019c8330b06c6a258880a00e