### PR TITLE
Fix Pinia store initialization

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,9 @@
 import { createApp } from "vue";
 import App from "./App.vue";
 import registerIcons from "./icons";
+import createStore from "./stores";
 
 const app = createApp(App);
 registerIcons(app);
+app.use(createStore());
+app.mount("#q-app");

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -83,9 +83,6 @@ type KeysetCounter = {
   counter: number;
 };
 
-const receiveStore = useReceiveTokensStore();
-const tokenStore = useTokensStore();
-const proofsStore = useProofsStore();
 
 export const useWalletStore = defineStore("wallet", {
   state: () => {
@@ -518,6 +515,9 @@ export const useWalletStore = defineStore("wallet", {
       const uIStore = useUiStore();
       const mintStore = useMintsStore();
       const p2pkStore = useP2PKStore();
+      const receiveStore = useReceiveTokensStore();
+      const tokenStore = useTokensStore();
+      const proofsStore = useProofsStore();
 
       receiveStore.showReceiveTokens = false;
 
@@ -1139,6 +1139,7 @@ export const useWalletStore = defineStore("wallet", {
     checkOutgoingInvoice: async function (quote: string, verbose = true) {
       const uIStore = useUiStore();
       const mintStore = useMintsStore();
+      const proofsStore = useProofsStore();
       const invoice = this.invoiceHistory.find((i) => i.quote === quote);
       if (!invoice) {
         throw new Error("invoice not found");
@@ -1468,6 +1469,7 @@ export const useWalletStore = defineStore("wallet", {
       await this.meltQuoteInvoiceData();
     },
     handleCashuToken: function () {
+      const receiveStore = useReceiveTokensStore();
       this.payInvoiceData.show = false;
       receiveStore.showReceiveTokens = true;
     },
@@ -1483,6 +1485,7 @@ export const useWalletStore = defineStore("wallet", {
     },
     decodeRequest: async function (req: string) {
       const p2pkStore = useP2PKStore();
+      const receiveStore = useReceiveTokensStore();
       req = req.trim();
       this.payInvoiceData.input.request = req;
       if (req.toLowerCase().startsWith("lnbc")) {


### PR DESCRIPTION
## Summary
- avoid calling Pinia stores before Pinia is created
- wire up Pinia in `src/main.js`

## Testing
- `npm test` *(fails: Cannot find module 'vite-jsconfig-paths')*
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_684427a52bb08330b402bac90596dbbc