### PR TITLE
Clarify npm usage

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,1 @@
-# pnpm-related options
-shamefully-hoist=true
-strict-peer-dependencies=false
+# Using npm as the package manager

--- a/README.md
+++ b/README.md
@@ -103,6 +103,22 @@ Fundstr is currently in Alpha/Beta.
 - Community features like comments and badges
 - Decentralized creator registration via Nostr
 
+## Development
+
+This project uses **npm** as its package manager.
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+Start a development server:
+
+```bash
+npm run dev
+```
+
 ## Contributing
 Contributions are welcome! Open an issue or pull request to discuss your ideas. Bug reports and feature requests are encouraged. Help with translation and documentation is always appreciated.
 


### PR DESCRIPTION
## Summary
- clarify that npm is the package manager
- remove pnpm options from `.npmrc`
- add development instructions to the README

## Testing
- `npm test` *(fails: Cannot find module 'vite-jsconfig-paths')*

------
https://chatgpt.com/codex/tasks/task_e_684188a279488330960812d6bb50e435