### PR TITLE
Add helper text for moving tokens

### DIFF
--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -1290,6 +1290,11 @@ timelock: {
     },
     not_found: "Bucket not found.",
   },
+  MoveTokens: {
+    title: "Move tokens",
+    empty: "No tokens",
+    helper: "Move tokens between buckets to organize them.",
+  },
   restore: {
     mnemonic_error_text: "الرجاء إدخال كلمة تذكيرية",
     restore_mint_error_text: "خطأ في استعادة mint: { error }",

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -1297,6 +1297,11 @@ export default {
     },
     not_found: "Bucket not found.",
   },
+  MoveTokens: {
+    title: "Move tokens",
+    empty: "No tokens",
+    helper: "Move tokens between buckets to organize them.",
+  },
   restore: {
     mnemonic_error_text: "Bitte geben Sie ein Mnemonisch ein",
     restore_mint_error_text: "Fehler beim Wiederherstellen der Mint: { error }",

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -1300,6 +1300,11 @@ timelock: {
     },
     not_found: "Bucket not found.",
   },
+  MoveTokens: {
+    title: "Move tokens",
+    empty: "No tokens",
+    helper: "Move tokens between buckets to organize them.",
+  },
   restore: {
     mnemonic_error_text: "Παρακαλώ εισαγάγετε ένα μνημονικό",
     restore_mint_error_text: "Σφάλμα κατά την επαναφορά του mint: { error }",

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1448,6 +1448,7 @@ export default {
   MoveTokens: {
     title: "Move tokens",
     empty: "No tokens",
+    helper: "Move tokens between buckets to organize them.",
   },
   LockedTokensTable: {
     empty_text: "No locked tokens",

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -1298,6 +1298,11 @@ timelock: {
     },
     not_found: "Bucket not found.",
   },
+  MoveTokens: {
+    title: "Move tokens",
+    empty: "No tokens",
+    helper: "Move tokens between buckets to organize them.",
+  },
   restore: {
     mnemonic_error_text: "Por favor, ingresa un mnemónico",
     restore_mint_error_text: "Error restaurando mint: { error }",

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -1286,6 +1286,11 @@ timelock: {
     },
     not_found: "Bucket not found.",
   },
+  MoveTokens: {
+    title: "Move tokens",
+    empty: "No tokens",
+    helper: "Move tokens between buckets to organize them.",
+  },
   restore: {
     mnemonic_error_text: "Veuillez entrer un mnémonique",
     restore_mint_error_text:

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -1280,6 +1280,11 @@ timelock: {
     },
     not_found: "Bucket not found.",
   },
+  MoveTokens: {
+    title: "Move tokens",
+    empty: "No tokens",
+    helper: "Move tokens between buckets to organize them.",
+  },
   restore: {
     mnemonic_error_text: "Inserisci un mnemonico",
     restore_mint_error_text: "Errore nel ripristino del mint: { error }",

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -1280,6 +1280,11 @@ timelock: {
     },
     not_found: "Bucket not found.",
   },
+  MoveTokens: {
+    title: "Move tokens",
+    empty: "No tokens",
+    helper: "Move tokens between buckets to organize them.",
+  },
   restore: {
     mnemonic_error_text: "ニーモニックを入力してください",
     restore_mint_error_text: "ミントの復元エラー: { error }",

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -1280,6 +1280,11 @@ timelock: {
     },
     not_found: "Bucket not found.",
   },
+  MoveTokens: {
+    title: "Move tokens",
+    empty: "No tokens",
+    helper: "Move tokens between buckets to organize them.",
+  },
   restore: {
     mnemonic_error_text: "Ange en mnemonisk fras",
     restore_mint_error_text: "Fel vid återställning av mint: { error }",

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -1277,6 +1277,11 @@ timelock: {
     },
     not_found: "Bucket not found.",
   },
+  MoveTokens: {
+    title: "Move tokens",
+    empty: "No tokens",
+    helper: "Move tokens between buckets to organize them.",
+  },
   restore: {
     mnemonic_error_text: "โปรดป้อน mnemonic",
     restore_mint_error_text: "ข้อผิดพลาดในการกู้คืน Mint: { error }",

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -1282,6 +1282,11 @@ timelock: {
     },
     not_found: "Bucket not found.",
   },
+  MoveTokens: {
+    title: "Move tokens",
+    empty: "No tokens",
+    helper: "Move tokens between buckets to organize them.",
+  },
   restore: {
     mnemonic_error_text: "Lütfen bir anımsatıcı girin",
     restore_mint_error_text: "Nane geri yükleme hatası: { error }",

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -1270,6 +1270,11 @@ timelock: {
     },
     not_found: "Bucket not found.",
   },
+  MoveTokens: {
+    title: "Move tokens",
+    empty: "No tokens",
+    helper: "Move tokens between buckets to organize them.",
+  },
   restore: {
     mnemonic_error_text: "请输入助记符",
     restore_mint_error_text: "恢复 Mint 错误: { error }",

--- a/src/pages/MoveTokens.vue
+++ b/src/pages/MoveTokens.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="q-pa-md">
-    <h5 class="q-my-none q-mb-md">{{ $t("MoveTokens.title") }}</h5>
+    <h5 class="q-my-none q-mb-none">{{ $t("MoveTokens.title") }}</h5>
+    <div class="text-body2 q-mb-md">{{ $t('MoveTokens.helper') }}</div>
     <q-select
       dense
       outlined


### PR DESCRIPTION
## Summary
- add helper text under Move Tokens heading
- add `MoveTokens.helper` translations across languages

## Testing
- `npm test` *(fails: Cannot find module 'vite-jsconfig-paths')*

------
https://chatgpt.com/codex/tasks/task_e_6843db9990148330ad3389c839d4f6ff