### PR TITLE
Fix token re-use on multi-month subscriptions

### DIFF
--- a/src/stores/donationPresets.ts
+++ b/src/stores/donationPresets.ts
@@ -84,9 +84,8 @@ export const useDonationPresetsStore = defineStore("donationPresets", {
           locktime,
           bucketId,
         });
-        proofs = mintsStore.activeProofs.filter(
-          (p) => p.bucketId === bucketId
-        );
+        await proofsStore.updateActiveProofs();
+        proofs = mintsStore.activeProofs.filter((p) => p.bucketId === bucketId);
       }
       return tokens.join("\n");
     },


### PR DESCRIPTION
## Summary
- refresh proofs after each monthly locktime token is created

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684516ecba4483309415037bf61360f3