### PR TITLE
Fetch older direct messages

### DIFF
--- a/src/stores/messenger.ts
+++ b/src/stores/messenger.ts
@@ -139,12 +139,17 @@ export const useMessengerStore = defineStore("messenger", {
         notifyError('No private key set. Please configure your Nostr identity.');
         return;
       }
+      const since = this.eventLog.reduce(
+        (max, m) => (m.created_at > max ? m.created_at : max),
+        0
+      );
       await nostr.subscribeToNip04DirectMessagesCallback(
         privKey,
         nostr.pubkey,
         async (ev, _decrypted) => {
           await this.addIncomingMessage(ev as NostrEvent);
-        }
+        },
+        since
       );
       this.started = true;
     },

--- a/test/vitest/__tests__/messenger.spec.ts
+++ b/test/vitest/__tests__/messenger.spec.ts
@@ -8,7 +8,7 @@ var walletGen: any
 vi.mock('../../../src/stores/nostr', () => {
   sendDm = vi.fn(async () => ({ success: true, event: { id: '1', created_at: 0 } }))
   decryptDm = vi.fn(async () => 'msg')
-  subscribe = vi.fn(async (_priv: string, _pub: string, cb: any) => { cb && cb({} as any, '') })
+  subscribe = vi.fn(async (_priv: string, _pub: string, cb: any, _since?: number) => { cb && cb({} as any, '') })
   walletGen = vi.fn()
   const store = {
     sendNip04DirectMessage: sendDm,
@@ -70,6 +70,7 @@ describe('messenger store', () => {
     const args = subscribe.mock.calls[0]
     expect(args[0]).toBe('priv')
     expect(args[1]).toBe('pub')
+    expect(args[3]).toBe(0)
   })
 
   it('notifies when starting without privkey', async () => {


### PR DESCRIPTION
## Summary
- respect `lastEventTimestamp` in `subscribeToNip04DirectMessagesCallback`
- include a `since` timestamp when subscribing in the messenger store
- adjust messenger tests for the new argument

## Testing
- `npm test` *(fails: "getActivePinia()" was called but there was no active Pinia)*

------
https://chatgpt.com/codex/tasks/task_e_6845b0a6503c8330b844813cdf7b3dd6