### PR TITLE
refactor messenger identity retrieval

### DIFF
--- a/src/components/NostrIdentityManager.vue
+++ b/src/components/NostrIdentityManager.vue
@@ -31,12 +31,14 @@
 <script lang="ts" setup>
 import { ref } from 'vue';
 import { useMessengerStore } from 'src/stores/messenger';
+import { useNostrStore } from 'src/stores/nostr';
 
 const messenger = useMessengerStore();
+const nostr = useNostrStore();
 
 const showDialog = ref(false);
-const privKey = ref(messenger.privKey);
-const pubKey = ref(messenger.pubKey);
+const privKey = ref(nostr.privateKeySignerPrivateKey);
+const pubKey = ref(nostr.pubkey);
 const relayInput = ref('');
 const relays = ref<string[]>([...messenger.relays]);
 
@@ -52,10 +54,11 @@ const removeRelay = (index: number) => {
 };
 
 const save = () => {
-  messenger.privKey = privKey.value;
-  messenger.pubKey = pubKey.value;
+  nostr.privateKeySignerPrivateKey = privKey.value;
+  nostr.initPrivateKeySigner();
   messenger.relays = relays.value as any;
   messenger.start();
+  pubKey.value = nostr.pubkey;
   showDialog.value = false;
 };
 </script>

--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -74,7 +74,6 @@ import MessageInput from 'components/MessageInput.vue';
 import EventLog from 'components/EventLog.vue';
 
 const messenger = useMessengerStore();
-messenger.loadIdentity();
 onMounted(() => {
   messenger.start();
 });


### PR DESCRIPTION
## Summary
- remove privKey/pubKey state from messenger store
- use nostr store getters for keys
- adjust NostrIdentityManager.vue and NostrMessenger.vue
- derive public key from hex private key via `hexToBytes`

## Testing
- `npm test` *(fails: Cannot find module 'vite-jsconfig-paths')*

------
https://chatgpt.com/codex/tasks/task_e_68441641dc888330a111e5ca7fbeca76