### PR TITLE
Fix overlapping header buttons in messenger

### DIFF
--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -40,7 +40,7 @@
               class="q-mr-sm"
               @click="drawer = !drawer"
             />
-            <q-toolbar-title class="text-h6">
+            <q-toolbar-title class="text-h6 ellipsis">
               Nostr Messenger
               <q-badge
                 :color="messenger.connected ? 'positive' : 'negative'"
@@ -107,3 +107,8 @@ const goBack = () => {
   router.push('/wallet');
 };
 </script>
+<style scoped>
+.q-toolbar {
+  flex-wrap: nowrap;
+}
+</style>


### PR DESCRIPTION
## Summary
- prevent header buttons from wrapping by adding ellipsis class to toolbar title and forcing no-wrap

## Testing
- `npm test` *(fails: Cannot find module 'vite-jsconfig-paths')*

------
https://chatgpt.com/codex/tasks/task_e_6843d6cef4a08330bd76fbaa12733087