### PR TITLE
Add subscriptions overview page

### DIFF
--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -190,6 +190,19 @@
           }}</q-item-label>
         </q-item-section>
       </q-item>
+      <q-item clickable @click="gotoSubscriptions">
+        <q-item-section avatar>
+          <q-icon name="auto_awesome_motion" />
+        </q-item-section>
+        <q-item-section>
+          <q-item-label>{{
+            $t("MainHeader.menu.subscriptions.subscriptions.title")
+          }}</q-item-label>
+          <q-item-label caption>{{
+            $t("MainHeader.menu.subscriptions.subscriptions.caption")
+          }}</q-item-label>
+        </q-item-section>
+      </q-item>
       <q-item clickable @click="gotoChats">
         <q-item-section avatar>
           <q-icon name="chat" />
@@ -398,6 +411,11 @@ export default defineComponent({
       leftDrawerOpen.value = false;
     };
 
+    const gotoSubscriptions = () => {
+      router.push("/subscriptions");
+      leftDrawerOpen.value = false;
+    };
+
     const gotoChats = () => {
       router.push("/nostr-messenger");
       leftDrawerOpen.value = false;
@@ -425,6 +443,7 @@ export default defineComponent({
       gotoFindCreators,
       gotoCreatorHub,
       gotoMyProfile,
+      gotoSubscriptions,
       gotoChats,
       gotoNostrLogin,
       gotoWallet,

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -133,6 +133,13 @@ export default {
           caption: "Manage buckets",
         },
       },
+      subscriptions: {
+        title: "Subscriptions",
+        subscriptions: {
+          title: "Subscriptions",
+          caption: "Overview of your subscriptions",
+        },
+      },
       terms: {
         title: "Terms",
         terms: {
@@ -1461,6 +1468,16 @@ export default {
     title: "Move tokens",
     empty: "No tokens",
     helper: "Move tokens between buckets to organize them.",
+  },
+  SubscriptionsOverview: {
+    title: "Subscriptions",
+    columns: {
+      creator: "Creator",
+      total: "Total",
+      next_unlock: "Next unlock",
+      remaining: "Months left",
+    },
+    empty: "No subscriptions",
   },
   LockedTokensTable: {
     empty_text: "No locked tokens",

--- a/src/pages/SubscriptionsOverview.vue
+++ b/src/pages/SubscriptionsOverview.vue
@@ -1,0 +1,86 @@
+<template>
+  <div class="q-pa-md">
+    <h5 class="q-my-none q-mb-md">{{ $t('SubscriptionsOverview.title') }}</h5>
+    <q-markup-table flat bordered dense>
+      <thead>
+        <tr>
+          <th class="text-left">{{ $t('SubscriptionsOverview.columns.creator') }}</th>
+          <th class="text-right">{{ $t('SubscriptionsOverview.columns.total') }}</th>
+          <th class="text-left">{{ $t('SubscriptionsOverview.columns.next_unlock') }}</th>
+          <th class="text-right">{{ $t('SubscriptionsOverview.columns.remaining') }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="row in rows" :key="row.creator">
+          <td>{{ shortenString(pubkeyNpub(row.creator), 15, 6) }}</td>
+          <td class="text-right">{{ formatCurrency(row.total) }}</td>
+          <td>{{ row.nextUnlock ? formatTs(row.nextUnlock) : '-' }}</td>
+          <td class="text-right">{{ row.monthsLeft }}</td>
+        </tr>
+        <tr v-if="rows.length === 0">
+          <td colspan="4" class="text-center text-grey">{{ $t('SubscriptionsOverview.empty') }}</td>
+        </tr>
+      </tbody>
+    </q-markup-table>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { storeToRefs } from 'pinia';
+import { useLockedTokensStore, type LockedToken } from 'stores/lockedTokens';
+import { useBucketsStore } from 'stores/buckets';
+import { useMintsStore } from 'stores/mints';
+import { useUiStore } from 'stores/ui';
+import { nip19 } from 'nostr-tools';
+import { shortenString } from 'src/js/string-utils';
+
+const lockedStore = useLockedTokensStore();
+const bucketsStore = useBucketsStore();
+const mintsStore = useMintsStore();
+const uiStore = useUiStore();
+const { activeUnit } = storeToRefs(mintsStore);
+
+function pubkeyNpub(hex: string): string {
+  try {
+    return nip19.npubEncode(hex);
+  } catch {
+    return hex;
+  }
+}
+
+function formatCurrency(amount: number): string {
+  return uiStore.formatCurrency(amount, activeUnit.value);
+}
+
+function formatTs(ts: number): string {
+  const d = new Date(ts * 1000);
+  return `${d.getFullYear()}-${('0' + (d.getMonth() + 1)).slice(-2)}-${('0' + d.getDate()).slice(-2)}`;
+}
+
+const groups = computed<Record<string, LockedToken[]>>(() => {
+  const map: Record<string, LockedToken[]> = {};
+  lockedStore.lockedTokens.forEach((t) => {
+    const bucket = bucketsStore.bucketList.find((b) => b.id === t.bucketId);
+    const pubkey = bucket?.creatorPubkey || t.pubkey;
+    if (!map[pubkey]) map[pubkey] = [];
+    map[pubkey].push(t);
+  });
+  return map;
+});
+
+const rows = computed(() => {
+  const now = Math.floor(Date.now() / 1000);
+  return Object.entries(groups.value).map(([creator, tokens]) => {
+    const total = tokens.reduce((sum, t) => sum + t.amount, 0);
+    const future = tokens.filter((t) => t.locktime && t.locktime > now);
+    const nextUnlock = future.sort((a, b) => (a.locktime! - b.locktime!))[0]?.locktime || null;
+    const monthsLeft = future.length;
+    return { creator, total, nextUnlock, monthsLeft };
+  });
+});
+</script>
+
+<style scoped>
+</style>
+

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -74,6 +74,13 @@ const routes = [
     ],
   },
   {
+    path: "/subscriptions",
+    component: () => import("layouts/FullscreenLayout.vue"),
+    children: [
+      { path: "", component: () => import("src/pages/SubscriptionsOverview.vue") },
+    ],
+  },
+  {
     path: "/nostr-messenger",
     component: () => import("layouts/MainLayout.vue"),
     children: [


### PR DESCRIPTION
## Summary
- show locked tokens per creator in new SubscriptionsOverview page
- hook the route `/subscriptions` into router
- extend MainHeader menu with link to Subscriptions page
- localize menu item and page text in en-US i18n

## Testing
- `npm test` *(fails: Cannot set property permissions of [object Object] etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6845ce6e3bdc83308395074574b863ea