### PR TITLE
Fix nostr identity handling

### DIFF
--- a/src/stores/payment-request.ts
+++ b/src/stores/payment-request.ts
@@ -48,7 +48,7 @@ export const usePRStore = defineStore("payment-request", {
       const transport = [
         {
           type: PaymentRequestTransportType.NOSTR,
-          target: nostrStore.seedSignerNprofile,
+          target: nostrStore.nprofile,
           tags: tags,
         },
       ] as PaymentRequestTransport[];


### PR DESCRIPTION
## Summary
- centralize nostr active private key selection
- use active signer for messaging and payment requests
- rely on active signer when subscribing to nostr DMs

## Testing
- `npm test` *(fails: Cannot set property permissions of [object Object])*

------
https://chatgpt.com/codex/tasks/task_e_68454cf2bbbc8330aa8c23afb3ed46b8