### PR TITLE
Reduce wallet action button size

### DIFF
--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -10,7 +10,7 @@
         <q-btn
           rounded
           dense
-          class="q-px-md wallet-action-btn q-mb-md"
+          class="q-px-sm wallet-action-btn q-mb-md"
           color="primary"
           @click="showReceiveDialog = true"
         >
@@ -36,7 +36,7 @@
         <q-btn
           rounded
           dense
-          class="q-px-md wallet-action-btn q-mb-md"
+          class="q-px-sm wallet-action-btn q-mb-md"
           color="primary"
           @click="showSendDialog = true"
         >
@@ -202,7 +202,7 @@
 .wallet-action-btn {
   flex: 1;
   white-space: nowrap;
-  font-size: 1.2rem;
+  font-size: 1rem;
 }
 
 .button-content {


### PR DESCRIPTION
## Summary
- make Send and Receive buttons smaller on the wallet page

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_68414cebd2a48330a95c5747783bccfe