### PR TITLE
Add aria labels to key buttons

### DIFF
--- a/src/components/AddMintDialog.vue
+++ b/src/components/AddMintDialog.vue
@@ -22,6 +22,7 @@
       <div class="row q-mt-lg">
         <div class="col">
           <q-btn
+            aria-label="Add mint"
             class="float-left"
             rounded
             v-close-popup
@@ -38,7 +39,7 @@
           </q-btn>
         </div>
         <div class="col">
-          <q-btn v-close-popup flat class="float-right" color="grey">{{
+          <q-btn aria-label="Cancel" v-close-popup flat class="float-right" color="grey">{{
             $t("AddMintDialog.actions.cancel.label")
           }}</q-btn>
         </div>

--- a/src/components/AndroidPWAPrompt.vue
+++ b/src/components/AndroidPWAPrompt.vue
@@ -15,6 +15,7 @@
           </template>
         </i18n-t>
         <q-btn
+          aria-label="Close"
           flat
           icon="close"
           @click="closePrompt"

--- a/src/components/BalanceView.vue
+++ b/src/components/BalanceView.vue
@@ -127,6 +127,7 @@
   <div class="row q-mt-xs q-mb-none" v-if="pendingBalance > 0">
     <div class="col-12">
       <q-btn
+        aria-label="Check pending tokens"
         name="history"
         size="sm"
         align="between"

--- a/src/components/MintSettings.vue
+++ b/src/components/MintSettings.vue
@@ -230,6 +230,7 @@
         <div class="add-mint-actions">
           <div class="row justify-between items-center q-mt-xs">
             <q-btn
+              aria-label="Add mint"
               flat
               :disable="addMintData.url.length === 0"
               @click="
@@ -244,7 +245,7 @@
               <span>{{ $t("MintSettings.add.actions.add_mint.label") }}</span>
             </q-btn>
 
-            <q-btn flat @click="showCamera" class="text-white">
+            <q-btn aria-label="Scan" flat @click="showCamera" class="text-white">
               <q-icon name="qr_code" size="20px" class="q-mr-sm" />
               <span>{{ $t("MintSettings.add.actions.scan.label") }}</span>
             </q-btn>
@@ -275,6 +276,7 @@
         </q-item>
         <q-item class="q-pt-sm">
           <q-btn
+            aria-label="Discover mints"
             class="q-ml-sm q-px-md"
             color="primary"
             rounded
@@ -433,6 +435,7 @@
             "
           ></q-input>
           <q-btn
+            aria-label="Swap"
             class="q-ml-sm q-px-md"
             color="primary"
             rounded

--- a/src/components/ReceiveTokenDialog.vue
+++ b/src/components/ReceiveTokenDialog.vue
@@ -9,6 +9,7 @@
   >
     <q-card v-model="showReceiveTokens" class="q-pa-lg qcard q-card-top">
       <q-btn
+        aria-label="Close"
         v-close-popup
         rounded
         flat
@@ -68,6 +69,7 @@
       <div class="row">
         <!-- if !tokenDecodesCorrectly, display error -->
         <q-btn
+          aria-label="Invalid token"
           v-if="receiveData.tokensBase64.length && !tokenDecodesCorrectly"
           disabled
           color="yellow"
@@ -81,6 +83,7 @@
         <!-- EMPTY INPUT -->
         <div v-if="!receiveData.tokensBase64.length">
           <q-btn
+            aria-label="Paste"
             unelevated
             dense
             class="q-mr-sm"
@@ -92,6 +95,7 @@
             }}</q-btn
           >
           <q-btn
+            aria-label="Scan"
             unelevated
             dense
             class="q-mx-sm"
@@ -104,6 +108,7 @@
             }}</span>
           </q-btn>
           <q-btn
+            aria-label="NFC scan"
             unelevated
             dense
             class="q-mx-sm"
@@ -141,6 +146,7 @@
           </div>
           <div class="row q-pt-md" v-if="!swapSelected">
             <q-btn
+              aria-label="Receive tokens"
               @click="receiveIfDecodes"
               color="primary"
               rounded
@@ -161,6 +167,7 @@
             </q-btn>
             <!-- swap to trusted mint -->
             <q-btn
+              aria-label="Swap"
               v-if="enableReceiveSwaps && activeMintUrl && mints.length"
               @click="swapSelected = true"
               color="primary"
@@ -175,6 +182,7 @@
               }}</q-tooltip>
             </q-btn>
             <q-btn
+              aria-label="Receive later"
               @click="addPendingTokenToHistory(receiveData.tokensBase64)"
               color="primary"
               rounded
@@ -216,6 +224,7 @@
           </div>
           <div class="row q-pt-sm" v-if="swapSelected">
             <q-btn
+              aria-label="Confirm swap"
               @click="handleSwapToTrustedMint"
               color="primary"
               rounded
@@ -234,6 +243,7 @@
               }}</q-tooltip>
             </q-btn>
             <q-btn
+              aria-label="Cancel swap"
               @click="swapSelected = false"
               color="grey"
               rounded

--- a/src/components/ToggleUnit.vue
+++ b/src/components/ToggleUnit.vue
@@ -1,5 +1,6 @@
 <template>
   <q-btn
+    aria-label="Toggle unit"
     rounded
     outline
     :color="color"

--- a/src/components/iOSPWAPrompt.vue
+++ b/src/components/iOSPWAPrompt.vue
@@ -14,6 +14,7 @@
           </template>
         </i18n-t>
         <q-btn
+          aria-label="Close"
           flat
           icon="close"
           @click="closePrompt"

--- a/src/pages/AlreadyRunning.vue
+++ b/src/pages/AlreadyRunning.vue
@@ -8,6 +8,7 @@
         {{ $t("AlreadyRunning.text") }}
       </div>
       <q-btn
+        aria-label="Retry"
         rounded
         class="q-mt-md"
         color="white"

--- a/src/pages/ErrorNotFound.vue
+++ b/src/pages/ErrorNotFound.vue
@@ -8,6 +8,7 @@
         {{ $t("ErrorNotFound.text") }}
       </div>
       <q-btn
+        aria-label="Home"
         rounded
         size="lg"
         class="q-mt-xl"

--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -12,6 +12,7 @@
           style="margin-right: 10%"
         >
           <q-btn
+            aria-label="Receive"
             rounded
             dense
             class="q-px-md wallet-action-btn"
@@ -27,7 +28,14 @@
 
         <transition appear enter-active-class="animated pulse">
           <div class="scan-button-container">
-            <q-btn size="lg" outline color="primary" flat @click="showCamera">
+            <q-btn
+              size="lg"
+              outline
+              color="primary"
+              flat
+              aria-label="Scan invoice"
+              @click="showCamera"
+            >
               <ScanIcon size="2em" />
             </q-btn>
           </div>
@@ -36,6 +44,7 @@
         <!-- button to showSendDialog -->
         <div class="col-6 q-mb-md flex justify-center items-center">
           <q-btn
+            aria-label="Send"
             rounded
             dense
             class="q-px-md wallet-action-btn"
@@ -116,6 +125,7 @@
         <div class="row q-pt-sm">
           <div class="col-12 q-pt-xs">
             <q-btn
+              aria-label="Install app"
               class="q-mx-xs q-px-sm q-my-sm"
               outline
               size="0.6rem"

--- a/src/pages/WelcomePage.vue
+++ b/src/pages/WelcomePage.vue
@@ -32,6 +32,7 @@
 
       <div class="q-pa-md flex justify-between">
         <q-btn
+          aria-label="Previous"
           flat
           icon="arrow_left"
           :label="$t('WelcomePage.actions.previous.label')"
@@ -56,6 +57,7 @@
         </div>
         <q-space />
         <q-btn
+          aria-label="Next"
           flat
           icon="arrow_right"
           :label="$t('WelcomePage.actions.next.label')"

--- a/src/pages/welcome/WelcomeSlide3.vue
+++ b/src/pages/welcome/WelcomeSlide3.vue
@@ -16,6 +16,7 @@
       >
         <template v-slot:append>
           <q-btn
+            aria-label="Toggle mnemonic visibility"
             flat
             dense
             icon="visibility"
@@ -23,6 +24,7 @@
             @click="toggleMnemonicVisibility"
           ></q-btn>
           <q-btn
+            aria-label="Copy mnemonic"
             flat
             dense
             icon="content_copy"


### PR DESCRIPTION
## Summary
- add aria labels for key interactions across pages and dialogs
- patch WalletPage buttons
- patch AddMintDialog, MintSettings, BalanceView, etc.

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846788cfe608330b1706206166afa31