### PR TITLE
Use global Nostr signer for messenger DMs

### DIFF
--- a/test/vitest/__tests__/messenger.spec.ts
+++ b/test/vitest/__tests__/messenger.spec.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+var sendDm: any
+var decryptDm: any
+var subscribe: any
+var walletGen: any
+
+vi.mock('../../../src/stores/nostr', () => {
+  sendDm = vi.fn(async () => ({ success: true, event: { id: '1', created_at: 0 } }))
+  decryptDm = vi.fn(async () => 'msg')
+  subscribe = vi.fn(async (_priv: string, _pub: string, cb: any) => { cb && cb({} as any, '') })
+  walletGen = vi.fn()
+  const store = {
+    sendNip04DirectMessage: sendDm,
+    decryptNip04: decryptDm,
+    subscribeToNip04DirectMessagesCallback: subscribe,
+    walletSeedGenerateKeyPair: walletGen,
+    privateKeySignerPrivateKey: 'priv',
+    seedSignerPrivateKey: '',
+    pubkey: 'pub',
+    connected: true,
+    relays: [] as string[],
+  }
+  return { useNostrStore: () => store }
+})
+
+vi.mock('../../../src/js/message-utils', () => ({
+  sanitizeMessage: vi.fn((s: string) => s)
+}))
+
+import { useMessengerStore } from '../../../src/stores/messenger'
+import { useNostrStore } from '../../../src/stores/nostr'
+
+beforeEach(() => {
+  localStorage.clear()
+  vi.clearAllMocks()
+})
+
+describe('messenger store', () => {
+  it('uses global key when sending DMs', async () => {
+    const messenger = useMessengerStore()
+    await messenger.sendDm('r', 'm')
+    expect(sendDm).toHaveBeenCalledWith('r', 'm', 'priv', 'pub')
+  })
+
+  it('decrypts incoming messages with global key', async () => {
+    const messenger = useMessengerStore()
+    await messenger.addIncomingMessage({ id: '1', pubkey: 's', content: 'c', created_at: 1 } as any)
+    expect(decryptDm).toHaveBeenCalledWith('priv', 's', 'c')
+  })
+
+  it('subscribes using global key on start', async () => {
+    const messenger = useMessengerStore()
+    await messenger.start()
+    expect(subscribe).toHaveBeenCalled()
+    const args = subscribe.mock.calls[0]
+    expect(args[0]).toBe('priv')
+    expect(args[1]).toBe('pub')
+  })
+})

--- a/vitest-jsconfig-paths.js
+++ b/vitest-jsconfig-paths.js
@@ -1,0 +1,5 @@
+export default function jsconfigPaths() {
+  return {
+    name: 'vite-jsconfig-paths-stub'
+  };
+}

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,7 +1,8 @@
 import { defineConfig } from "vitest/config";
 import vue from "@vitejs/plugin-vue";
 import { quasar, transformAssetUrls } from "@quasar/vite-plugin";
-import jsconfigPaths from "vite-jsconfig-paths";
+import jsconfigPaths from "./vitest-jsconfig-paths";
+import path from "path";
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -22,6 +23,18 @@ export default defineConfig({
       "src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}",
       "test/vitest/__tests__/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}",
     ],
+  },
+  resolve: {
+    alias: {
+      src: path.resolve(__dirname, "src"),
+      app: path.resolve(__dirname),
+      components: path.resolve(__dirname, "src/components"),
+      layouts: path.resolve(__dirname, "src/layouts"),
+      pages: path.resolve(__dirname, "src/pages"),
+      assets: path.resolve(__dirname, "src/assets"),
+      boot: path.resolve(__dirname, "src/boot"),
+      stores: path.resolve(__dirname, "src/stores"),
+    },
   },
   plugins: [
     vue({


### PR DESCRIPTION
## Summary
- depend on Nostr store for messenger identity
- adjust DM send/receive/start to pull keys from global signer
- add minimal jsconfig paths plugin stub for Vitest and define aliases
- test that messenger uses global signer when encrypting and decrypting DMs

## Testing
- `npx vitest run test/vitest/__tests__/messenger.spec.ts`

------
https://chatgpt.com/codex/tasks/task_e_68447cf1f00883309abbdfa1cd26e219