### PR TITLE
Auto bucket selection and token label display

### DIFF
--- a/src/components/LockedTokensTable.vue
+++ b/src/components/LockedTokensTable.vue
@@ -12,6 +12,7 @@
           <q-item-label class="text-weight-bold">
             {{ formatCurrency(token.amount, activeUnit) }}
           </q-item-label>
+          <q-item-label caption>{{ token.label || 'Locked tokens' }}</q-item-label>
           <q-item-label caption>
             {{
               $t("LockedTokensTable.row.receiver_label", {

--- a/src/components/SubscribeDialog.vue
+++ b/src/components/SubscribeDialog.vue
@@ -6,6 +6,7 @@
       </q-card-section>
       <q-card-section>
         <q-select
+          v-if="showBucketSelect"
           v-model="bucketId"
           :options="bucketOptions"
           emit-value
@@ -72,6 +73,7 @@ export default defineComponent({
     modelValue: Boolean,
     tier: { type: Object, required: true },
     supporterPubkey: { type: String, default: "" },
+    creatorPubkey: { type: String, default: "" },
   },
   emits: ["update:modelValue", "confirm"],
   setup(props, { emit }) {
@@ -121,6 +123,38 @@ export default defineComponent({
       }))
     );
 
+    const showBucketSelect = computed(() => !props.creatorPubkey);
+
+    const selectCreatorBucket = () => {
+      if (!props.creatorPubkey) return;
+      const existing = bucketList.value.find(
+        (b) => b.creatorPubkey === props.creatorPubkey
+      );
+      if (existing) {
+        bucketId.value = existing.id;
+      } else {
+        const created = bucketsStore.addBucket({
+          name: props.creatorPubkey.slice(0, 8),
+          creatorPubkey: props.creatorPubkey,
+        });
+        if (created) bucketId.value = created.id;
+      }
+    };
+
+    watch(
+      () => props.modelValue,
+      (val) => {
+        if (val) selectCreatorBucket();
+      }
+    );
+
+    watch(
+      () => props.creatorPubkey,
+      () => {
+        if (props.modelValue) selectCreatorBucket();
+      }
+    );
+
     const cancel = () => {
       emit("update:modelValue", false);
     };
@@ -144,6 +178,7 @@ export default defineComponent({
       model,
       bucketId,
       bucketOptions,
+      showBucketSelect,
       amount,
       months,
       presetOptions,

--- a/src/pages/FindCreators.vue
+++ b/src/pages/FindCreators.vue
@@ -11,6 +11,7 @@
       v-model="showSubscribeDialog"
       :tier="selectedTier"
       :supporter-pubkey="nostr.pubkey"
+      :creator-pubkey="dialogPubkey.value"
       @confirm="confirmSubscribe"
     />
     <SubscriptionReceipt v-model="showReceiptDialog" :receipts="receiptList" />
@@ -152,7 +153,6 @@ function openSubscribe(tier: any) {
 }
 
 async function confirmSubscribe({
-  bucketId,
   months,
   amount,
   startDate,
@@ -165,7 +165,7 @@ async function confirmSubscribe({
       months,
       amount,
       dialogPubkey.value,
-      bucketId,
+      undefined,
       startDate,
       true
     )) as any[];

--- a/src/pages/PublicCreatorProfilePage.vue
+++ b/src/pages/PublicCreatorProfilePage.vue
@@ -19,6 +19,7 @@
       v-model="showSubscribeDialog"
       :tier="selectedTier"
       :supporter-pubkey="nostr.pubkey"
+      :creator-pubkey="creatorNpub"
       @confirm="confirmSubscribe"
     />
     <SubscriptionReceipt v-model="showReceiptDialog" :receipts="receiptList" />
@@ -148,7 +149,6 @@ export default defineComponent({
     };
 
     const confirmSubscribe = async ({
-      bucketId,
       months,
       amount,
       startDate,
@@ -160,7 +160,7 @@ export default defineComponent({
           months,
           amount,
           creatorNpub,
-          bucketId,
+          undefined,
           startDate,
           true
         )) as any[];

--- a/src/stores/lockedTokens.ts
+++ b/src/stores/lockedTokens.ts
@@ -7,6 +7,7 @@ export type LockedToken = {
   amount: number;
   token: string;
   pubkey: string;
+  label?: string;
   locktime?: number;
   refundPubkey?: string;
   bucketId: string;
@@ -32,11 +33,17 @@ export const useLockedTokensStore = defineStore("lockedTokens", {
       },
   },
   actions: {
-    addLockedToken(data: Omit<LockedToken, "id" | "date"> & { date?: string }) {
+    addLockedToken(
+      data: Omit<LockedToken, "id" | "date" | "label"> & {
+        date?: string;
+        label?: string;
+      }
+    ) {
       const token: LockedToken = {
         id: uuidv4(),
         date: data.date || new Date().toISOString(),
         ...data,
+        label: data.label ?? "Locked tokens",
       };
       this.lockedTokens.push(token);
       return token;


### PR DESCRIPTION
## Summary
- pre-select creator buckets in `SubscribeDialog` and hide bucket select
- show locked token labels
- add optional label parameter to locked token store
- link subscribe dialog to creator in profile and search pages
- call `createDonationPreset` without bucket id from subscribe flow

## Testing
- `npm test` *(fails: getActivePinia error, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6845d68dd9388330817008251b652070