### PR TITLE
Display total in subscription dialog

### DIFF
--- a/src/components/SubscribeDialog.vue
+++ b/src/components/SubscribeDialog.vue
@@ -33,6 +33,9 @@
           :min="today"
           required
         />
+        <div class="q-mt-md text-right">
+          Total: {{ total }} sats
+        </div>
       </q-card-section>
       <q-card-actions align="right">
         <q-btn flat color="primary" @click="cancel">{{
@@ -64,6 +67,7 @@ export default defineComponent({
     const amount = ref(0);
     const today = new Date().toISOString().slice(0, 10);
     const startDate = ref(today);
+    const total = computed(() => amount.value * months.value);
 
     watch(
       () => props.tier,
@@ -100,6 +104,7 @@ export default defineComponent({
         months: months.value,
         amount: amount.value,
         startDate: ts,
+        total: total.value,
       });
       emit("update:modelValue", false);
     };
@@ -111,6 +116,7 @@ export default defineComponent({
       presetOptions,
       startDate,
       today,
+      total,
       cancel,
       confirm,
     };

--- a/src/pages/FindCreators.vue
+++ b/src/pages/FindCreators.vue
@@ -123,7 +123,7 @@ function openSubscribe(tier: any) {
   showSubscribeDialog.value = true;
 }
 
-async function confirmSubscribe({ months, amount, startDate }: any) {
+async function confirmSubscribe({ months, amount, startDate, total }: any) {
   if (!dialogPubkey.value) return;
   const tokens = await donationStore.createDonationPreset(
     months,
@@ -148,7 +148,7 @@ async function confirmSubscribe({ months, amount, startDate }: any) {
   } catch {}
   await nostr.sendNip04DirectMessage(
     dialogPubkey.value,
-    `${supporterName} just subscribed to ${selectedTier.value.name}. Here is your receipt:\n${tokens}`,
+    `${supporterName} just subscribed to ${selectedTier.value.name} for ${total} sats. Here is your receipt:\n${tokens}`,
   );
   showSubscribeDialog.value = false;
   showTierDialog.value = false;

--- a/src/pages/PublicCreatorProfilePage.vue
+++ b/src/pages/PublicCreatorProfilePage.vue
@@ -128,7 +128,7 @@ export default defineComponent({
       showSubscribeDialog.value = true;
     };
 
-    const confirmSubscribe = async ({ months, amount, startDate }: any) => {
+    const confirmSubscribe = async ({ months, amount, startDate, total }: any) => {
       const tokens = await donationStore.createDonationPreset(
         months,
         amount,
@@ -152,7 +152,7 @@ export default defineComponent({
       } catch {}
       await nostr.sendNip04DirectMessage(
         creatorNpub,
-        `${supporterName} just subscribed to ${selectedTier.value.name}. Here is your receipt:\n${tokens}`,
+        `${supporterName} just subscribed to ${selectedTier.value.name} for ${total} sats. Here is your receipt:\n${tokens}`,
       );
       showSubscribeDialog.value = false;
     };


### PR DESCRIPTION
## Summary
- display the total cost in `SubscribeDialog`
- emit the total cost through the confirm event
- include the total in DM text for subscriptions

## Testing
- `npm test --silent` *(fails: Cannot find module 'vite-jsconfig-paths')*

------
https://chatgpt.com/codex/tasks/task_e_6843f673fb80833080f3de193eaacb82