### PR TITLE
Add basic store tests

### DIFF
--- a/test/vitest/__tests__/camera.spec.ts
+++ b/test/vitest/__tests__/camera.spec.ts
@@ -1,0 +1,25 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useCameraStore } from '../../../src/stores/camera'
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+describe('Camera store', () => {
+  it('toggles camera visibility', () => {
+    const store = useCameraStore()
+    expect(store.camera.show).toBe(false)
+    store.showCamera()
+    expect(store.camera.show).toBe(true)
+    store.closeCamera()
+    expect(store.camera.show).toBe(false)
+  })
+
+  it('checks camera permission', async () => {
+    const queryMock = vi.fn().mockResolvedValue({ state: 'granted' })
+    ;(navigator as any).permissions = { query: queryMock }
+    const store = useCameraStore()
+    await store.hasCamera()
+    expect(queryMock).toHaveBeenCalledWith({ name: 'camera' })
+  })
+})

--- a/test/vitest/__tests__/dexie.spec.ts
+++ b/test/vitest/__tests__/dexie.spec.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useDexieStore, cashuDb } from '../../../src/stores/dexie'
+
+vi.mock('../../../src/stores/storage', () => ({
+  useStorageStore: () => ({
+    exportWalletState: vi.fn()
+  })
+}))
+
+vi.mock('../../../src/stores/proofs', () => ({
+  useProofsStore: () => ({
+    getProofs: vi.fn(async () => []),
+    sumProofs: vi.fn(() => 0)
+  })
+}))
+
+beforeEach(async () => {
+  localStorage.clear()
+  await cashuDb.delete()
+  await cashuDb.open()
+})
+
+describe('Dexie store', () => {
+  it('marks migrated when there is nothing to migrate', async () => {
+    const store = useDexieStore()
+    await store.migrateToDexie()
+    expect(store.migratedToDexie).toBe(true)
+  })
+
+  it('migrates proofs from localStorage', async () => {
+    const proofs = [{ id: '1', secret: 's', C: 'c', amount: 1, reserved: false }]
+    localStorage.setItem('cashu.proofs', JSON.stringify(proofs))
+    const store = useDexieStore()
+    await store.migrateToDexie()
+    // wait for Dexie writes
+    const stored = await cashuDb.proofs.toArray()
+    expect(stored.length).toBe(1)
+    expect(store.migratedToDexie).toBe(true)
+    expect(localStorage.getItem('cashu.proofs')).toBeNull()
+  })
+
+  it('deletes all tables', async () => {
+    await cashuDb.proofs.add({ id: '1', secret: 's', C: 'c', amount: 1, reserved: false })
+    const store = useDexieStore()
+    store.deleteAllTables()
+    const stored = await cashuDb.proofs.toArray()
+    expect(stored.length).toBe(0)
+  })
+})

--- a/test/vitest/__tests__/dmChats.spec.ts
+++ b/test/vitest/__tests__/dmChats.spec.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useDmChatsStore } from '../../../src/stores/dmChats'
+
+vi.mock('../../../src/js/message-utils', () => ({
+  sanitizeMessage: vi.fn((s: string) => s)
+}))
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+describe('DM chats store', () => {
+  it('loads chats from localStorage', () => {
+    localStorage.setItem('cashu.dmChats', JSON.stringify({ a: [{ id: '1' }] }))
+    localStorage.setItem('cashu.dmChats.unread', JSON.stringify({ a: 2 }))
+    const store = useDmChatsStore()
+    store.loadChats()
+    expect(store.chats.a.length).toBe(1)
+    expect(store.unreadCounts.a).toBe(2)
+  })
+
+  it('adds incoming message and increments unread', () => {
+    const store = useDmChatsStore()
+    store.addIncoming({ id: '1', pubkey: 'pk', content: 'hi', created_at: 1 } as any)
+    expect(store.chats.pk.length).toBe(1)
+    expect(store.unreadCounts.pk).toBe(1)
+  })
+
+  it('adds outgoing message', () => {
+    const store = useDmChatsStore()
+    store.addOutgoing({ id: '1', content: 'hi', created_at: 1, tags: [['p', 'pk']] } as any)
+    expect(store.chats.pk.length).toBe(1)
+    expect(store.chats.pk[0].outgoing).toBe(true)
+  })
+
+  it('marks chat read', () => {
+    const store = useDmChatsStore()
+    store.unreadCounts.pk = 5
+    store.markChatRead('pk')
+    expect(store.unreadCounts.pk).toBe(0)
+  })
+})

--- a/test/vitest/__tests__/price.spec.ts
+++ b/test/vitest/__tests__/price.spec.ts
@@ -1,0 +1,33 @@
+import { vi, beforeEach, describe, expect, it } from 'vitest'
+
+vi.mock('../../../src/stores/settings', () => ({
+  useSettingsStore: vi.fn(() => ({ getBitcoinPrice: true }))
+}))
+
+vi.mock('axios', () => ({
+  default: { get: vi.fn(async () => ({ data: { data: { rates: { USD: 20 } } } })) }
+}))
+
+import { usePriceStore } from '../../../src/stores/price'
+import { useSettingsStore } from '../../../src/stores/settings'
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+describe('Price store', () => {
+  it('fetches bitcoin price', async () => {
+    const store = usePriceStore()
+    await store.fetchBitcoinPriceUSD()
+    expect(store.bitcoinPrice).toBe(20)
+    expect(store.bitcoinPriceLastUpdated).not.toBe(0)
+  })
+
+  it('respects disabled setting', async () => {
+    vi.mocked(useSettingsStore).mockReturnValueOnce({ getBitcoinPrice: false } as any)
+    const store = usePriceStore()
+    await store.fetchBitcoinPriceUSD()
+    expect(store.bitcoinPrice).toBe(0)
+    expect(store.bitcoinPriceLastUpdated).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary
- add camera store spec
- add dexie store spec
- add dmChats store spec
- add price store spec

## Testing
- `NODE_PATH=$(pwd)/test/mocks npx vitest run` *(fails: Cannot find module 'vite-jsconfig-paths')*

------
https://chatgpt.com/codex/tasks/task_e_68418c02358c8330ba7d3d856fd6893a