### PR TITLE
Ensure one-month preset exists

### DIFF
--- a/src/stores/donationPresets.ts
+++ b/src/stores/donationPresets.ts
@@ -18,12 +18,16 @@ const DEFAULT_PRESETS: DonationPreset[] = [
 ];
 
 export const useDonationPresetsStore = defineStore("donationPresets", {
-  state: () => ({
-    presets: useLocalStorage<DonationPreset[]>(
+  state: () => {
+    const presets = useLocalStorage<DonationPreset[]>(
       "cashu.donationPresets",
       DEFAULT_PRESETS
-    ),
-  }),
+    );
+    if (!presets.value.find((p) => p.months === 1)) {
+      presets.value.unshift({ months: 1 });
+    }
+    return { presets };
+  },
   actions: {
     async createDonationPreset(
       months: number | undefined,

--- a/test/vitest/__tests__/donationPresets.spec.ts
+++ b/test/vitest/__tests__/donationPresets.spec.ts
@@ -40,6 +40,7 @@ describe("Donation presets", () => {
   it("has default presets", () => {
     const store = useDonationPresetsStore();
     expect(store.presets.length).toBe(4);
+    expect(store.presets[0].months).toBe(1);
   });
 
   it("calls sendToLock with sequential locktimes", async () => {


### PR DESCRIPTION
## Summary
- ensure 1-month subscription option is available
- test for one-month preset

## Testing
- `npm test --silent` *(fails: Cannot find module 'vite-jsconfig-paths')*

------
https://chatgpt.com/codex/tasks/task_e_6843f9a76b008330bab554646b4e0acb