### PR TITLE
Fix public profile route path

### DIFF
--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -57,7 +57,7 @@ const routes = [
     ],
   },
   {
-    path: "/creator/:npubHex",
+    path: "/creator/:npub",
     name: "PublicCreatorProfile",
     component: () => import("src/pages/PublicCreatorProfilePage.vue"),
   },


### PR DESCRIPTION
## Summary
- ensure the creator public profile route uses the `:npub` param

## Testing
- `npm run lint` *(fails: eslint config missing)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842cc398e808330942d133496a59030