### PR TITLE
Improve bucket manager UI and rename move page

### DIFF
--- a/src/components/BucketManager.vue
+++ b/src/components/BucketManager.vue
@@ -1,5 +1,6 @@
 <template>
   <div style="max-width: 800px; margin: 0 auto">
+    <div class="text-body2 q-mb-md">{{ $t('BucketManager.helper.intro') }}</div>
     <q-list padding>
       <div
         v-for="bucket in bucketList"
@@ -13,13 +14,7 @@
           style="text-decoration: none; display: block"
           class="text-dark"
         >
-          <q-item
-            clickable
-            :style="{
-              border: '1px solid rgba(128,128,128,0.2)',
-              'border-radius': '10px',
-            }"
-          >
+          <q-item clickable class="q-card q-pa-md">
             <q-item-section avatar>
               <q-icon
                 name="circle"
@@ -60,7 +55,9 @@
                 @click.stop.prevent="openEdit(bucket)"
                 aria-label="Edit"
                 title="Edit"
-              />
+              >
+                <q-tooltip>{{ $t('BucketManager.tooltips.edit_button') }}</q-tooltip>
+              </q-btn>
               <q-btn
                 icon="delete"
                 flat
@@ -69,22 +66,28 @@
                 @click.stop.prevent="openDelete(bucket.id)"
                 :aria-label="$t('BucketManager.actions.delete')"
                 :title="$t('BucketManager.actions.delete')"
-              />
+              >
+                <q-tooltip>{{ $t('BucketManager.tooltips.delete_button') }}</q-tooltip>
+              </q-btn>
             </q-item-section>
           </q-item>
         </router-link>
       </div>
       <q-item>
         <q-item-section>
-          <q-btn color="primary" icon="add" outline @click="openAdd">{{
-            $t("BucketManager.actions.add")
-          }}</q-btn>
+          <q-btn color="primary" icon="add" outline @click="openAdd">
+            {{ $t("BucketManager.actions.add") }}
+            <q-tooltip>{{ $t('BucketManager.tooltips.add_button') }}</q-tooltip>
+          </q-btn>
         </q-item-section>
       </q-item>
       <q-item>
         <q-item-section>
-          <router-link to="/move-proofs" style="text-decoration: none">
-            <q-btn color="primary" outline>{{ $t("BucketDetail.move") }}</q-btn>
+          <router-link to="/move-tokens" style="text-decoration: none">
+            <q-btn color="primary" outline>
+              {{ $t("BucketDetail.move") }}
+              <q-tooltip>{{ $t('BucketManager.tooltips.move_button') }}</q-tooltip>
+            </q-btn>
           </router-link>
         </q-item-section>
       </q-item>
@@ -130,16 +133,34 @@
           v-model.number="form.goal"
           outlined
           :rules="goalRules"
-          :label="$t('BucketManager.inputs.goal')"
           type="number"
           class="q-mb-sm"
-        />
+        >
+          <template #label>
+            <div class="row items-center no-wrap">
+              <span>{{ $t('BucketManager.inputs.goal') }}</span>
+              <InfoTooltip
+                class="q-ml-xs"
+                :text="$t('BucketManager.tooltips.goal')"
+              />
+            </div>
+          </template>
+        </q-input>
         <q-input
           v-model="form.creatorPubkey"
           outlined
-          :label="$t('BucketManager.inputs.creator_pubkey')"
           class="q-mb-sm"
-        />
+        >
+          <template #label>
+            <div class="row items-center no-wrap">
+              <span>{{ $t('BucketManager.inputs.creator_pubkey') }}</span>
+              <InfoTooltip
+                class="q-ml-xs"
+                :text="$t('BucketManager.tooltips.creator_pubkey')"
+              />
+            </div>
+          </template>
+        </q-input>
         <div class="row q-mt-md">
           <q-btn color="primary" rounded @click="saveBucket">{{
             $t("global.actions.update.label")

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1394,6 +1394,7 @@ export default {
     actions: {
       add: "Create new Bucket",
       delete: "Delete",
+      edit: "Edit"
     },
     inputs: {
       name: "Name",
@@ -1404,6 +1405,16 @@ export default {
     },
     tooltips: {
       description: "Buckets are for categorizing tokens",
+      goal: "Set a target amount for this bucket",
+      creator_pubkey: "Nostr pubkey to receive locked tokens",
+      add_button: "Add a new bucket",
+      edit_button: "Edit this bucket",
+      delete_button: "Remove this bucket",
+      move_button: "Move tokens between buckets"
+    },
+    helper: {
+      intro:
+        "Buckets let you organize tokens. Drag tokens into a bucket or use the 'Move tokens' button."
     },
     validation: {
       name: "Name is required",
@@ -1430,7 +1441,7 @@ export default {
     },
     not_found: "Bucket not found.",
   },
-  MoveProofs: {
+  MoveTokens: {
     title: "Move tokens",
     empty: "No tokens",
   },

--- a/src/pages/MoveTokens.vue
+++ b/src/pages/MoveTokens.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="q-pa-md">
-    <h5 class="q-my-none q-mb-md">{{ $t("MoveProofs.title") }}</h5>
+    <h5 class="q-my-none q-mb-md">{{ $t("MoveTokens.title") }}</h5>
     <q-select
       dense
       outlined
@@ -51,7 +51,7 @@
             </q-item-section>
           </q-item>
           <q-item v-if="!proofsByBucket[bucket.id].length">
-            <q-item-section>{{ $t("MoveProofs.empty") }}</q-item-section>
+            <q-item-section>{{ $t("MoveTokens.empty") }}</q-item-section>
           </q-item>
         </q-list>
       </q-expansion-item>

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -67,10 +67,10 @@ const routes = [
     children: [{ path: "", component: () => import("src/pages/Buckets.vue") }],
   },
   {
-    path: "/move-proofs",
+    path: "/move-tokens",
     component: () => import("layouts/FullscreenLayout.vue"),
     children: [
-      { path: "", component: () => import("src/pages/MoveProofs.vue") },
+      { path: "", component: () => import("src/pages/MoveTokens.vue") },
     ],
   },
   {

--- a/test/vitest/__tests__/moveTokens.spec.ts
+++ b/test/vitest/__tests__/moveTokens.spec.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { shallowMount } from '@vue/test-utils'
-import MoveProofs from '../../src/pages/MoveProofs.vue'
+import MoveTokens from '../../src/pages/MoveTokens.vue'
 
 const moveProofsMock = vi.fn()
 
@@ -33,9 +33,9 @@ beforeEach(() => {
   moveProofsMock.mockReset()
 })
 
-describe('MoveProofs component', () => {
+describe('MoveTokens component', () => {
   it('toggles token selection', () => {
-    const wrapper = shallowMount(MoveProofs)
+    const wrapper = shallowMount(MoveTokens)
     const vm: any = wrapper.vm
 
     vm.toggleProof('s1', true)
@@ -46,7 +46,7 @@ describe('MoveProofs component', () => {
   })
 
   it('moves selected tokens', async () => {
-    const wrapper = shallowMount(MoveProofs)
+    const wrapper = shallowMount(MoveTokens)
     const vm: any = wrapper.vm
     vm.selectedSecrets = ['a', 'b']
     vm.targetBucketId = 'b2'


### PR DESCRIPTION
## Summary
- enhance BucketManager with help text and tooltips
- style bucket entries with cards
- add tooltips for edit, delete, add and move buttons
- add goal and creator pubkey help text
- rename "MoveProofs" to "MoveTokens" throughout

## Testing
- `npm test` *(fails: Cannot find module 'vite-jsconfig-paths')*

------
https://chatgpt.com/codex/tasks/task_e_6843d0059c308330a2036749f19863d9