### PR TITLE
Add nostr login page

### DIFF
--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -187,6 +187,14 @@
           <q-item-label>Chats</q-item-label>
         </q-item-section>
       </q-item>
+      <q-item v-if="needsNostrLogin" clickable @click="gotoNostrLogin">
+        <q-item-section avatar>
+          <q-icon name="vpn_key" />
+        </q-item-section>
+        <q-item-section>
+          <q-item-label>Setup Nostr Identity</q-item-label>
+        </q-item-section>
+      </q-item>
       <q-item-label header>{{
         $t("MainHeader.menu.terms.title")
       }}</q-item-label>
@@ -236,6 +244,7 @@ import { defineComponent, ref, computed } from "vue";
 import { useRouter } from "vue-router";
 import EssentialLink from "components/EssentialLink.vue";
 import { useUiStore } from "src/stores/ui";
+import { useNostrStore } from "src/stores/nostr";
 import { useI18n } from "vue-i18n";
 
 export default defineComponent({
@@ -249,6 +258,8 @@ export default defineComponent({
     const uiStore = useUiStore();
     const { t } = useI18n();
     const router = useRouter();
+    const nostrStore = useNostrStore();
+    const needsNostrLogin = computed(() => !nostrStore.privateKeySignerPrivateKey);
     const showBackButton = computed(() => true);
     const countdown = ref(0);
     let countdownInterval;
@@ -339,6 +350,11 @@ export default defineComponent({
       leftDrawerOpen.value = false;
     };
 
+    const gotoNostrLogin = () => {
+      router.push("/nostr-login");
+      leftDrawerOpen.value = false;
+    };
+
     const gotoWallet = () => {
       router.push("/wallet");
       leftDrawerOpen.value = false;
@@ -357,8 +373,10 @@ export default defineComponent({
       gotoCreatorHub,
       gotoMyProfile,
       gotoChats,
+      gotoNostrLogin,
       gotoWallet,
       showBackButton,
+      needsNostrLogin,
     };
   },
 });

--- a/src/pages/NostrLogin.vue
+++ b/src/pages/NostrLogin.vue
@@ -1,0 +1,54 @@
+<template>
+  <div :class="[$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark', 'q-pa-md flex flex-center']">
+    <q-card class="q-pa-md" style="max-width:400px; width:100%">
+      <q-card-section class="text-h6">Nostr Identity</q-card-section>
+      <q-card-section>
+        <q-input v-model="key" type="text" label="nsec or hex private key" />
+      </q-card-section>
+      <q-card-actions vertical class="q-gutter-sm">
+        <q-btn color="primary" @click="submitKey">Use Key</q-btn>
+        <q-btn flat color="primary" @click="createIdentity">Create Identity</q-btn>
+      </q-card-actions>
+    </q-card>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, ref } from 'vue';
+import { useRouter } from 'vue-router';
+import { useNostrStore } from 'stores/nostr';
+import { generateSecretKey, nip19 } from 'nostr-tools';
+import { hexToBytes } from '@noble/hashes/utils';
+
+export default defineComponent({
+  name: 'NostrLogin',
+  setup() {
+    const key = ref('');
+    const router = useRouter();
+    const nostr = useNostrStore();
+
+    const normalizeKey = (input: string): string => {
+      const trimmed = input.trim();
+      if (/^[0-9a-fA-F]{64}$/.test(trimmed)) {
+        return nip19.nsecEncode(hexToBytes(trimmed));
+      }
+      return trimmed;
+    };
+
+    const submitKey = async () => {
+      if (!key.value.trim()) return;
+      await nostr.initPrivateKeySigner(normalizeKey(key.value));
+      if (nostr.pubkey) router.push('/wallet');
+    };
+
+    const createIdentity = async () => {
+      const sk = generateSecretKey();
+      const nsec = nip19.nsecEncode(sk);
+      await nostr.initPrivateKeySigner(nsec);
+      if (nostr.pubkey) router.push('/wallet');
+    };
+
+    return { key, submitKey, createIdentity };
+  }
+});
+</script>

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -130,6 +130,13 @@ const routes = [
       { path: "", component: () => import("src/pages/AboutPage.vue") },
     ],
   },
+  {
+    path: "/nostr-login",
+    component: () => import("layouts/FullscreenLayout.vue"),
+    children: [
+      { path: "", component: () => import("src/pages/NostrLogin.vue") },
+    ],
+  },
 
   // Always leave this as last one,
   // but you can also remove it


### PR DESCRIPTION
## Summary
- add `NostrLogin.vue` page to allow entering an nsec or creating a new identity
- link to the new page from the drawer when no nostr key exists
- register the route for `/nostr-login`

## Testing
- `npm test` *(fails: Failed Suites due to unresolved imports)*

------
https://chatgpt.com/codex/tasks/task_e_6844814507a88330904a5b8bdc7bacbf