### PR TITLE
Add profile info dialog

### DIFF
--- a/src/components/ActiveChatHeader.vue
+++ b/src/components/ActiveChatHeader.vue
@@ -24,18 +24,19 @@
           <span v-else>{{ initials }}</span>
         </q-avatar>
         <div class="text-h6 ellipsis">{{ displayName }}</div>
-        <q-btn flat round dense icon="more_vert" class="q-ml-xs">
-          <q-menu auto-close>
-            <q-list style="min-width: 120px">
-              <q-item clickable v-close-popup @click="viewProfile">
-                <q-item-section>View Profile</q-item-section>
-              </q-item>
-              <q-item clickable v-close-popup @click="clearChat">
-                <q-item-section>Clear Chat</q-item-section>
-              </q-item>
-            </q-list>
-          </q-menu>
-        </q-btn>
+        <q-btn
+          flat
+          round
+          dense
+          icon="more_vert"
+          class="q-ml-xs"
+          @click="showProfileDialog = true"
+        />
+        <ProfileInfoDialog
+          v-model="showProfileDialog"
+          :pubkey="props.pubkey"
+          @clear-chat="clearChat"
+        />
       </template>
       <template v-else>
         <div class="text-grey-6">Select a conversation to start chatting.</div>
@@ -54,11 +55,11 @@
 <script lang="ts" setup>
 import { ref, watch, computed } from 'vue';
 import { useQuasar } from 'quasar';
-import { useRouter } from 'vue-router';
 import { useNostrStore } from 'src/stores/nostr';
 import { useMessengerStore } from 'src/stores/messenger';
 import { useSendTokensStore } from 'src/stores/sendTokensStore';
 import { nip19 } from 'nostr-tools';
+import ProfileInfoDialog from './ProfileInfoDialog.vue';
 
 const props = defineProps<{ pubkey: string }>();
 const nostr = useNostrStore();
@@ -105,7 +106,7 @@ const initials = computed(() => {
 });
 
 const sendTokensStore = useSendTokensStore();
-const router = useRouter();
+const showProfileDialog = ref(false);
 
 function openSendTokenDialog() {
   if (!props.pubkey) return;
@@ -115,10 +116,6 @@ function openSendTokenDialog() {
   sendTokensStore.showSendTokens = true;
 }
 
-function viewProfile() {
-  if (!props.pubkey) return;
-  router.push(`/creator/${props.pubkey}`);
-}
 
 function clearChat() {
   if (!props.pubkey) return;

--- a/src/components/ProfileInfoDialog.vue
+++ b/src/components/ProfileInfoDialog.vue
@@ -1,0 +1,130 @@
+<template>
+  <q-dialog v-model="showLocal" persistent backdrop-filter="blur(2px) brightness(60%)">
+    <q-card style="min-width:350px">
+      <q-card-section class="row items-center q-gutter-sm">
+        <q-avatar size="64px">
+          <template v-if="profile?.picture">
+            <img :src="profile.picture" />
+          </template>
+          <template v-else>
+            <div class="placeholder text-white">{{ initials }}</div>
+          </template>
+        </q-avatar>
+        <div class="column">
+          <div class="text-h6">{{ displayName }}</div>
+          <div v-if="joinedText" class="text-caption">Joined {{ joinedText }}</div>
+        </div>
+      </q-card-section>
+      <q-card-section v-if="profile?.about" class="text-body2">
+        {{ profile.about }}
+      </q-card-section>
+      <q-card-section class="text-caption" v-if="followers !== null">
+        Followers: {{ followers }} | Following: {{ following }}
+      </q-card-section>
+      <q-card-section v-if="recentPost">
+        <div class="text-subtitle1 q-mb-xs">Most Recent Post</div>
+        <div class="text-body2">{{ recentPost }}</div>
+      </q-card-section>
+      <q-card-section v-if="tiers.length">
+        <div class="text-subtitle1 q-mb-sm">Tiers</div>
+        <div v-for="t in tiers" :key="t.id" class="q-mb-sm">
+          <div class="text-body1">{{ t.name }} - {{ t.price_sats }} sats/month</div>
+          <div class="text-caption">{{ t.description }}</div>
+        </div>
+      </q-card-section>
+      <q-card-actions align="right">
+        <q-btn flat color="negative" @click="handleClear">Clear Chat</q-btn>
+        <q-btn flat v-close-popup color="grey">Close</q-btn>
+      </q-card-actions>
+    </q-card>
+  </q-dialog>
+</template>
+
+<script lang="ts" setup>
+import { ref, computed, watch } from 'vue';
+import { useNostrStore } from 'src/stores/nostr';
+import { useCreatorsStore } from 'src/stores/creators';
+import { nip19 } from 'nostr-tools';
+
+const props = defineProps<{ modelValue: boolean; pubkey: string }>();
+const emit = defineEmits(['update:modelValue', 'clear-chat']);
+
+const showLocal = computed({
+  get: () => props.modelValue,
+  set: (v: boolean) => emit('update:modelValue', v),
+});
+
+const nostr = useNostrStore();
+const creators = useCreatorsStore();
+
+const profile = ref<any>(null);
+const followers = ref<number | null>(null);
+const following = ref<number | null>(null);
+const joined = ref<number | null>(null);
+const recentPost = ref<string | null>(null);
+const tiers = ref<any[]>([]);
+
+async function load() {
+  if (!props.pubkey) return;
+  profile.value = await nostr.getProfile(props.pubkey);
+  followers.value = await nostr.fetchFollowerCount(props.pubkey);
+  following.value = await nostr.fetchFollowingCount(props.pubkey);
+  joined.value = await nostr.fetchJoinDate(props.pubkey);
+  recentPost.value = await nostr.fetchMostRecentPost(props.pubkey);
+  await creators.fetchTierDefinitions(props.pubkey);
+  tiers.value = creators.tiersMap[props.pubkey] || [];
+}
+
+watch(
+  () => props.pubkey,
+  () => {
+    load();
+  },
+  { immediate: true }
+);
+
+const displayName = computed(() => {
+  if (!props.pubkey) return '';
+  const p: any = profile.value;
+  if (p?.display_name) return p.display_name;
+  if (p?.name) return p.name;
+  try {
+    return nip19.npubEncode(nostr.resolvePubkey(props.pubkey));
+  } catch (e) {
+    return props.pubkey.slice(0, 8) + '...' + props.pubkey.slice(-4);
+  }
+});
+
+const initials = computed(() => {
+  const name = displayName.value.trim();
+  if (!name) return '';
+  const parts = name.split(' ');
+  if (parts.length >= 2) {
+    return (parts[0][0] + parts[1][0]).toUpperCase();
+  }
+  return name.slice(0, 2).toUpperCase();
+});
+
+const joinedText = computed(() => {
+  if (!joined.value) return '';
+  const d = new Date(joined.value * 1000);
+  return d.toLocaleDateString();
+});
+
+function handleClear() {
+  emit('clear-chat');
+}
+</script>
+
+<style scoped>
+.placeholder {
+  background: var(--divider-color);
+  width: 64px;
+  height: 64px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+}
+</style>
+

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -437,6 +437,22 @@ export const useNostrStore = defineStore("nostr", {
       }
       return earliest;
     },
+
+    fetchMostRecentPost: async function (
+      pubkey: string
+    ): Promise<string | null> {
+      pubkey = this.resolvePubkey(pubkey);
+      await this.initNdkReadOnly();
+      const filter: NDKFilter = { kinds: [1], authors: [pubkey], limit: 1 };
+      const events = await this.ndk.fetchEvents(filter);
+      let latest: NDKEvent | null = null;
+      events.forEach((ev) => {
+        if (!latest || ev.created_at > (latest.created_at || 0)) {
+          latest = ev as NDKEvent;
+        }
+      });
+      return latest ? (latest.content as string) : null;
+    },
     fetchMints: async function () {
       const filter: NDKFilter = { kinds: [38000 as NDKKind], limit: 2000 };
       const events = await this.ndk.fetchEvents(filter);


### PR DESCRIPTION
## Summary
- create `ProfileInfoDialog.vue` to display nostr profile details
- add `fetchMostRecentPost` action in nostr store
- show dialog from `ActiveChatHeader` and remove old menu

## Testing
- `npm test` *(fails: getActivePinia() called but no active Pinia)*

------
https://chatgpt.com/codex/tasks/task_e_6845d19343e88330870aa15996383097