### PR TITLE
Add toolbar navigation controls

### DIFF
--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -30,6 +30,8 @@
     <div class="col column q-pa-md">
       <q-header elevated class="q-mb-md bg-transparent">
         <q-toolbar>
+          <q-btn flat round dense icon="arrow_back" @click="goBack" />
+          <q-btn flat round dense icon="menu" @click="toggleDrawer" class="q-ml-sm" />
           <q-toolbar-title class="text-h6 ellipsis">
             Nostr Messenger
             <q-badge
@@ -59,6 +61,7 @@
 
 <script lang="ts" setup>
 import { computed, ref, onMounted, watch } from "vue";
+import { useRouter } from "vue-router";
 import { useLocalStorage } from "@vueuse/core";
 import { useMessengerStore } from "src/stores/messenger";
 
@@ -76,6 +79,20 @@ messenger.loadIdentity();
 onMounted(() => {
   messenger.start();
 });
+
+const router = useRouter();
+
+const goBack = () => {
+  if (window.history.length > 1) {
+    router.back();
+  } else {
+    router.push('/wallet');
+  }
+};
+
+const toggleDrawer = () => {
+  drawer.value = !drawer.value;
+};
 
 const drawer = computed({
   get: () => messenger.drawerOpen,


### PR DESCRIPTION
## Summary
- add back and drawer buttons to NostrMessenger header
- wire up navigation helpers using vue-router

## Testing
- `npm test` *(fails: getActivePinia was called but there was no active Pinia)*

------
https://chatgpt.com/codex/tasks/task_e_684545fe7ea08330ae7a32b68fef83ac