### PR TITLE
Use npub/nsec getters in Nostr views

### DIFF
--- a/src/components/NostrIdentityManager.vue
+++ b/src/components/NostrIdentityManager.vue
@@ -35,10 +35,8 @@ import { useNostrStore } from 'src/stores/nostr';
 const nostr = useNostrStore();
 
 const showDialog = ref(false);
-const privKey = ref(
-  nostr.privateKeySignerPrivateKey || nostr.seedSignerPrivateKey
-);
-const pubKey = ref(nostr.pubkey);
+const privKey = ref(nostr.activePrivateKeyNsec);
+const pubKey = ref(nostr.npub);
 const relayInput = ref('');
 const relays = ref<string[]>([...nostr.relays]);
 
@@ -56,7 +54,7 @@ const removeRelay = (index: number) => {
 const save = async () => {
   nostr.relays = relays.value as any;
   await nostr.initPrivateKeySigner(privKey.value as any);
-  pubKey.value = nostr.pubkey;
+  pubKey.value = nostr.npub;
   showDialog.value = false;
 };
 </script>

--- a/src/pages/MyProfilePage.vue
+++ b/src/pages/MyProfilePage.vue
@@ -10,7 +10,7 @@
         {{ $t("CreatorHub.profile.back") }}
       </q-btn>
     </div>
-    <div class="text-h5 q-mb-md">{{ profile.display_name || pubkey }}</div>
+    <div class="text-h5 q-mb-md">{{ profile.display_name || npub }}</div>
     <div v-if="profile.picture" class="q-mb-md">
       <img :src="profile.picture" style="max-width: 150px" />
     </div>
@@ -18,13 +18,13 @@
 
     <div class="q-mb-md text-caption">
       <div class="row items-center q-gutter-x-sm">
-        <div><strong>npub:</strong> {{ pubkey }}</div>
+        <div><strong>npub:</strong> {{ npub }}</div>
         <q-btn
-          v-if="pubkey"
+          v-if="npub"
           flat
           dense
           icon="content_copy"
-          @click="copyText(pubkey)"
+          @click="copyText(npub)"
         />
       </div>
       <div v-if="seedSignerPrivateKeyNsecComputed" class="row items-center q-gutter-x-sm q-mt-xs">
@@ -95,8 +95,11 @@ export default defineComponent({
     const { t } = useI18n();
 
     const nostr = useNostrStore();
-    const { pubkey, seedSignerPrivateKeyNsecComputed, privateKeySignerPrivateKey } =
-      storeToRefs(nostr);
+    const {
+      npub,
+      seedSignerPrivateKeyNsecComputed,
+      privateKeySignerPrivateKey,
+    } = storeToRefs(nostr);
     const hub = useCreatorHubStore();
     const priceStore = usePriceStore();
     const uiStore = useUiStore();
@@ -113,8 +116,8 @@ export default defineComponent({
     );
 
     onMounted(async () => {
-      if (!pubkey.value) return;
-      const p = await nostr.getProfile(pubkey.value);
+      if (!npub.value) return;
+      const p = await nostr.getProfile(npub.value);
       if (p) profile.value = { ...p };
     });
 
@@ -132,7 +135,7 @@ export default defineComponent({
       if (tier.welcomeMessage) {
         try {
           await useNostrStore().sendNip04DirectMessage(
-            pubkey.value,
+            npub.value,
             tier.welcomeMessage,
           );
         } catch (e) {
@@ -151,7 +154,7 @@ export default defineComponent({
     }
 
     return {
-      pubkey,
+      npub,
       seedSignerPrivateKeyNsecComputed,
       privateKeySignerPrivateKey,
       profile,

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -136,6 +136,25 @@ export const useNostrStore = defineStore("nostr", {
       };
       return nip19.nprofileEncode(profile);
     },
+    npub: (state) => {
+      try {
+        return nip19.npubEncode(state.pubkey);
+      } catch (e) {
+        return state.pubkey;
+      }
+    },
+    activePrivateKeyNsec: (state) => {
+      const keyHex =
+        state.signerType === SignerType.PRIVATEKEY
+          ? state.privateKeySignerPrivateKey
+          : state.seedSignerPrivateKey;
+      if (!keyHex) return "";
+      try {
+        return nip19.nsecEncode(hexToBytes(keyHex));
+      } catch (e) {
+        return "";
+      }
+    },
     privKeyHex: (state) => {
       switch (state.signerType) {
         case SignerType.PRIVATEKEY:


### PR DESCRIPTION
## Summary
- expose `npub` and `activePrivateKeyNsec` getters from `nostr` store
- show npub string on My Profile page
- display npub and nsec in Nostr identity manager

## Testing
- `npm test --silent` *(fails: Cannot set property permissions of [object Object] which has only a getter)*

------
https://chatgpt.com/codex/tasks/task_e_6845bf28d21c83309ba9eb0f49a93eb3