### PR TITLE
Update dark mode toggle usage

### DIFF
--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -81,6 +81,7 @@ onMounted(() => {
 });
 
 const router = useRouter();
+const { toggleDarkMode } = (window as any).windowMixin.methods;
 
 const drawer = ref(true);
 const selected = ref('');


### PR DESCRIPTION
## Summary
- use the global `toggleDarkMode` helper in NostrMessenger page

## Testing
- `npm run test:ci` *(fails: Cannot find module 'vite-jsconfig-paths')*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68415a4244e4833099c285abe1bda2df