### PR TITLE
Add chat notifications

### DIFF
--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -60,7 +60,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, ref, onMounted } from 'vue';
+import { computed, ref, onMounted, watch } from 'vue';
 import { useRouter } from 'vue-router';
 import { useMessengerStore } from 'src/stores/messenger';
 
@@ -87,15 +87,25 @@ const selected = ref('');
 const messages = computed(() => messenger.conversations[selected.value] || []);
 const eventLog = computed(() => messenger.eventLog);
 
+watch(
+  selected,
+  (val) => {
+    messenger.setCurrentConversation(val);
+  },
+  { immediate: true }
+);
+
 const selectConversation = (pubkey: string) => {
   selected.value = pubkey;
   messenger.markRead(pubkey);
+  messenger.setCurrentConversation(pubkey);
 };
 
 const startChat = (pubkey: string) => {
   messenger.createConversation(pubkey);
   selected.value = pubkey;
   messenger.markRead(pubkey);
+  messenger.setCurrentConversation(pubkey);
 };
 
 const sendMessage = (text: string) => {

--- a/src/stores/messenger.ts
+++ b/src/stores/messenger.ts
@@ -6,6 +6,7 @@ import { useNostrStore } from "./nostr";
 import { v4 as uuidv4 } from "uuid";
 import { useSettingsStore } from "./settings";
 import { sanitizeMessage } from "src/js/message-utils";
+import { notifySuccess } from "src/js/notify";
 
 export type MessengerMessage = {
   id: string;
@@ -30,6 +31,7 @@ export const useMessengerStore = defineStore("messenger", {
       "cashu.messenger.eventLog",
       [] as MessengerMessage[]
     ),
+    currentConversation: "",
     started: false,
     watchInitialized: false,
   }),
@@ -108,6 +110,10 @@ export const useMessengerStore = defineStore("messenger", {
       this.unreadCounts[event.pubkey] =
         (this.unreadCounts[event.pubkey] || 0) + 1;
       this.eventLog.push(msg);
+      if (this.currentConversation !== event.pubkey) {
+        const snippet = msg.content.slice(0, 40);
+        notifySuccess(snippet);
+      }
     },
 
     async start() {
@@ -174,6 +180,10 @@ export const useMessengerStore = defineStore("messenger", {
 
     markRead(pubkey: string) {
       this.unreadCounts[pubkey] = 0;
+    },
+
+    setCurrentConversation(pubkey: string) {
+      this.currentConversation = pubkey;
     },
   },
 });

--- a/test/vitest/__tests__/messenger.spec.ts
+++ b/test/vitest/__tests__/messenger.spec.ts
@@ -28,6 +28,12 @@ vi.mock('../../../src/js/message-utils', () => ({
   sanitizeMessage: vi.fn((s: string) => s)
 }))
 
+var notifySpy: any
+vi.mock('../../../src/js/notify', () => {
+  notifySpy = vi.fn()
+  return { notifySuccess: notifySpy }
+})
+
 import { useMessengerStore } from '../../../src/stores/messenger'
 import { useNostrStore } from '../../../src/stores/nostr'
 


### PR DESCRIPTION
## Summary
- track currently open chat in messenger store
- display Quasar notification for incoming messages when chat is not open
- hook up `currentConversation` in `NostrMessenger.vue`
- mock notification helper in messenger tests

## Testing
- `npm test --silent` *(fails: Cannot set property permissions of [object Object] which has only a getter)*

------
https://chatgpt.com/codex/tasks/task_e_684532ee6edc83308e800f6440bea5b2