### PR TITLE
Update backgrounds & chat bubbles

### DIFF
--- a/src/components/FindCreatorsView.vue
+++ b/src/components/FindCreatorsView.vue
@@ -1,11 +1,11 @@
 <template>
   <q-page
     class="creators-page q-pa-md"
-    :class="$q.dark.isActive ? 'bg-dark text-white' : 'bg-grey-2 text-dark'"
+    :class="$q.dark.isActive ? 'bg-dark text-white' : 'bg-gray-100 text-dark'"
   >
     <div
       class="creators-container"
-      :class="$q.dark.isActive ? 'bg-grey-10 text-white' : 'bg-white text-dark'"
+      :class="$q.dark.isActive ? 'bg-gray-50 text-white' : 'bg-white text-dark'"
     >
     <q-input
       rounded

--- a/src/components/MessageList.vue
+++ b/src/components/MessageList.vue
@@ -1,12 +1,21 @@
 <template>
   <q-scroll-area class="col column q-pa-md">
-    <q-chat-message
+    <div
       v-for="msg in messages"
       :key="msg.id"
-      :sent="msg.outgoing"
-      :text="[msg.content]"
-      :stamp="formatDate(msg.created_at)"
-    />
+      class="q-my-xs flex column"
+      :class="msg.outgoing ? 'items-end' : 'items-start'"
+    >
+      <div :class="msg.outgoing ? 'chat-bubble-sent' : 'chat-bubble-received'">
+        {{ msg.content }}
+      </div>
+      <div
+        class="text-caption q-mt-xs"
+        :class="msg.outgoing ? 'text-right' : 'text-left'"
+      >
+        {{ formatDate(msg.created_at) }}
+      </div>
+    </div>
     <div ref="bottom"></div>
   </q-scroll-area>
 </template>

--- a/src/components/ReceiveDialog.vue
+++ b/src/components/ReceiveDialog.vue
@@ -135,7 +135,7 @@ export default defineComponent({
     },
     cardClass: function () {
       return this.$q.dark.isActive
-        ? "bg-grey-10 text-white"
+        ? "bg-gray-100 text-white"
         : "bg-white text-dark";
     },
     iconBgColor: function () {

--- a/src/components/ReceiveEcashDrawer.vue
+++ b/src/components/ReceiveEcashDrawer.vue
@@ -193,7 +193,7 @@ export default defineComponent({
     ...mapState(useCameraStore, ["lastScannedResult"]),
     cardClass: function () {
       return this.$q.dark.isActive
-        ? "bg-grey-10 text-white"
+        ? "bg-gray-100 text-white"
         : "bg-white text-dark";
     },
     iconBgColor: function () {

--- a/src/components/SendDialog.vue
+++ b/src/components/SendDialog.vue
@@ -134,7 +134,7 @@ export default defineComponent({
     },
     cardClass: function () {
       return this.$q.dark.isActive
-        ? "bg-grey-10 text-white"
+        ? "bg-gray-100 text-white"
         : "bg-white text-dark";
     },
     iconBgColor: function () {

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -100,3 +100,36 @@ body.body--light {
   --custom-btn-bg: var(--custom-btn-light);
   --custom-btn-text: black;
 }
+
+/* utility background classes */
+.bg-gray-50 {
+  background-color: #f9fafb !important;
+}
+
+.bg-gray-100 {
+  background-color: #f3f4f6 !important;
+}
+
+.accent-purple {
+  background-color: #7e22ce !important;
+  color: #ffffff !important;
+}
+
+.chat-bubble-sent {
+  @extend .accent-purple;
+  align-self: flex-end;
+  padding: 6px 12px;
+  border-radius: 16px;
+  max-width: 70%;
+  word-break: break-word;
+}
+
+.chat-bubble-received {
+  @extend .bg-gray-100;
+  align-self: flex-start;
+  color: #000 !important;
+  padding: 6px 12px;
+  border-radius: 16px;
+  max-width: 70%;
+  word-break: break-word;
+}


### PR DESCRIPTION
## Summary
- tweak background CSS classes for light theme
- add purple accent chat bubble styles
- use chat bubbles in `MessageList.vue`

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot find module 'vite-jsconfig-paths')*

------
https://chatgpt.com/codex/tasks/task_e_6840aa355cf08330bcd43b058e3ac51b