### PR TITLE
Improve creator navigation and tier layout

### DIFF
--- a/public/find-creators.html
+++ b/public/find-creators.html
@@ -570,12 +570,7 @@
                 viewButton.textContent = 'View';
                 viewButton.onclick = (e) => {
                     e.stopPropagation();
-                    // In a real app, this would navigate to the profile page
-                    // For now, just an alert and log
-                    alert(`View profile: ${profile.name || npub}`);
-                    console.log('View profile clicked for pubkey:', profile.pubkey);
-                    // Example navigation (if you had a router):
-                    // window.location.href = `/profile/${npub}`; 
+                    window.parent.postMessage({ type: 'viewProfile', pubkey: profile.pubkey }, '*');
                 };
 
                 const messageButton = document.createElement('button');

--- a/src/pages/FindCreators.vue
+++ b/src/pages/FindCreators.vue
@@ -17,6 +17,8 @@ import DonateDialog from 'components/DonateDialog.vue';
 import SendTokenDialog from 'components/SendTokenDialog.vue';
 import { useSendTokensStore } from 'stores/sendTokensStore';
 import { useDonationPresetsStore } from 'stores/donationPresets';
+import { useRouter } from 'vue-router';
+import { useCreatorsStore } from 'stores/creators';
 
 const iframeEl = ref<HTMLIFrameElement | null>(null);
 const showDonateDialog = ref(false);
@@ -24,11 +26,15 @@ const selectedPubkey = ref('');
 
 const sendTokensStore = useSendTokensStore();
 const donationStore = useDonationPresetsStore();
+const router = useRouter();
+const creators = useCreatorsStore();
 
 function onMessage(ev: MessageEvent) {
   if (ev.data && ev.data.type === 'donate' && ev.data.pubkey) {
     selectedPubkey.value = ev.data.pubkey;
     showDonateDialog.value = true;
+  } else if (ev.data && ev.data.type === 'viewProfile' && ev.data.pubkey) {
+    goToCreatorProfile(ev.data.pubkey);
   }
 }
 
@@ -54,6 +60,11 @@ function handleDonate({ bucketId, locked, type, amount, months, message }: any) 
     );
     showDonateDialog.value = false;
   }
+}
+
+function goToCreatorProfile(npub: string) {
+  creators.fetchTierDefinitions(npub);
+  router.push(`/creators/${npub}`);
 }
 
 onMounted(() => {

--- a/src/pages/PublicCreatorProfilePage.vue
+++ b/src/pages/PublicCreatorProfilePage.vue
@@ -23,14 +23,24 @@
     <div>
       <div class="text-h6 q-mb-sm">{{ $t("CreatorHub.profile.tiers") }}</div>
       <div v-if="!tiers.length">Creator has no subscription tiers</div>
-      <div v-else>
-        <div v-for="t in tiers" :key="t.id" class="q-pa-sm q-my-sm bg-grey-2">
-          <div class="text-h6">{{ t.name }} — {{ t.price_sats }} sats/month</div>
-          <div class="text-body1">{{ t.description }}</div>
-          <ul>
-            <li v-for="benefit in t.benefits" :key="benefit">{{ benefit }}</li>
-          </ul>
-        </div>
+      <div v-else class="q-gutter-md">
+        <q-card v-for="t in tiers" :key="t.id" flat bordered>
+          <q-card-section class="bg-grey-2">
+            <div class="row items-center justify-between">
+              <div class="text-subtitle1">{{ t.name }}</div>
+              <div class="text-subtitle2">
+                {{ t.price_sats }} sats/month
+                <span v-if="bitcoinPrice"> ({{ formatFiat(t.price_sats) }})</span>
+              </div>
+            </div>
+          </q-card-section>
+          <q-card-section>
+            <div class="text-body1 q-mb-sm">{{ t.description }}</div>
+            <ul class="q-pl-md">
+              <li v-for="benefit in t.benefits" :key="benefit">{{ benefit }}</li>
+            </ul>
+          </q-card-section>
+        </q-card>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- enable routing to creator profiles from the search iframe
- handle `viewProfile` events in `FindCreators.vue`
- display subscription tiers with `q-card` in creator profile page for clarity

## Testing
- `npm test` *(fails: Cannot find module 'vite-jsconfig-paths')*

------
https://chatgpt.com/codex/tasks/task_e_6842affc5f7883309eab13dffdedd84c