### PR TITLE
Handle tokens for monthly donation presets

### DIFF
--- a/src/pages/FindCreators.vue
+++ b/src/pages/FindCreators.vue
@@ -125,31 +125,31 @@ function openSubscribe(tier: any) {
 
 async function confirmSubscribe({ months, amount, startDate }: any) {
   if (!dialogPubkey.value) return;
-  const token = await donationStore.createDonationPreset(
+  const tokens = await donationStore.createDonationPreset(
     months,
     amount,
     dialogPubkey.value,
     selectedTier.value.id,
     startDate,
   );
-  if (token) {
+  if (!months || months <= 0) {
     lockedStore.addLockedToken({
       amount,
-      token,
+      token: tokens,
       pubkey: dialogPubkey.value,
       bucketId: selectedTier.value.id,
     });
-    let supporterName = nostr.pubkey;
-    try {
-      const prof = await nostr.getProfile(nostr.pubkey);
-      supporterName =
-        prof?.display_name || prof?.name || prof?.username || nostr.pubkey;
-    } catch {}
-    await nostr.sendNip04DirectMessage(
-      dialogPubkey.value,
-      `${supporterName} just subscribed to ${selectedTier.value.name}. Here is your receipt:\n${token}`,
-    );
   }
+  let supporterName = nostr.pubkey;
+  try {
+    const prof = await nostr.getProfile(nostr.pubkey);
+    supporterName =
+      prof?.display_name || prof?.name || prof?.username || nostr.pubkey;
+  } catch {}
+  await nostr.sendNip04DirectMessage(
+    dialogPubkey.value,
+    `${supporterName} just subscribed to ${selectedTier.value.name}. Here is your receipt:\n${tokens}`,
+  );
   showSubscribeDialog.value = false;
   showTierDialog.value = false;
 }

--- a/src/pages/PublicCreatorProfilePage.vue
+++ b/src/pages/PublicCreatorProfilePage.vue
@@ -129,17 +129,17 @@ export default defineComponent({
     };
 
     const confirmSubscribe = async ({ months, amount, startDate }: any) => {
-      const token = await donationStore.createDonationPreset(
+      const tokens = await donationStore.createDonationPreset(
         months,
         amount,
         creatorNpub,
         selectedTier.value.id,
         startDate,
       );
-      if (token) {
+      if (!months || months <= 0) {
         lockedStore.addLockedToken({
           amount,
-          token,
+          token: tokens,
           pubkey: creatorNpub,
           bucketId: selectedTier.value.id,
         });
@@ -150,12 +150,10 @@ export default defineComponent({
         supporterName =
           prof?.display_name || prof?.name || prof?.username || nostr.pubkey;
       } catch {}
-      if (token) {
-        await nostr.sendNip04DirectMessage(
-          creatorNpub,
-          `${supporterName} just subscribed to ${selectedTier.value.name}. Here is your receipt:\n${token}`,
-        );
-      }
+      await nostr.sendNip04DirectMessage(
+        creatorNpub,
+        `${supporterName} just subscribed to ${selectedTier.value.name}. Here is your receipt:\n${tokens}`,
+      );
       showSubscribeDialog.value = false;
     };
     function renderMarkdown(text: string): string {

--- a/src/stores/donationPresets.ts
+++ b/src/stores/donationPresets.ts
@@ -31,7 +31,7 @@ export const useDonationPresetsStore = defineStore("donationPresets", {
       pubkey: string,
       bucketId: string = DEFAULT_BUCKET_ID,
       startDate?: number,
-    ): Promise<string | void> {
+    ): Promise<string> {
       const walletStore = useWalletStore();
       const proofsStore = useProofsStore();
       const mintsStore = useMintsStore();
@@ -53,6 +53,7 @@ export const useDonationPresetsStore = defineStore("donationPresets", {
         return proofsStore.serializeProofs(sendProofs);
       }
 
+      const tokens: string[] = [];
       const base =
         startDate ?? Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60;
       for (let i = 0; i < months; i++) {
@@ -66,6 +67,7 @@ export const useDonationPresetsStore = defineStore("donationPresets", {
           locktime,
         );
         const token = proofsStore.serializeProofs(sendProofs);
+        tokens.push(token);
         lockedStore.addLockedToken({
           amount,
           token,
@@ -74,6 +76,7 @@ export const useDonationPresetsStore = defineStore("donationPresets", {
           bucketId,
         });
       }
+      return tokens.join("\n");
     },
   },
 });


### PR DESCRIPTION
## Summary
- collect tokens for scheduled donations and return them
- send receipts for all donations via DM

## Testing
- `npm test` *(fails: Cannot find module 'vite-jsconfig-paths')*

------
https://chatgpt.com/codex/tasks/task_e_6843f3f52e448330b3c46ca0e5de9a02