### PR TITLE
Fix chat page navigation buttons

### DIFF
--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -251,7 +251,7 @@
 </template>
 
 <script>
-import { defineComponent, ref, computed } from "vue";
+import { defineComponent, ref, computed, onMounted, onUnmounted } from "vue";
 import { useRouter, useRoute } from "vue-router";
 import EssentialLink from "components/EssentialLink.vue";
 import { useUiStore } from "src/stores/ui";
@@ -325,6 +325,14 @@ export default defineComponent({
     const toggleLeftDrawer = () => {
       leftDrawerOpen.value = !leftDrawerOpen.value;
     };
+
+    onMounted(() => {
+      window.addEventListener("toggle-left-drawer", toggleLeftDrawer);
+    });
+
+    onUnmounted(() => {
+      window.removeEventListener("toggle-left-drawer", toggleLeftDrawer);
+    });
 
     const toggleMessengerDrawer = () => {
       messenger.toggleDrawer();

--- a/src/pages/ChatView.vue
+++ b/src/pages/ChatView.vue
@@ -10,6 +10,22 @@
       style="border-bottom: 1px solid rgba(0, 0, 0, 0.1)"
     >
       <q-toolbar class="q-pa-sm">
+        <q-btn
+          flat
+          round
+          dense
+          icon="menu"
+          @click="openDrawer"
+          class="q-mr-sm"
+        />
+        <q-btn
+          flat
+          round
+          dense
+          icon="arrow_back"
+          @click="goBack"
+          class="q-mr-sm"
+        />
         <q-avatar v-if="avatar" size="md" class="q-mr-sm">
           <img :src="avatar" />
         </q-avatar>
@@ -59,7 +75,7 @@ import {
   onMounted,
   nextTick,
 } from "vue";
-import { useRoute } from "vue-router";
+import { useRoute, useRouter } from "vue-router";
 import { useDmChatsStore } from "stores/dmChats";
 import { storeToRefs } from "pinia";
 import { useNostrStore } from "stores/nostr";
@@ -69,6 +85,7 @@ export default defineComponent({
   name: "ChatView",
   setup() {
     const route = useRoute();
+    const router = useRouter();
     const pubkey = route.params.pubkey as string;
     const dmStore = useDmChatsStore();
     dmStore.loadChats();
@@ -129,6 +146,14 @@ export default defineComponent({
 
     const formatDate = (ts: number) => new Date(ts * 1000).toLocaleString();
 
+    const openDrawer = () => {
+      window.dispatchEvent(new Event("toggle-left-drawer"));
+    };
+
+    const goBack = () => {
+      router.push("/chats");
+    };
+
     return {
       messages,
       displayName,
@@ -138,6 +163,8 @@ export default defineComponent({
       sanitizeMessage,
       formatDate,
       bottomMarker,
+      openDrawer,
+      goBack,
     };
   },
 });


### PR DESCRIPTION
## Summary
- add menu and back buttons to ChatView
- allow MainHeader to respond to a global `toggle-left-drawer` event

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68453e31815083309a39329522e05a40