### PR TITLE
Add emoji and wallet buttons to chat input

### DIFF
--- a/src/components/MessageInput.vue
+++ b/src/components/MessageInput.vue
@@ -1,14 +1,28 @@
 <template>
   <div class="row no-wrap items-center q-pa-sm">
-    <q-input v-model="text" class="col" dense outlined @keyup.enter="send" />
-    <q-btn flat round icon="send" color="primary" class="q-ml-sm" :disable="!text.trim()" @click="send" />
+    <q-input v-model="text" class="col" dense outlined @keyup.enter="send">
+      <template v-slot:append>
+        <q-btn flat round icon="emoji-emotions-outline" @click="toggleEmojiPicker" />
+        <q-btn flat round icon="attach-file" @click="onAttachFile" />
+        <q-btn flat round icon="account-balance-wallet" @click="sendToken" />
+        <q-btn
+          flat
+          round
+          icon="send"
+          color="primary"
+          class="q-ml-sm"
+          :disable="!text.trim()"
+          @click="send"
+        />
+      </template>
+    </q-input>
   </div>
 </template>
 
 <script lang="ts" setup>
 import { ref } from 'vue';
 
-const emit = defineEmits(['send']);
+const emit = defineEmits(['send', 'sendToken']);
 const text = ref('');
 
 const send = () => {
@@ -18,4 +32,11 @@ const send = () => {
     text.value = '';
   }
 };
+
+const sendToken = () => {
+  emit('sendToken');
+};
+
+const toggleEmojiPicker = () => {};
+const onAttachFile = () => {};
 </script>


### PR DESCRIPTION
## Summary
- extend `MessageInput` with emoji, attachment and token buttons
- stub out handlers for new buttons

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68467643ebc483308d5af987cb0c9489