### PR TITLE
Validate pubkey before starting chat

### DIFF
--- a/src/components/NewChat.vue
+++ b/src/components/NewChat.vue
@@ -15,6 +15,8 @@
 
 <script lang="ts" setup>
 import { ref } from 'vue';
+import { nip19 } from 'nostr-tools';
+import { notifyError } from 'src/js/notify';
 
 const emit = defineEmits(['start']);
 const pubkey = ref('');
@@ -22,6 +24,17 @@ const pubkey = ref('');
 const start = () => {
   const pk = pubkey.value.trim();
   if (!pk) return;
+  let valid = /^[0-9a-fA-F]{64}$/.test(pk);
+  if (!valid && pk.startsWith('npub')) {
+    try {
+      const decoded = nip19.decode(pk);
+      valid = decoded.type === 'npub' && typeof decoded.data === 'string';
+    } catch {}
+  }
+  if (!valid) {
+    notifyError('Invalid Nostr pubkey');
+    return;
+  }
   emit('start', pk);
   pubkey.value = '';
 };


### PR DESCRIPTION
## Summary
- ensure Nostr pubkeys are valid when starting a new chat

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684549e37d5c8330bd518276f325186a