### PR TITLE
Add aria labels and update message input

### DIFF
--- a/src/components/ActiveChatHeader.vue
+++ b/src/components/ActiveChatHeader.vue
@@ -8,7 +8,7 @@
         icon="payments"
         class="q-mr-sm"
         @click="openSendTokenDialog"
-      />
+       aria-label="button"/>
       <q-btn
         v-if="$q.screen.lt.sm"
         flat
@@ -17,7 +17,7 @@
         icon="menu"
         class="q-mr-sm"
         @click="messenger.toggleDrawer()"
-      />
+       aria-label="button"/>
       <template v-if="pubkey">
         <q-avatar size="md" class="q-mr-sm">
           <img v-if="profile?.picture" :src="profile.picture" />
@@ -31,7 +31,7 @@
           icon="more_vert"
           class="q-ml-xs"
           @click="showProfileDialog = true"
-        />
+         aria-label="button"/>
         <ProfileInfoDialog
           v-model="showProfileDialog"
           :pubkey="props.pubkey"
@@ -48,7 +48,7 @@
       round
       :icon="$q.dark.isActive ? 'wb_sunny' : 'brightness_3'"
       @click="$q.dark.toggle()"
-    />
+     aria-label="button"/>
   </div>
 </template>
 

--- a/src/components/AddMintDialog.vue
+++ b/src/components/AddMintDialog.vue
@@ -44,7 +44,7 @@
             :loading="addMintBlocking"
             @click="addMintLocal"
             style="width: calc(75%)"
-            >{{ $t("AddMintDialog.actions.add_mint.label") }}
+             aria-label="button">{{ $t("AddMintDialog.actions.add_mint.label") }}
             <template v-slot:loading>
               <q-spinner-hourglass />
               {{ $t("AddMintDialog.actions.add_mint.in_progress") }}</template
@@ -52,7 +52,7 @@
           </q-btn>
         </div>
         <div class="col">
-          <q-btn v-close-popup flat class="float-right" color="grey">{{
+          <q-btn v-close-popup flat class="float-right" color="grey" aria-label="button">{{
             $t("AddMintDialog.actions.cancel.label")
           }}</q-btn>
         </div>

--- a/src/components/AddTierDialog.vue
+++ b/src/components/AddTierDialog.vue
@@ -54,8 +54,8 @@
         />
       </q-card-section>
       <q-card-actions align="between" class="q-pt-none">
-        <q-btn flat color="primary" @click="save">{{ $t('CreatorHub.dashboard.save_tier') }}</q-btn>
-        <q-btn flat color="grey" v-close-popup>{{ $t('global.actions.cancel.label') }}</q-btn>
+        <q-btn flat color="primary" @click="save" aria-label="button">{{ $t('CreatorHub.dashboard.save_tier') }}</q-btn>
+        <q-btn flat color="grey" v-close-popup aria-label="button">{{ $t('global.actions.cancel.label') }}</q-btn>
       </q-card-actions>
     </q-card>
   </q-dialog>

--- a/src/components/BalanceView.vue
+++ b/src/components/BalanceView.vue
@@ -158,7 +158,7 @@
         outline
         class="q-mx-none q-mt-xs q-pr-sm cursor-pointer"
         @click="checkPendingTokens()"
-        ><q-icon name="history" size="1rem" class="q-mx-xs" />
+        ><q-icon name="history" size="1rem" class="q-mx-xs"  aria-label="button"/>
         {{ $t("BalanceView.pending.label") }}:
         {{ formatCurrency(pendingBalance, this.activeUnit) }}
         <q-tooltip>{{ $t("BalanceView.pending.tooltip") }}</q-tooltip>

--- a/src/components/BucketManager.vue
+++ b/src/components/BucketManager.vue
@@ -87,7 +87,7 @@
       </div>
       <q-item>
         <q-item-section>
-          <q-btn color="primary" icon="add" outline @click="openAdd">
+          <q-btn color="primary" icon="add" outline @click="openAdd" aria-label="button">
             {{ $t("BucketManager.actions.add") }}
             <q-tooltip>{{ $t("BucketManager.tooltips.add_button") }}</q-tooltip>
           </q-btn>
@@ -96,7 +96,7 @@
       <q-item>
         <q-item-section>
           <router-link to="/move-tokens" style="text-decoration: none">
-            <q-btn color="primary" outline>
+            <q-btn color="primary" outline aria-label="button">
               {{ $t("BucketDetail.move") }}
               <q-tooltip>{{
                 $t("BucketManager.tooltips.move_button")
@@ -172,10 +172,10 @@
           </template>
         </q-input>
         <div class="row q-mt-md">
-          <q-btn color="primary" rounded @click="saveBucket">{{
+          <q-btn color="primary" rounded @click="saveBucket" aria-label="button">{{
             $t("global.actions.update.label")
           }}</q-btn>
-          <q-btn flat rounded color="grey" class="q-ml-auto" v-close-popup>{{
+          <q-btn flat rounded color="grey" class="q-ml-auto" v-close-popup aria-label="button">{{
             $t("global.actions.cancel.label")
           }}</q-btn>
         </div>
@@ -192,10 +192,10 @@
         }}</span>
       </q-card-section>
       <q-card-actions align="right">
-        <q-btn flat color="grey" v-close-popup>{{
+        <q-btn flat color="grey" v-close-popup aria-label="button">{{
           $t("global.actions.cancel.label")
         }}</q-btn>
-        <q-btn color="negative" @click="deleteBucket">{{
+        <q-btn color="negative" @click="deleteBucket" aria-label="button">{{
           $t("BucketManager.actions.delete")
         }}</q-btn>
       </q-card-actions>

--- a/src/components/ChooseExistingTokenDialog.vue
+++ b/src/components/ChooseExistingTokenDialog.vue
@@ -16,7 +16,7 @@
         </q-list>
       </q-card-section>
       <q-card-actions align="right">
-        <q-btn flat color="primary" @click="back">{{ $t('global.actions.cancel.label') }}</q-btn>
+        <q-btn flat color="primary" @click="back" aria-label="button">{{ $t('global.actions.cancel.label') }}</q-btn>
       </q-card-actions>
     </q-card>
   </q-dialog>

--- a/src/components/DonateDialog.vue
+++ b/src/components/DonateDialog.vue
@@ -59,10 +59,10 @@
         />
       </q-card-section>
       <q-card-actions align="right">
-        <q-btn flat color="primary" @click="cancel">{{
+        <q-btn flat color="primary" @click="cancel" aria-label="button">{{
           $t("global.actions.cancel.label")
         }}</q-btn>
-        <q-btn flat color="primary" @click="confirm">{{
+        <q-btn flat color="primary" @click="confirm" aria-label="button">{{
           $t("global.actions.send.label")
         }}</q-btn>
       </q-card-actions>

--- a/src/components/EditMintDialog.vue
+++ b/src/components/EditMintDialog.vue
@@ -47,9 +47,9 @@
           rounded
           color="primary"
           @click="updateMintLocal"
-          >{{ $t("EditMintDialog.actions.update.label") }}</q-btn
+           aria-label="button">{{ $t("EditMintDialog.actions.update.label") }}</q-btn
         >
-        <q-btn v-close-popup flat class="q-ml-auto" color="grey">{{
+        <q-btn v-close-popup flat class="q-ml-auto" color="grey" aria-label="button">{{
           $t("EditMintDialog.actions.cancel.label")
         }}</q-btn>
       </div>

--- a/src/components/HelpPopup.vue
+++ b/src/components/HelpPopup.vue
@@ -13,7 +13,7 @@
           <slot>{{ text }}</slot>
         </q-card-section>
         <q-card-actions align="right">
-          <q-btn flat color="primary" v-close-popup>{{ closeLabel }}</q-btn>
+          <q-btn flat color="primary" v-close-popup aria-label="button">{{ closeLabel }}</q-btn>
         </q-card-actions>
       </q-card>
     </q-dialog>

--- a/src/components/HistoryTable.vue
+++ b/src/components/HistoryTable.vue
@@ -91,7 +91,7 @@
             icon="arrow_circle_down"
             @click="receiveToken(token.token)"
             class="cursor-pointer"
-            v-if="token.status === 'pending' && token.amount > 0"
+            v-if="token.status === 'pending' && token.amount  aria-label="button"> 0"
             :aria-label="$t('HistoryTable.actions.receive.tooltip_text')"
             :title="$t('HistoryTable.actions.receive.tooltip_text')"
           >
@@ -118,7 +118,7 @@
         "
         class="q-ml-sm q-px-md"
         size="sm"
-      />
+       aria-label="button"/>
     </div>
     <div v-if="paginatedTokens.length === 0" class="text-center q-mt-lg">
       <q-item-label caption class="text-primary">{{
@@ -155,10 +155,10 @@
           :label="$t('BucketManager.inputs.color')"
         />
         <div class="row q-mt-md">
-          <q-btn color="primary" rounded @click="saveLabel">{{
+          <q-btn color="primary" rounded @click="saveLabel" aria-label="button">{{
             $t('global.actions.update.label')
           }}</q-btn>
-          <q-btn flat rounded color="grey" class="q-ml-auto" v-close-popup>{{
+          <q-btn flat rounded color="grey" class="q-ml-auto" v-close-popup aria-label="button">{{
             $t('global.actions.cancel.label')
           }}</q-btn>
         </div>

--- a/src/components/InvoiceDetailDialog.vue
+++ b/src/components/InvoiceDetailDialog.vue
@@ -51,14 +51,14 @@
             color="primary"
             @click="toggleUnit()"
             :label="activeUnitLabel"
-          />
+           aria-label="button"/>
         </q-input>
         <div class="row items-center no-wrap q-my-sm q-py-none">
           <q-btn
             color="primary"
             rounded
             @click="requestMintButton"
-            :disable="!(invoiceData.amount > 0) || createInvoiceButtonBlocked"
+            :disable="!(invoiceData.amount  aria-label="button"> 0) || createInvoiceButtonBlocked"
             :label="
               createInvoiceButtonBlocked
                 ? $t('InvoiceDetailDialog.actions.create.label_blocked')
@@ -71,7 +71,7 @@
               {{ $t("InvoiceDetailDialog.actions.create.in_progress") }}
             </template>
           </q-btn>
-          <q-btn v-close-popup rounded flat color="grey" class="q-ml-auto">{{
+          <q-btn v-close-popup rounded flat color="grey" class="q-ml-auto" aria-label="button">{{
             $t("InvoiceDetailDialog.actions.close.label")
           }}</q-btn>
         </div>
@@ -157,9 +157,9 @@
             size="md"
             flat
             @click="copyText(invoiceData.bolt11)"
-            >{{ $t("InvoiceDetailDialog.invoice.actions.copy.label") }}</q-btn
+             aria-label="button">{{ $t("InvoiceDetailDialog.invoice.actions.copy.label") }}</q-btn
           >
-          <q-btn v-close-popup flat color="grey" class="q-ml-auto">{{
+          <q-btn v-close-popup flat color="grey" class="q-ml-auto" aria-label="button">{{
             $t("InvoiceDetailDialog.invoice.actions.close.label")
           }}</q-btn>
         </div>

--- a/src/components/InvoicesTable.vue
+++ b/src/components/InvoicesTable.vue
@@ -45,7 +45,7 @@
               dense
               icon="sync"
               @click="
-                invoice.amount > 0
+                invoice.amount  aria-label="button"> 0
                   ? checkInvoice(invoice.quote, true)
                   : checkOutgoingInvoice(invoice.quote, true)
               "
@@ -78,7 +78,7 @@
           "
           class="q-ml-sm q-px-md"
           size="sm"
-        />
+         aria-label="button"/>
       </div>
       <div v-if="paginatedInvoices.length === 0" class="text-center q-mt-lg">
         <q-item-label caption class="text-primary">{{

--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -88,7 +88,7 @@
         dense
         round
         size="0.8em"
-        :icon="countdown > 0 ? 'close' : 'refresh'"
+        :icon="countdown  aria-label="button"> 0 ? 'close' : 'refresh'"
         :color="countdown > 0 ? 'negative' : 'primary'"
         aria-label="Refresh"
         @click="reload"

--- a/src/components/MessageInput.vue
+++ b/src/components/MessageInput.vue
@@ -1,7 +1,21 @@
 <template>
   <div class="row no-wrap items-center q-pa-sm">
-    <q-input v-model="text" class="col" dense outlined @keyup.enter="send" />
-    <q-btn flat round icon="send" color="primary" class="q-ml-sm" :disable="!text.trim()" @click="send" />
+    <q-input
+      v-model="text"
+      class="col"
+      dense
+      outlined
+      @keyup.enter.prevent="onSend"
+    />
+    <q-btn
+      flat
+      round
+      icon="send"
+      color="primary"
+      class="q-ml-sm"
+      :disable="!text.trim()"
+      @click="send"
+      aria-label="Send message"/>
   </div>
 </template>
 
@@ -10,6 +24,12 @@ import { ref } from 'vue';
 
 const emit = defineEmits(['send']);
 const text = ref('');
+
+const onSend = (e: KeyboardEvent) => {
+  if (!e.shiftKey) {
+    send();
+  }
+};
 
 const send = () => {
   const m = text.value.trim();

--- a/src/components/MintSettings.vue
+++ b/src/components/MintSettings.vue
@@ -233,7 +233,7 @@
               flat
               :disable="addMintData.url.length === 0"
               @click="
-                addMintData.url.length > 0
+                addMintData.url.length  aria-label="button"> 0
                   ? sanitizeMintUrlAndShowAddDialog()
                   : null
               "
@@ -244,7 +244,7 @@
               <span>{{ $t("MintSettings.add.actions.add_mint.label") }}</span>
             </q-btn>
 
-            <q-btn flat @click="showCamera" class="text-white">
+            <q-btn flat @click="showCamera" class="text-white" aria-label="button">
               <q-icon name="qr_code" size="20px" class="q-mr-sm" />
               <span>{{ $t("MintSettings.add.actions.scan.label") }}</span>
             </q-btn>
@@ -281,7 +281,7 @@
             outline
             :loading="discoveringMints"
             @click="fetchMintsFromNdk"
-            >{{ $t("MintSettings.discover.actions.discover.label") }}
+             aria-label="button">{{ $t("MintSettings.discover.actions.discover.label") }}
             <template v-slot:loading>
               <q-spinner-hourglass class="on-left" />
               {{ $t("MintSettings.discover.actions.discover.in_progress") }}
@@ -440,7 +440,7 @@
             :disable="
               !swapData.fromUrl ||
               !swapData.toUrl ||
-              !(swapData.amount > 0) ||
+              !(swapData.amount  aria-label="button"> 0) ||
               swapData.fromUrl == swapData.toUrl
             "
             :loading="swapBlocking"

--- a/src/components/NWCDialog.vue
+++ b/src/components/NWCDialog.vue
@@ -49,9 +49,9 @@
             size="md"
             flat
             @click="copyText(showNWCData.connectionString)"
-            >{{ $t("NWCDialog.actions.copy.label") }}</q-btn
+             aria-label="button">{{ $t("NWCDialog.actions.copy.label") }}</q-btn
           >
-          <q-btn v-close-popup flat color="grey" class="q-ml-auto">{{
+          <q-btn v-close-popup flat color="grey" class="q-ml-auto" aria-label="button">{{
             $t("NWCDialog.actions.close.label")
           }}</q-btn>
         </div>

--- a/src/components/NewChat.vue
+++ b/src/components/NewChat.vue
@@ -9,7 +9,7 @@
       @click="start"
       :disable="!pubkey.trim()"
       dense
-    />
+     aria-label="button"/>
   </div>
 </template>
 

--- a/src/components/NoMintWarnBanner.vue
+++ b/src/components/NoMintWarnBanner.vue
@@ -24,7 +24,7 @@
           class="q-px-md"
           :label="$t('NoMintWarnBanner.actions.add_mint.label')"
           @click="handleAddMintClick"
-        />
+         aria-label="button"/>
       </div>
       <div class="row items-center justify-center q-pt-md">
         <q-btn
@@ -34,7 +34,7 @@
           class="q-px-md"
           :label="$t('NoMintWarnBanner.actions.receive.label')"
           @click="handleReceiveEcash"
-        />
+         aria-label="button"/>
       </div>
     </q-card-section>
   </q-card>

--- a/src/components/NostrIdentityManager.vue
+++ b/src/components/NostrIdentityManager.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <q-btn label="Identity / Relays" color="primary" @click="showDialog = true" />
+    <q-btn label="Identity / Relays" color="primary" @click="showDialog = true"  aria-label="button"/>
     <q-dialog v-model="showDialog">
       <q-card style="min-width: 350px">
         <q-card-section class="text-h6">Identity &amp; Relays</q-card-section>
@@ -13,15 +13,15 @@
               <q-item v-for="(r, index) in relays" :key="index">
                 <q-item-section>{{ r }}</q-item-section>
                 <q-item-section side>
-                  <q-btn flat dense icon="delete" @click="removeRelay(index)" />
+                  <q-btn flat dense icon="delete" @click="removeRelay(index)"  aria-label="button"/>
                 </q-item-section>
               </q-item>
             </q-list>
           </div>
         </q-card-section>
         <q-card-actions align="right">
-          <q-btn flat v-close-popup label="Close" />
-          <q-btn flat label="Save" @click="save" />
+          <q-btn flat v-close-popup label="Close"  aria-label="button"/>
+          <q-btn flat label="Save" @click="save"  aria-label="button"/>
         </q-card-actions>
       </q-card>
     </q-dialog>

--- a/src/components/NumericKeyboard.vue
+++ b/src/components/NumericKeyboard.vue
@@ -14,28 +14,28 @@
       v-if="showNumericKeyboard"
     >
       <div class="keyboard-grid">
-        <q-btn flat dense class="text-h5" @click="addDigit('1')">1</q-btn>
-        <q-btn flat dense class="text-h5" @click="addDigit('2')">2</q-btn>
-        <q-btn flat dense class="text-h5" @click="addDigit('3')">3</q-btn>
+        <q-btn flat dense class="text-h5" @click="addDigit('1')" aria-label="button">1</q-btn>
+        <q-btn flat dense class="text-h5" @click="addDigit('2')" aria-label="button">2</q-btn>
+        <q-btn flat dense class="text-h5" @click="addDigit('3')" aria-label="button">3</q-btn>
 
-        <q-btn flat dense class="text-h5" @click="addDigit('4')">4</q-btn>
-        <q-btn flat dense class="text-h5" @click="addDigit('5')">5</q-btn>
-        <q-btn flat dense class="text-h5" @click="addDigit('6')">6</q-btn>
+        <q-btn flat dense class="text-h5" @click="addDigit('4')" aria-label="button">4</q-btn>
+        <q-btn flat dense class="text-h5" @click="addDigit('5')" aria-label="button">5</q-btn>
+        <q-btn flat dense class="text-h5" @click="addDigit('6')" aria-label="button">6</q-btn>
 
-        <q-btn flat dense class="text-h5" @click="addDigit('7')">7</q-btn>
-        <q-btn flat dense class="text-h5" @click="addDigit('8')">8</q-btn>
-        <q-btn flat dense class="text-h5" @click="addDigit('9')">9</q-btn>
+        <q-btn flat dense class="text-h5" @click="addDigit('7')" aria-label="button">7</q-btn>
+        <q-btn flat dense class="text-h5" @click="addDigit('8')" aria-label="button">8</q-btn>
+        <q-btn flat dense class="text-h5" @click="addDigit('9')" aria-label="button">9</q-btn>
 
-        <q-btn flat dense class="text-h5" @click="addComma">.</q-btn>
-        <q-btn flat dense class="text-h5" @click="addDigit('0')">0</q-btn>
-        <q-btn flat dense class="text-h5" @click="backspace">
+        <q-btn flat dense class="text-h5" @click="addComma" aria-label="button">.</q-btn>
+        <q-btn flat dense class="text-h5" @click="addDigit('0')" aria-label="button">0</q-btn>
+        <q-btn flat dense class="text-h5" @click="backspace" aria-label="button">
           <q-icon name="backspace" size="sm" />
         </q-btn>
-        <q-btn flat dense @click="closeKeyboard">{{
+        <q-btn flat dense @click="closeKeyboard" aria-label="button">{{
           $t("NumericKeyboard.actions.close.label")
         }}</q-btn>
         <br />
-        <q-btn flat dense @click="emitDone">{{
+        <q-btn flat dense @click="emitDone" aria-label="button">{{
           $t("NumericKeyboard.actions.enter.label")
         }}</q-btn>
       </div>

--- a/src/components/P2PKDialog.vue
+++ b/src/components/P2PKDialog.vue
@@ -47,7 +47,7 @@
           rounded
           dense
           @click="newKeys"
-        >
+         aria-label="button">
           <q-icon name="refresh" class="q-pr-sm" size="xs" />
           {{ $t("P2PKDialog.actions.new_key.label") }}</q-btn
         >
@@ -57,9 +57,9 @@
             size="md"
             flat
             @click="copyText(showP2PKData.publicKey)"
-            >{{ $t("P2PKDialog.actions.copy.label") }}</q-btn
+             aria-label="button">{{ $t("P2PKDialog.actions.copy.label") }}</q-btn
           >
-          <q-btn v-close-popup flat color="grey" class="q-ml-auto">{{
+          <q-btn v-close-popup flat color="grey" class="q-ml-auto" aria-label="button">{{
             $t("P2PKDialog.actions.close.label")
           }}</q-btn>
         </div>

--- a/src/components/PayInvoiceDialog.vue
+++ b/src/components/PayInvoiceDialog.vue
@@ -103,12 +103,12 @@
             "
             :loading="globalMutexLock && !payInvoiceData.blocking"
             class="q-px-lg"
-          >
+           aria-label="button">
             <template v-slot:loading>
               <q-spinner-hourglass />
             </template>
           </q-btn>
-          <q-btn v-close-popup flat color="grey" class="q-ml-auto">{{
+          <q-btn v-close-popup flat color="grey" class="q-ml-auto" aria-label="button">{{
             $t("PayInvoiceDialog.invoice.actions.close.label")
           }}</q-btn>
         </div>
@@ -119,11 +119,11 @@
             disabled
             color="yellow"
             text-color="black"
-            >{{
+             aria-label="button">{{
               $t("PayInvoiceDialog.invoice.balance_too_low_warning_text")
             }}</q-btn
           >
-          <q-btn v-close-popup flat color="grey" class="q-ml-auto">{{
+          <q-btn v-close-popup flat color="grey" class="q-ml-auto" aria-label="button">{{
             $t("PayInvoiceDialog.invoice.actions.close.label")
           }}</q-btn>
         </div>
@@ -217,10 +217,10 @@
             </div>
           </div>
           <div class="row q-mt-lg">
-            <q-btn unelevated color="primary" type="submit">{{
+            <q-btn unelevated color="primary" type="submit" aria-label="button">{{
               $t("PayInvoiceDialog.lnurlpay.actions.send.label")
             }}</q-btn>
-            <q-btn v-close-popup flat color="grey" class="q-ml-auto">{{
+            <q-btn v-close-popup flat color="grey" class="q-ml-auto" aria-label="button">{{
               $t("PayInvoiceDialog.lnurlpay.actions.close.label")
             }}</q-btn>
           </div>
@@ -266,7 +266,7 @@
               class="q-mr-sm"
               v-if="payInvoiceData.input.request != ''"
               type="submit"
-              >{{
+               aria-label="button">{{
                 $t("PayInvoiceDialog.input_data.actions.enter.label")
               }}</q-btn
             >
@@ -275,7 +275,7 @@
               dense
               v-if="canPasteFromClipboard && payInvoiceData.input.request == ''"
               @click="pasteToParseDialog"
-              ><q-icon name="content_paste" class="q-pr-sm" />{{
+              ><q-icon name="content_paste" class="q-pr-sm"  aria-label="button"/>{{
                 $t("PayInvoiceDialog.input_data.actions.paste.label")
               }}</q-btn
             >
@@ -284,13 +284,13 @@
               class="q-mx-0"
               v-if="hasCamera && payInvoiceData.input.request == ''"
               @click="showCamera"
-            >
+             aria-label="button">
               <ScanIcon />
               <span class="q-pl-sm">{{
                 $t("PayInvoiceDialog.input_data.actions.scan.label")
               }}</span>
             </q-btn>
-            <q-btn v-close-popup flat rounded color="grey" class="q-ml-auto">{{
+            <q-btn v-close-popup flat rounded color="grey" class="q-ml-auto" aria-label="button">{{
               $t("PayInvoiceDialog.input_data.actions.close.label")
             }}</q-btn>
           </div>
@@ -303,7 +303,7 @@
               ></qrcode-stream>
             </q-responsive>
             <div class="row q-mt-lg">
-              <q-btn @click="closeCamera" flat color="grey" class="q-ml-auto">
+              <q-btn @click="closeCamera" flat color="grey" class="q-ml-auto" aria-label="button">
                 Close
               </q-btn>
             </div>

--- a/src/components/PaymentRequestDialog.vue
+++ b/src/components/PaymentRequestDialog.vue
@@ -66,7 +66,7 @@
           <q-card-section class="q-pa-sm">
             <div class="row justify-center q-pt-sm">
               <div v-if="!isEditingAmount">
-                <q-btn color="primary" rounded @click="startEditingAmount">
+                <q-btn color="primary" rounded @click="startEditingAmount" aria-label="button">
                   <q-icon name="edit_note" size="xs" class="q-mr-sm" />
                   {{ amountLabel }}</q-btn
                 >
@@ -93,7 +93,7 @@
           rounded
           dense
           @click="newRequest"
-        >
+         aria-label="button">
           <q-icon name="refresh" class="q-pr-sm" size="xs" />
           {{ $t("PaymentRequestDialog.actions.new_request.label") }}</q-btn
         >
@@ -103,9 +103,9 @@
             size="md"
             flat
             @click="copyText(showPRKData)"
-            >{{ $t("PaymentRequestDialog.actions.copy.label") }}</q-btn
+             aria-label="button">{{ $t("PaymentRequestDialog.actions.copy.label") }}</q-btn
           >
-          <q-btn v-close-popup flat color="grey" class="q-ml-auto">{{
+          <q-btn v-close-popup flat color="grey" class="q-ml-auto" aria-label="button">{{
             $t("PaymentRequestDialog.actions.close.label")
           }}</q-btn>
         </div>

--- a/src/components/ProfileInfoDialog.vue
+++ b/src/components/ProfileInfoDialog.vue
@@ -33,8 +33,8 @@
         </div>
       </q-card-section>
       <q-card-actions align="right">
-        <q-btn flat color="negative" @click="handleClear">Clear Chat</q-btn>
-        <q-btn flat v-close-popup color="grey">Close</q-btn>
+        <q-btn flat color="negative" @click="handleClear" aria-label="button">Clear Chat</q-btn>
+        <q-btn flat v-close-popup color="grey" aria-label="button">Close</q-btn>
       </q-card-actions>
     </q-card>
   </q-dialog>

--- a/src/components/QrcodeReader.vue
+++ b/src/components/QrcodeReader.vue
@@ -132,11 +132,11 @@ export default {
         unelevated
         v-if="canPasteFromClipboard"
         @click="pasteToParseDialog"
-      >
+       aria-label="button">
         <q-icon name="content_paste" class="q-mr-sm" />
         {{ $t("QrcodeReader.actions.paste.label") }}</q-btn
       >
-      <q-btn @click="closeCamera" flat color="grey" class="q-ml-auto">{{
+      <q-btn @click="closeCamera" flat color="grey" class="q-ml-auto" aria-label="button">{{
         $t("QrcodeReader.actions.close.label")
       }}</q-btn>
     </div>

--- a/src/components/ReceiveDialog.vue
+++ b/src/components/ReceiveDialog.vue
@@ -43,7 +43,7 @@
           <q-btn
             class="full-width custom-btn"
             @click="toggleReceiveEcashDrawer"
-          >
+           aria-label="button">
             <div class="row items-center full-width">
               <div class="icon-background q-mr-md" :style="{ backgroundColor: iconBgColor }">
                 <CoinsIcon />
@@ -56,7 +56,7 @@
             </div>
           </q-btn>
 
-          <q-btn class="full-width custom-btn" @click="showInvoiceCreateDialog">
+          <q-btn class="full-width custom-btn" @click="showInvoiceCreateDialog" aria-label="button">
             <div class="row items-center full-width">
               <div class="icon-background q-mr-md" :style="{ backgroundColor: iconBgColor }">
                 <ZapIcon />

--- a/src/components/ReceiveEcashDrawer.vue
+++ b/src/components/ReceiveEcashDrawer.vue
@@ -9,7 +9,7 @@
   >
     <q-card :class="[cardClass, 'full-width-card q-pb-lg']">
       <q-card-section class="row items-center q-pb-sm">
-        <q-btn flat round dense @click="goBack" class="q-ml-sm" color="primary">
+        <q-btn flat round dense @click="goBack" class="q-ml-sm" color="primary" aria-label="button">
           <ChevronLeftIcon />
         </q-btn>
         <div class="col text-center">
@@ -22,14 +22,14 @@
           @click="showCamera"
           class="q-mr-sm"
           color="primary"
-        >
+         aria-label="button">
           <ScanIcon />
         </q-btn>
       </q-card-section>
 
       <q-card-section class="q-pa-md">
         <div class="q-gutter-y-md">
-          <q-btn class="full-width custom-btn" @click="handlePasteBtn">
+          <q-btn class="full-width custom-btn" @click="handlePasteBtn" aria-label="button">
             <div class="row items-center full-width">
               <div class="icon-background q-mr-md" :style="{ backgroundColor: iconBgColor }">
                 <ClipboardIcon />
@@ -42,7 +42,7 @@
             </div>
           </q-btn>
 
-          <q-btn class="full-width custom-btn" @click="showCamera">
+          <q-btn class="full-width custom-btn" @click="showCamera" aria-label="button">
             <div class="row items-center full-width">
               <div class="icon-background q-mr-md" :style="{ backgroundColor: iconBgColor }">
                 <ScanIcon />
@@ -59,7 +59,7 @@
             v-if="enablePaymentRequest"
             class="full-width custom-btn"
             @click="handlePaymentRequestBtn"
-          >
+           aria-label="button">
             <div class="row items-center full-width">
               <div class="icon-background q-mr-md" :style="{ backgroundColor: iconBgColor }">
                 <FileTextIcon />
@@ -76,7 +76,7 @@
             v-if="showP2PkButtonInDrawer"
             class="full-width custom-btn"
             @click="handleLockBtn"
-          >
+           aria-label="button">
             <div class="row items-center full-width">
               <div class="icon-background q-mr-md" :style="{ backgroundColor: iconBgColor }">
                 <LockIcon />
@@ -93,7 +93,7 @@
             v-if="ndefSupported && showNfcButtonInDrawer"
             class="full-width custom-btn"
             @click="handleNFCBtn"
-          >
+           aria-label="button">
             <div class="row items-center full-width">
               <div class="icon-background q-mr-md" :style="{ backgroundColor: iconBgColor }">
                 <q-spinner v-if="scanningCard" size="sm" />

--- a/src/components/ReceiveTokenDialog.vue
+++ b/src/components/ReceiveTokenDialog.vue
@@ -14,7 +14,7 @@
         flat
         color="grey"
         class="close-btn-position"
-        >{{ $t("ReceiveTokenDialog.actions.close.label") }}</q-btn
+         aria-label="button">{{ $t("ReceiveTokenDialog.actions.close.label") }}</q-btn
       >
       <div>
         <div class="row items-center no-wrap q-mb-sm q-mb-sm q-py-lg">
@@ -76,7 +76,7 @@
           unelevated
           class="q-ml-xs q-mr-sm"
           :label="$t('ReceiveTokenDialog.errors.invalid_token.label')"
-        ></q-btn>
+        ></q-btn aria-label="button">
 
         <!-- EMPTY INPUT -->
         <div v-if="!receiveData.tokensBase64.length">
@@ -86,7 +86,7 @@
             class="q-mr-sm"
             v-if="canPasteFromClipboard"
             @click="pasteToParseDialog(true)"
-          >
+           aria-label="button">
             <q-icon name="content_paste" class="q-pr-sm" />{{
               $t("ReceiveTokenDialog.actions.paste.label")
             }}</q-btn
@@ -97,7 +97,7 @@
             class="q-mx-sm"
             v-if="hasCamera"
             @click="showCamera"
-          >
+           aria-label="button">
             <ScanIcon size="1.5em" />
             <span class="q-pl-sm">{{
               $t("ReceiveTokenDialog.actions.scan.label")
@@ -111,7 +111,7 @@
             :loading="scanningCard"
             :disabled="scanningCard"
             @click="toggleScanner"
-          >
+           aria-label="button">
             <NfcIcon class="q-pr-xs" />
             <q-tooltip>{{
               ndefSupported
@@ -208,7 +208,7 @@
                     : $t('ReceiveTokenDialog.actions.receive.label_known_mint')
                   : $t('ReceiveTokenDialog.actions.receive.label')
               "
-            >
+             aria-label="button">
               <template v-slot:loading>
                 <q-spinner-hourglass />
               </template>
@@ -221,7 +221,7 @@
               rounded
               flat
               class="q-mr-none"
-            >
+             aria-label="button">
               <q-icon name="swap_horiz" class="q-pr-sm" />
               {{ $t("ReceiveTokenDialog.actions.swap.label") }}
               <q-tooltip>{{
@@ -234,7 +234,7 @@
               rounded
               flat
               class="q-mr-none"
-              >{{ $t("ReceiveTokenDialog.actions.later.label") }}
+               aria-label="button">{{ $t("ReceiveTokenDialog.actions.later.label") }}
               <q-tooltip>{{
                 $t("ReceiveTokenDialog.actions.later.tooltip_text")
               }}</q-tooltip>
@@ -276,7 +276,7 @@
               class="q-pr-md"
               :loading="swapBlocking"
               :disabled="activeMintUrl == tokenMint"
-            >
+             aria-label="button">
               <q-icon name="swap_horiz" class="q-pr-sm" />
               {{ $t("ReceiveTokenDialog.actions.confirm_swap.label") }}
               <template v-slot:loading>
@@ -294,7 +294,7 @@
               flat
               class="q-mr-none q-pr-sm"
               v-if="!swapBlocking"
-            >
+             aria-label="button">
               <q-icon name="close" class="q-pr-sm" />
               {{ $t("ReceiveTokenDialog.actions.cancel_swap.label") }}
               <q-tooltip>{{

--- a/src/components/RelayManager.vue
+++ b/src/components/RelayManager.vue
@@ -8,8 +8,8 @@
       dense
     />
     <div class="row q-gutter-sm">
-      <q-btn label="Connect" color="primary" @click="connect" dense />
-      <q-btn label="Disconnect" color="primary" @click="disconnect" dense />
+      <q-btn label="Connect" color="primary" @click="connect" dense  aria-label="button"/>
+      <q-btn label="Disconnect" color="primary" @click="disconnect" dense  aria-label="button"/>
     </div>
   </div>
 </template>

--- a/src/components/RemoveMintDialog.vue
+++ b/src/components/RemoveMintDialog.vue
@@ -51,11 +51,11 @@
             color="primary"
             rounded
             @click="removeMintLocal"
-            >{{ $t("RemoveMintDialog.actions.confirm.label") }}</q-btn
+             aria-label="button">{{ $t("RemoveMintDialog.actions.confirm.label") }}</q-btn
           >
         </div>
         <div class="col">
-          <q-btn v-close-popup flat color="grey" class="float-right">{{
+          <q-btn v-close-popup flat color="grey" class="float-right" aria-label="button">{{
             $t("RemoveMintDialog.actions.cancel.label")
           }}</q-btn>
         </div>

--- a/src/components/RestoreView.vue
+++ b/src/components/RestoreView.vue
@@ -37,7 +37,7 @@
                       icon="content_paste"
                       @click="pasteMnemonic"
                       class="cursor-pointer q-mt-md"
-                    ></q-btn>
+                    ></q-btn aria-label="button">
                   </template>
                 </q-input>
               </div>
@@ -90,7 +90,7 @@
         outline
         @click="restoreAllMints"
         :disabled="!isMnemonicValid || restoringState"
-      >
+       aria-label="button">
         <q-spinner-hourglass size="sm" v-if="restoringState" class="q-mr-sm" />
         {{ restoreAllMintsText }}
       </q-btn>
@@ -155,7 +155,7 @@
                 :disabled="!isMnemonicValid || restoringState"
                 :loading="restoringMint === mint.url"
                 :label="$t('RestoreView.actions.restore.label')"
-              />
+               aria-label="button"/>
             </q-item-section>
           </q-item>
           <q-separator spaced />

--- a/src/components/SendDialog.vue
+++ b/src/components/SendDialog.vue
@@ -40,7 +40,7 @@
 
       <q-card-section class="q-pa-md">
         <div class="q-gutter-y-md">
-          <q-btn class="full-width custom-btn" @click="showSendTokensDialog">
+          <q-btn class="full-width custom-btn" @click="showSendTokensDialog" aria-label="button">
             <div class="row items-center full-width">
               <div class="icon-background q-mr-md" :style="{ backgroundColor: iconBgColor }">
                 <CoinsIcon />
@@ -53,7 +53,7 @@
             </div>
           </q-btn>
 
-          <q-btn class="full-width custom-btn" @click="showParseDialog">
+          <q-btn class="full-width custom-btn" @click="showParseDialog" aria-label="button">
             <div class="row items-center full-width">
               <div class="icon-background q-mr-md" :style="{ backgroundColor: iconBgColor }">
                 <ZapIcon />

--- a/src/components/SendMessageDialog.vue
+++ b/src/components/SendMessageDialog.vue
@@ -11,8 +11,8 @@
         />
       </q-card-section>
       <q-card-actions align="right">
-        <q-btn flat color="primary" @click="cancel">{{ $t('SendMessageDialog.actions.cancel.label') }}</q-btn>
-        <q-btn flat color="primary" @click="confirm">{{ $t('SendMessageDialog.actions.send.label') }}</q-btn>
+        <q-btn flat color="primary" @click="cancel" aria-label="button">{{ $t('SendMessageDialog.actions.cancel.label') }}</q-btn>
+        <q-btn flat color="primary" @click="confirm" aria-label="button">{{ $t('SendMessageDialog.actions.send.label') }}</q-btn>
       </q-card-actions>
     </q-card>
   </q-dialog>

--- a/src/components/SendPaymentRequest.vue
+++ b/src/components/SendPaymentRequest.vue
@@ -7,7 +7,7 @@
         color="primary"
         class="q-px-md"
         @click="clickPaymentRequest"
-      >
+       aria-label="button">
         <q-icon v-if="!loading" name="send" class="q-pr-xs" />
         <q-spinner-hourglass v-else size="1em" class="q-mr-md" />
         Pay via {{ getPaymentRequestTransportType(sendData.paymentRequest) }}

--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -140,7 +140,7 @@
               color="primary"
               @click="toggleUnit()"
               :label="activeUnitLabel"
-            />
+             aria-label="button"/>
           </q-input>
           <q-input
             filled
@@ -243,7 +243,7 @@
               rounded
               type="submit"
               :loading="globalMutexLock"
-              >{{ $t("SendTokenDialog.actions.send.label") }}
+               aria-label="button">{{ $t("SendTokenDialog.actions.send.label") }}
               <template v-slot:loading>
                 <q-spinner-hourglass />
               </template>
@@ -265,7 +265,7 @@
                 >
                   Locked
                 </q-chip>
-                <!-- <q-btn rounded flat color="primary" icon="lock">Locked</q-btn> -->
+                <!-- <q-btn rounded flat color="primary" icon="lock" aria-label="button">Locked</q-btn> -->
               </transition>
             </div>
             <transition
@@ -275,7 +275,7 @@
             >
               <q-btn
                 v-if="
-                  sendData.amount > 0 &&
+                  sendData.amount  aria-label="button"> 0 &&
                   !showLockInput &&
                   activeBalance >= sendData.amount
                 "
@@ -290,7 +290,7 @@
                 {{ $t("SendTokenDialog.actions.lock.label") }}</q-btn
               >
             </transition>
-            <q-btn v-close-popup rounded flat color="grey" class="q-ml-auto">{{
+            <q-btn v-close-popup rounded flat color="grey" class="q-ml-auto" aria-label="button">{{
               $t("SendTokenDialog.actions.close.label")
             }}</q-btn>
           </div>
@@ -301,11 +301,11 @@
               disabled
               color="yellow"
               text-color="black"
-              >{{
+               aria-label="button">{{
                 $t("SendTokenDialog.inputs.amount.invalid_too_much_error_text")
               }}</q-btn
             >
-            <q-btn v-close-popup rounded flat color="grey" class="q-ml-auto">{{
+            <q-btn v-close-popup rounded flat color="grey" class="q-ml-auto" aria-label="button">{{
               $t("SendTokenDialog.actions.close.label")
             }}</q-btn>
           </div>
@@ -341,7 +341,7 @@
               color="grey"
               class="q-ma-none"
               @click="changeSpeed"
-            >
+             aria-label="button">
               <q-icon name="speed" style="margin-right: 8px"></q-icon>
               Speed: {{ fragmentSpeedLabel }}
             </q-btn>
@@ -359,7 +359,7 @@
               class="q-ma-none"
               color="grey"
               @click="changeSize"
-            >
+             aria-label="button">
               <q-icon name="zoom_in" style="margin-right: 8px"></q-icon>
               Size: {{ fragmentLengthLabel }}
             </q-btn>
@@ -443,7 +443,7 @@
                   flat
                   dense
                   @click="copyText(sendData.tokensBase64)"
-                  >{{ $t("SendTokenDialog.actions.copy_tokens.label") }}</q-btn
+                   aria-label="button">{{ $t("SendTokenDialog.actions.copy_tokens.label") }}</q-btn
                 >
                 <q-btn
                   class="q-mx-none"
@@ -451,7 +451,7 @@
                   flat
                   dense
                   @click="toggleExpandButtons"
-                >
+                 aria-label="button">
                   <q-icon
                     :name="
                       showExpandedButtons ? 'chevron_left' : 'chevron_right'
@@ -466,7 +466,7 @@
                     flat
                     dense
                     @click="copyText(encodeToPeanut(sendData.tokensBase64))"
-                    >{{ $t("SendTokenDialog.actions.copy_emoji.label") }}
+                     aria-label="button">{{ $t("SendTokenDialog.actions.copy_emoji.label") }}
                     <q-tooltip>{{
                       $t("SendTokenDialog.actions.copy_emoji.tooltip_text")
                     }}</q-tooltip>
@@ -582,7 +582,7 @@
                 flat
                 color="grey"
                 class="q-ml-auto q-mr-md"
-                >{{
+                 aria-label="button">{{
                   $t("SendTokenDialog.actions.close_card_scanner.label")
                 }}</q-btn
               >
@@ -594,7 +594,7 @@
                 flat
                 color="grey"
                 class="q-ml-auto"
-                >{{ $t("SendTokenDialog.actions.close.label") }}</q-btn
+                 aria-label="button">{{ $t("SendTokenDialog.actions.close.label") }}</q-btn
               >
             </div>
           </q-card-section>
@@ -629,10 +629,10 @@
             color="negative"
             rounded
             class="q-mr-sm"
-            >Delete</q-btn
+             aria-label="button">Delete</q-btn
           >
           <q-btn v-close-popup rounded flat color="grey" class="q-ml-auto"
-            >Cancel</q-btn
+             aria-label="button">Cancel</q-btn
           >
         </div>
       </q-card-section>

--- a/src/components/SettingsView.vue
+++ b/src/components/SettingsView.vue
@@ -82,7 +82,7 @@
             rounded
             outline
             to="/restore"
-            >{{ $t("Settings.backup_restore.restore_ecash.button") }}</q-btn
+             aria-label="button">{{ $t("Settings.backup_restore.restore_ecash.button") }}</q-btn
           >
         </q-item>
       </q-list>
@@ -404,7 +404,7 @@
                     icon="add"
                     color="primary"
                     @click="addNostrRelay"
-                  ></q-btn>
+                  ></q-btn aria-label="button">
                 </template>
               </q-input>
             </q-item-section>
@@ -546,7 +546,7 @@
             rounded
             outline
             @click="listenToNWCCommands()"
-            >Link wallet</q-btn
+             aria-label="button">Link wallet</q-btn
           >
         </q-item> -->
         <q-item v-if="enableNwc">
@@ -663,7 +663,7 @@
                       icon="add"
                       color="primary"
                       @click="addRelay"
-                    ></q-btn>
+                    ></q-btn aria-label="button">
                   </template>
                 </q-input>
               </q-item-section>
@@ -873,7 +873,7 @@
                 rounded
                 outline
                 @click="generateKeypair"
-                >{{ $t("Settings.p2pk_features.generate_button") }}</q-btn
+                 aria-label="button">{{ $t("Settings.p2pk_features.generate_button") }}</q-btn
               >
             </q-item>
             <q-item style="display: inline-block">
@@ -884,7 +884,7 @@
                 rounded
                 outline
                 @click="importNsec"
-                >{{ $t("Settings.p2pk_features.import_button") }}</q-btn
+                 aria-label="button">{{ $t("Settings.p2pk_features.import_button") }}</q-btn
               >
             </q-item>
             <q-item>
@@ -1151,7 +1151,7 @@
                   @click="copyText(auditorUrl)"
                   size="sm"
                   color="grey"
-                />
+                 aria-label="button"/>
               </template>
             </q-input>
           </div>
@@ -1175,7 +1175,7 @@
                   @click="copyText(auditorApiUrl)"
                   size="sm"
                   color="grey"
-                />
+                 aria-label="button"/>
               </template>
             </q-input>
           </div>
@@ -1229,7 +1229,7 @@
                 </q-item-label>
                 <!-- <div class="row q-py-md">
               <q-btn dense flat rounded @click="toggleDarkMode" size="md"
-                >Toggle dark mode<q-icon
+                 aria-label="button">Toggle dark mode<q-icon
                   class="q-ml-sm"
                   :name="$q.dark.isActive ? 'brightness_3' : 'wb_sunny'"
                 />
@@ -1452,7 +1452,7 @@
                         flat
                         dense
                         @click="confirmMnemonic = !confirmMnemonic"
-                        >{{
+                         aria-label="button">{{
                           $t("Settings.advanced.developer.new_seed.button")
                         }}</q-btn
                       >
@@ -1480,7 +1480,7 @@
                         class="q-ml-sm"
                         color="warning"
                         @click="confirmMnemonic = false"
-                        >{{
+                         aria-label="button">{{
                           $t("Settings.advanced.developer.new_seed.cancel")
                         }}</q-btn
                       >
@@ -1493,7 +1493,7 @@
                           confirmMnemonic = false;
                           generateNewMnemonic();
                         "
-                        >{{
+                         aria-label="button">{{
                           $t("Settings.advanced.developer.new_seed.confirm")
                         }}</q-btn
                       >
@@ -1510,7 +1510,7 @@
                       outline
                       click
                       @click="checkActiveProofsSpendable"
-                      >{{
+                       aria-label="button">{{
                         $t("Settings.advanced.developer.remove_spent.button")
                       }}</q-btn
                     ></row
@@ -1528,7 +1528,7 @@
               <q-item>
                 <q-item-section>
                   <row>
-                    <q-btn dense flat outline click @click="toggleTerminal">
+                    <q-btn dense flat outline click @click="toggleTerminal" aria-label="button">
                       {{
                         $t("Settings.advanced.developer.debug_console.button")
                       }}
@@ -1547,7 +1547,7 @@
               <q-item>
                 <q-item-section>
                   <row>
-                    <q-btn dense flat outline click @click="exportActiveProofs">
+                    <q-btn dense flat outline click @click="exportActiveProofs" aria-label="button">
                       {{
                         $t("Settings.advanced.developer.export_proofs.button")
                       }}
@@ -1596,7 +1596,7 @@
                         flat
                         click
                         @click="increaseKeysetCounter(counter.id, 1)"
-                        >{{ counter.id }} - counter: {{ counter.counter }}
+                         aria-label="button">{{ counter.id }} - counter: {{ counter.counter }}
                       </q-btn>
                     </row>
                   </row>
@@ -1611,7 +1611,7 @@
                       outline
                       click
                       @click="unsetAllReservedProofs"
-                    >
+                     aria-label="button">
                       {{
                         $t("Settings.advanced.developer.unset_reserved.button")
                       }}
@@ -1630,7 +1630,7 @@
               <q-item>
                 <q-item-section>
                   <row>
-                    <q-btn dense flat outline click @click="showOnboarding">
+                    <q-btn dense flat outline click @click="showOnboarding" aria-label="button">
                       {{
                         $t("Settings.advanced.developer.show_onboarding.button")
                       }}
@@ -1656,7 +1656,7 @@
                       outline
                       click
                       @click="confirmNuke = !confirmNuke"
-                    >
+                     aria-label="button">
                       {{
                         $t("Settings.advanced.developer.reset_wallet.button")
                       }}
@@ -1682,7 +1682,7 @@
                       class="q-ml-sm"
                       color="primary"
                       @click="confirmNuke = false"
-                      >{{
+                       aria-label="button">{{
                         $t("Settings.advanced.developer.reset_wallet.cancel")
                       }}</q-btn
                     >
@@ -1695,7 +1695,7 @@
                         confirmNuke = false;
                         nukeWallet();
                       "
-                      >{{
+                       aria-label="button">{{
                         $t("Settings.advanced.developer.reset_wallet.confirm")
                       }}</q-btn
                     >
@@ -1705,7 +1705,7 @@
               <q-item>
                 <q-item-section>
                   <row>
-                    <q-btn dense flat outline click @click="exportWalletState">
+                    <q-btn dense flat outline click @click="exportWalletState" aria-label="button">
                       {{
                         $t("Settings.advanced.developer.export_wallet.button")
                       }}

--- a/src/components/SubscribeDialog.vue
+++ b/src/components/SubscribeDialog.vue
@@ -48,10 +48,10 @@
         </div>
       </q-card-section>
       <q-card-actions align="right">
-        <q-btn flat color="primary" @click="cancel">{{
+        <q-btn flat color="primary" @click="cancel" aria-label="button">{{
           $t("global.actions.cancel.label")
         }}</q-btn>
-        <q-btn flat color="primary" @click="confirm">{{
+        <q-btn flat color="primary" @click="confirm" aria-label="button">{{
           $t("global.actions.ok.label")
         }}</q-btn>
       </q-card-actions>

--- a/src/components/SubscriptionReceipt.vue
+++ b/src/components/SubscriptionReceipt.vue
@@ -26,7 +26,7 @@
                     :icon="expanded[r.id] ? 'expand_less' : 'expand_more'"
                     class="q-ml-xs"
                     @click.stop="toggle(r.id)"
-                  />
+                   aria-label="button"/>
                 </div>
                 <q-slide-transition>
                   <div v-if="expanded[r.id]" class="text-caption q-mt-xs token-full">
@@ -35,10 +35,10 @@
                 </q-slide-transition>
               </td>
               <td class="text-right">
-                <q-btn flat color="primary" size="sm" @click="copyToken(r.token)">
+                <q-btn flat color="primary" size="sm" @click="copyToken(r.token)" aria-label="button">
                   {{ $t('global.actions.copy.label') }}
                 </q-btn>
-                <q-btn flat color="primary" size="sm" @click="saveToken(r.token)">
+                <q-btn flat color="primary" size="sm" @click="saveToken(r.token)" aria-label="button">
                   {{ $t('SubscriptionReceipt.actions.save.label') }}
                 </q-btn>
               </td>
@@ -50,7 +50,7 @@
         </q-markup-table>
       </q-card-section>
       <q-card-actions align="right">
-        <q-btn v-close-popup flat color="grey">{{ $t('global.actions.close.label') }}</q-btn>
+        <q-btn v-close-popup flat color="grey" aria-label="button">{{ $t('global.actions.close.label') }}</q-btn>
       </q-card-actions>
     </q-card>
   </q-dialog>

--- a/src/components/ToggleUnit.vue
+++ b/src/components/ToggleUnit.vue
@@ -5,7 +5,7 @@
     :color="color"
     @click="toggleUnit()"
     :label="activeUnitLabelAdopted"
-  />
+   aria-label="button"/>
 </template>
 <script>
 import { defineComponent } from "vue";

--- a/src/components/WelcomeDialog.vue
+++ b/src/components/WelcomeDialog.vue
@@ -58,14 +58,14 @@
             "
             color="primary"
             @click="triggerPwaInstall()"
-            >Install Cashu</q-btn
+             aria-label="button">Install Cashu</q-btn
           >
           <q-btn
             flat
             size="0.6rem"
             class="q-mx-xs q-px-none"
             @click="copyText(baseURL)"
-            >Copy URL</q-btn
+             aria-label="button">Copy URL</q-btn
           >
           <q-btn
             flat
@@ -74,7 +74,7 @@
             color="warning"
             icon="upload_for_offline"
             @click="browseBackupFile"
-            >Restore<q-tooltip
+             aria-label="button">Restore<q-tooltip
               >You can drag &amp; drop the wallet backup here!</q-tooltip
             ></q-btn
           >
@@ -84,7 +84,7 @@
             size="0.8rem"
             class="q-ml-auto"
             @click="setWelcomeDialogSeen()"
-            >Continue</q-btn
+             aria-label="button">Continue</q-btn
           >
         </div>
       </q-card-section>

--- a/src/components/iOSPWAPrompt.vue
+++ b/src/components/iOSPWAPrompt.vue
@@ -19,7 +19,7 @@
           @click="closePrompt"
           size="sm"
           class="close-btn q-px-sm"
-        />
+         aria-label="button"/>
       </div>
 
       <div class="pwa-prompt-arrow"></div>

--- a/src/pages/AlreadyRunning.vue
+++ b/src/pages/AlreadyRunning.vue
@@ -15,7 +15,7 @@
         unelevated
         to="/"
         :label="$t('AlreadyRunning.actions.retry.label')"
-      />
+       aria-label="button"/>
     </div>
   </div>
 </template>

--- a/src/pages/BucketDetail.vue
+++ b/src/pages/BucketDetail.vue
@@ -65,13 +65,13 @@
         </template>
       </q-select>
       <div class="row q-gutter-sm">
-        <q-btn color="primary" :disable="!selectedSecrets.length" @click="moveSelected">
+        <q-btn color="primary" :disable="!selectedSecrets.length" @click="moveSelected" aria-label="button">
           {{ $t('BucketDetail.move') }}
         </q-btn>
-        <q-btn color="primary" outline :disable="!selectedSecrets.length" @click="sendSelected">
+        <q-btn color="primary" outline :disable="!selectedSecrets.length" @click="sendSelected" aria-label="button">
           {{ $t('BucketDetail.send') }}
         </q-btn>
-        <q-btn color="primary" outline :disable="!bucketProofs.length" @click="exportBucket">
+        <q-btn color="primary" outline :disable="!bucketProofs.length" @click="exportBucket" aria-label="button">
           {{ $t('BucketDetail.export') }}
         </q-btn>
         <q-btn
@@ -80,7 +80,7 @@
           outline
           :disable="!bucketLockedTokens.length"
           @click="sendBucketToCreator"
-        >
+         aria-label="button">
           {{ $t('BucketDetail.send_to_creator') }}
         </q-btn>
       </div>
@@ -103,8 +103,8 @@
           label="Color"
         />
         <div class="row q-mt-md">
-          <q-btn color="primary" rounded @click="saveEdit">Update</q-btn>
-          <q-btn flat rounded color="grey" class="q-ml-auto" v-close-popup>Cancel</q-btn>
+          <q-btn color="primary" rounded @click="saveEdit" aria-label="button">Update</q-btn>
+          <q-btn flat rounded color="grey" class="q-ml-auto" v-close-popup aria-label="button">Cancel</q-btn>
         </div>
       </q-card>
     </q-dialog>

--- a/src/pages/CreatorDashboardPage.vue
+++ b/src/pages/CreatorDashboardPage.vue
@@ -2,7 +2,7 @@
   <div :class="[$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark', 'q-pa-md']">
     <div class="row items-center justify-between">
       <div class="text-h5">{{ $t('CreatorHub.dashboard.title') }}</div>
-      <q-btn flat color="primary" @click="logout">{{ $t('CreatorHub.dashboard.logout') }}</q-btn>
+      <q-btn flat color="primary" @click="logout" aria-label="button">{{ $t('CreatorHub.dashboard.logout') }}</q-btn>
     </div>
 
     <div class="q-mt-md">
@@ -10,7 +10,7 @@
       <q-input v-model="profile.display_name" label="Display Name" class="q-mt-sm" />
       <q-input v-model="profile.picture" label="Profile Picture URL" class="q-mt-sm" />
       <q-input v-model="profile.about" type="textarea" label="Bio" class="q-mt-sm" />
-      <q-btn color="primary" flat class="q-mt-sm" @click="saveProfile">{{ $t('global.actions.update.label') }}</q-btn>
+      <q-btn color="primary" flat class="q-mt-sm" @click="saveProfile" aria-label="button">{{ $t('global.actions.update.label') }}</q-btn>
     </div>
 
     <div class="q-mt-lg">
@@ -82,7 +82,7 @@
               color="primary"
               flat
               @click="saveTier(tier)"
-              >{{ $t('CreatorHub.dashboard.save_tier') }}</q-btn
+               aria-label="button">{{ $t('CreatorHub.dashboard.save_tier') }}</q-btn
             >
             <q-btn
               outline
@@ -90,20 +90,20 @@
               class="q-mr-sm"
               :style="{ borderRadius: '8px' }"
               @click="cancelEdit(tier.id)"
-              >{{ $t('global.actions.cancel.label') }}</q-btn
+               aria-label="button">{{ $t('global.actions.cancel.label') }}</q-btn
             >
             <q-btn
               color="negative"
               flat
               @click="removeTier(tier.id)"
-              >{{ $t('CreatorHub.dashboard.delete_tier') }}</q-btn
+               aria-label="button">{{ $t('CreatorHub.dashboard.delete_tier') }}</q-btn
             >
           </q-card-actions>
         </q-card>
       </div>
       <div class="row q-gutter-sm q-mt-md">
-        <q-btn color="primary" flat @click="openAddTier">{{ $t('CreatorHub.dashboard.add_tier') }}</q-btn>
-        <q-btn color="primary" flat @click="saveAllTiers">{{ $t('CreatorHub.dashboard.save_tier') }}</q-btn>
+        <q-btn color="primary" flat @click="openAddTier" aria-label="button">{{ $t('CreatorHub.dashboard.add_tier') }}</q-btn>
+        <q-btn color="primary" flat @click="saveAllTiers" aria-label="button">{{ $t('CreatorHub.dashboard.save_tier') }}</q-btn>
       </div>
     </div>
   </div>

--- a/src/pages/CreatorHubPage.vue
+++ b/src/pages/CreatorHubPage.vue
@@ -7,7 +7,7 @@
       <div class="text-h5 text-center q-mb-lg">Creator Hub</div>
 
       <div v-if="!loggedIn" class="text-center q-my-xl">
-        <q-btn color="primary" to="/creator/login" rounded unelevated label="Login" />
+        <q-btn color="primary" to="/creator/login" rounded unelevated label="Login"  aria-label="button"/>
       </div>
 
       <div v-else>
@@ -23,7 +23,7 @@
           </q-card>
         </div>
         <div class="text-center q-mt-md">
-          <q-btn color="primary" to="/creator/dashboard" rounded unelevated label="Edit Tiers" />
+          <q-btn color="primary" to="/creator/dashboard" rounded unelevated label="Edit Tiers"  aria-label="button"/>
         </div>
       </div>
     </div>

--- a/src/pages/CreatorLoginPage.vue
+++ b/src/pages/CreatorLoginPage.vue
@@ -3,10 +3,10 @@
     <q-card class="q-pa-md" style="max-width:400px; width:100%">
       <q-card-section class="text-h6">{{ $t('CreatorHub.login.title') }}</q-card-section>
       <q-card-actions vertical>
-        <q-btn color="primary" @click="loginNip07">{{ $t('CreatorHub.login.nip07') }}</q-btn>
+        <q-btn color="primary" @click="loginNip07" aria-label="button">{{ $t('CreatorHub.login.nip07') }}</q-btn>
         <q-input v-model="nsec" type="password" :label="$t('CreatorHub.login.nsec')" class="q-mt-md" />
         <div class="text-negative text-caption q-mt-sm">{{ $t('CreatorHub.login.nsec_warning') }}</div>
-        <q-btn color="primary" flat @click="loginNsec" class="q-mt-md">{{ $t('CreatorHub.login.nsec_button') }}</q-btn>
+        <q-btn color="primary" flat @click="loginNsec" class="q-mt-md" aria-label="button">{{ $t('CreatorHub.login.nsec_button') }}</q-btn>
       </q-card-actions>
     </q-card>
   </div>

--- a/src/pages/ErrorNotFound.vue
+++ b/src/pages/ErrorNotFound.vue
@@ -16,7 +16,7 @@
         unelevated
         to="/"
         :label="$t('ErrorNotFound.actions.home.label')"
-      />
+       aria-label="button"/>
     </div>
   </div>
 </template>

--- a/src/pages/MoveTokens.vue
+++ b/src/pages/MoveTokens.vue
@@ -26,7 +26,7 @@
       :disable="!selectedSecrets.length || !targetBucketId"
       @click="moveSelected"
       class="q-mb-lg"
-    >
+     aria-label="button">
       {{ $t("BucketDetail.move") }}
     </q-btn>
     <div v-for="bucket in bucketList" :key="bucket.id" class="q-mb-md">

--- a/src/pages/MyProfilePage.vue
+++ b/src/pages/MyProfilePage.vue
@@ -6,7 +6,7 @@
     ]"
   >
     <div class="q-mb-md">
-      <q-btn flat color="primary" to="/creator/dashboard">
+      <q-btn flat color="primary" to="/creator/dashboard" aria-label="button">
         {{ $t("CreatorHub.profile.back") }}
       </q-btn>
     </div>
@@ -25,7 +25,7 @@
           dense
           icon="content_copy"
           @click="copyText(npub)"
-        />
+         aria-label="button"/>
       </div>
       <div v-if="seedSignerPrivateKeyNsecComputed" class="row items-center q-gutter-x-sm q-mt-xs">
         <div><strong>nsec:</strong> {{ seedSignerPrivateKeyNsecComputed }}</div>
@@ -34,7 +34,7 @@
           dense
           icon="content_copy"
           @click="copyText(seedSignerPrivateKeyNsecComputed)"
-        />
+         aria-label="button"/>
       </div>
       <div v-if="privateKeySignerPrivateKey" class="row items-center q-gutter-x-sm q-mt-xs">
         <div><strong>hex:</strong> {{ privateKeySignerPrivateKey }}</div>
@@ -43,7 +43,7 @@
           dense
           icon="content_copy"
           @click="copyText(privateKeySignerPrivateKey)"
-        />
+         aria-label="button"/>
       </div>
       <div class="q-mt-sm">
         <strong>Wallet balance:</strong>
@@ -68,7 +68,7 @@
           dense
           class="q-mt-sm"
           @click="supportTier(tier)"
-          >{{ $t("CreatorHub.profile.support") }}</q-btn
+           aria-label="button">{{ $t("CreatorHub.profile.support") }}</q-btn
         >
       </div>
     </div>

--- a/src/pages/NostrLogin.vue
+++ b/src/pages/NostrLogin.vue
@@ -6,8 +6,8 @@
         <q-input v-model="key" type="text" label="nsec or hex private key" />
       </q-card-section>
       <q-card-actions vertical class="q-gutter-sm">
-        <q-btn color="primary" @click="submitKey">Use Key</q-btn>
-        <q-btn flat color="primary" @click="createIdentity">Create Identity</q-btn>
+        <q-btn color="primary" @click="submitKey" aria-label="button">Use Key</q-btn>
+        <q-btn flat color="primary" @click="createIdentity" aria-label="button">Create Identity</q-btn>
       </q-card-actions>
     </q-card>
   </div>

--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -35,7 +35,7 @@
     <div :class="['col column', $q.screen.gt.xs ? 'q-pa-lg' : 'q-pa-md']">
       <q-header elevated class="q-mb-md bg-transparent">
         <q-toolbar>
-          <q-btn flat round dense icon="arrow_back" @click="goBack" />
+          <q-btn flat round dense icon="arrow_back" @click="goBack"  aria-label="button"/>
           <q-toolbar-title class="text-h6 ellipsis">
             Nostr Messenger
             <q-badge

--- a/src/pages/PublicCreatorProfilePage.vue
+++ b/src/pages/PublicCreatorProfilePage.vue
@@ -6,7 +6,7 @@
     ]"
   >
     <div class="q-mb-md">
-      <q-btn flat color="primary" to="/find-creators">{{
+      <q-btn flat color="primary" to="/find-creators" aria-label="button">{{
         $t("CreatorHub.profile.back")
       }}</q-btn>
     </div>
@@ -63,7 +63,7 @@
                 color="primary"
                 class="subscribe-btn"
                 @click="openSubscribe(t)"
-              />
+               aria-label="button"/>
             </div>
             <PaywalledContent
               :creator-npub="creatorNpub"

--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -13,7 +13,7 @@
           class="wallet-action-btn q-mb-md text-subtitle2"
           color="primary"
           @click="showReceiveDialog = true"
-        >
+         aria-label="button">
           <div class="button-content">
             <q-icon name="south_west" size="1.2rem" class="q-mr-xs" />
             <span>{{ $t("WalletPage.actions.receive.label") }}</span>
@@ -22,7 +22,7 @@
 
         <transition appear enter-active-class="animated pulse">
           <div class="scan-button-container">
-            <q-btn size="lg" outline color="primary" flat @click="showCamera">
+            <q-btn size="lg" outline color="primary" flat @click="showCamera" aria-label="button">
               <ScanIcon size="2.5em" />
             </q-btn>
             <InfoTooltip
@@ -39,7 +39,7 @@
           class="wallet-action-btn q-mb-md text-subtitle2"
           color="primary"
           @click="showSendDialog = true"
-        >
+         aria-label="button">
           <div class="button-content">
             <q-icon name="north_east" size="1.2rem" class="q-mr-xs" />
             <span>{{ $t("WalletPage.actions.send.label") }}</span>
@@ -130,7 +130,7 @@
               "
               color="primary"
               @click="triggerPwaInstall()"
-              ><b>{{ $t("WalletPage.install.text") }}</b
+              ><b aria-label="button">{{ $t("WalletPage.install.text") }}</b
               ><q-tooltip>{{
                 $t("WalletPage.install.tooltip")
               }}</q-tooltip></q-btn

--- a/src/pages/WelcomePage.vue
+++ b/src/pages/WelcomePage.vue
@@ -37,7 +37,7 @@
           :label="$t('WelcomePage.actions.previous.label')"
           v-if="welcomeStore.canGoPrev"
           @click="welcomeStore.goToPrevSlide"
-        />
+         aria-label="button"/>
         <!-- language selector -->
         <div
           class="q-ml-md"
@@ -61,13 +61,13 @@
           :label="$t('WelcomePage.actions.next.label')"
           :disable="!welcomeStore.canProceed"
           @click="welcomeStore.goToNextSlide"
-        />
+         aria-label="button"/>
         <q-btn
           flat
           icon="close"
           :label="$t('WelcomePage.actions.skip.label')"
           @click="welcomeStore.skipTutorial"
-        />
+         aria-label="button"/>
       </div>
     </q-card>
   </q-dialog>


### PR DESCRIPTION
## Summary
- add `aria-label` to every `<q-btn>`
- handle `Enter` key in message input, ignoring shift+enter

## Testing
- `npm test` *(fails: getActivePinia errors)*

------
https://chatgpt.com/codex/tasks/task_e_6846744b37a883309ae2c9807a988336