### PR TITLE
Improve Nostr messenger responsiveness

### DIFF
--- a/src/components/ActiveChatHeader.vue
+++ b/src/components/ActiveChatHeader.vue
@@ -1,21 +1,45 @@
 <template>
-  <div class="q-pa-sm row items-center" v-if="pubkey">
-    <q-avatar v-if="profile?.picture" size="md" class="q-mr-sm">
-      <img :src="profile.picture" />
-    </q-avatar>
-    <div class="text-h6 ellipsis">{{ displayName }}</div>
-  </div>
-  <div class="q-pa-sm text-grey-6" v-else>
-    Select a conversation to start chatting.
+  <div class="q-pa-sm row items-center justify-between">
+    <div class="row items-center">
+      <q-btn
+        v-if="$q.screen.lt.sm"
+        flat
+        round
+        dense
+        icon="menu"
+        class="q-mr-sm"
+        @click="messenger.toggleDrawer()"
+      />
+      <template v-if="pubkey">
+        <q-avatar v-if="profile?.picture" size="md" class="q-mr-sm">
+          <img :src="profile.picture" />
+        </q-avatar>
+        <div class="text-h6 ellipsis">{{ displayName }}</div>
+      </template>
+      <template v-else>
+        <div class="text-grey-6">Select a conversation to start chatting.</div>
+      </template>
+    </div>
+    <q-btn
+      flat
+      dense
+      round
+      :icon="$q.dark.isActive ? 'wb_sunny' : 'brightness_3'"
+      @click="$q.dark.toggle()"
+    />
   </div>
 </template>
 
 <script lang="ts" setup>
 import { ref, watch, computed } from 'vue';
+import { useQuasar } from 'quasar';
 import { useNostrStore } from 'src/stores/nostr';
+import { useMessengerStore } from 'src/stores/messenger';
 
 const props = defineProps<{ pubkey: string }>();
 const nostr = useNostrStore();
+const messenger = useMessengerStore();
+const $q = useQuasar();
 const profile = ref<any>(null);
 
 const loadProfile = async () => {

--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -5,29 +5,32 @@
     @touchstart="onTouchStart"
     @touchend="onTouchEnd"
   >
-    <q-drawer
-      v-model="drawer"
-      side="left"
-      show-if-above
-      bordered
-      :width="300"
-      class="q-pa-md"
-    >
-      <NostrIdentityManager class="q-mb-md" />
-      <q-expansion-item
-        class="q-mb-md"
-        dense
-        dense-toggle
-        label="Relays"
-        v-model="showRelays"
+    <q-responsive>
+      <q-drawer
+        v-model="drawer"
+        side="left"
+        show-if-above
+        :breakpoint="600"
+        bordered
+        :width="300"
+        :class="$q.screen.gt.xs ? 'q-pa-lg' : 'q-pa-md'"
       >
-        <RelayManager class="q-mb-md" />
-      </q-expansion-item>
-      <NewChat class="q-mb-md" @start="startChat" />
-      <ConversationList @select="selectConversation" />
-    </q-drawer>
+        <NostrIdentityManager class="q-mb-md" />
+        <q-expansion-item
+          class="q-mb-md"
+          dense
+          dense-toggle
+          label="Relays"
+          v-model="showRelays"
+        >
+          <RelayManager class="q-mb-md" />
+        </q-expansion-item>
+        <NewChat class="q-mb-md" @start="startChat" />
+        <ConversationList @select="selectConversation" />
+      </q-drawer>
+    </q-responsive>
 
-    <div class="col column q-pa-md">
+    <div :class="['col column', $q.screen.gt.xs ? 'q-pa-lg' : 'q-pa-md']">
       <q-header elevated class="q-mb-md bg-transparent">
         <q-toolbar>
           <q-btn flat round dense icon="arrow_back" @click="goBack" />


### PR DESCRIPTION
## Summary
- make messenger drawer responsive
- add dark mode toggle & hamburger menu to ActiveChatHeader
- standardize padding for chat layout

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845750317548330bc3ac7136f18cc79