### PR TITLE
Add start date option for subscription presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,9 @@ Fundstr is currently in Alpha/Beta.
 2. Optionally create Token Buckets for organization.
 3. Browse or search for creators.
 4. Visit a creator's profile and choose a tier, donation or recurring pledge.
-5. Follow prompts to send Cashu ecash.
-6. Chat with creators or other users via Nostr DMs.
+5. (Optional) Pick a start date if you want your subscription to begin later.
+6. Follow prompts to send Cashu ecash.
+7. Chat with creators or other users via Nostr DMs.
 
 ### 3. For Creators
 1. Go to the **Creator Hub** section.

--- a/src/components/SubscribeDialog.vue
+++ b/src/components/SubscribeDialog.vue
@@ -23,6 +23,14 @@
           class="q-mt-md"
           :label="$t('DonateDialog.inputs.preset')"
         />
+        <q-input
+          v-model="startDate"
+          type="date"
+          outlined
+          dense
+          class="q-mt-md"
+          label="Start Date"
+        />
       </q-card-section>
       <q-card-actions align="right">
         <q-btn flat color="primary" @click="cancel">{{
@@ -52,6 +60,7 @@ export default defineComponent({
     const donationStore = useDonationPresetsStore();
     const months = ref(donationStore.presets[0]?.months || 0);
     const amount = ref(0);
+    const startDate = ref('');
 
     watch(
       () => props.tier,
@@ -80,7 +89,14 @@ export default defineComponent({
     };
 
     const confirm = () => {
-      emit('confirm', { months: months.value, amount: amount.value });
+      const ts = startDate.value
+        ? Math.floor(new Date(startDate.value).getTime() / 1000)
+        : undefined;
+      emit('confirm', {
+        months: months.value,
+        amount: amount.value,
+        startDate: ts,
+      });
       emit('update:modelValue', false);
     };
 
@@ -89,6 +105,7 @@ export default defineComponent({
       amount,
       months,
       presetOptions,
+      startDate,
       cancel,
       confirm,
     };

--- a/src/pages/FindCreators.vue
+++ b/src/pages/FindCreators.vue
@@ -123,13 +123,14 @@ function openSubscribe(tier: any) {
   showSubscribeDialog.value = true;
 }
 
-async function confirmSubscribe({ months, amount }: any) {
+async function confirmSubscribe({ months, amount, startDate }: any) {
   if (!dialogPubkey.value) return;
   const token = await donationStore.createDonationPreset(
     months,
     amount,
     dialogPubkey.value,
     selectedTier.value.id,
+    startDate,
   );
   if (token) {
     lockedStore.addLockedToken({

--- a/src/pages/PublicCreatorProfilePage.vue
+++ b/src/pages/PublicCreatorProfilePage.vue
@@ -128,12 +128,13 @@ export default defineComponent({
       showSubscribeDialog.value = true;
     };
 
-    const confirmSubscribe = async ({ months, amount }: any) => {
+    const confirmSubscribe = async ({ months, amount, startDate }: any) => {
       const token = await donationStore.createDonationPreset(
         months,
         amount,
         creatorNpub,
         selectedTier.value.id,
+        startDate,
       );
       if (token) {
         lockedStore.addLockedToken({

--- a/src/stores/donationPresets.ts
+++ b/src/stores/donationPresets.ts
@@ -30,6 +30,7 @@ export const useDonationPresetsStore = defineStore("donationPresets", {
       amount: number,
       pubkey: string,
       bucketId: string = DEFAULT_BUCKET_ID,
+      startDate?: number,
     ): Promise<string | void> {
       const walletStore = useWalletStore();
       const proofsStore = useProofsStore();
@@ -52,9 +53,10 @@ export const useDonationPresetsStore = defineStore("donationPresets", {
         return proofsStore.serializeProofs(sendProofs);
       }
 
+      const base =
+        startDate ?? Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60;
       for (let i = 0; i < months; i++) {
-        const locktime =
-          Math.floor(Date.now() / 1000) + (i + 1) * 30 * 24 * 60 * 60;
+        const locktime = base + i * 30 * 24 * 60 * 60;
         const { sendProofs } = await walletStore.sendToLock(
           proofs,
           wallet,

--- a/test/vitest/__tests__/donationPresets.spec.ts
+++ b/test/vitest/__tests__/donationPresets.spec.ts
@@ -64,4 +64,16 @@ describe("Donation presets", () => {
     expect(spy.mock.calls[0][2]).toBe(5);
     expect(token).toBe("tok");
   });
+
+  it("uses provided startDate for locktimes", async () => {
+    const store = useDonationPresetsStore();
+    const wallet = useWalletStore();
+    const spy = wallet.sendToLock as any;
+    const start = 1000;
+    await store.createDonationPreset(3, 1, "pk", "b", start);
+    expect(spy).toHaveBeenCalledTimes(3);
+    expect(spy.mock.calls[0][5]).toBe(start);
+    expect(spy.mock.calls[1][5]).toBe(start + 30 * 24 * 60 * 60);
+    expect(spy.mock.calls[2][5]).toBe(start + 2 * 30 * 24 * 60 * 60);
+  });
 });


### PR DESCRIPTION
## Summary
- allow `createDonationPreset` to accept optional `startDate`
- add start date picker to subscribe dialog
- pass `startDate` through subscription flows
- test start date locktime offsets
- document optional start date in README

## Testing
- `npm test --silent` *(fails: Cannot find module 'vite-jsconfig-paths')*

------
https://chatgpt.com/codex/tasks/task_e_6843efd990488330af7cc783de0e16fa