### PR TITLE
Show tiers dialog from find-creators

### DIFF
--- a/src/pages/PublicCreatorProfilePage.vue
+++ b/src/pages/PublicCreatorProfilePage.vue
@@ -64,7 +64,7 @@ export default defineComponent({
     const priceStore = usePriceStore();
     const uiStore = useUiStore();
     const bitcoinPrice = computed(() => priceStore.bitcoinPrice);
-    const creatorNpub = route.params.npubOrVanityName as string;
+    const creatorNpub = route.params.npub as string;
     const profile = ref<any>({});
     const tiers = computed(() => creators.tiersMap[creatorNpub] || []);
     const followers = ref<number | null>(null);

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -57,14 +57,9 @@ const routes = [
     ],
   },
   {
-    path: "/creators/:npubOrVanityName",
-    component: () => import("layouts/FullscreenLayout.vue"),
-    children: [
-      {
-        path: "",
-        component: () => import("src/pages/PublicCreatorProfilePage.vue"),
-      },
-    ],
+    path: "/creator/:npub",
+    name: "PublicCreatorProfile",
+    component: () => import("src/pages/PublicCreatorProfilePage.vue"),
   },
   {
     path: "/buckets",


### PR DESCRIPTION
## Summary
- route public creator profile as `/creator/:npub`
- show tiers inside a dialog on FindCreators page
- fetch tiers for direct profile pages

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842b5ad19b8833098ea460f873be76c