### PR TITLE
Downgrade TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "eslint-config-prettier": "^8.10.0",
     "eslint-plugin-vue": "^9.26.0",
     "prettier": "^2.8.8",
-    "typescript": "^5.4.5",
+    "typescript": "5.1.6",
     "workbox-build": "^6.6.1",
     "workbox-cacheable-response": "^6.6.1",
     "workbox-core": "^6.6.1",


### PR DESCRIPTION
## Summary
- downgrade TypeScript version to 5.1.6

## Testing
- `npm run lint`

`npm install` failed due to missing network access.

------
https://chatgpt.com/codex/tasks/task_e_684189d49e248330b1618d26da12d768