### PR TITLE
Fix path alias in ConversationList

### DIFF
--- a/src/components/ConversationList.vue
+++ b/src/components/ConversationList.vue
@@ -32,8 +32,8 @@
 <script lang="ts" setup>
 import { computed, watch, onMounted, ref } from 'vue';
 import { storeToRefs } from 'pinia';
-import { useMessengerStore } from '@/stores/messenger';
-import { useNostrStore } from '@/stores/nostr';
+import { useMessengerStore } from 'src/stores/messenger';
+import { useNostrStore } from 'src/stores/nostr';
 import ConversationListItem from './ConversationListItem.vue';
 
 const emit = defineEmits(['select']);


### PR DESCRIPTION
## Summary
- fix path alias to messenger and nostr stores in ConversationList.vue

## Testing
- `npm test` *(fails: Cannot set property permissions of [object Object])*


------
https://chatgpt.com/codex/tasks/task_e_68467788f9e48330bb4ef59307a5ed32