### PR TITLE
Update subscription defaults

### DIFF
--- a/src/components/SubscribeDialog.vue
+++ b/src/components/SubscribeDialog.vue
@@ -30,14 +30,16 @@
           dense
           class="q-mt-md"
           label="Start Date"
+          :min="today"
+          required
         />
       </q-card-section>
       <q-card-actions align="right">
         <q-btn flat color="primary" @click="cancel">{{
-          $t('global.actions.cancel.label')
+          $t("global.actions.cancel.label")
         }}</q-btn>
         <q-btn flat color="primary" @click="confirm">{{
-          $t('global.actions.ok.label')
+          $t("global.actions.ok.label")
         }}</q-btn>
       </q-card-actions>
     </q-card>
@@ -45,22 +47,23 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, computed, ref, watch } from 'vue';
-import { useDonationPresetsStore } from 'stores/donationPresets';
+import { defineComponent, computed, ref, watch } from "vue";
+import { useDonationPresetsStore } from "stores/donationPresets";
 
 export default defineComponent({
-  name: 'SubscribeDialog',
+  name: "SubscribeDialog",
   props: {
     modelValue: Boolean,
     tier: { type: Object, required: true },
-    supporterPubkey: { type: String, default: '' },
+    supporterPubkey: { type: String, default: "" },
   },
-  emits: ['update:modelValue', 'confirm'],
+  emits: ["update:modelValue", "confirm"],
   setup(props, { emit }) {
     const donationStore = useDonationPresetsStore();
     const months = ref(donationStore.presets[0]?.months || 0);
     const amount = ref(0);
-    const startDate = ref('');
+    const today = new Date().toISOString().slice(0, 10);
+    const startDate = ref(today);
 
     watch(
       () => props.tier,
@@ -69,35 +72,36 @@ export default defineComponent({
           amount.value = t.price_sats ?? t.price ?? 0;
         }
       },
-      { immediate: true, deep: true },
+      { immediate: true, deep: true }
     );
 
     const model = computed({
       get: () => props.modelValue,
-      set: (v: boolean) => emit('update:modelValue', v),
+      set: (v: boolean) => emit("update:modelValue", v),
     });
 
     const presetOptions = computed(() =>
       donationStore.presets.map((p) => ({
         label: `${p.months}m`,
         value: p.months,
-      })),
+      }))
     );
 
     const cancel = () => {
-      emit('update:modelValue', false);
+      emit("update:modelValue", false);
     };
 
     const confirm = () => {
-      const ts = startDate.value
-        ? Math.floor(new Date(startDate.value).getTime() / 1000)
-        : undefined;
-      emit('confirm', {
+      if (!startDate.value) {
+        return;
+      }
+      const ts = Math.floor(new Date(startDate.value).getTime() / 1000);
+      emit("confirm", {
         months: months.value,
         amount: amount.value,
         startDate: ts,
       });
-      emit('update:modelValue', false);
+      emit("update:modelValue", false);
     };
 
     return {
@@ -106,10 +110,10 @@ export default defineComponent({
       months,
       presetOptions,
       startDate,
+      today,
       cancel,
       confirm,
     };
   },
 });
 </script>
-

--- a/src/stores/donationPresets.ts
+++ b/src/stores/donationPresets.ts
@@ -21,7 +21,7 @@ export const useDonationPresetsStore = defineStore("donationPresets", {
   state: () => ({
     presets: useLocalStorage<DonationPreset[]>(
       "cashu.donationPresets",
-      DEFAULT_PRESETS,
+      DEFAULT_PRESETS
     ),
   }),
   actions: {
@@ -30,7 +30,7 @@ export const useDonationPresetsStore = defineStore("donationPresets", {
       amount: number,
       pubkey: string,
       bucketId: string = DEFAULT_BUCKET_ID,
-      startDate?: number,
+      startDate?: number
     ): Promise<string> {
       const walletStore = useWalletStore();
       const proofsStore = useProofsStore();
@@ -39,7 +39,7 @@ export const useDonationPresetsStore = defineStore("donationPresets", {
 
       const wallet = walletStore.wallet;
       const proofs = mintsStore.activeProofs.filter(
-        (p) => p.bucketId === bucketId,
+        (p) => p.bucketId === bucketId
       );
 
       if (!months || months <= 0) {
@@ -48,14 +48,13 @@ export const useDonationPresetsStore = defineStore("donationPresets", {
           wallet,
           amount,
           pubkey,
-          bucketId,
+          bucketId
         );
         return proofsStore.serializeProofs(sendProofs);
       }
 
       const tokens: string[] = [];
-      const base =
-        startDate ?? Math.floor(Date.now() / 1000) + 30 * 24 * 60 * 60;
+      const base = startDate ?? Math.floor(Date.now() / 1000);
       for (let i = 0; i < months; i++) {
         const locktime = base + i * 30 * 24 * 60 * 60;
         const { sendProofs } = await walletStore.sendToLock(
@@ -64,7 +63,7 @@ export const useDonationPresetsStore = defineStore("donationPresets", {
           amount,
           pubkey,
           bucketId,
-          locktime,
+          locktime
         );
         const token = proofsStore.serializeProofs(sendProofs);
         tokens.push(token);


### PR DESCRIPTION
## Summary
- set subscription start date to default to today and require a date
- restrict selectable dates to today or later
- prevent emitting when no start date is selected
- start scheduled donation locktime from today when no start date provided

## Testing
- `npm test` *(fails: Cannot find module 'vite-jsconfig-paths')*

------
https://chatgpt.com/codex/tasks/task_e_6843f567bdb88330823e5b6b1c2dce76