### PR TITLE
Fix theme colors

### DIFF
--- a/src/components/MintSettings.vue
+++ b/src/components/MintSettings.vue
@@ -160,7 +160,8 @@
                       "
                     >
                       <span
-                        style="color: white; font-size: 14px; font-weight: 500"
+                        class="text-white"
+                        style="font-size: 14px; font-weight: 500"
                       >
                         {{
                           formatCurrency(
@@ -199,8 +200,7 @@
         </div>
 
         <div
-          class="add-mint-description q-mb-lg text-left"
-          style="color: rgba(255, 255, 255, 0.7)"
+          class="add-mint-description q-mb-lg text-left text-grey-6"
         >
           {{ $t("MintSettings.add.description") }}
         </div>


### PR DESCRIPTION
## Summary
- use Quasar text classes instead of hard-coded colors in `MintSettings`

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot find module 'vite-jsconfig-paths')*

------
https://chatgpt.com/codex/tasks/task_e_68415138f69c8330a82faa5d823ffab6