### PR TITLE
Add memo option for donations

### DIFF
--- a/src/components/DonateDialog.vue
+++ b/src/components/DonateDialog.vue
@@ -22,6 +22,13 @@
           :label="$t('DonateDialog.inputs.amount')"
           class="q-mt-sm"
         />
+        <q-input
+          v-model.trim="message"
+          dense
+          outlined
+          :label="$t('DonateDialog.inputs.message')"
+          class="q-mt-sm"
+        />
         <q-select
           v-model="type"
           :options="typeOptions"
@@ -90,6 +97,7 @@ export default defineComponent({
     const locked = ref<"normal" | "locked">("normal");
     const type = ref<"one-time" | "schedule">("one-time");
     const amount = ref<number>(0);
+    const message = ref<string>("");
     const preset = ref<number>(donationStore.presets[0]?.months || 0);
 
     const model = computed({
@@ -135,6 +143,7 @@ export default defineComponent({
         type: type.value,
         amount: amount.value,
         months: preset.value,
+        message: message.value,
       });
       emit("update:modelValue", false);
     };
@@ -145,6 +154,7 @@ export default defineComponent({
       locked,
       type,
       amount,
+      message,
       preset,
       bucketOptions,
       typeOptions,

--- a/src/components/FindCreatorsView.vue
+++ b/src/components/FindCreatorsView.vue
@@ -170,12 +170,14 @@ export default defineComponent({
       type,
       amount,
       months,
+      message,
     }: {
       bucketId: string;
       locked: boolean;
       type: string;
       amount: number;
       months: number;
+      message: string;
     }) => {
       selectedBucketId.value = bucketId;
       selectedLocked.value = locked;
@@ -185,6 +187,7 @@ export default defineComponent({
         sendTokensStore.sendViaNostr = true;
         sendTokensStore.sendData.bucketId = bucketId;
         sendTokensStore.sendData.amount = amount;
+        sendTokensStore.sendData.memo = message;
         sendTokensStore.sendData.p2pkPubkey = locked
           ? donateCreator.value.pubkey
           : "";

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1384,6 +1384,7 @@ export default {
       preset: "Donation months",
       type: "Donation type",
       amount: "Amount",
+      message: "Message",
     },
     helper: {
       months: "Number of months (0 = one-time)",

--- a/src/pages/FindCreators.vue
+++ b/src/pages/FindCreators.vue
@@ -32,7 +32,7 @@ function onMessage(ev: MessageEvent) {
   }
 }
 
-function handleDonate({ bucketId, locked, type, amount, months }: any) {
+function handleDonate({ bucketId, locked, type, amount, months, message }: any) {
   if (!selectedPubkey.value) return;
   if (type === 'one-time') {
     sendTokensStore.clearSendData();
@@ -40,6 +40,7 @@ function handleDonate({ bucketId, locked, type, amount, months }: any) {
     sendTokensStore.sendViaNostr = true;
     sendTokensStore.sendData.bucketId = bucketId;
     sendTokensStore.sendData.amount = amount;
+    sendTokensStore.sendData.memo = message;
     sendTokensStore.sendData.p2pkPubkey = locked ? selectedPubkey.value : '';
     sendTokensStore.showLockInput = locked;
     showDonateDialog.value = false;


### PR DESCRIPTION
## Summary
- allow entering a message when donating
- forward memo to token send flow
- add DonateDialog translation

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot find module 'vite-jsconfig-paths')*

------
https://chatgpt.com/codex/tasks/task_e_68414cf2d6a083308aa763336ac0a141