### PR TITLE
Fix message button redirect

### DIFF
--- a/public/find-creators.html
+++ b/public/find-creators.html
@@ -583,8 +583,8 @@
                 messageButton.textContent = 'Message';
                 messageButton.onclick = (e) => {
                     e.stopPropagation();
-                    alert(`Message ${profile.name || npub}`);
-                    console.log('Message clicked for pubkey:', profile.pubkey);
+                    // Navigate the parent application to the chat view
+                    window.parent.location.href = `/chats/${profile.pubkey}`;
                 };
 
                 const donateButton = document.createElement('button');


### PR DESCRIPTION
## Summary
- make Message button open chat page in parent window

## Testing
- `npm test` *(fails: cannot find module `vite-jsconfig-paths`)*

------
https://chatgpt.com/codex/tasks/task_e_684149da65d88330a766dac87075573f