### PR TITLE
Adjust wallet action button size

### DIFF
--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -10,6 +10,7 @@
         <q-btn
           rounded
           dense
+          size="sm"
           class="q-px-sm wallet-action-btn q-mb-md"
           color="primary"
           @click="showReceiveDialog = true"
@@ -36,6 +37,7 @@
         <q-btn
           rounded
           dense
+          size="sm"
           class="q-px-sm wallet-action-btn q-mb-md"
           color="primary"
           @click="showSendDialog = true"
@@ -202,7 +204,7 @@
 .wallet-action-btn {
   flex: 1;
   white-space: nowrap;
-  font-size: 1rem;
+  font-size: 0.8rem;
 }
 
 .button-content {


### PR DESCRIPTION
## Summary
- shrink wallet action buttons via `size="sm"`
- reduce font size of `.wallet-action-btn`

## Testing
- `npm run lint`
- `npm run test` *(fails: Cannot find module 'vite-jsconfig-paths')*

------
https://chatgpt.com/codex/tasks/task_e_684157f8833c8330981acdc53a9b2130