### PR TITLE
Fix duplicate prop in ConversationListItem

### DIFF
--- a/src/components/ConversationListItem.vue
+++ b/src/components/ConversationListItem.vue
@@ -21,7 +21,7 @@
         <template v-if="loaded">
           <span
             :class="['text-subtitle1 ellipsis', { 'text-weight-bold': unreadCount > 0 }]"
-            >{{ showRaw ? pubkey : displayName }}</span
+            >{{ showRaw ? props.pubkey : displayName }}</span
           >
           <span class="timestamp text-caption q-ml-auto">{{ timeAgo }}</span>
           <q-btn
@@ -116,7 +116,7 @@ export default defineComponent({
       loaded,
       unreadCount,
       showRaw,
-      pubkey: props.pubkey,
+      props,
     };
   }
 });


### PR DESCRIPTION
## Summary
- use `props.pubkey` directly in template
- expose `props` in setup so template can access it

## Testing
- `npm test` *(fails: getActivePinia etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68467b3881008330a518ea435322cc69