### PR TITLE
Add global toggle for messenger drawer

### DIFF
--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -28,6 +28,17 @@
         </span>
       </q-btn>
       <q-toolbar-title></q-toolbar-title>
+      <q-btn
+        v-if="isMessengerPage"
+        flat
+        dense
+        round
+        icon="menu"
+        color="primary"
+        aria-label="Toggle Chat Menu"
+        @click="toggleMessengerDrawer"
+        class="q-mr-sm"
+      />
       <transition
         appear
         enter-active-class="animated wobble"
@@ -245,6 +256,7 @@ import { useRouter, useRoute } from "vue-router";
 import EssentialLink from "components/EssentialLink.vue";
 import { useUiStore } from "src/stores/ui";
 import { useNostrStore } from "src/stores/nostr";
+import { useMessengerStore } from "src/stores/messenger";
 import { useI18n } from "vue-i18n";
 
 export default defineComponent({
@@ -260,15 +272,16 @@ export default defineComponent({
     const router = useRouter();
     const route = useRoute();
     const nostrStore = useNostrStore();
+    const messenger = useMessengerStore();
     const needsNostrLogin = computed(
       () => !nostrStore.privateKeySignerPrivateKey
     );
-    const isChatPage = computed(
+    const isMessengerPage = computed(
       () =>
         route.path.startsWith("/nostr-messenger") ||
         route.path.startsWith("/chats")
     );
-    const showBackButton = computed(() => isChatPage.value);
+    const showBackButton = computed(() => isMessengerPage.value);
     const backRoute = computed(() => {
       if (route.path.startsWith("/chats/")) return "/chats";
       return "/wallet";
@@ -311,6 +324,10 @@ export default defineComponent({
 
     const toggleLeftDrawer = () => {
       leftDrawerOpen.value = !leftDrawerOpen.value;
+    };
+
+    const toggleMessengerDrawer = () => {
+      messenger.toggleDrawer();
     };
 
     const isStaging = () => {
@@ -390,6 +407,8 @@ export default defineComponent({
       showBackButton,
       backRoute,
       needsNostrLogin,
+      toggleMessengerDrawer,
+      isMessengerPage,
     };
   },
 });

--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -2,6 +2,8 @@
   <q-page
     class="row full-height"
     :class="[$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark']"
+    @touchstart="onTouchStart"
+    @touchend="onTouchEnd"
   >
     <q-drawer
       v-model="drawer"
@@ -58,7 +60,10 @@ onMounted(() => {
   messenger.start();
 });
 
-const drawer = ref(true);
+const drawer = computed({
+  get: () => messenger.drawerOpen,
+  set: (val) => messenger.setDrawer(val),
+});
 const selected = ref("");
 const messages = computed(() => messenger.conversations[selected.value] || []);
 const eventLog = computed(() => messenger.eventLog);
@@ -87,6 +92,17 @@ const startChat = (pubkey: string) => {
 const sendMessage = (text: string) => {
   if (!selected.value) return;
   messenger.sendDm(selected.value, text);
+};
+
+let touchStartX = 0;
+const onTouchStart = (e: TouchEvent) => {
+  touchStartX = e.touches[0].clientX;
+};
+
+const onTouchEnd = (e: TouchEvent) => {
+  const dx = e.changedTouches[0].clientX - touchStartX;
+  if (dx > 50) messenger.setDrawer(true);
+  if (dx < -50) messenger.setDrawer(false);
 };
 </script>
 <style scoped>

--- a/src/stores/messenger.ts
+++ b/src/stores/messenger.ts
@@ -32,6 +32,7 @@ export const useMessengerStore = defineStore("messenger", {
       [] as MessengerMessage[]
     ),
     currentConversation: "",
+    drawerOpen: useLocalStorage<boolean>("cashu.messenger.drawerOpen", true),
     started: false,
     watchInitialized: false,
   }),
@@ -184,6 +185,14 @@ export const useMessengerStore = defineStore("messenger", {
 
     setCurrentConversation(pubkey: string) {
       this.currentConversation = pubkey;
+    },
+
+    toggleDrawer() {
+      this.drawerOpen = !this.drawerOpen;
+    },
+
+    setDrawer(open: boolean) {
+      this.drawerOpen = open;
     },
   },
 });


### PR DESCRIPTION
## Summary
- control the messenger drawer with Pinia state
- expose actions to toggle the drawer in the messenger store
- add a chat menu button in `MainHeader` that toggles the drawer
- handle simple swipe gestures on mobile to open/close the drawer

## Testing
- `npm run lint`
- `npm run test` *(fails: getActivePinia and missing files)*

------
https://chatgpt.com/codex/tasks/task_e_6845388d2c0483308576c7ab233ee72c