### PR TITLE
Add paywalled content component

### DIFF
--- a/src/components/PaywalledContent.vue
+++ b/src/components/PaywalledContent.vue
@@ -1,0 +1,35 @@
+<template>
+  <div>
+    <div v-if="hasAccess">
+      <slot />
+    </div>
+    <div v-else class="q-pa-md text-center">
+      <slot name="fallback">
+        <div class="q-mb-sm">Subscribe to access this content.</div>
+      </slot>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, computed } from 'vue';
+import { useLockedTokensStore } from 'stores/lockedTokens';
+
+export default defineComponent({
+  name: 'PaywalledContent',
+  props: {
+    creatorNpub: { type: String, required: true },
+    tierId: { type: String, required: true },
+  },
+  setup(props) {
+    const store = useLockedTokensStore();
+    const validTokens = computed(() =>
+      store.validTokensForTier(props.creatorNpub, props.tierId)
+    );
+    const hasAccess = computed(() => validTokens.value.length > 0);
+    return { hasAccess };
+  },
+});
+</script>
+
+<style scoped></style>

--- a/src/pages/PublicCreatorProfilePage.vue
+++ b/src/pages/PublicCreatorProfilePage.vue
@@ -44,6 +44,13 @@
             <div class="q-mt-md text-right subscribe-container">
               <q-btn label="Subscribe" color="primary" class="subscribe-btn" />
             </div>
+            <PaywalledContent
+              :creator-npub="creatorNpub"
+              :tier-id="t.id"
+              class="q-mt-md"
+            >
+              <div>Protected content visible to subscribers.</div>
+            </PaywalledContent>
           </q-card-section>
         </q-card>
       </div>
@@ -59,9 +66,11 @@ import { useNostrStore } from 'stores/nostr';
 import { usePriceStore } from 'stores/price';
 import { useUiStore } from 'stores/ui';
 import { renderMarkdown as renderMarkdownFn } from 'src/js/simple-markdown';
+import PaywalledContent from 'components/PaywalledContent.vue';
 
 export default defineComponent({
   name: "PublicCreatorProfilePage",
+  components: { PaywalledContent },
   setup() {
     const route = useRoute();
     const creatorNpub = route.params.npub as string;

--- a/src/stores/lockedTokens.ts
+++ b/src/stores/lockedTokens.ts
@@ -20,6 +20,16 @@ export const useLockedTokensStore = defineStore("lockedTokens", {
   getters: {
     tokensByBucket: (state) => (bucketId: string) =>
       state.lockedTokens.filter((t) => t.bucketId === bucketId),
+    validTokensForTier:
+      (state) => (creatorPubkey: string, tierId: string) => {
+        const now = Math.floor(Date.now() / 1000);
+        return state.lockedTokens.filter(
+          (t) =>
+            t.bucketId === tierId &&
+            t.pubkey === creatorPubkey &&
+            (!t.locktime || t.locktime <= now)
+        );
+      },
   },
   actions: {
     addLockedToken(data: Omit<LockedToken, "id" | "date"> & { date?: string }) {

--- a/test/vitest/__tests__/lockedTokens.spec.ts
+++ b/test/vitest/__tests__/lockedTokens.spec.ts
@@ -19,4 +19,16 @@ describe('LockedTokens store', () => {
     store.deleteLockedToken(t.id)
     expect(store.lockedTokens.length).toBe(0)
   })
+
+  it('returns valid tokens for tier', () => {
+    const store = useLockedTokensStore()
+    const past = Math.floor(Date.now() / 1000) - 10
+    const future = Math.floor(Date.now() / 1000) + 100
+    const t1 = store.addLockedToken({ amount: 1, token: 'a', pubkey: 'pk', bucketId: 'b', locktime: past })
+    store.addLockedToken({ amount: 1, token: 'b', pubkey: 'pk', bucketId: 'b', locktime: future })
+    store.addLockedToken({ amount: 1, token: 'c', pubkey: 'other', bucketId: 'b' })
+    const tokens = store.validTokensForTier('pk', 'b')
+    expect(tokens.length).toBe(1)
+    expect(tokens[0].id).toBe(t1.id)
+  })
 })


### PR DESCRIPTION
## Summary
- add `PaywalledContent` component
- add helper `validTokensForTier` to lockedTokens store
- integrate paywalled content on public creator profiles
- test locked token helper

## Testing
- `npm test` *(fails: Cannot find module 'vite-jsconfig-paths')*

------
https://chatgpt.com/codex/tasks/task_e_6843d397940c8330947c25fa4b3c3247