### PR TITLE
Add db export alias

### DIFF
--- a/src/stores/dexie.ts
+++ b/src/stores/dexie.ts
@@ -131,6 +131,7 @@ export class CashuDexie extends Dexie {
 }
 
 export const cashuDb = new CashuDexie();
+export const db = cashuDb;
 
 export const useDexieStore = defineStore("dexie", {
   state: () => ({


### PR DESCRIPTION
## Summary
- re-export `cashuDb` as `db` from `dexie.ts`

## Testing
- `npm test` *(fails: Cannot find module 'vite-jsconfig-paths')*

------
https://chatgpt.com/codex/tasks/task_e_6842a02db91883309a8208180b31586a