### PR TITLE
Fix relay reconnection for messenger

### DIFF
--- a/src/stores/messenger.ts
+++ b/src/stores/messenger.ts
@@ -162,18 +162,13 @@ export const useMessengerStore = defineStore("messenger", {
     connect(relays: string[]) {
       const nostr = useNostrStore();
       this.relays = relays as any;
-      nostr.relays = relays as any;
-      nostr.initNdkReadOnly();
+      // Reconnect the nostr store with the updated relays
+      nostr.connect(relays as any);
     },
 
     disconnect() {
       const nostr = useNostrStore();
-      if (nostr.ndk && (nostr.ndk as any).pool) {
-        for (const relay of (nostr.ndk as any).pool.relays.values()) {
-          relay.disconnect && relay.disconnect();
-        }
-      }
-      nostr.connected = false;
+      nostr.disconnect();
     },
 
     createConversation(pubkey: string) {

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -156,6 +156,27 @@ export const useNostrStore = defineStore("nostr", {
       this.ndk.connect();
       this.connected = true;
     },
+    disconnect: function () {
+      if (this.ndk && (this.ndk as any).pool) {
+        for (const relay of (this.ndk as any).pool.relays.values()) {
+          relay.disconnect && relay.disconnect();
+        }
+      }
+      this.connected = false;
+    },
+    connect: function (relays?: string[]) {
+      if (relays) {
+        this.relays = relays as any;
+      }
+      this.disconnect();
+      const opts: any = { explicitRelayUrls: this.relays };
+      if (this.signer) {
+        opts.signer = this.signer;
+      }
+      this.ndk = new NDK(opts);
+      this.ndk.connect();
+      this.connected = true;
+    },
     initSignerIfNotSet: async function () {
       if (!this.initialized) {
         await this.initSigner();


### PR DESCRIPTION
## Summary
- reconnect Nostr when relay list changes
- expose connect/disconnect helpers in the Nostr store
- use new helpers from the Messenger store

## Testing
- `npm test` *(fails: 15 failed, 6 passed)*
- `npm run lint`
- `npm run checkformat` *(fails with code style issues)*

------
https://chatgpt.com/codex/tasks/task_e_6845b68a42b48330a3aa2ef6b9789206