### PR TITLE
Update SubscriptionReceipt for list of tokens

### DIFF
--- a/src/pages/FindCreators.vue
+++ b/src/pages/FindCreators.vue
@@ -13,7 +13,7 @@
       :supporter-pubkey="nostr.pubkey"
       @confirm="confirmSubscribe"
     />
-    <SubscriptionReceipt v-model="showReceiptDialog" :token="receiptToken" />
+    <SubscriptionReceipt v-model="showReceiptDialog" :receipts="receiptList" />
     <SendTokenDialog />
     <QDialog v-model="showTierDialog">
       <QCard class="tier-dialog">
@@ -104,7 +104,7 @@ const { t } = useI18n();
 const tiers = computed(() => creators.tiersMap[dialogPubkey.value] || []);
 const showSubscribeDialog = ref(false);
 const showReceiptDialog = ref(false);
-const receiptToken = ref("");
+const receiptList = ref<any[]>([]);
 const selectedTier = ref<any>(null);
 
 function getPrice(t: any): number {
@@ -168,7 +168,6 @@ async function confirmSubscribe({
       startDate,
       true
     )) as any[];
-    const tokenString = receipts.map((r) => r.token).join("\n");
     let supporterName = nostr.pubkey;
     try {
       const prof = await nostr.getProfile(nostr.pubkey);
@@ -192,7 +191,7 @@ async function confirmSubscribe({
     } else {
       notifyWarning(t("wallet.notifications.nostr_dm_failed"));
     }
-    receiptToken.value = tokenString;
+    receiptList.value = receipts;
     showReceiptDialog.value = true;
     showSubscribeDialog.value = false;
     showTierDialog.value = false;

--- a/src/pages/PublicCreatorProfilePage.vue
+++ b/src/pages/PublicCreatorProfilePage.vue
@@ -21,7 +21,7 @@
       :supporter-pubkey="nostr.pubkey"
       @confirm="confirmSubscribe"
     />
-    <SubscriptionReceipt v-model="showReceiptDialog" :token="receiptToken" />
+    <SubscriptionReceipt v-model="showReceiptDialog" :receipts="receiptList" />
     <div v-if="followers !== null" class="text-caption q-mb-md">
       {{ $t("FindCreators.labels.followers") }}: {{ followers }} |
       {{ $t("FindCreators.labels.following") }}: {{ following }}
@@ -116,7 +116,7 @@ export default defineComponent({
     const tiers = computed(() => creators.tiersMap[creatorNpub] || []);
     const showSubscribeDialog = ref(false);
     const showReceiptDialog = ref(false);
-    const receiptToken = ref("");
+    const receiptList = ref<any[]>([]);
     const selectedTier = ref<any>(null);
     const followers = ref<number | null>(null);
     const following = ref<number | null>(null);
@@ -163,7 +163,6 @@ export default defineComponent({
           startDate,
           true
         )) as any[];
-        const tokenString = receipts.map((r) => r.token).join("\n");
         let supporterName = nostr.pubkey;
         try {
           const prof = await nostr.getProfile(nostr.pubkey);
@@ -187,7 +186,7 @@ export default defineComponent({
         } else {
           notifyWarning(t("wallet.notifications.nostr_dm_failed"));
         }
-        receiptToken.value = tokenString;
+        receiptList.value = receipts;
         showReceiptDialog.value = true;
         showSubscribeDialog.value = false;
       } catch (e: any) {
@@ -216,7 +215,7 @@ export default defineComponent({
       tiers,
       showSubscribeDialog,
       showReceiptDialog,
-      receiptToken,
+      receiptList,
       selectedTier,
       followers,
       following,


### PR DESCRIPTION
## Summary
- support multiple receipts in SubscriptionReceipt dialog
- show a table of receipts with copy/save buttons
- update creator profile and find creators pages to pass receipt array

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot set property permissions of [object Object] which has only a getter)*

------
https://chatgpt.com/codex/tasks/task_e_68452c07a95c83308469d244cf3ff4c7