### PR TITLE
Add modern pastel theme

### DIFF
--- a/src/components/SettingsView.vue
+++ b/src/components/SettingsView.vue
@@ -1367,6 +1367,20 @@
                       $t("Settings.appearance.theme.tooltips.flamingo")
                     }}</q-tooltip>
                   </q-btn>
+                  <q-btn
+                    v-if="themes.includes('modern')"
+                    dense
+                    flat
+                    @click="changeColor('modern')"
+                    icon="format_color_fill"
+                    color="blue-4"
+                    size="md"
+                    :aria-label="$t('Settings.appearance.theme.tooltips.modern')"
+                    :title="$t('Settings.appearance.theme.tooltips.modern')"
+                    ><q-tooltip>{{
+                      $t('Settings.appearance.theme.tooltips.modern')
+                    }}</q-tooltip>
+                  </q-btn>
                 </div>
               </q-item-section>
             </q-item>
@@ -1766,6 +1780,7 @@ export default defineComponent({
         "freedom",
         "cyber",
         "flamingo",
+        "modern",
       ],
       selectedLanguage: navigator.language || "en-US",
       languageOptions: [

--- a/src/css/base.scss
+++ b/src/css/base.scss
@@ -63,15 +63,23 @@ $themes: (
     marginal-bg: #000,
     marginal-text: rgb(255, 255, 255),
   ),
-  "cyber": (
-    primary: #00ff00,
-    secondary: #00ff00,
-    dark: #000,
-    info: #1b1b1b,
-    marginal-bg: #000,
-    marginal-text: rgb(255, 255, 255),
-  ),
-);
+    "cyber": (
+      primary: #00ff00,
+      secondary: #00ff00,
+      dark: #000,
+      info: #1b1b1b,
+      marginal-bg: #000,
+      marginal-text: rgb(255, 255, 255),
+    ),
+    "modern": (
+      primary: #a1c2e3,
+      secondary: #f3b6c4,
+      dark: #2f3e46,
+      info: #36454f,
+      marginal-bg: #2f3e46,
+      marginal-text: #fff,
+    ),
+  );
 @each $theme, $colors in $themes {
   @each $name, $color in $colors {
     @if $name== "dark" {

--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -380,6 +380,7 @@ export default {
           nut: "جوز",
           blu: "أزرق",
           flamingo: "فلامينجو",
+          modern: "modern",
         },
       },
     },

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -386,6 +386,7 @@ export default {
           nut: "nut",
           blu: "blu",
           flamingo: "flamingo",
+          modern: "modern",
         },
       },
     },

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -385,6 +385,7 @@ export default {
           nut: "nut",
           blu: "blu",
           flamingo: "flamingo",
+          modern: "modern",
         },
       },
     },

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -423,6 +423,7 @@ export default {
           nut: "nut",
           blu: "blu",
           flamingo: "flamingo",
+          modern: "modern",
         },
       },
     },

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -383,6 +383,7 @@ export default {
           nut: "nuez",
           blu: "azul",
           flamingo: "flamenco",
+          modern: "modern",
         },
       },
     },

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -384,6 +384,7 @@ export default {
           nut: "nut",
           blu: "blu",
           flamingo: "flamingo",
+          modern: "modern",
         },
       },
     },

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -382,6 +382,7 @@ export default {
           nut: "nut",
           blu: "blu",
           flamingo: "flamingo",
+          modern: "modern",
         },
       },
     },

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -382,6 +382,7 @@ export default {
           nut: "ナッツ",
           blu: "ブルー",
           flamingo: "フラミンゴ",
+          modern: "modern",
         },
       },
     },

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -381,6 +381,7 @@ export default {
           nut: "nöt",
           blu: "blå",
           flamingo: "flamingo",
+          modern: "modern",
         },
       },
     },

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -380,6 +380,7 @@ export default {
           nut: "nut",
           blu: "blu",
           flamingo: "flamingo",
+          modern: "modern",
         },
       },
     },

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -383,6 +383,7 @@ export default {
           nut: "ceviz",
           blu: "mavi",
           flamingo: "flamingo",
+          modern: "modern",
         },
       },
     },

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -376,6 +376,7 @@ export default {
           nut: "坚果",
           blu: "蓝色",
           flamingo: "火烈鸟",
+          modern: "modern",
         },
       },
     },


### PR DESCRIPTION
## Summary
- add `modern` theme colors in SCSS
- show modern theme switch in settings
- allow theme selection via SettingsView
- update i18n tooltips for modern theme

## Testing
- `npm test` *(fails: Cannot find module 'vite-jsconfig-paths')*

------
https://chatgpt.com/codex/tasks/task_e_6843d93eb12883309648df8d081e9c92