### PR TITLE
Fix lint error in SubscriptionReceipt

### DIFF
--- a/src/components/SubscriptionReceipt.vue
+++ b/src/components/SubscriptionReceipt.vue
@@ -3,7 +3,13 @@
     <q-card class="q-pa-md qcard" style="min-width:300px">
       <q-card-section class="text-h6">{{ $t('SubscriptionReceipt.title') }}</q-card-section>
       <q-card-section>
-        <q-input v-model="token" readonly type="textarea" autogrow style="font-family: monospace" />
+        <q-input
+          :model-value="token"
+          readonly
+          type="textarea"
+          autogrow
+          style="font-family: monospace"
+        />
       </q-card-section>
       <q-card-actions align="right">
         <q-btn flat color="primary" @click="copyToken">{{ $t('global.actions.copy.label') }}</q-btn>


### PR DESCRIPTION
## Summary
- fix `vue/no-mutating-props` lint error by binding `q-input` readonly value with `:model-value`

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run dev` *(fails: quasar not found)*

------
https://chatgpt.com/codex/tasks/task_e_684411a525c88330905c863c5eec3386