### PR TITLE
Update donation presets test

### DIFF
--- a/test/vitest/__tests__/donationPresets.spec.ts
+++ b/test/vitest/__tests__/donationPresets.spec.ts
@@ -39,7 +39,7 @@ vi.mock("../../../src/stores/mints", () => ({
 describe("Donation presets", () => {
   it("has default presets", () => {
     const store = useDonationPresetsStore();
-    expect(store.presets.length).toBe(3);
+    expect(store.presets.length).toBe(4);
   });
 
   it("calls sendToLock with sequential locktimes", async () => {


### PR DESCRIPTION
## Summary
- correct the default donation presets count from 3 to 4

## Testing
- `npx vitest run test/vitest/__tests__/donationPresets.spec.ts` *(fails: Cannot find module 'vite-jsconfig-paths')*

------
https://chatgpt.com/codex/tasks/task_e_6843de7c5e108330a11e2e65a25dc6ba