### PR TITLE
Handle DM failure in subscription flow

### DIFF
--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -94,25 +94,25 @@
             </div>
           </div>
           <div class="row items-center no-wrap q-my-sm q-py-none">
-          <div class="col-12">
-            <ChooseMint />
+            <div class="col-12">
+              <ChooseMint />
+            </div>
           </div>
-        </div>
-        <div class="row q-my-sm">
-          <div class="col-12">
-            <q-select
-              v-model="sendData.bucketId"
-              :options="bucketOptions"
-              emit-value
-              map-options
-              outlined
-              dense
-              :label="$t('BucketManager.inputs.name')"
-            />
+          <div class="row q-my-sm">
+            <div class="col-12">
+              <q-select
+                v-model="sendData.bucketId"
+                :options="bucketOptions"
+                emit-value
+                map-options
+                outlined
+                dense
+                :label="$t('BucketManager.inputs.name')"
+              />
+            </div>
           </div>
-        </div>
 
-        <q-input
+          <q-input
             ref="amountInput"
             type="number"
             v-model.number="sendData.amount"
@@ -159,63 +159,73 @@
                   <q-input
                     v-model="sendData.p2pkPubkey"
                     :label="
-                    sendData.p2pkPubkey && !isValidPubkey(sendData.p2pkPubkey)
-                      ? $t('SendTokenDialog.inputs.p2pk_pubkey.label_invalid')
-                      : $t('SendTokenDialog.inputs.p2pk_pubkey.label')
-                  "
+                      sendData.p2pkPubkey && !isValidPubkey(sendData.p2pkPubkey)
+                        ? $t('SendTokenDialog.inputs.p2pk_pubkey.label_invalid')
+                        : $t('SendTokenDialog.inputs.p2pk_pubkey.label')
+                    "
+                    outlined
+                    clearable
+                    :color="
+                      sendData.p2pkPubkey && !isValidPubkey(sendData.p2pkPubkey)
+                        ? 'red'
+                        : ''
+                    "
+                    @keyup.enter="lockTokens"
+                  ></q-input>
+                </div>
+                <div class="col-4 q-mx-md">
+                  <q-btn
+                    unelevated
+                    v-if="canPasteFromClipboard && !sendData.p2pkPubkey"
+                    icon="content_paste"
+                    @click="pasteToP2PKField"
+                    :aria-label="
+                      $t(
+                        'SendTokenDialog.actions.paste_p2pk_pubkey.tooltip_text'
+                      )
+                    "
+                    :title="
+                      $t(
+                        'SendTokenDialog.actions.paste_p2pk_pubkey.tooltip_text'
+                      )
+                    "
+                    ><q-tooltip>{{
+                      $t(
+                        "SendTokenDialog.actions.paste_p2pk_pubkey.tooltip_text"
+                      )
+                    }}</q-tooltip></q-btn
+                  >
+                  <q-btn
+                    align="center"
+                    v-if="!sendData.p2pkPubkey"
+                    flat
+                    outline
+                    color="primary"
+                    round
+                    @click="showCamera"
+                    :aria-label="$t('global.actions.scan.label')"
+                    :title="$t('global.actions.scan.label')"
+                    ><ScanIcon size="1.5em"
+                  /></q-btn>
+                </div>
+              </div>
+              <div class="row q-mt-md">
+                <q-input
+                  v-model="locktimeInput"
+                  type="datetime-local"
+                  :label="$t('SendTokenDialog.inputs.locktime.label')"
                   outlined
-                  clearable
-                  :color="
-                    sendData.p2pkPubkey && !isValidPubkey(sendData.p2pkPubkey)
-                      ? 'red'
-                      : ''
-                  "
-                  @keyup.enter="lockTokens"
-                ></q-input>
+                  dense
+                  class="col-12 q-mb-sm"
+                />
+                <q-input
+                  v-model="sendData.refundPubkey"
+                  :label="$t('SendTokenDialog.inputs.refund_pubkey.label')"
+                  outlined
+                  dense
+                  class="col-12"
+                />
               </div>
-              <div class="col-4 q-mx-md">
-                <q-btn
-                  unelevated
-                  v-if="canPasteFromClipboard && !sendData.p2pkPubkey"
-                  icon="content_paste"
-                  @click="pasteToP2PKField"
-                  :aria-label="$t('SendTokenDialog.actions.paste_p2pk_pubkey.tooltip_text')"
-                  :title="$t('SendTokenDialog.actions.paste_p2pk_pubkey.tooltip_text')"
-                  ><q-tooltip>{{
-                    $t("SendTokenDialog.actions.paste_p2pk_pubkey.tooltip_text")
-                  }}</q-tooltip></q-btn
-                >
-                <q-btn
-                  align="center"
-                v-if="!sendData.p2pkPubkey"
-                flat
-                outline
-                color="primary"
-                round
-                @click="showCamera"
-                :aria-label="$t('global.actions.scan.label')"
-                :title="$t('global.actions.scan.label')"
-                ><ScanIcon size="1.5em"
-                /></q-btn>
-              </div>
-            </div>
-            <div class="row q-mt-md">
-              <q-input
-                v-model="locktimeInput"
-                type="datetime-local"
-                :label="$t('SendTokenDialog.inputs.locktime.label')"
-              outlined
-              dense
-              class="col-12 q-mb-sm"
-            />
-            <q-input
-              v-model="sendData.refundPubkey"
-              :label="$t('SendTokenDialog.inputs.refund_pubkey.label')"
-              outlined
-              dense
-              class="col-12"
-            />
-            </div>
             </div>
           </transition>
           <div v-if="activeBalance >= sendData.amount" class="row q-mt-lg">
@@ -470,8 +480,12 @@
                     @click="
                       copyText(baseURL + '#token=' + sendData.tokensBase64)
                     "
-                    :aria-label="$t('SendTokenDialog.actions.copy_link.tooltip_text')"
-                    :title="$t('SendTokenDialog.actions.copy_link.tooltip_text')"
+                    :aria-label="
+                      $t('SendTokenDialog.actions.copy_link.tooltip_text')
+                    "
+                    :title="
+                      $t('SendTokenDialog.actions.copy_link.tooltip_text')
+                    "
                     ><q-tooltip>{{
                       $t("SendTokenDialog.actions.copy_link.tooltip_text")
                     }}</q-tooltip></q-btn
@@ -508,13 +522,21 @@
                     flat
                     :aria-label="
                       ndefSupported
-                        ? $t('SendTokenDialog.actions.write_tokens_to_card.tooltips.ndef_supported_text')
-                        : $t('SendTokenDialog.actions.write_tokens_to_card.tooltips.ndef_unsupported_text')
+                        ? $t(
+                            'SendTokenDialog.actions.write_tokens_to_card.tooltips.ndef_supported_text'
+                          )
+                        : $t(
+                            'SendTokenDialog.actions.write_tokens_to_card.tooltips.ndef_unsupported_text'
+                          )
                     "
                     :title="
                       ndefSupported
-                        ? $t('SendTokenDialog.actions.write_tokens_to_card.tooltips.ndef_supported_text')
-                        : $t('SendTokenDialog.actions.write_tokens_to_card.tooltips.ndef_unsupported_text')
+                        ? $t(
+                            'SendTokenDialog.actions.write_tokens_to_card.tooltips.ndef_supported_text'
+                          )
+                        : $t(
+                            'SendTokenDialog.actions.write_tokens_to_card.tooltips.ndef_unsupported_text'
+                          )
                     "
                   >
                     <NfcIcon />
@@ -542,7 +564,9 @@
                       closeCardScanner();
                     "
                     flat
-                    :aria-label="$t('SendTokenDialog.actions.delete.tooltip_text')"
+                    :aria-label="
+                      $t('SendTokenDialog.actions.delete.tooltip_text')
+                    "
                     :title="$t('SendTokenDialog.actions.delete.tooltip_text')"
                   >
                     <q-tooltip>{{
@@ -1166,7 +1190,7 @@ export default defineComponent({
           this.sendData.p2pkPubkey,
           bucketId,
           this.sendData.locktime || undefined,
-          this.sendData.refundPubkey || undefined,
+          this.sendData.refundPubkey || undefined
         );
         // update UI
         this.sendData.tokens = sendProofs;
@@ -1175,7 +1199,10 @@ export default defineComponent({
         if (this.sendViaNostr && this.recipientPubkey) {
           try {
             let recipient = this.recipientPubkey;
-            if (recipient.startsWith("npub") || recipient.startsWith("nprofile")) {
+            if (
+              recipient.startsWith("npub") ||
+              recipient.startsWith("nprofile")
+            ) {
               try {
                 const decoded = nip19.decode(recipient);
                 recipient =
@@ -1189,12 +1216,13 @@ export default defineComponent({
             const dmContent = this.sendData.memo
               ? `${this.sendData.memo}\n${this.sendData.tokensBase64}`
               : this.sendData.tokensBase64;
-            const ev = await useNostrStore().sendNip04DirectMessage(
-              recipient,
-              dmContent,
-            );
-            if (ev) {
-              useDmChatsStore().addOutgoing(ev);
+            const { success, event } =
+              await useNostrStore().sendNip04DirectMessage(
+                recipient,
+                dmContent
+              );
+            if (success && event) {
+              useDmChatsStore().addOutgoing(event);
               Dialog.create({
                 message: this.$t(
                   "wallet.notifications.nostr_dm_sent"
@@ -1242,20 +1270,22 @@ export default defineComponent({
           message: this.$t(
             "FindCreators.notifications.donation_sent"
           ) as string,
-          ok: { label: this.$t("FindCreators.actions.back_to_search") as string },
+          ok: {
+            label: this.$t("FindCreators.actions.back_to_search") as string,
+          },
         }).onOk(() => {
           this.showSendTokens = false;
           this.$router.push("/find-creators");
         });
 
-      if (!this.g.offline) {
-        this.onTokenPaid(historyToken);
+        if (!this.g.offline) {
+          this.onTokenPaid(historyToken);
+        }
+      } catch (error) {
+        console.error(error);
+        notifyError("Failed to send tokens");
       }
-    } catch (error) {
-      console.error(error);
-      notifyError("Failed to send tokens");
-    }
-  },
+    },
     sendTokens: async function () {
       /*
       calls send, displays token and kicks off the spendableWorker
@@ -1281,7 +1311,9 @@ export default defineComponent({
         }
       }
       if (!nostrDm) {
-        this.sendData.p2pkPubkey = this.maybeConvertNpub(this.sendData.p2pkPubkey);
+        this.sendData.p2pkPubkey = this.maybeConvertNpub(
+          this.sendData.p2pkPubkey
+        );
         if (
           this.sendData.p2pkPubkey &&
           this.isValidPubkey(this.sendData.p2pkPubkey)
@@ -1312,7 +1344,10 @@ export default defineComponent({
         if (this.sendViaNostr && this.recipientPubkey) {
           try {
             let recipient = this.recipientPubkey;
-            if (recipient.startsWith("npub") || recipient.startsWith("nprofile")) {
+            if (
+              recipient.startsWith("npub") ||
+              recipient.startsWith("nprofile")
+            ) {
               try {
                 const decoded = nip19.decode(recipient);
                 recipient =
@@ -1326,12 +1361,13 @@ export default defineComponent({
             const dmContent2 = this.sendData.memo
               ? `${this.sendData.memo}\n${this.sendData.tokensBase64}`
               : this.sendData.tokensBase64;
-            const ev = await useNostrStore().sendNip04DirectMessage(
-              recipient,
-              dmContent2,
-            );
-            if (ev) {
-              useDmChatsStore().addOutgoing(ev);
+            const { success, event } =
+              await useNostrStore().sendNip04DirectMessage(
+                recipient,
+                dmContent2
+              );
+            if (success && event) {
+              useDmChatsStore().addOutgoing(event);
               Dialog.create({
                 message: this.$t(
                   "wallet.notifications.nostr_dm_sent"
@@ -1373,14 +1409,14 @@ export default defineComponent({
         this.addPendingToken(historyToken);
         this.sendData.historyToken = historyToken;
 
-      if (!this.g.offline) {
-        this.onTokenPaid(historyToken);
+        if (!this.g.offline) {
+          this.onTokenPaid(historyToken);
+        }
+      } catch (error) {
+        console.error(error);
+        notifyError("Failed to send tokens");
       }
-    } catch (error) {
-      console.error(error);
-      notifyError("Failed to send tokens");
-    }
-  },
+    },
     pasteToP2PKField: async function () {
       console.log("pasteToParseDialog");
       const text = await useUiStore().pasteFromClipboard();

--- a/src/pages/ChatView.vue
+++ b/src/pages/ChatView.vue
@@ -3,22 +3,27 @@
     :class="[$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark']"
     class="flex column full-height"
   >
-    <q-header elevated reveal class="border-bottom" style="border-bottom: 1px solid rgba(0,0,0,0.1)">
+    <q-header
+      elevated
+      reveal
+      class="border-bottom"
+      style="border-bottom: 1px solid rgba(0, 0, 0, 0.1)"
+    >
       <q-toolbar class="q-pa-sm">
         <q-btn
           flat
           dense
           round
           icon="arrow_back"
-        color="primary"
-        @click="goBack"
-        aria-label="Go back"
-        class="q-mr-sm"
-      />
-      <q-avatar v-if="avatar" size="md" class="q-mr-sm">
-        <img :src="avatar" />
-      </q-avatar>
-      <q-toolbar-title class="text-h6">{{ displayName }}</q-toolbar-title>
+          color="primary"
+          @click="goBack"
+          aria-label="Go back"
+          class="q-mr-sm"
+        />
+        <q-avatar v-if="avatar" size="md" class="q-mr-sm">
+          <img :src="avatar" />
+        </q-avatar>
+        <q-toolbar-title class="text-h6">{{ displayName }}</q-toolbar-title>
       </q-toolbar>
     </q-header>
     <div class="q-pa-md scroll-area col" ref="scrollArea">
@@ -56,15 +61,22 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, computed, watch, onMounted, nextTick } from 'vue';
-import { useRoute, useRouter } from 'vue-router';
-import { useDmChatsStore } from 'stores/dmChats';
-import { storeToRefs } from 'pinia';
-import { useNostrStore } from 'stores/nostr';
-import { sanitizeMessage } from 'src/js/message-utils';
+import {
+  defineComponent,
+  ref,
+  computed,
+  watch,
+  onMounted,
+  nextTick,
+} from "vue";
+import { useRoute, useRouter } from "vue-router";
+import { useDmChatsStore } from "stores/dmChats";
+import { storeToRefs } from "pinia";
+import { useNostrStore } from "stores/nostr";
+import { sanitizeMessage } from "src/js/message-utils";
 
 export default defineComponent({
-  name: 'ChatView',
+  name: "ChatView",
   setup() {
     const route = useRoute();
     const router = useRouter();
@@ -74,7 +86,7 @@ export default defineComponent({
     const { chats } = storeToRefs(dmStore);
     const nostrStore = useNostrStore();
     const profile = ref<any>(null);
-    const newMessage = ref('');
+    const newMessage = ref("");
     const bottomMarker = ref<HTMLElement | null>(null);
 
     const messages = computed(() => chats.value[pubkey] || []);
@@ -86,7 +98,7 @@ export default defineComponent({
     const scrollToBottom = () => {
       nextTick(() => {
         if (bottomMarker.value) {
-          bottomMarker.value.scrollIntoView({ behavior: 'smooth' });
+          bottomMarker.value.scrollIntoView({ behavior: "smooth" });
         }
       });
     };
@@ -106,26 +118,29 @@ export default defineComponent({
     const sendMessage = async () => {
       const content = newMessage.value.trim();
       if (!content) return;
-      const ev = await nostrStore.sendNip04DirectMessage(pubkey, content);
-      if (ev) {
-        dmStore.addOutgoing(ev);
-        newMessage.value = '';
+      const { success, event } = await nostrStore.sendNip04DirectMessage(
+        pubkey,
+        content
+      );
+      if (success && event) {
+        dmStore.addOutgoing(event);
+        newMessage.value = "";
       }
     };
 
     const goBack = () => {
-      router.push('/chats');
+      router.push("/chats");
     };
 
     const displayName = computed(() => {
       return (
         profile.value?.display_name ||
         profile.value?.name ||
-        pubkey.slice(0, 8) + '...' + pubkey.slice(-4)
+        pubkey.slice(0, 8) + "..." + pubkey.slice(-4)
       );
     });
 
-    const avatar = computed(() => profile.value?.picture || '');
+    const avatar = computed(() => profile.value?.picture || "");
 
     const formatDate = (ts: number) => new Date(ts * 1000).toLocaleString();
 

--- a/src/pages/PublicCreatorProfilePage.vue
+++ b/src/pages/PublicCreatorProfilePage.vue
@@ -33,7 +33,13 @@
         Creator has no subscription tiers
       </div>
       <div v-else>
-        <q-card v-for="t in tiers" :key="t.id" flat bordered class="q-mb-md tier-card">
+        <q-card
+          v-for="t in tiers"
+          :key="t.id"
+          flat
+          bordered
+          class="q-mb-md tier-card"
+        >
           <q-card-section class="row items-center justify-between bg-grey-2">
             <div class="text-subtitle1">{{ t.name }}</div>
             <div class="text-subtitle2">
@@ -46,7 +52,9 @@
           <q-card-section>
             <div class="text-body1 q-mb-sm">{{ t.description }}</div>
             <ul class="q-pl-md q-mb-none">
-              <li v-for="benefit in t.benefits" :key="benefit">{{ benefit }}</li>
+              <li v-for="benefit in t.benefits" :key="benefit">
+                {{ benefit }}
+              </li>
             </ul>
             <div class="q-mt-md text-right subscribe-container">
               <q-btn
@@ -71,22 +79,22 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, ref, onMounted, computed } from 'vue';
-import { useRoute } from 'vue-router';
-import { useCreatorsStore } from 'stores/creators';
-import { useNostrStore } from 'stores/nostr';
-import { useDonationPresetsStore } from 'stores/donationPresets';
-import { useLockedTokensStore } from 'stores/lockedTokens';
-import { usePriceStore } from 'stores/price';
-import { useUiStore } from 'stores/ui';
-import SubscribeDialog from 'components/SubscribeDialog.vue';
-import SubscriptionReceipt from 'components/SubscriptionReceipt.vue';
-import { useMintsStore } from 'stores/mints';
-import { notifyError, notifySuccess } from 'src/js/notify';
-import { useI18n } from 'vue-i18n';
-import { Loading } from 'quasar';
-import { renderMarkdown as renderMarkdownFn } from 'src/js/simple-markdown';
-import PaywalledContent from 'components/PaywalledContent.vue';
+import { defineComponent, ref, onMounted, computed } from "vue";
+import { useRoute } from "vue-router";
+import { useCreatorsStore } from "stores/creators";
+import { useNostrStore } from "stores/nostr";
+import { useDonationPresetsStore } from "stores/donationPresets";
+import { useLockedTokensStore } from "stores/lockedTokens";
+import { usePriceStore } from "stores/price";
+import { useUiStore } from "stores/ui";
+import SubscribeDialog from "components/SubscribeDialog.vue";
+import SubscriptionReceipt from "components/SubscriptionReceipt.vue";
+import { useMintsStore } from "stores/mints";
+import { notifyError, notifySuccess } from "src/js/notify";
+import { useI18n } from "vue-i18n";
+import { Loading } from "quasar";
+import { renderMarkdown as renderMarkdownFn } from "src/js/simple-markdown";
+import PaywalledContent from "components/PaywalledContent.vue";
 
 export default defineComponent({
   name: "PublicCreatorProfilePage",
@@ -107,7 +115,7 @@ export default defineComponent({
     const tiers = computed(() => creators.tiersMap[creatorNpub] || []);
     const showSubscribeDialog = ref(false);
     const showReceiptDialog = ref(false);
-    const receiptToken = ref('');
+    const receiptToken = ref("");
     const selectedTier = ref<any>(null);
     const followers = ref<number | null>(null);
     const following = ref<number | null>(null);
@@ -125,22 +133,28 @@ export default defineComponent({
         ? info.nut_supports
         : Object.keys(info.nuts || {}).map((n) => Number(n));
       if (!(nuts.includes(10) && nuts.includes(11))) {
-        notifyError(t('wallet.notifications.lock_not_supported'));
+        notifyError(t("wallet.notifications.lock_not_supported"));
         return;
       }
       selectedTier.value = tier;
       showSubscribeDialog.value = true;
     };
 
-    const confirmSubscribe = async ({ bucketId, months, amount, startDate, total }: any) => {
-      Loading.show({ message: 'Loading...' });
+    const confirmSubscribe = async ({
+      bucketId,
+      months,
+      amount,
+      startDate,
+      total,
+    }: any) => {
+      Loading.show({ message: "Loading..." });
       try {
         const tokens = await donationStore.createDonationPreset(
           months,
           amount,
           creatorNpub,
           bucketId,
-          startDate,
+          startDate
         );
         if (months === undefined || months <= 0) {
           lockedStore.addLockedToken({
@@ -156,14 +170,14 @@ export default defineComponent({
           supporterName =
             prof?.display_name || prof?.name || prof?.username || nostr.pubkey;
         } catch {}
-        const ev = await nostr.sendNip04DirectMessage(
+        const { success } = await nostr.sendNip04DirectMessage(
           creatorNpub,
-          `${supporterName} just subscribed to ${selectedTier.value.name} for ${total} sats. Here is your receipt:\n${tokens}`,
+          `${supporterName} just subscribed to ${selectedTier.value.name} for ${total} sats. Here is your receipt:\n${tokens}`
         );
-        if (ev) {
-          notifySuccess(t('FindCreators.notifications.subscription_success'));
+        if (success) {
+          notifySuccess(t("FindCreators.notifications.subscription_success"));
         } else {
-          notifyError('Failed to send direct message');
+          notifyWarning(t("wallet.notifications.nostr_dm_failed"));
         }
         receiptToken.value = tokens;
         showReceiptDialog.value = true;

--- a/src/stores/messenger.ts
+++ b/src/stores/messenger.ts
@@ -27,15 +27,15 @@ export const useMessengerStore = defineStore("messenger", {
     relays: useSettingsStore().defaultNostrRelays,
     conversations: useLocalStorage<Record<string, MessengerMessage[]>>(
       "cashu.messenger.conversations",
-      {} as Record<string, MessengerMessage[]>,
+      {} as Record<string, MessengerMessage[]>
     ),
     unreadCounts: useLocalStorage<Record<string, number>>(
       "cashu.messenger.unread",
-      {} as Record<string, number>,
+      {} as Record<string, number>
     ),
     eventLog: useLocalStorage<MessengerMessage[]>(
       "cashu.messenger.eventLog",
-      [] as MessengerMessage[],
+      [] as MessengerMessage[]
     ),
     started: false,
     watchInitialized: false,
@@ -59,22 +59,22 @@ export const useMessengerStore = defineStore("messenger", {
     async sendDm(recipient: string, message: string) {
       this.loadIdentity();
       const nostr = useNostrStore();
-      const ev = await nostr.sendNip04DirectMessage(
+      const { success, event } = await nostr.sendNip04DirectMessage(
         recipient,
         message,
         this.privKey,
-        this.pubKey,
+        this.pubKey
       );
-      if (ev) {
-        this.addOutgoingMessage(recipient, message, ev.created_at, ev.id);
+      if (success && event) {
+        this.addOutgoingMessage(recipient, message, event.created_at, event.id);
       }
-      return ev as any;
+      return { success, event } as any;
     },
     addOutgoingMessage(
       pubkey: string,
       content: string,
       created_at?: number,
-      id?: string,
+      id?: string
     ) {
       const messageId = id || uuidv4();
       if (this.eventLog.some((m) => m.id === messageId)) return;
@@ -96,7 +96,7 @@ export const useMessengerStore = defineStore("messenger", {
       const decrypted = await nostr.decryptNip04(
         this.privKey,
         event.pubkey,
-        event.content,
+        event.content
       );
       if (this.eventLog.some((m) => m.id === event.id)) return;
       const msg: MessengerMessage = {
@@ -126,7 +126,7 @@ export const useMessengerStore = defineStore("messenger", {
               this.start();
             }
           },
-          { deep: true },
+          { deep: true }
         );
         this.watchInitialized = true;
       }
@@ -140,7 +140,7 @@ export const useMessengerStore = defineStore("messenger", {
         this.pubKey,
         async (ev, _decrypted) => {
           await this.addIncomingMessage(ev as NostrEvent);
-        },
+        }
       );
       this.started = true;
     },
@@ -181,4 +181,3 @@ export const useMessengerStore = defineStore("messenger", {
     },
   },
 });
-

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -432,7 +432,7 @@ export const useNostrStore = defineStore("nostr", {
       message: string,
       privKey?: string,
       pubKey?: string
-    ) {
+    ): Promise<{ success: boolean; event: NDKEvent | null }> {
       recipient = this.resolvePubkey(recipient);
       if (pubKey) {
         pubKey = this.resolvePubkey(pubKey);
@@ -462,11 +462,11 @@ export const useNostrStore = defineStore("nostr", {
       try {
         await pool.publish(this.relays, nostrEvent);
         notifySuccess("NIP-04 event published");
-        return event;
+        return { success: true, event };
       } catch (e) {
         console.error(e);
         notifyError("Could not publish NIP-04 event");
-        return null;
+        return { success: false, event: null };
       }
     },
     subscribeToNip04DirectMessages: async function () {
@@ -804,7 +804,7 @@ export function getEventHash(event: NostrEvent): string {
 
 export async function signEvent(
   event: NostrEvent,
-  privkey: string,
+  privkey: string
 ): Promise<string> {
   try {
     const signed = finalizeEvent(event as any, hexToBytes(privkey));
@@ -826,10 +826,7 @@ export async function publishEvent(event: NostrEvent): Promise<void> {
   }
 }
 
-export function subscribeToNostr(
-  filter: any,
-  cb: (ev: NostrEvent) => void,
-) {
+export function subscribeToNostr(filter: any, cb: (ev: NostrEvent) => void) {
   const relays = useSettingsStore().defaultNostrRelays;
   const pool = new SimplePool();
   try {

--- a/test/vitest/__tests__/nostr.spec.ts
+++ b/test/vitest/__tests__/nostr.spec.ts
@@ -117,9 +117,10 @@ describe("sendNip04DirectMessage", () => {
     const store = useNostrStore();
     const promise = store.sendNip04DirectMessage("r", "m");
     vi.runAllTimers();
-    const ev = await promise;
-    expect(ev).not.toBeNull();
-    expect(ev!.sig).toBeDefined();
+    const res = await promise;
+    expect(res.success).toBe(true);
+    expect(res.event).not.toBeNull();
+    expect(res.event!.sig).toBeDefined();
     const used = encryptMock.mock.calls[0][0];
     const parsed = JSON.parse(used);
     expect(parsed.sig).toBeDefined();
@@ -127,19 +128,20 @@ describe("sendNip04DirectMessage", () => {
 
   it("constructs event with correct kind and tags", async () => {
     const store = useNostrStore();
-    const ev = await store.sendNip04DirectMessage("receiver", "msg");
+    const res = await store.sendNip04DirectMessage("receiver", "msg");
     vi.runAllTimers();
-    expect(ev!.kind).toBe(NDKKind.EncryptedDirectMessage);
-    expect(ev!.tags).toContainEqual(["p", "receiver"]);
-    expect(ev!.tags).toContainEqual(["p", store.seedSignerPublicKey]);
+    expect(res.event!.kind).toBe(NDKKind.EncryptedDirectMessage);
+    expect(res.event!.tags).toContainEqual(["p", "receiver"]);
+    expect(res.event!.tags).toContainEqual(["p", store.seedSignerPublicKey]);
   });
 
   it("generates keypair if not set", async () => {
     const store = useNostrStore();
     expect(store.seedSignerPrivateKey).toBe("");
-    const ev = await store.sendNip04DirectMessage("receiver", "msg");
+    const res = await store.sendNip04DirectMessage("receiver", "msg");
     vi.runAllTimers();
-    expect(ev).not.toBeNull();
+    expect(res.success).toBe(true);
+    expect(res.event).not.toBeNull();
     expect(store.seedSignerPrivateKey).not.toBe("");
   });
 
@@ -148,8 +150,9 @@ describe("sendNip04DirectMessage", () => {
     publishSuccess = false;
     const promise = store.sendNip04DirectMessage("r", "m");
     vi.runAllTimers();
-    const ev = await promise;
-    expect(ev).toBeNull();
+    const res = await promise;
+    expect(res.success).toBe(false);
+    expect(res.event).toBeNull();
     expect(notifyError).toHaveBeenCalled();
     publishSuccess = true;
   });


### PR DESCRIPTION
## Summary
- return `{ success, event }` from `sendNip04DirectMessage`
- update usage sites to check the success flag
- warn on DM failure when subscribing to a creator
- adjust unit tests for the new return type

## Testing
- `npm test` *(fails: Cannot find module 'vite-jsconfig-paths')*

------
https://chatgpt.com/codex/tasks/task_e_6844079d6f348330b055339d6d102d0d