### PR TITLE
Fix donation bucket with tier id

### DIFF
--- a/src/pages/FindCreators.vue
+++ b/src/pages/FindCreators.vue
@@ -126,13 +126,14 @@ async function confirmSubscribe({ months, amount }: any) {
     months,
     amount,
     dialogPubkey.value,
+    selectedTier.value.id,
   );
   if (token) {
     lockedStore.addLockedToken({
       amount,
       token,
       pubkey: dialogPubkey.value,
-      bucketId: DEFAULT_BUCKET_ID,
+      bucketId: selectedTier.value.id,
     });
     let supporterName = nostr.pubkey;
     try {

--- a/src/pages/PublicCreatorProfilePage.vue
+++ b/src/pages/PublicCreatorProfilePage.vue
@@ -130,13 +130,14 @@ export default defineComponent({
         months,
         amount,
         creatorNpub,
+        selectedTier.value.id,
       );
       if (token) {
         lockedStore.addLockedToken({
           amount,
           token,
           pubkey: creatorNpub,
-          bucketId: DEFAULT_BUCKET_ID,
+          bucketId: selectedTier.value.id,
         });
       }
       let supporterName = nostr.pubkey;


### PR DESCRIPTION
## Summary
- ensure tier id is used as the bucket id when subscribing

## Testing
- `npm test` *(fails: Cannot find module 'vite-jsconfig-paths')*

------
https://chatgpt.com/codex/tasks/task_e_6843dd59322083308a52e21b19c8b18f