### PR TITLE
Fix P2PK timelock check

### DIFF
--- a/src/pages/FindCreators.vue
+++ b/src/pages/FindCreators.vue
@@ -111,8 +111,11 @@ async function onMessage(ev: MessageEvent) {
 }
 
 function openSubscribe(tier: any) {
-  const nutSupport = mintsStore.activeInfo?.nut_supports || [];
-  if (!(nutSupport.includes(10) && nutSupport.includes(11))) {
+  const info = mintsStore.activeInfo || {};
+  const nuts = Array.isArray(info.nut_supports)
+    ? info.nut_supports
+    : Object.keys(info.nuts || {}).map((n) => Number(n));
+  if (!(nuts.includes(10) && nuts.includes(11))) {
     notifyError(t('wallet.notifications.lock_not_supported'));
     return;
   }

--- a/src/pages/PublicCreatorProfilePage.vue
+++ b/src/pages/PublicCreatorProfilePage.vue
@@ -116,8 +116,11 @@ export default defineComponent({
     });
 
     const openSubscribe = (tier: any) => {
-      const nutSupport = mintsStore.activeInfo?.nut_supports || [];
-      if (!(nutSupport.includes(10) && nutSupport.includes(11))) {
+      const info = mintsStore.activeInfo || {};
+      const nuts = Array.isArray(info.nut_supports)
+        ? info.nut_supports
+        : Object.keys(info.nuts || {}).map((n) => Number(n));
+      if (!(nuts.includes(10) && nuts.includes(11))) {
         notifyError(t('wallet.notifications.lock_not_supported'));
         return;
       }

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -392,8 +392,11 @@ export const useWalletStore = defineStore("wallet", {
       refundPubkey?: string,
     ) {
       const mintStore = useMintsStore();
-      const nutSupport = mintStore.activeInfo?.nut_supports || [];
-      if (!(nutSupport.includes(10) && nutSupport.includes(11))) {
+      const info = mintStore.activeInfo || {};
+      const nuts = Array.isArray(info.nut_supports)
+        ? info.nut_supports
+        : Object.keys(info.nuts || {}).map((n) => Number(n));
+      if (!(nuts.includes(10) && nuts.includes(11))) {
         notifyError(this.t("wallet.notifications.lock_not_supported"));
         throw new Error("Mint does not support timelocks or P2PK");
       }


### PR DESCRIPTION
## Summary
- check NUT support via info `nuts` field when `nut_supports` is missing
- ensure Subscribe dialogs verify mint's P2PK/timelock support properly

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843e414db008330b97ab5eb97c72f8d