### PR TITLE
Refactor to use active Nostr key

### DIFF
--- a/src/components/NostrIdentityManager.vue
+++ b/src/components/NostrIdentityManager.vue
@@ -5,7 +5,6 @@
       <q-card style="min-width: 350px">
         <q-card-section class="text-h6">Identity &amp; Relays</q-card-section>
         <q-card-section>
-          <q-input v-model="privKey" label="Private Key" type="text" />
           <q-input v-model="pubKey" label="Public Key" readonly class="q-mt-md" />
           <div class="q-mt-md">
             <q-input v-model="relayInput" label="Add Relay" @keyup.enter="addRelay" />
@@ -31,12 +30,13 @@
 <script lang="ts" setup>
 import { ref } from 'vue';
 import { useMessengerStore } from 'src/stores/messenger';
+import { useNostrStore } from 'src/stores/nostr';
 
 const messenger = useMessengerStore();
+const nostr = useNostrStore();
 
 const showDialog = ref(false);
-const privKey = ref(messenger.privKey);
-const pubKey = ref(messenger.pubKey);
+const pubKey = ref(nostr.pubkey);
 const relayInput = ref('');
 const relays = ref<string[]>([...messenger.relays]);
 
@@ -52,8 +52,6 @@ const removeRelay = (index: number) => {
 };
 
 const save = () => {
-  messenger.privKey = privKey.value;
-  messenger.pubKey = pubKey.value;
   messenger.relays = relays.value as any;
   messenger.start();
   showDialog.value = false;

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -35,9 +35,8 @@ export default route(function (/* { store, ssrContext } */) {
   });
 
   Router.beforeEach((to, from, next) => {
-    const hasKey =
-      localStorage.getItem("cashu.ndk.privateKeySignerPrivateKey") ||
-      localStorage.getItem("cashu.ndk.seedSignerPrivateKey");
+    const nostr = useNostrStore();
+    const hasKey = !!nostr.pubkey;
     if (!hasKey && to.path !== "/identity") {
       next("/identity");
     } else {

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -136,6 +136,15 @@ export const useNostrStore = defineStore("nostr", {
       };
       return nip19.nprofileEncode(profile);
     },
+    activePrivKey: (state): string => {
+      if (state.signerType === SignerType.PRIVATEKEY) {
+        return state.privateKeySignerPrivateKey;
+      }
+      if (state.signerType === SignerType.SEED) {
+        return state.seedSignerPrivateKey;
+      }
+      return "";
+    },
   },
   actions: {
     initNdkReadOnly: function () {


### PR DESCRIPTION
## Summary
- gate routing using active nostr key state
- update messenger store to depend on nostr store
- remove private key editing from identity manager
- expose active private key in nostr store

## Testing
- `npm test` *(fails: Cannot find module 'vite-jsconfig-paths')*

------
https://chatgpt.com/codex/tasks/task_e_68441fbe8c88833096a89b336deef958