### PR TITLE
Fix inline text colors in MintSettings

### DIFF
--- a/src/components/MintSettings.vue
+++ b/src/components/MintSettings.vue
@@ -159,9 +159,7 @@
                         display: inline-block;
                       "
                     >
-                      <span
-                        style="color: white; font-size: 14px; font-weight: 500"
-                      >
+                      <span class="unit-balance-text">
                         {{
                           formatCurrency(
                             mintClass(mint).unitBalance(unit),
@@ -199,8 +197,7 @@
         </div>
 
         <div
-          class="add-mint-description q-mb-lg text-left"
-          style="color: rgba(255, 255, 255, 0.7)"
+          class="add-mint-description q-mb-lg text-left text-grey-6"
         >
           {{ $t("MintSettings.add.description") }}
         </div>
@@ -729,6 +726,13 @@ export default defineComponent({
   top: 18px;
   right: 24px;
   z-index: 10;
+}
+
+/* Text color for unit balances adapts via CSS variable */
+.unit-balance-text {
+  color: var(--unit-balance-color);
+  font-size: 14px;
+  font-weight: 500;
 }
 
 /* Add Mint Section Styles */

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -93,12 +93,14 @@ body.body--dark {
   --icon-bg-color: var(--icon-bg-dark);
   --custom-btn-bg: var(--custom-btn-dark);
   --custom-btn-text: white;
+  --unit-balance-color: white;
 }
 
 body.body--light {
   --icon-bg-color: var(--icon-bg-light);
   --custom-btn-bg: var(--custom-btn-light);
   --custom-btn-text: black;
+  --unit-balance-color: white;
 }
 
 /* utility background classes */


### PR DESCRIPTION
## Summary
- clean up inline styles in `MintSettings.vue`
- use a new `unit-balance-text` class and adapt color with CSS variable
- apply Quasar utility class for add mint description

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot find module 'vite-jsconfig-paths')*

------
https://chatgpt.com/codex/tasks/task_e_6841516461288330b8d3759220c32344