### PR TITLE
Add messenger drawer layout

### DIFF
--- a/src/components/ConversationList.vue
+++ b/src/components/ConversationList.vue
@@ -1,22 +1,26 @@
 <template>
-  <q-drawer v-model="drawer" side="left" bordered :width="260">
+  <div>
     <q-toolbar>
       <q-toolbar-title>Conversations</q-toolbar-title>
     </q-toolbar>
     <q-list>
-      <q-item v-for="(msgs, pubkey) in conversations" :key="pubkey" clickable @click="select(pubkey)">
+      <q-item
+        v-for="(msgs, pubkey) in conversations"
+        :key="pubkey"
+        clickable
+        @click="select(pubkey)"
+      >
         <q-item-section>{{ pubkey }}</q-item-section>
       </q-item>
     </q-list>
-  </q-drawer>
+  </div>
 </template>
 
 <script lang="ts" setup>
-import { computed, ref } from 'vue';
+import { computed } from 'vue';
 import { useMessengerStore } from 'src/stores/messenger';
 
 const emit = defineEmits(['select']);
-const drawer = ref(true);
 const messenger = useMessengerStore();
 const conversations = computed(() => messenger.conversations);
 

--- a/src/components/NewChat.vue
+++ b/src/components/NewChat.vue
@@ -1,0 +1,28 @@
+<template>
+  <div>
+    <div class="text-subtitle1 q-mb-sm">New Chat</div>
+    <q-input v-model="pubkey" label="Recipient Pubkey" @keyup.enter="start" dense />
+    <q-btn
+      label="Start"
+      color="primary"
+      class="q-mt-sm"
+      @click="start"
+      :disable="!pubkey.trim()"
+      dense
+    />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue';
+
+const emit = defineEmits(['start']);
+const pubkey = ref('');
+
+const start = () => {
+  const pk = pubkey.value.trim();
+  if (!pk) return;
+  emit('start', pk);
+  pubkey.value = '';
+};
+</script>

--- a/src/components/RelayManager.vue
+++ b/src/components/RelayManager.vue
@@ -1,0 +1,34 @@
+<template>
+  <div>
+    <div class="text-subtitle1 q-mb-sm">Relays</div>
+    <q-input v-model="relayInput" label="Add Relay" @keyup.enter="addRelay" dense />
+    <q-list bordered class="q-mt-sm">
+      <q-item v-for="(r, index) in relays" :key="index">
+        <q-item-section>{{ r }}</q-item-section>
+        <q-item-section side>
+          <q-btn flat dense icon="delete" @click="removeRelay(index)" />
+        </q-item-section>
+      </q-item>
+    </q-list>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue';
+import { useMessengerStore } from 'src/stores/messenger';
+
+const messenger = useMessengerStore();
+const relayInput = ref('');
+const relays = messenger.relays;
+
+const addRelay = () => {
+  if (relayInput.value.trim()) {
+    relays.push(relayInput.value.trim());
+    relayInput.value = '';
+  }
+};
+
+const removeRelay = (index: number) => {
+  relays.splice(index, 1);
+};
+</script>

--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -1,26 +1,29 @@
 <template>
   <q-page
-    class="column full-height"
-    :class="[$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark', 'q-pa-md']"
+    class="row full-height"
+    :class="[$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark']"
   >
-    <div class="text-h5 q-mb-md">
-      Nostr Messenger
-      <q-badge
-        :color="messenger.connected ? 'positive' : 'negative'"
-        class="q-ml-sm"
-      >
-        {{ messenger.connected ? 'Online' : 'Offline' }}
-      </q-badge>
-    </div>
-    <NostrIdentityManager class="q-mb-md" />
-    <div class="row col-grow">
+    <q-drawer v-model="drawer" side="left" show-if-above bordered :width="300" class="q-pa-md">
+      <NostrIdentityManager class="q-mb-md" />
+      <RelayManager class="q-mb-md" />
+      <NewChat class="q-mb-md" @start="startChat" />
       <ConversationList @select="selectConversation" />
-      <div class="col column">
-        <MessageList :messages="messages" class="col" />
-        <MessageInput @send="sendMessage" />
+    </q-drawer>
+
+    <div class="col column q-pa-md">
+      <div class="text-h5 q-mb-md">
+        Nostr Messenger
+        <q-badge
+          :color="messenger.connected ? 'positive' : 'negative'"
+          class="q-ml-sm"
+        >
+          {{ messenger.connected ? 'Online' : 'Offline' }}
+        </q-badge>
       </div>
+      <MessageList :messages="messages" class="col" />
+      <MessageInput @send="sendMessage" />
+      <EventLog class="q-mt-md" :events="eventLog" />
     </div>
-    <EventLog class="q-mt-md" :events="eventLog" />
   </q-page>
 </template>
 
@@ -29,6 +32,8 @@ import { computed, ref, onMounted } from 'vue';
 import { useMessengerStore } from 'src/stores/messenger';
 
 import NostrIdentityManager from 'components/NostrIdentityManager.vue';
+import RelayManager from 'components/RelayManager.vue';
+import NewChat from 'components/NewChat.vue';
 import ConversationList from 'components/ConversationList.vue';
 import MessageList from 'components/MessageList.vue';
 import MessageInput from 'components/MessageInput.vue';
@@ -40,11 +45,17 @@ onMounted(() => {
   messenger.start();
 });
 
+const drawer = ref(true);
 const selected = ref('');
 const messages = computed(() => messenger.conversations[selected.value] || []);
 const eventLog = computed(() => messenger.eventLog);
 
 const selectConversation = (pubkey: string) => {
+  selected.value = pubkey;
+};
+
+const startChat = (pubkey: string) => {
+  if (!messenger.conversations[pubkey]) messenger.conversations[pubkey] = [];
   selected.value = pubkey;
 };
 


### PR DESCRIPTION
## Summary
- revamp `NostrMessenger` layout with a left drawer
- create `RelayManager` and `NewChat` drawer components
- simplify `ConversationList` so it can live inside the drawer

## Testing
- `npm test` *(fails: Cannot find module 'vite-jsconfig-paths')*

------
https://chatgpt.com/codex/tasks/task_e_6840a806dda08330a64a876de2da24f6