### PR TITLE
Add chat navigation controls to header

### DIFF
--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -17,9 +17,9 @@
         dense
         rounded
         icon="arrow_back_ios_new"
-        to="/wallet"
+        :to="backRoute"
         color="primary"
-        aria-label="Back to wallet"
+        aria-label="Back"
         no-caps
         class="q-ml-sm"
       >
@@ -241,7 +241,7 @@
 
 <script>
 import { defineComponent, ref, computed } from "vue";
-import { useRouter } from "vue-router";
+import { useRouter, useRoute } from "vue-router";
 import EssentialLink from "components/EssentialLink.vue";
 import { useUiStore } from "src/stores/ui";
 import { useNostrStore } from "src/stores/nostr";
@@ -258,9 +258,21 @@ export default defineComponent({
     const uiStore = useUiStore();
     const { t } = useI18n();
     const router = useRouter();
+    const route = useRoute();
     const nostrStore = useNostrStore();
-    const needsNostrLogin = computed(() => !nostrStore.privateKeySignerPrivateKey);
-    const showBackButton = computed(() => true);
+    const needsNostrLogin = computed(
+      () => !nostrStore.privateKeySignerPrivateKey
+    );
+    const isChatPage = computed(
+      () =>
+        route.path.startsWith("/nostr-messenger") ||
+        route.path.startsWith("/chats")
+    );
+    const showBackButton = computed(() => isChatPage.value);
+    const backRoute = computed(() => {
+      if (route.path.startsWith("/chats/")) return "/chats";
+      return "/wallet";
+    });
     const countdown = ref(0);
     let countdownInterval;
 
@@ -376,6 +388,7 @@ export default defineComponent({
       gotoNostrLogin,
       gotoWallet,
       showBackButton,
+      backRoute,
       needsNostrLogin,
     };
   },

--- a/src/pages/ChatView.vue
+++ b/src/pages/ChatView.vue
@@ -10,16 +10,6 @@
       style="border-bottom: 1px solid rgba(0, 0, 0, 0.1)"
     >
       <q-toolbar class="q-pa-sm">
-        <q-btn
-          flat
-          dense
-          round
-          icon="arrow_back"
-          color="primary"
-          @click="goBack"
-          aria-label="Go back"
-          class="q-mr-sm"
-        />
         <q-avatar v-if="avatar" size="md" class="q-mr-sm">
           <img :src="avatar" />
         </q-avatar>
@@ -69,7 +59,7 @@ import {
   onMounted,
   nextTick,
 } from "vue";
-import { useRoute, useRouter } from "vue-router";
+import { useRoute } from "vue-router";
 import { useDmChatsStore } from "stores/dmChats";
 import { storeToRefs } from "pinia";
 import { useNostrStore } from "stores/nostr";
@@ -79,7 +69,6 @@ export default defineComponent({
   name: "ChatView",
   setup() {
     const route = useRoute();
-    const router = useRouter();
     const pubkey = route.params.pubkey as string;
     const dmStore = useDmChatsStore();
     dmStore.loadChats();
@@ -128,10 +117,6 @@ export default defineComponent({
       }
     };
 
-    const goBack = () => {
-      router.push("/chats");
-    };
-
     const displayName = computed(() => {
       return (
         profile.value?.display_name ||
@@ -153,7 +138,6 @@ export default defineComponent({
       sanitizeMessage,
       formatDate,
       bottomMarker,
-      goBack,
     };
   },
 });

--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -3,53 +3,33 @@
     class="row full-height"
     :class="[$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark']"
   >
-      <q-drawer
-        v-model="drawer"
-        side="left"
-        show-if-above
-        bordered
-        :width="300"
-        class="q-pa-md"
-      >
-        <NostrIdentityManager class="q-mb-md" />
-        <RelayManager class="q-mb-md" />
-        <NewChat class="q-mb-md" @start="startChat" />
-        <ConversationList @select="selectConversation" />
-      </q-drawer>
+    <q-drawer
+      v-model="drawer"
+      side="left"
+      show-if-above
+      bordered
+      :width="300"
+      class="q-pa-md"
+    >
+      <NostrIdentityManager class="q-mb-md" />
+      <RelayManager class="q-mb-md" />
+      <NewChat class="q-mb-md" @start="startChat" />
+      <ConversationList @select="selectConversation" />
+    </q-drawer>
 
     <div class="col column q-pa-md">
-        <q-header elevated class="q-mb-md bg-transparent">
-          <q-toolbar>
-            <q-btn
-              flat
-              dense
-              round
-              icon="arrow_back"
-              color="primary"
-              aria-label="Go back"
-              class="q-mr-sm"
-              @click="goBack"
-            />
-            <q-btn
-              flat
-              dense
-              round
-              icon="menu"
-              color="primary"
-              aria-label="Toggle navigation"
-              class="q-mr-sm"
-              @click="drawer = !drawer"
-            />
-            <q-toolbar-title class="text-h6 ellipsis">
-              Nostr Messenger
-              <q-badge
-                :color="messenger.connected ? 'positive' : 'negative'"
-                class="q-ml-sm"
-              >
-                {{ messenger.connected ? 'Online' : 'Offline' }}
-              </q-badge>
-            </q-toolbar-title>
-          </q-toolbar>
+      <q-header elevated class="q-mb-md bg-transparent">
+        <q-toolbar>
+          <q-toolbar-title class="text-h6 ellipsis">
+            Nostr Messenger
+            <q-badge
+              :color="messenger.connected ? 'positive' : 'negative'"
+              class="q-ml-sm"
+            >
+              {{ messenger.connected ? "Online" : "Offline" }}
+            </q-badge>
+          </q-toolbar-title>
+        </q-toolbar>
       </q-header>
       <ActiveChatHeader :pubkey="selected" />
       <MessageList :messages="messages" class="col" />
@@ -60,18 +40,17 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, ref, onMounted, watch } from 'vue';
-import { useRouter } from 'vue-router';
-import { useMessengerStore } from 'src/stores/messenger';
+import { computed, ref, onMounted, watch } from "vue";
+import { useMessengerStore } from "src/stores/messenger";
 
-import NostrIdentityManager from 'components/NostrIdentityManager.vue';
-import RelayManager from 'components/RelayManager.vue';
-import NewChat from 'components/NewChat.vue';
-import ConversationList from 'components/ConversationList.vue';
-import ActiveChatHeader from 'components/ActiveChatHeader.vue';
-import MessageList from 'components/MessageList.vue';
-import MessageInput from 'components/MessageInput.vue';
-import EventLog from 'components/EventLog.vue';
+import NostrIdentityManager from "components/NostrIdentityManager.vue";
+import RelayManager from "components/RelayManager.vue";
+import NewChat from "components/NewChat.vue";
+import ConversationList from "components/ConversationList.vue";
+import ActiveChatHeader from "components/ActiveChatHeader.vue";
+import MessageList from "components/MessageList.vue";
+import MessageInput from "components/MessageInput.vue";
+import EventLog from "components/EventLog.vue";
 
 const messenger = useMessengerStore();
 messenger.loadIdentity();
@@ -79,11 +58,8 @@ onMounted(() => {
   messenger.start();
 });
 
-const router = useRouter();
-const { toggleDarkMode } = (window as any).windowMixin.methods;
-
 const drawer = ref(true);
-const selected = ref('');
+const selected = ref("");
 const messages = computed(() => messenger.conversations[selected.value] || []);
 const eventLog = computed(() => messenger.eventLog);
 
@@ -111,10 +87,6 @@ const startChat = (pubkey: string) => {
 const sendMessage = (text: string) => {
   if (!selected.value) return;
   messenger.sendDm(selected.value, text);
-};
-
-const goBack = () => {
-  router.push('/wallet');
 };
 </script>
 <style scoped>


### PR DESCRIPTION
## Summary
- show back button in `MainHeader` only on chat routes
- clean up `NostrMessenger` page header
- remove back button from `ChatView`
- keep sticky header style

## Testing
- `npm run lint`
- `npm test` *(fails: getActivePinia error)*

------
https://chatgpt.com/codex/tasks/task_e_6845350c57bc8330b379882b60996c27