### PR TITLE
Fix navigation drawer position

### DIFF
--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -98,7 +98,8 @@
     </q-toolbar>
   </q-header>
 
-  <q-drawer v-model="leftDrawerOpen" side="right" bordered>
+  <!-- Drawer positioned on the left for main navigation -->
+  <q-drawer v-model="leftDrawerOpen" side="left" bordered>
     <q-list>
       <q-item-label header>{{
         $t("MainHeader.menu.settings.title")


### PR DESCRIPTION
## Summary
- ensure the main navigation drawer slides in from the left

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684147206d788330ac8f9cf93e535829