### PR TITLE
Add subscription receipt dialog

### DIFF
--- a/src/components/SubscriptionReceipt.vue
+++ b/src/components/SubscriptionReceipt.vue
@@ -1,0 +1,63 @@
+<template>
+  <q-dialog v-model="model" persistent backdrop-filter="blur(2px) brightness(60%)">
+    <q-card class="q-pa-md qcard" style="min-width:300px">
+      <q-card-section class="text-h6">{{ $t('SubscriptionReceipt.title') }}</q-card-section>
+      <q-card-section>
+        <q-input v-model="token" readonly type="textarea" autogrow style="font-family: monospace" />
+      </q-card-section>
+      <q-card-actions align="right">
+        <q-btn flat color="primary" @click="copyToken">{{ $t('global.actions.copy.label') }}</q-btn>
+        <q-btn flat color="primary" @click="saveToken">{{ $t('SubscriptionReceipt.actions.save.label') }}</q-btn>
+        <q-btn v-close-popup flat color="grey">{{ $t('global.actions.close.label') }}</q-btn>
+      </q-card-actions>
+    </q-card>
+  </q-dialog>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  name: 'SubscriptionReceipt',
+  mixins: [windowMixin],
+  props: {
+    modelValue: Boolean,
+    token: {
+      type: String,
+      required: true,
+    },
+  },
+  emits: ['update:modelValue'],
+  computed: {
+    model: {
+      get(): boolean {
+        return this.modelValue;
+      },
+      set(v: boolean) {
+        this.$emit('update:modelValue', v);
+      },
+    },
+  },
+  methods: {
+    copyToken() {
+      this.copyText(this.token);
+    },
+    saveToken() {
+      const blob = new Blob([this.token], { type: 'text/plain' });
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = 'subscription_token.txt';
+      link.style.display = 'none';
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      window.URL.revokeObjectURL(url);
+    },
+  },
+});
+</script>
+
+<style scoped>
+</style>
+

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -37,6 +37,9 @@ export default {
       send: {
         label: "Send",
       },
+      save: {
+        label: "Save",
+      },
       swap: {
         label: "Swap",
       },
@@ -1071,6 +1074,14 @@ export default {
     inputs: {
       amount: {
         placeholder: "Enter amount",
+      },
+    },
+  },
+  SubscriptionReceipt: {
+    title: "Subscription Receipt",
+    actions: {
+      save: {
+        label: "@:global.actions.save.label",
       },
     },
   },

--- a/src/pages/FindCreators.vue
+++ b/src/pages/FindCreators.vue
@@ -13,6 +13,7 @@
       :supporter-pubkey="nostr.pubkey"
       @confirm="confirmSubscribe"
     />
+    <SubscriptionReceipt v-model="showReceiptDialog" :token="receiptToken" />
     <SendTokenDialog />
     <QDialog v-model="showTierDialog">
       <QCard class="tier-dialog">
@@ -55,6 +56,7 @@
 import { ref, computed, onMounted, onBeforeUnmount, nextTick } from 'vue';
 import DonateDialog from 'components/DonateDialog.vue';
 import SubscribeDialog from 'components/SubscribeDialog.vue';
+import SubscriptionReceipt from 'components/SubscriptionReceipt.vue';
 import SendTokenDialog from 'components/SendTokenDialog.vue';
 import { useSendTokensStore } from 'stores/sendTokensStore';
 import { useDonationPresetsStore } from 'stores/donationPresets';
@@ -82,6 +84,8 @@ const mintsStore = useMintsStore();
 const { t } = useI18n();
 const tiers = computed(() => creators.tiersMap[dialogPubkey.value] || []);
 const showSubscribeDialog = ref(false);
+const showReceiptDialog = ref(false);
+const receiptToken = ref('');
 const selectedTier = ref<any>(null);
 
 function getPrice(t: any): number {
@@ -156,6 +160,8 @@ async function confirmSubscribe({ bucketId, months, amount, startDate, total }: 
     } else {
       notifyError('Failed to send direct message');
     }
+    receiptToken.value = tokens;
+    showReceiptDialog.value = true;
     showSubscribeDialog.value = false;
     showTierDialog.value = false;
   } catch (e: any) {

--- a/src/pages/PublicCreatorProfilePage.vue
+++ b/src/pages/PublicCreatorProfilePage.vue
@@ -21,6 +21,7 @@
       :supporter-pubkey="nostr.pubkey"
       @confirm="confirmSubscribe"
     />
+    <SubscriptionReceipt v-model="showReceiptDialog" :token="receiptToken" />
     <div v-if="followers !== null" class="text-caption q-mb-md">
       {{ $t("FindCreators.labels.followers") }}: {{ followers }} |
       {{ $t("FindCreators.labels.following") }}: {{ following }}
@@ -79,6 +80,7 @@ import { useLockedTokensStore } from 'stores/lockedTokens';
 import { usePriceStore } from 'stores/price';
 import { useUiStore } from 'stores/ui';
 import SubscribeDialog from 'components/SubscribeDialog.vue';
+import SubscriptionReceipt from 'components/SubscriptionReceipt.vue';
 import { useMintsStore } from 'stores/mints';
 import { notifyError, notifySuccess } from 'src/js/notify';
 import { useI18n } from 'vue-i18n';
@@ -88,7 +90,7 @@ import PaywalledContent from 'components/PaywalledContent.vue';
 
 export default defineComponent({
   name: "PublicCreatorProfilePage",
-  components: { PaywalledContent },
+  components: { PaywalledContent, SubscriptionReceipt },
   setup() {
     const route = useRoute();
     const creatorNpub = route.params.npub as string;
@@ -104,6 +106,8 @@ export default defineComponent({
     const profile = ref<any>({});
     const tiers = computed(() => creators.tiersMap[creatorNpub] || []);
     const showSubscribeDialog = ref(false);
+    const showReceiptDialog = ref(false);
+    const receiptToken = ref('');
     const selectedTier = ref<any>(null);
     const followers = ref<number | null>(null);
     const following = ref<number | null>(null);
@@ -161,6 +165,8 @@ export default defineComponent({
         } else {
           notifyError('Failed to send direct message');
         }
+        receiptToken.value = tokens;
+        showReceiptDialog.value = true;
         showSubscribeDialog.value = false;
       } catch (e: any) {
         notifyError(e.message);
@@ -187,6 +193,8 @@ export default defineComponent({
       profile,
       tiers,
       showSubscribeDialog,
+      showReceiptDialog,
+      receiptToken,
       selectedTier,
       followers,
       following,


### PR DESCRIPTION
## Summary
- add new `SubscriptionReceipt` dialog to display subscription tokens
- allow copying or saving the token string
- show receipt dialog when confirming subscription on creator profile pages
- localize new dialog and action labels

## Testing
- `npm test` *(fails: Cannot find module 'vite-jsconfig-paths')*

------
https://chatgpt.com/codex/tasks/task_e_684405e9c22c8330961433de8f6fc6f0