### PR TITLE
Add relay manager and chat features

### DIFF
--- a/src/components/RelayManager.vue
+++ b/src/components/RelayManager.vue
@@ -1,34 +1,44 @@
 <template>
   <div>
     <div class="text-subtitle1 q-mb-sm">Relays</div>
-    <q-input v-model="relayInput" label="Add Relay" @keyup.enter="addRelay" dense />
-    <q-list bordered class="q-mt-sm">
-      <q-item v-for="(r, index) in relays" :key="index">
-        <q-item-section>{{ r }}</q-item-section>
-        <q-item-section side>
-          <q-btn flat dense icon="delete" @click="removeRelay(index)" />
-        </q-item-section>
-      </q-item>
-    </q-list>
+    <q-input
+      v-model="relayText"
+      type="textarea"
+      label="Relay URLs (one per line)"
+      class="q-mb-sm"
+      dense
+    />
+    <div class="row q-gutter-sm">
+      <q-btn label="Connect" color="primary" @click="connect" dense />
+      <q-btn label="Disconnect" color="primary" @click="disconnect" dense />
+    </div>
   </div>
 </template>
 
 <script lang="ts" setup>
-import { ref } from 'vue';
+import { ref, watch } from 'vue';
 import { useMessengerStore } from 'src/stores/messenger';
 
 const messenger = useMessengerStore();
-const relayInput = ref('');
-const relays = messenger.relays;
 
-const addRelay = () => {
-  if (relayInput.value.trim()) {
-    relays.push(relayInput.value.trim());
-    relayInput.value = '';
-  }
+const relayText = ref(messenger.relays.join('\n'));
+
+watch(
+  () => messenger.relays,
+  (r) => {
+    relayText.value = r.join('\n');
+  },
+);
+
+const connect = () => {
+  const relays = relayText.value
+    .split(/\n|\r/)
+    .map((r) => r.trim())
+    .filter((r) => r.length);
+  messenger.connect(relays);
 };
 
-const removeRelay = (index: number) => {
-  relays.splice(index, 1);
+const disconnect = () => {
+  messenger.disconnect();
 };
 </script>

--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -55,7 +55,7 @@ const selectConversation = (pubkey: string) => {
 };
 
 const startChat = (pubkey: string) => {
-  if (!messenger.conversations[pubkey]) messenger.conversations[pubkey] = [];
+  messenger.createConversation(pubkey);
   selected.value = pubkey;
 };
 

--- a/src/stores/messenger.ts
+++ b/src/stores/messenger.ts
@@ -123,6 +123,29 @@ export const useMessengerStore = defineStore("messenger", {
       const nostr = useNostrStore();
       return nostr.connected;
     },
+
+    connect(relays: string[]) {
+      const nostr = useNostrStore();
+      this.relays = relays as any;
+      nostr.relays = relays as any;
+      nostr.initNdkReadOnly();
+    },
+
+    disconnect() {
+      const nostr = useNostrStore();
+      if (nostr.ndk && (nostr.ndk as any).pool) {
+        for (const relay of (nostr.ndk as any).pool.relays.values()) {
+          relay.disconnect && relay.disconnect();
+        }
+      }
+      nostr.connected = false;
+    },
+
+    createConversation(pubkey: string) {
+      if (!this.conversations[pubkey]) {
+        this.conversations[pubkey] = [];
+      }
+    },
   },
 });
 


### PR DESCRIPTION
## Summary
- add RelayManager with textarea for relays and connect/disconnect buttons
- add connect/disconnect/createConversation actions in messenger store
- hook new startChat behaviour to the messenger store

## Testing
- `npm run test` *(fails: Cannot find module 'vite-jsconfig-paths')*

------
https://chatgpt.com/codex/tasks/task_e_6840a9a7304083309987b41297a7d8a6