### PR TITLE
Enhance creator UI layout and feedback

### DIFF
--- a/src/pages/CreatorDashboardPage.vue
+++ b/src/pages/CreatorDashboardPage.vue
@@ -124,6 +124,7 @@ import { useRouter } from 'vue-router';
 import { usePriceStore } from 'stores/price';
 import { useUiStore } from 'stores/ui';
 import { v4 as uuidv4 } from 'uuid';
+import { notifySuccess } from 'src/js/notify';
 
 export default defineComponent({
   name: 'CreatorDashboardPage',
@@ -167,6 +168,7 @@ export default defineComponent({
 
     const saveProfile = async () => {
       await store.updateProfile(profile.value);
+      notifySuccess('Profile saved');
     };
 
     const showAddTierDialog = ref(false);
@@ -187,16 +189,19 @@ export default defineComponent({
       showAddTierDialog.value = false;
       store.addTier(tier);
       await store.publishTierDefinitions();
+      notifySuccess('Tier added');
     };
 
     const saveAllTiers = async () => {
       tiers.value.forEach((t) => saveTier(t));
       await store.publishTierDefinitions();
+      notifySuccess('All tiers saved');
     };
 
     const removeTier = async (id: string) => {
       store.removeTier(id);
       await store.publishTierDefinitions();
+      notifySuccess('Tier removed');
     };
 
     const saveTier = async (tier: Tier) => {
@@ -204,6 +209,7 @@ export default defineComponent({
       if (data) {
         store.updateTier(tier.id, { ...data });
         await store.publishTierDefinitions();
+        notifySuccess('Tier updated');
       }
     };
 

--- a/src/pages/CreatorHubPage.vue
+++ b/src/pages/CreatorHubPage.vue
@@ -1,28 +1,31 @@
 <template>
   <q-page
-    :class="[
-      $q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark',
-      'q-pa-md',
-    ]"
+    class="q-pa-md flex flex-center"
+    :class="$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark'"
   >
-    <div class="text-h5 q-mb-md">Creator Hub</div>
+    <div style="width:100%;max-width:500px;">
+      <div class="text-h5 text-center q-mb-lg">Creator Hub</div>
 
-    <div v-if="!loggedIn" class="q-mt-md">
-      <q-btn color="primary" to="/creator/login">Login</q-btn>
-    </div>
-
-    <div v-else>
-      <div v-for="tier in tiers" :key="tier.id" class="q-mb-md">
-        <q-card>
-          <q-card-section>
-            <div class="text-subtitle1">
-              {{ tier.name }} - {{ tier.price }} sats/month
-            </div>
-            <div class="text-caption" v-html="renderMarkdown(tier.description)"></div>
-          </q-card-section>
-        </q-card>
+      <div v-if="!loggedIn" class="text-center q-my-xl">
+        <q-btn color="primary" to="/creator/login" rounded unelevated label="Login" />
       </div>
-      <q-btn color="primary" to="/creator/dashboard">Edit Tiers</q-btn>
+
+      <div v-else>
+        <div v-for="tier in tiers" :key="tier.id" class="q-mb-md">
+          <q-card flat bordered>
+            <q-card-section>
+              <div class="row items-center justify-between">
+                <div class="text-subtitle1">{{ tier.name }}</div>
+                <div class="text-subtitle2 text-primary">{{ tier.price }} sats/month</div>
+              </div>
+              <div class="q-mt-sm" v-html="renderMarkdown(tier.description)" />
+            </q-card-section>
+          </q-card>
+        </div>
+        <div class="text-center q-mt-md">
+          <q-btn color="primary" to="/creator/dashboard" rounded unelevated label="Edit Tiers" />
+        </div>
+      </div>
     </div>
   </q-page>
 </template>

--- a/src/pages/FindCreators.vue
+++ b/src/pages/FindCreators.vue
@@ -9,27 +9,28 @@
     <DonateDialog v-model="showDonateDialog" @confirm="handleDonate" />
     <SendTokenDialog />
     <QDialog v-model="showTierDialog">
-      <QCard>
-        <QCardSection>
-          <div v-if="!tiers.length">Creator has no subscription tiers</div>
-          <div v-else>
-            <div
-              v-for="t in tiers"
-              :key="t.id"
-              class="q-pa-sm q-mb-sm bg-grey-2"
-            >
-              <div class="text-h6">
-                {{ t.name }} — {{ t.price_sats }} sat/month
-              </div>
-              <div class="text-body1">{{ t.description }}</div>
-              <ul class="q-pl-md q-mt-xs">
-                <li v-for="b in t.benefits" :key="b">{{ b }}</li>
-              </ul>
-            </div>
-          </div>
+      <QCard class="tier-dialog">
+        <QCardSection class="row items-center justify-between">
+          <div class="text-h6">Subscription Tiers</div>
+          <QBtn dense flat icon="close" @click="showTierDialog = false" />
         </QCardSection>
-        <QCardSection align="right">
-          <QBtn flat label="Close" @click="showTierDialog = false" />
+        <QSeparator />
+        <QCardSection>
+          <div v-if="!tiers.length" class="text-center">Creator has no subscription tiers</div>
+          <div v-else>
+            <QCard v-for="t in tiers" :key="t.id" flat bordered class="q-mb-md">
+              <QCardSection>
+                <div class="row items-center justify-between">
+                  <div class="text-subtitle1">{{ t.name }}</div>
+                  <div class="text-subtitle2 text-primary">{{ t.price_sats }} sat/month</div>
+                </div>
+                <div class="q-mt-sm">{{ t.description }}</div>
+                <ul class="q-pl-md q-mt-xs text-caption">
+                  <li v-for="b in t.benefits" :key="b">{{ b }}</li>
+                </ul>
+              </QCardSection>
+            </QCard>
+          </div>
         </QCardSection>
       </QCard>
     </QDialog>
@@ -43,7 +44,7 @@ import SendTokenDialog from 'components/SendTokenDialog.vue';
 import { useSendTokensStore } from 'stores/sendTokensStore';
 import { useDonationPresetsStore } from 'stores/donationPresets';
 import { useCreatorsStore } from 'stores/creators';
-import { QDialog, QCard, QCardSection, QBtn } from 'quasar';
+import { QDialog, QCard, QCardSection, QBtn, QSeparator } from 'quasar';
 import { nip19 } from 'nostr-tools';
 
 const iframeEl = ref<HTMLIFrameElement | null>(null);
@@ -122,5 +123,10 @@ onBeforeUnmount(() => {
   border: none;
   width: 100%;
   height: 100%;
+}
+
+.tier-dialog {
+  width: 100%;
+  max-width: 500px;
 }
 </style>


### PR DESCRIPTION
## Summary
- polish Creator Hub layout and tiers list styling
- modernize tiers popup on Find Creators page
- show success toasts when saving profiles or tiers

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68433f4993588330a72850e8c8cc6191