### PR TITLE
Ensure header drawer accessible from messenger

### DIFF
--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -98,7 +98,7 @@
     </q-toolbar>
   </q-header>
 
-  <q-drawer v-model="leftDrawerOpen" bordered>
+  <q-drawer v-model="leftDrawerOpen" side="right" bordered>
     <q-list>
       <q-item-label header>{{
         $t("MainHeader.menu.settings.title")


### PR DESCRIPTION
## Summary
- allow the navigation drawer to open on the right so it doesn't clash with the messenger sidebar

## Testing
- `npm run test` *(fails: Cannot find module 'vite-jsconfig-paths')*

------
https://chatgpt.com/codex/tasks/task_e_68414284dba88330a8ae3080be6c8146