### PR TITLE
Update divider-text colors

### DIFF
--- a/src/components/MintDetailsDialog.vue
+++ b/src/components/MintDetailsDialog.vue
@@ -592,7 +592,6 @@ export default defineComponent({
   padding: 0 10px;
   font-size: 14px;
   font-weight: 600;
-  color: #ffffff;
   text-transform: uppercase;
 }
 

--- a/src/components/MintSettings.vue
+++ b/src/components/MintSettings.vue
@@ -793,7 +793,6 @@ export default defineComponent({
   padding: 0 10px;
   font-size: 14px;
   font-weight: 600;
-  color: #ffffff;
   text-transform: uppercase;
 }
 </style>

--- a/src/components/SettingsView.vue
+++ b/src/components/SettingsView.vue
@@ -2096,6 +2096,5 @@ export default defineComponent({
   padding: 0 10px;
   font-size: 14px;
   font-weight: 600;
-  color: #ffffff;
 }
 </style>

--- a/src/css/base.scss
+++ b/src/css/base.scss
@@ -263,3 +263,11 @@ video {
 ::-webkit-scrollbar {
   display: none;
 }
+
+body.body--dark .divider-text {
+  color: #ffffff;
+}
+
+body.body--light .divider-text {
+  color: #000000;
+}


### PR DESCRIPTION
## Summary
- add global color rules for `.divider-text`
- remove old color overrides in several components

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot find module 'vite-jsconfig-paths')*

------
https://chatgpt.com/codex/tasks/task_e_68415034c5708330bba261f77ab270bf