### PR TITLE
Fix locked token logic for subscriptions

### DIFF
--- a/src/pages/FindCreators.vue
+++ b/src/pages/FindCreators.vue
@@ -132,7 +132,7 @@ async function confirmSubscribe({ months, amount, startDate, total }: any) {
     selectedTier.value.id,
     startDate,
   );
-  if (!months || months <= 0) {
+  if (months === undefined || months <= 0) {
     lockedStore.addLockedToken({
       amount,
       token: tokens,

--- a/src/pages/PublicCreatorProfilePage.vue
+++ b/src/pages/PublicCreatorProfilePage.vue
@@ -136,7 +136,7 @@ export default defineComponent({
         selectedTier.value.id,
         startDate,
       );
-      if (!months || months <= 0) {
+      if (months === undefined || months <= 0) {
         lockedStore.addLockedToken({
           amount,
           token: tokens,


### PR DESCRIPTION
## Summary
- ensure `confirmSubscribe` only adds a locked token when `createDonationPreset` returns a single token

## Testing
- `npm test --silent` *(fails: Cannot find module 'vite-jsconfig-paths')*

------
https://chatgpt.com/codex/tasks/task_e_6843f7df2a048330a4f80ab5baad09e6