### PR TITLE
Add identity setup page

### DIFF
--- a/src/pages/IdentityPage.vue
+++ b/src/pages/IdentityPage.vue
@@ -1,0 +1,60 @@
+<template>
+  <div :class="[$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark', 'q-pa-md flex flex-center']">
+    <q-card class="q-pa-md" style="max-width:400px; width:100%">
+      <q-card-section class="text-h6">Identity Setup</q-card-section>
+      <q-input v-model="key" type="text" label="nsec or hex private key" class="q-mt-md" />
+      <div class="text-negative text-caption q-mt-sm" v-if="error">{{ error }}</div>
+      <q-card-actions align="around" class="q-mt-md">
+        <q-btn color="primary" @click="useKey">Use Key</q-btn>
+        <q-btn outline color="primary" @click="generateKey">Generate New</q-btn>
+      </q-card-actions>
+    </q-card>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref } from 'vue';
+import { useRouter } from 'vue-router';
+import { useNostrStore } from 'stores/nostr';
+import { nip19, generateSecretKey, getPublicKey } from 'nostr-tools';
+import { bytesToHex } from '@noble/hashes/utils';
+
+export default defineComponent({
+  name: 'IdentityPage',
+  setup() {
+    const nostr = useNostrStore();
+    const router = useRouter();
+    const key = ref('');
+    const error = ref('');
+
+    const useKey = async () => {
+      if (!key.value) return;
+      try {
+        let hex;
+        if (key.value.startsWith('nsec')) {
+          hex = bytesToHex(nip19.decode(key.value).data as Uint8Array);
+        } else {
+          hex = key.value;
+        }
+        nostr.privateKeySignerPrivateKey = hex;
+        await nostr.initPrivateKeySigner();
+        router.push('/wallet');
+      } catch (e) {
+        console.error(e);
+        error.value = 'Invalid key';
+      }
+    };
+
+    const generateKey = async () => {
+      const sk = generateSecretKey();
+      key.value = nip19.nsecEncode(sk);
+      nostr.privateKeySignerPrivateKey = bytesToHex(sk);
+      await nostr.initPrivateKeySigner();
+      router.push('/wallet');
+    };
+
+    return { key, useKey, generateKey, error };
+  }
+});
+</script>
+

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -6,6 +6,7 @@ import {
   createWebHashHistory,
 } from "vue-router";
 import routes from "./routes";
+import { useNostrStore } from "src/stores/nostr";
 
 /*
  * If not building with SSR mode, you can
@@ -31,6 +32,17 @@ export default route(function (/* { store, ssrContext } */) {
     // quasar.conf.js -> build -> vueRouterMode
     // quasar.conf.js -> build -> publicPath
     history: createHistory(process.env.VUE_ROUTER_BASE),
+  });
+
+  Router.beforeEach((to, from, next) => {
+    const hasKey =
+      localStorage.getItem("cashu.ndk.privateKeySignerPrivateKey") ||
+      localStorage.getItem("cashu.ndk.seedSignerPrivateKey");
+    if (!hasKey && to.path !== "/identity") {
+      next("/identity");
+    } else {
+      next();
+    }
   });
 
   return Router;

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -130,6 +130,13 @@ const routes = [
       { path: "", component: () => import("src/pages/AboutPage.vue") },
     ],
   },
+  {
+    path: "/identity",
+    component: () => import("layouts/FullscreenLayout.vue"),
+    children: [
+      { path: "", component: () => import("src/pages/IdentityPage.vue") },
+    ],
+  },
 
   // Always leave this as last one,
   // but you can also remove it


### PR DESCRIPTION
## Summary
- add IdentityPage component to input or generate nostr key
- register `/identity` route
- redirect to identity setup if no nostr key present

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot find module 'vite-jsconfig-paths')*

------
https://chatgpt.com/codex/tasks/task_e_684418cfa6508330a17fc84b57aebe36