### PR TITLE
Fix duplicate toggleDarkMode constant

### DIFF
--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -83,8 +83,6 @@ onMounted(() => {
 const router = useRouter();
 const { toggleDarkMode } = (window as any).windowMixin.methods;
 
-const { toggleDarkMode } = window.windowMixin.methods;
-
 const drawer = ref(true);
 const selected = ref('');
 const messages = computed(() => messenger.conversations[selected.value] || []);


### PR DESCRIPTION
## Summary
- remove duplicate `toggleDarkMode` declaration in `NostrMessenger.vue`

## Testing
- `npm run build`
- `npm run dev` *(terminated after startup)*

------
https://chatgpt.com/codex/tasks/task_e_68418018d6d08330afe4f8cbe21fc4f8