### PR TITLE
Fix subscribe button in FindCreators

### DIFF
--- a/src/pages/FindCreators.vue
+++ b/src/pages/FindCreators.vue
@@ -110,13 +110,13 @@ async function onMessage(ev: MessageEvent) {
   }
 }
 
-function openSubscribe(t: any) {
+function openSubscribe(tier: any) {
   const nutSupport = mintsStore.activeInfo?.nut_supports || [];
   if (!(nutSupport.includes(10) && nutSupport.includes(11))) {
     notifyError(t('wallet.notifications.lock_not_supported'));
     return;
   }
-  selectedTier.value = t;
+  selectedTier.value = tier;
   showSubscribeDialog.value = true;
 }
 


### PR DESCRIPTION
## Summary
- avoid shadowing translation function by renaming parameter in `openSubscribe` on FindCreators page

## Testing
- `npm test` *(fails: Cannot find module 'vite-jsconfig-paths')*

------
https://chatgpt.com/codex/tasks/task_e_6843e0eae7d8833089f9c46f878e43db