### PR TITLE
Fix subscription issues

### DIFF
--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -16,6 +16,9 @@ export default {
       close: {
         label: "إغلاق",
       },
+      ok: {
+        label: "OK",
+      },
       enter: {
         label: "إدخال",
       },

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -16,6 +16,9 @@ export default {
       close: {
         label: "Schließen",
       },
+      ok: {
+        label: "OK",
+      },
       enter: {
         label: "Eingeben",
       },

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -16,6 +16,9 @@ export default {
       close: {
         label: "Κλείσιμο",
       },
+      ok: {
+        label: "OK",
+      },
       enter: {
         label: "Είσοδος",
       },

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -16,6 +16,9 @@ export default {
       close: {
         label: "Close",
       },
+      ok: {
+        label: "OK",
+      },
       enter: {
         label: "Enter",
       },

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -16,6 +16,9 @@ export default {
       close: {
         label: "Cerrar",
       },
+      ok: {
+        label: "OK",
+      },
       enter: {
         label: "Entrar",
       },

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -16,6 +16,9 @@ export default {
       close: {
         label: "Fermer",
       },
+      ok: {
+        label: "OK",
+      },
       enter: {
         label: "Entrer",
       },

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -16,6 +16,9 @@ export default {
       close: {
         label: "Chiudi",
       },
+      ok: {
+        label: "OK",
+      },
       enter: {
         label: "Invio",
       },

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -16,6 +16,9 @@ export default {
       close: {
         label: "閉じる",
       },
+      ok: {
+        label: "OK",
+      },
       enter: {
         label: "入力",
       },

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -16,6 +16,9 @@ export default {
       close: {
         label: "Stäng",
       },
+      ok: {
+        label: "OK",
+      },
       enter: {
         label: "Ange",
       },

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -16,6 +16,9 @@ export default {
       close: {
         label: "ปิด",
       },
+      ok: {
+        label: "OK",
+      },
       enter: {
         label: "ป้อน",
       },

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -16,6 +16,9 @@ export default {
       close: {
         label: "Kapat",
       },
+      ok: {
+        label: "OK",
+      },
       enter: {
         label: "Gir",
       },

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -16,6 +16,9 @@ export default {
       close: {
         label: "关闭",
       },
+      ok: {
+        label: "OK",
+      },
       enter: {
         label: "输入",
       },

--- a/src/pages/FindCreators.vue
+++ b/src/pages/FindCreators.vue
@@ -61,6 +61,9 @@ import { useDonationPresetsStore } from 'stores/donationPresets';
 import { useLockedTokensStore } from 'stores/lockedTokens';
 import { useCreatorsStore } from 'stores/creators';
 import { useNostrStore } from 'stores/nostr';
+import { useMintsStore } from 'stores/mints';
+import { notifyError } from 'src/js/notify';
+import { useI18n } from 'vue-i18n';
 import { DEFAULT_BUCKET_ID } from 'stores/buckets';
 import { QDialog, QCard, QCardSection, QCardActions, QBtn, QSeparator } from 'quasar';
 import { nip19 } from 'nostr-tools';
@@ -76,6 +79,8 @@ const donationStore = useDonationPresetsStore();
 const lockedStore = useLockedTokensStore();
 const creators = useCreatorsStore();
 const nostr = useNostrStore();
+const mintsStore = useMintsStore();
+const { t } = useI18n();
 const tiers = computed(() => creators.tiersMap[dialogPubkey.value] || []);
 const showSubscribeDialog = ref(false);
 const selectedTier = ref<any>(null);
@@ -106,6 +111,11 @@ async function onMessage(ev: MessageEvent) {
 }
 
 function openSubscribe(t: any) {
+  const nutSupport = mintsStore.activeInfo?.nut_supports || [];
+  if (!(nutSupport.includes(10) && nutSupport.includes(11))) {
+    notifyError(t('wallet.notifications.lock_not_supported'));
+    return;
+  }
   selectedTier.value = t;
   showSubscribeDialog.value = true;
 }

--- a/src/pages/PublicCreatorProfilePage.vue
+++ b/src/pages/PublicCreatorProfilePage.vue
@@ -80,6 +80,9 @@ import { usePriceStore } from 'stores/price';
 import { useUiStore } from 'stores/ui';
 import SubscribeDialog from 'components/SubscribeDialog.vue';
 import { DEFAULT_BUCKET_ID } from 'stores/buckets';
+import { useMintsStore } from 'stores/mints';
+import { notifyError } from 'src/js/notify';
+import { useI18n } from 'vue-i18n';
 import { renderMarkdown as renderMarkdownFn } from 'src/js/simple-markdown';
 import PaywalledContent from 'components/PaywalledContent.vue';
 
@@ -95,6 +98,8 @@ export default defineComponent({
     const lockedStore = useLockedTokensStore();
     const priceStore = usePriceStore();
     const uiStore = useUiStore();
+    const mintsStore = useMintsStore();
+    const { t } = useI18n();
     const bitcoinPrice = computed(() => priceStore.bitcoinPrice);
     const profile = ref<any>({});
     const tiers = computed(() => creators.tiersMap[creatorNpub] || []);
@@ -111,6 +116,11 @@ export default defineComponent({
     });
 
     const openSubscribe = (tier: any) => {
+      const nutSupport = mintsStore.activeInfo?.nut_supports || [];
+      if (!(nutSupport.includes(10) && nutSupport.includes(11))) {
+        notifyError(t('wallet.notifications.lock_not_supported'));
+        return;
+      }
       selectedTier.value = tier;
       showSubscribeDialog.value = true;
     };

--- a/src/stores/donationPresets.ts
+++ b/src/stores/donationPresets.ts
@@ -11,6 +11,7 @@ export type DonationPreset = {
 };
 
 const DEFAULT_PRESETS: DonationPreset[] = [
+  { months: 1 },
   { months: 3 },
   { months: 6 },
   { months: 12 },


### PR DESCRIPTION
## Summary
- add missing OK translations
- add 1 month default preset
- pre-check mint locking support before displaying Subscribe dialog

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot find module 'vite-jsconfig-paths')*

------
https://chatgpt.com/codex/tasks/task_e_6843d7a47c2083309997413586af41c0