### PR TITLE
Fix creator profile npub param usage

### DIFF
--- a/src/pages/PublicCreatorProfilePage.vue
+++ b/src/pages/PublicCreatorProfilePage.vue
@@ -64,18 +64,18 @@ export default defineComponent({
   name: "PublicCreatorProfilePage",
   setup() {
     const route = useRoute();
+    const creatorNpub = route.params.npub as string;
     const creators = useCreatorsStore();
     const nostr = useNostrStore();
     const priceStore = usePriceStore();
     const uiStore = useUiStore();
     const bitcoinPrice = computed(() => priceStore.bitcoinPrice);
-    const creatorNpub = route.params.npubHex as string;
     const profile = ref<any>({});
     const tiers = computed(() => creators.tiersMap[creatorNpub] || []);
     const followers = ref<number | null>(null);
     const following = ref<number | null>(null);
     onMounted(async () => {
-      creators.fetchTierDefinitions(creatorNpub);
+      await creators.fetchTierDefinitions(creatorNpub);
       const p = await nostr.getProfile(creatorNpub);
       if (p) profile.value = { ...p };
       followers.value = await nostr.fetchFollowerCount(creatorNpub);


### PR DESCRIPTION
## Summary
- use `route.params.npub` and init creators store after this line
- await `fetchTierDefinitions()` when loading public creator profile

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842cb5e4c4c8330948bc26d5b633d8a