### PR TITLE
Encode npub in display names

### DIFF
--- a/src/components/ActiveChatHeader.vue
+++ b/src/components/ActiveChatHeader.vue
@@ -58,6 +58,7 @@ import { useRouter } from 'vue-router';
 import { useNostrStore } from 'src/stores/nostr';
 import { useMessengerStore } from 'src/stores/messenger';
 import { useSendTokensStore } from 'src/stores/sendTokensStore';
+import { nip19 } from 'nostr-tools';
 
 const props = defineProps<{ pubkey: string }>();
 const nostr = useNostrStore();
@@ -84,11 +85,13 @@ watch(
 const displayName = computed(() => {
   if (!props.pubkey) return '';
   const p: any = profile.value;
-  return (
-    p?.display_name ||
-    p?.name ||
-    props.pubkey.slice(0, 8) + '...' + props.pubkey.slice(-4)
-  );
+  if (p?.display_name) return p.display_name;
+  if (p?.name) return p.name;
+  try {
+    return nip19.npubEncode(nostr.resolvePubkey(props.pubkey));
+  } catch (e) {
+    return props.pubkey.slice(0, 8) + '...' + props.pubkey.slice(-4);
+  }
 });
 
 const initials = computed(() => {

--- a/src/components/ConversationListItem.vue
+++ b/src/components/ConversationListItem.vue
@@ -45,6 +45,8 @@
 import { defineComponent, computed } from 'vue';
 import { QBadge } from 'quasar';
 import { useMessengerStore } from 'src/stores/messenger';
+import { useNostrStore } from 'src/stores/nostr';
+import { nip19 } from 'nostr-tools';
 import { formatDistanceToNow } from 'date-fns';
 
 export default defineComponent({
@@ -59,16 +61,19 @@ export default defineComponent({
   emits: ['click'],
   setup(props, { emit }) {
     const messenger = useMessengerStore();
+    const nostr = useNostrStore();
     const unreadCount = computed(
       () => messenger.unreadCounts[props.pubkey] || 0
     );
     const displayName = computed(() => {
       const p: any = props.profile;
-      return (
-        p?.display_name ||
-        p?.name ||
-        props.pubkey.slice(0, 8) + '...' + props.pubkey.slice(-4)
-      );
+      if (p?.display_name) return p.display_name;
+      if (p?.name) return p.name;
+      try {
+        return nip19.npubEncode(nostr.resolvePubkey(props.pubkey));
+      } catch (e) {
+        return props.pubkey.slice(0, 8) + '...' + props.pubkey.slice(-4);
+      }
     });
 
     const initials = computed(() => {


### PR DESCRIPTION
## Summary
- show npub IDs when no profile name is available

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845ceaebd7c8330a24b2b7013418833