### PR TITLE
Implement receipt DM formatter

### DIFF
--- a/src/js/receipt-utils.ts
+++ b/src/js/receipt-utils.ts
@@ -1,0 +1,25 @@
+export type Receipt = {
+  id: string;
+  amount: number;
+  token: string;
+  pubkey: string;
+  locktime?: number;
+  refundPubkey?: string;
+  bucketId: string;
+  date: string;
+};
+
+export function formatTimestamp(ts: number): string {
+  const d = new Date(ts * 1000);
+  return `${d.getFullYear()}-${("0" + (d.getMonth() + 1)).slice(-2)}-${("0" + d.getDate()).slice(-2)} ${("0" + d.getHours()).slice(-2)}:${("0" + d.getMinutes()).slice(-2)}`;
+}
+
+export function receiptsToDmText(receipts: Array<Receipt>, supporterName?: string): string {
+  return receipts
+    .map((r) => {
+      const date = r.locktime ? formatTimestamp(r.locktime) : new Date(r.date).toISOString();
+      const name = supporterName ? `from ${supporterName} ` : "";
+      return `${r.amount} sats ${name}on ${date} (ref ${r.id})\n${r.token}`;
+    })
+    .join("\n");
+}

--- a/src/pages/FindCreators.vue
+++ b/src/pages/FindCreators.vue
@@ -87,6 +87,7 @@ import {
   Loading,
 } from "quasar";
 import { nip19 } from "nostr-tools";
+import { receiptsToDmText } from "src/js/receipt-utils";
 
 const iframeEl = ref<HTMLIFrameElement | null>(null);
 const showDonateDialog = ref(false);
@@ -174,13 +175,7 @@ async function confirmSubscribe({
       supporterName =
         prof?.display_name || prof?.name || prof?.username || nostr.pubkey;
     } catch {}
-    const messages = receipts.map((r) => {
-      const date = r.locktime
-        ? formatTs(r.locktime)
-        : new Date(r.date).toISOString();
-      return `${r.amount} sats from ${supporterName} on ${date} (ref ${r.id})\n${r.token}`;
-    });
-    const dmMessage = messages.join("\n");
+    const dmMessage = receiptsToDmText(receipts, supporterName);
     const { success, event } = await nostr.sendNip04DirectMessage(
       dialogPubkey.value,
       dmMessage

--- a/src/pages/PublicCreatorProfilePage.vue
+++ b/src/pages/PublicCreatorProfilePage.vue
@@ -96,6 +96,7 @@ import { useI18n } from "vue-i18n";
 import { Loading } from "quasar";
 import { renderMarkdown as renderMarkdownFn } from "src/js/simple-markdown";
 import PaywalledContent from "components/PaywalledContent.vue";
+import { receiptsToDmText } from "src/js/receipt-utils";
 
 export default defineComponent({
   name: "PublicCreatorProfilePage",
@@ -169,13 +170,7 @@ export default defineComponent({
           supporterName =
             prof?.display_name || prof?.name || prof?.username || nostr.pubkey;
         } catch {}
-        const messages = receipts.map((r) => {
-          const date = r.locktime
-            ? formatTs(r.locktime)
-            : new Date(r.date).toISOString();
-          return `${r.amount} sats from ${supporterName} on ${date} (ref ${r.id})\n${r.token}`;
-        });
-        const dmMessage = messages.join("\n");
+        const dmMessage = receiptsToDmText(receipts, supporterName);
         const { success, event } = await nostr.sendNip04DirectMessage(
           creatorNpub,
           dmMessage


### PR DESCRIPTION
## Summary
- add `receipt-utils.ts` with helpers to format arrays of receipts
- use the new helper when sending subscription receipts to creators

## Testing
- `npm test` *(fails: failed suites)*

------
https://chatgpt.com/codex/tasks/task_e_684530843b488330a1248ac44f13da70