### PR TITLE
Enable donation messages from iframe

### DIFF
--- a/public/find-creators.html
+++ b/public/find-creators.html
@@ -592,13 +592,8 @@
                 donateButton.textContent = 'Donate';
                 donateButton.onclick = (e) => {
                     e.stopPropagation();
-                    if (profile.lud16) {
-                        alert(`Opening wallet for: ${profile.lud16}`);
-                        window.open(`lightning:${profile.lud16}`);
-                    } else {
-                        alert(`No Lightning Address (lud16) found for ${profile.name || npub} to donate.`);
-                    }
-                    console.log('Donate clicked for pubkey:', profile.pubkey, 'LUD16:', profile.lud16);
+                    window.parent.postMessage({ type: 'donate', pubkey: profile.pubkey }, '*');
+                    console.log('Donate clicked for pubkey:', profile.pubkey);
                 };
                 
                 actionsContainer.appendChild(viewButton); // Add View button first

--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -143,7 +143,6 @@
             />
           </q-input>
           <q-input
-            v-if="sendViaNostr"
             filled
             dense
             v-model.trim="sendData.memo"

--- a/src/pages/FindCreators.vue
+++ b/src/pages/FindCreators.vue
@@ -1,18 +1,67 @@
 <template>
   <div class="find-creators-wrapper">
     <iframe
+      ref="iframeEl"
       src="/find-creators.html"
       class="find-creators-frame"
       title="Find Creators"
     />
+    <DonateDialog v-model="showDonateDialog" @confirm="handleDonate" />
+    <SendTokenDialog />
   </div>
 </template>
 
 <script setup lang="ts">
-// The FindCreators page now loads a standalone HTML file that contains the
-// entire implementation for searching and displaying creators. We simply embed
-// that file in an iframe to keep it separate from the Quasar SPA while
-// retaining navigation via the router.
+import { ref, onMounted, onBeforeUnmount } from 'vue';
+import DonateDialog from 'components/DonateDialog.vue';
+import SendTokenDialog from 'components/SendTokenDialog.vue';
+import { useSendTokensStore } from 'stores/sendTokensStore';
+import { useDonationPresetsStore } from 'stores/donationPresets';
+
+const iframeEl = ref<HTMLIFrameElement | null>(null);
+const showDonateDialog = ref(false);
+const selectedPubkey = ref('');
+
+const sendTokensStore = useSendTokensStore();
+const donationStore = useDonationPresetsStore();
+
+function onMessage(ev: MessageEvent) {
+  if (ev.data && ev.data.type === 'donate' && ev.data.pubkey) {
+    selectedPubkey.value = ev.data.pubkey;
+    showDonateDialog.value = true;
+  }
+}
+
+function handleDonate({ bucketId, locked, type, amount, months }: any) {
+  if (!selectedPubkey.value) return;
+  if (type === 'one-time') {
+    sendTokensStore.clearSendData();
+    sendTokensStore.recipientPubkey = selectedPubkey.value;
+    sendTokensStore.sendViaNostr = true;
+    sendTokensStore.sendData.bucketId = bucketId;
+    sendTokensStore.sendData.amount = amount;
+    sendTokensStore.sendData.p2pkPubkey = locked ? selectedPubkey.value : '';
+    sendTokensStore.showLockInput = locked;
+    showDonateDialog.value = false;
+    sendTokensStore.showSendTokens = true;
+  } else {
+    donationStore.createDonationPreset(
+      months,
+      amount,
+      selectedPubkey.value,
+      bucketId,
+    );
+    showDonateDialog.value = false;
+  }
+}
+
+onMounted(() => {
+  window.addEventListener('message', onMessage);
+});
+
+onBeforeUnmount(() => {
+  window.removeEventListener('message', onMessage);
+});
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary
- send donation events to parent when donate clicked in static creators list
- listen for donation `postMessage` events and trigger wallet donation flow
- always show memo field when sending tokens

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot find module 'vite-jsconfig-paths')*

------
https://chatgpt.com/codex/tasks/task_e_68414b6f54a08330ac397d1ea7b6ba6c