### PR TITLE
Add go back button in Chats page

### DIFF
--- a/src/pages/Chats.vue
+++ b/src/pages/Chats.vue
@@ -2,6 +2,7 @@
   <q-page :class="[$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark']" class="column full-height">
     <q-header elevated reveal class="border-bottom" style="border-bottom: 1px solid rgba(0,0,0,0.1)">
       <q-toolbar class="q-pa-sm">
+        <q-btn flat round dense icon="arrow_back" @click="goBack" class="q-mr-sm" />
         <q-toolbar-title class="text-h6">Chats</q-toolbar-title>
       </q-toolbar>
     </q-header>
@@ -48,6 +49,10 @@ export default defineComponent({
     const nostrStore = useNostrStore();
     const profiles = ref<Record<string, any>>({});
 
+    const goBack = () => {
+      router.push('/wallet');
+    };
+
     const loadProfiles = async () => {
       for (const pk of Object.keys(chats.value)) {
         if (!profiles.value[pk]) {
@@ -91,6 +96,7 @@ export default defineComponent({
       lastMessageSnippet,
       unreadCounts,
       openChat,
+      goBack,
     };
   },
 });


### PR DESCRIPTION
## Summary
- add a back button in the Chats page header
- expose a `goBack` method in `Chats.vue` to return to wallet page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68454086ec90833080dd5544ea48d716