### PR TITLE
Use global dark mode function in messenger

### DIFF
--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -82,6 +82,8 @@ onMounted(() => {
 
 const router = useRouter();
 
+const { toggleDarkMode } = window.windowMixin.methods;
+
 const drawer = ref(true);
 const selected = ref('');
 const messages = computed(() => messenger.conversations[selected.value] || []);


### PR DESCRIPTION
## Summary
- switch NostrMessenger page to use `windowMixin` for the dark mode toggle

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68415bdb9970833093a67c7768d19117