### PR TITLE
Unify nostr identity across features

### DIFF
--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -136,6 +136,9 @@ export const useNostrStore = defineStore("nostr", {
       };
       return nip19.nprofileEncode(profile);
     },
+    privKeyHex: (state) => {
+      return state.privateKeySignerPrivateKey || state.seedSignerPrivateKey;
+    },
   },
   actions: {
     initNdkReadOnly: function () {


### PR DESCRIPTION
## Summary
- expose `privKeyHex` getter for active nostr key
- reuse central nostr key when generating NWC connection
- encrypt NWC replies using nostr store key
- use nostr relay list for NWC operations

## Testing
- `npm run test` *(fails: npm not available)*

------
https://chatgpt.com/codex/tasks/task_e_68451b5544988330bd7727e918309c38