### PR TITLE
Fix dynamic i18n imports

### DIFF
--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,3 +1,9 @@
+const messageModules = import.meta.glob<{ default: any }>("./*/index.ts");
+
 export async function loadMessages(locale: string) {
-  return (await import(`./${locale}`)).default
+  const loader = messageModules[`./${locale}/index.ts`];
+  if (!loader) {
+    throw new Error(`Locale messages not found: ${locale}`);
+  }
+  return (await loader()).default;
 }


### PR DESCRIPTION
## Summary
- update i18n loader to use `import.meta.glob`

## Testing
- `npm run lint`
- `npm run test` *(fails: Cannot find module 'vite-jsconfig-paths')*

------
https://chatgpt.com/codex/tasks/task_e_684181fa0be88330b6809647bf0eea1b