### PR TITLE
Make P2PK field readonly for creator buckets

### DIFF
--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -164,7 +164,8 @@
                         : $t('SendTokenDialog.inputs.p2pk_pubkey.label')
                     "
                     outlined
-                    clearable
+                    :clearable="!isCreatorP2PK"
+                    :readonly="isCreatorP2PK"
                     :color="
                       sendData.p2pkPubkey && !isValidPubkey(sendData.p2pkPubkey)
                         ? 'red'
@@ -173,7 +174,7 @@
                     @keyup.enter="lockTokens"
                   ></q-input>
                 </div>
-                <div class="col-4 q-mx-md">
+                <div class="col-4 q-mx-md" v-if="!isCreatorP2PK">
                   <q-btn
                     unelevated
                     v-if="canPasteFromClipboard && !sendData.p2pkPubkey"
@@ -759,6 +760,15 @@ export default defineComponent({
     ...mapState(useBucketsStore, ["bucketList"]),
     bucketOptions() {
       return this.bucketList.map((b) => ({ label: b.name, value: b.id }));
+    },
+    isCreatorP2PK() {
+      const bucket = this.bucketList.find(
+        (b) => b.id === this.sendData.bucketId
+      );
+      return (
+        !!bucket?.creatorPubkey &&
+        bucket.creatorPubkey === this.sendData.p2pkPubkey
+      );
     },
     // TOKEN METHODS
     sumProofs: function () {


### PR DESCRIPTION
## Summary
- add `isCreatorP2PK` computed property in `SendTokenDialog`
- disable pasting and scanning for preset creator keys
- use readonly binding for the P2PK input

## Testing
- `npm run lint`
- `npm run test` *(fails: Tests failed. Watching for file changes...)*

------
https://chatgpt.com/codex/tasks/task_e_68453fb6b88c8330943d2d24135f0d3c