### PR TITLE
Publish tiers as single kind-30000 event

### DIFF
--- a/src/pages/CreatorDashboardPage.vue
+++ b/src/pages/CreatorDashboardPage.vue
@@ -183,23 +183,27 @@ export default defineComponent({
       showAddTierDialog.value = true;
     };
 
-    const saveNewTier = (tier: Partial<Tier>) => {
+    const saveNewTier = async (tier: Partial<Tier>) => {
       showAddTierDialog.value = false;
       store.addTier(tier);
+      await store.publishTierDefinitions();
     };
 
-    const saveAllTiers = () => {
+    const saveAllTiers = async () => {
       tiers.value.forEach((t) => saveTier(t));
+      await store.publishTierDefinitions();
     };
 
-    const removeTier = (id: string) => {
+    const removeTier = async (id: string) => {
       store.removeTier(id);
+      await store.publishTierDefinitions();
     };
 
-    const saveTier = (tier: Tier) => {
+    const saveTier = async (tier: Tier) => {
       const data = editedTiers.value[tier.id];
       if (data) {
         store.updateTier(tier.id, { ...data });
+        await store.publishTierDefinitions();
       }
     };
 


### PR DESCRIPTION
## Summary
- update CreatorHub store to publish all tiers in one Nostr event
- adapt dashboard page to call the new publish action whenever tiers change

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68432fd484f48330869d2984fb3aba2f