### PR TITLE
Enhance chat bubble UI

### DIFF
--- a/src/components/ChatMessageBubble.vue
+++ b/src/components/ChatMessageBubble.vue
@@ -1,19 +1,73 @@
 <template>
-  <div class="q-my-xs flex column" :class="message.outgoing ? 'items-end' : 'items-start'">
-    <div :class="message.outgoing ? 'chat-bubble-sent' : 'chat-bubble-received'">
+  <div
+    class="q-my-xs flex column"
+    :class="message.outgoing ? 'items-end' : 'items-start'"
+  >
+    <div :class="message.outgoing ? 'sent' : 'received'">
       {{ message.content }}
     </div>
-    <div class="text-caption q-mt-xs" :class="message.outgoing ? 'text-right' : 'text-left'">
-      {{ time }}
+    <div
+      class="text-caption q-mt-xs row items-center"
+      :class="
+        message.outgoing ? 'justify-end text-right' : 'justify-start text-left'
+      "
+    >
+      <span>
+        {{ time }}
+        <q-tooltip>{{ isoTime }}</q-tooltip>
+      </span>
+      <q-icon
+        v-if="deliveryStatus"
+        :name="deliveryIcon"
+        size="16px"
+        class="q-ml-xs"
+      />
     </div>
   </div>
 </template>
 
 <script lang="ts" setup>
-import { computed } from 'vue';
-import type { MessengerMessage } from 'src/stores/messenger';
+import { computed } from "vue";
+import { mdiCheck, mdiCheckAll } from "@quasar/extras/mdi-v6";
+import type { MessengerMessage } from "src/stores/messenger";
 
-const props = defineProps<{ message: MessengerMessage }>();
-const time = computed(() => new Date(props.message.created_at * 1000).toLocaleString());
+const props = defineProps<{
+  message: MessengerMessage;
+  deliveryStatus?: "sent" | "delivered";
+}>();
+
+const time = computed(() =>
+  new Date(props.message.created_at * 1000).toLocaleString()
+);
+const isoTime = computed(() =>
+  new Date(props.message.created_at * 1000).toISOString()
+);
+const deliveryIcon = computed(() =>
+  props.deliveryStatus === "delivered" ? mdiCheckAll : mdiCheck
+);
 </script>
 
+<style scoped>
+.sent,
+.received {
+  padding: 16px;
+  border-radius: 12px;
+  max-width: 70%;
+  word-break: break-word;
+}
+
+.sent {
+  background-color: var(--q-color-primary);
+  color: #ffffff;
+}
+
+.received {
+  background-color: var(--q-color-grey-2);
+  color: #000000;
+}
+
+body.body--dark .received {
+  background-color: var(--q-color-grey-8);
+  color: #ffffff;
+}
+</style>

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -21,7 +21,6 @@ body,
   margin-top: var(--safe-area-inset-top);
 }
 
-
 .q-dialog__inner > div {
   border-top-left-radius: 0px;
   border-top-right-radius: 0px;
@@ -127,21 +126,24 @@ body.body--light {
   color: #ffffff !important;
 }
 
-.chat-bubble-sent {
-  @extend .accent-purple;
-  align-self: flex-end;
-  padding: 6px 12px;
-  border-radius: 16px;
+.sent,
+.received {
+  padding: 16px;
+  border-radius: 12px;
   max-width: 70%;
   word-break: break-word;
 }
 
-.chat-bubble-received {
+.sent {
+  @extend .accent-purple;
+}
+
+.received {
   @extend .bg-gray-100;
-  align-self: flex-start;
   color: #000 !important;
-  padding: 6px 12px;
-  border-radius: 16px;
-  max-width: 70%;
-  word-break: break-word;
+}
+
+body.body--dark .received {
+  background-color: var(--q-color-grey-8) !important;
+  color: #ffffff !important;
 }


### PR DESCRIPTION
## Summary
- tweak `ChatMessageBubble` to show delivery status and hover timestamp
- adjust global chat bubble styles for new classes `.sent` and `.received`

## Testing
- `npm test` *(fails: Cannot set property permissions of [object Object] which has only a getter)*
- `npm run checkformat` *(fails: Code style issues found in 103 files. Forgot to run Prettier?)*

------
https://chatgpt.com/codex/tasks/task_e_684580c1aa3c8330a6afc979fafc319c