### PR TITLE
Add toggle for Nostr event log

### DIFF
--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -36,13 +36,22 @@
       <ActiveChatHeader :pubkey="selected" />
       <MessageList :messages="messages" class="col" />
       <MessageInput @send="sendMessage" />
-      <EventLog class="q-mt-md" :events="eventLog" />
+      <q-expansion-item
+        class="q-mt-md"
+        dense
+        dense-toggle
+        label="Event Log"
+        v-model="showEventLog"
+      >
+        <EventLog :events="eventLog" />
+      </q-expansion-item>
     </div>
   </q-page>
 </template>
 
 <script lang="ts" setup>
 import { computed, ref, onMounted, watch } from "vue";
+import { useLocalStorage } from "@vueuse/core";
 import { useMessengerStore } from "src/stores/messenger";
 
 import NostrIdentityManager from "components/NostrIdentityManager.vue";
@@ -67,6 +76,10 @@ const drawer = computed({
 const selected = ref("");
 const messages = computed(() => messenger.conversations[selected.value] || []);
 const eventLog = computed(() => messenger.eventLog);
+const showEventLog = useLocalStorage<boolean>(
+  "cashu.messenger.showEventLog",
+  false,
+);
 
 watch(
   selected,


### PR DESCRIPTION
## Summary
- make Nostr messenger event log collapsible with `q-expansion-item`
- remember the open/closed state using `useLocalStorage`

## Testing
- `npm run lint`
- `npm run test` *(fails: Cannot set property permissions of [object Object])*

------
https://chatgpt.com/codex/tasks/task_e_68453b1d2e848330b64ec4a4875ed504