### PR TITLE
Call messenger.start when updating identity

### DIFF
--- a/src/components/NostrIdentityManager.vue
+++ b/src/components/NostrIdentityManager.vue
@@ -55,6 +55,7 @@ const save = () => {
   messenger.privKey = privKey.value;
   messenger.pubKey = pubKey.value;
   messenger.relays = relays.value as any;
+  messenger.start();
   showDialog.value = false;
 };
 </script>

--- a/src/stores/messenger.ts
+++ b/src/stores/messenger.ts
@@ -1,5 +1,6 @@
 import { defineStore } from "pinia";
 import { useLocalStorage } from "@vueuse/core";
+import { watch } from "vue";
 import {
   generateSecretKey,
   getPublicKey,
@@ -33,6 +34,7 @@ export const useMessengerStore = defineStore("messenger", {
       [] as MessengerMessage[],
     ),
     started: false,
+    watchInitialized: false,
   }),
   getters: {
     connected(): boolean {
@@ -104,6 +106,19 @@ export const useMessengerStore = defineStore("messenger", {
     },
 
     async start() {
+      if (!this.watchInitialized) {
+        watch(
+          () => [this.pubKey, this.relays],
+          () => {
+            if (this.started) {
+              this.started = false;
+              this.start();
+            }
+          },
+          { deep: true },
+        );
+        this.watchInitialized = true;
+      }
       if (this.started) {
         return;
       }


### PR DESCRIPTION
## Summary
- refresh DM subscriptions when identity is saved
- restart messenger automatically if relays or pubKey change

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot find module 'vite-jsconfig-paths')*

------
https://chatgpt.com/codex/tasks/task_e_6840aa3c9d208330aa7588291cbc682b