### PR TITLE
Make relays collapsible

### DIFF
--- a/src/components/RelayManager.vue
+++ b/src/components/RelayManager.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-    <div class="text-subtitle1 q-mb-sm">Relays</div>
     <q-input
       v-model="relayText"
       type="textarea"

--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -14,7 +14,15 @@
       class="q-pa-md"
     >
       <NostrIdentityManager class="q-mb-md" />
-      <RelayManager class="q-mb-md" />
+      <q-expansion-item
+        class="q-mb-md"
+        dense
+        dense-toggle
+        label="Relays"
+        v-model="showRelays"
+      >
+        <RelayManager class="q-mb-md" />
+      </q-expansion-item>
       <NewChat class="q-mb-md" @start="startChat" />
       <ConversationList @select="selectConversation" />
     </q-drawer>
@@ -79,6 +87,10 @@ const eventLog = computed(() => messenger.eventLog);
 const showEventLog = useLocalStorage<boolean>(
   "cashu.messenger.showEventLog",
   false,
+);
+const showRelays = useLocalStorage<boolean>(
+  "cashu.messenger.showRelays",
+  true,
 );
 
 watch(


### PR DESCRIPTION
## Summary
- add local storage backed `showRelays` flag
- wrap `RelayManager` in a Quasar expansion item
- remove duplicate heading from `RelayManager`

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68453e87f0f48330abbbf4126595f377