### PR TITLE
Fix tier pricing display and hover subscribe button

### DIFF
--- a/src/pages/FindCreators.vue
+++ b/src/pages/FindCreators.vue
@@ -18,17 +18,20 @@
         <QCardSection>
           <div v-if="!tiers.length" class="text-center">Creator has no subscription tiers</div>
           <div v-else>
-            <QCard v-for="t in tiers" :key="t.id" flat bordered class="q-mb-md">
+            <QCard v-for="t in tiers" :key="t.id" flat bordered class="q-mb-md tier-card">
               <QCardSection>
                 <div class="row items-center justify-between">
                   <div class="text-subtitle1">{{ t.name }}</div>
-                  <div class="text-subtitle2 text-primary">{{ t.price_sats }} sat/month</div>
+                  <div class="text-subtitle2 text-primary">{{ getPrice(t) }} sats/month</div>
                 </div>
                 <div class="q-mt-sm">{{ t.description }}</div>
                 <ul class="q-pl-md q-mt-xs text-caption">
                   <li v-for="b in t.benefits" :key="b">{{ b }}</li>
                 </ul>
               </QCardSection>
+              <QCardActions align="right" class="subscribe-container">
+                <QBtn label="Subscribe" color="primary" class="subscribe-btn" />
+              </QCardActions>
             </QCard>
           </div>
         </QCardSection>
@@ -44,7 +47,7 @@ import SendTokenDialog from 'components/SendTokenDialog.vue';
 import { useSendTokensStore } from 'stores/sendTokensStore';
 import { useDonationPresetsStore } from 'stores/donationPresets';
 import { useCreatorsStore } from 'stores/creators';
-import { QDialog, QCard, QCardSection, QBtn, QSeparator } from 'quasar';
+import { QDialog, QCard, QCardSection, QCardActions, QBtn, QSeparator } from 'quasar';
 import { nip19 } from 'nostr-tools';
 
 const iframeEl = ref<HTMLIFrameElement | null>(null);
@@ -57,6 +60,10 @@ const sendTokensStore = useSendTokensStore();
 const donationStore = useDonationPresetsStore();
 const creators = useCreatorsStore();
 const tiers = computed(() => creators.tiersMap[dialogPubkey.value] || []);
+
+function getPrice(t: any): number {
+  return t.price_sats ?? t.price ?? 0;
+}
 
 function bech32ToHex(pubkey: string): string {
   try {
@@ -128,5 +135,13 @@ onBeforeUnmount(() => {
 .tier-dialog {
   width: 100%;
   max-width: 500px;
+}
+
+.tier-card .subscribe-btn {
+  display: none;
+}
+
+.tier-card:hover .subscribe-btn {
+  display: inline-flex;
 }
 </style>

--- a/src/pages/PublicCreatorProfilePage.vue
+++ b/src/pages/PublicCreatorProfilePage.vue
@@ -26,13 +26,13 @@
         Creator has no subscription tiers
       </div>
       <div v-else>
-        <q-card v-for="t in tiers" :key="t.id" flat bordered class="q-mb-md">
+        <q-card v-for="t in tiers" :key="t.id" flat bordered class="q-mb-md tier-card">
           <q-card-section class="row items-center justify-between bg-grey-2">
             <div class="text-subtitle1">{{ t.name }}</div>
             <div class="text-subtitle2">
-              {{ t.price_sats }} sats/month
+              {{ getPrice(t) }} sats/month
               <span v-if="priceStore.bitcoinPrice">
-                ({{ formatFiat(t.price_sats) }})
+                ({{ formatFiat(getPrice(t)) }})
               </span>
             </div>
           </q-card-section>
@@ -41,8 +41,8 @@
             <ul class="q-pl-md q-mb-none">
               <li v-for="benefit in t.benefits" :key="benefit">{{ benefit }}</li>
             </ul>
-            <div class="q-mt-md text-right">
-              <q-btn label="Support" color="primary" />
+            <div class="q-mt-md text-right subscribe-container">
+              <q-btn label="Subscribe" color="primary" class="subscribe-btn" />
             </div>
           </q-card-section>
         </q-card>
@@ -91,6 +91,10 @@ export default defineComponent({
       return uiStore.formatCurrency(value, "USD", true);
     }
 
+    function getPrice(t: any): number {
+      return t.price_sats ?? t.price ?? 0;
+    }
+
     return {
       creatorNpub,
       profile,
@@ -101,7 +105,18 @@ export default defineComponent({
       priceStore,
       renderMarkdown,
       formatFiat,
+      getPrice,
     };
   },
 });
 </script>
+
+<style scoped>
+.tier-card .subscribe-btn {
+  display: none;
+}
+
+.tier-card:hover .subscribe-btn {
+  display: inline-flex;
+}
+</style>

--- a/src/stores/creators.ts
+++ b/src/stores/creators.ts
@@ -164,12 +164,18 @@ export const useCreatorsStore = defineStore("creators", {
     async fetchTierDefinitions(creatorNpub: string) {
       const cached = await db.creatorsTierDefinitions.get(creatorNpub);
       if (cached) {
-        this.tiersMap[creatorNpub] = cached.tiers;
+        this.tiersMap[creatorNpub] = cached.tiers.map((t: any) => ({
+          ...t,
+          price_sats: t.price_sats ?? t.price ?? 0,
+        }));
       }
       const filter = { authors: [creatorNpub], kinds: [30000], '#d': ['tiers'] };
       subscribeToNostr(filter, async (event) => {
         try {
-          const tiersArray: Tier[] = JSON.parse(event.content);
+          const tiersArray: Tier[] = JSON.parse(event.content).map((t: any) => ({
+            ...t,
+            price_sats: t.price_sats ?? t.price ?? 0,
+          }));
           this.tiersMap[creatorNpub] = tiersArray;
           await db.creatorsTierDefinitions.put({
             creatorNpub,


### PR DESCRIPTION
## Summary
- fix price display when viewing creator tiers
- show subscribe button on tiers when hovering
- normalize tier price in creators store

## Testing
- `npm test` *(fails: Cannot find module 'vite-jsconfig-paths')*

------
https://chatgpt.com/codex/tasks/task_e_6843419d50788330a07f09ef2595eb2a