### PR TITLE
Fix messenger header button

### DIFF
--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -31,7 +31,6 @@
       <q-header elevated class="q-mb-md bg-transparent">
         <q-toolbar>
           <q-btn flat round dense icon="arrow_back" @click="goBack" />
-          <q-btn flat round dense icon="menu" @click="toggleDrawer" class="q-ml-sm" />
           <q-toolbar-title class="text-h6 ellipsis">
             Nostr Messenger
             <q-badge
@@ -90,9 +89,6 @@ const goBack = () => {
   }
 };
 
-const toggleDrawer = () => {
-  drawer.value = !drawer.value;
-};
 
 const drawer = computed({
   get: () => messenger.drawerOpen,


### PR DESCRIPTION
## Summary
- remove the messenger drawer button from `NostrMessenger.vue`
- rely on `MainHeader.vue` to toggle the drawer

## Testing
- `npm test` *(fails: getActivePinia called with no active Pinia)*

------
https://chatgpt.com/codex/tasks/task_e_6845650157188330b409064016e352ab