### PR TITLE
Improve accessibility for clickable text

### DIFF
--- a/src/components/AnimatedNumber.vue
+++ b/src/components/AnimatedNumber.vue
@@ -1,5 +1,12 @@
 <template>
-  <span @click="$emit('click')">{{ formattedValue }}</span>
+  <span
+    @click="$emit('click')"
+    @keyup.enter="$emit('click')"
+    tabindex="0"
+    role="button"
+  >
+    {{ formattedValue }}
+  </span>
 </template>
 
 <script lang="ts">

--- a/src/components/BalanceView.vue
+++ b/src/components/BalanceView.vue
@@ -102,7 +102,13 @@
     <!-- mint url -->
     <div class="row q-mt-md q-mb-none text-secondary" v-if="activeMintUrl">
       <div class="col-12 cursor-pointer">
-        <span class="text-weight-light" @click="setTab('mints')">
+        <span
+          class="text-weight-light"
+          @click="setTab('mints')"
+          @keyup.enter="setTab('mints')"
+          tabindex="0"
+          role="button"
+        >
           {{ $t("BalanceView.mintUrl.label") }}: <b>{{ activeMintLabel }}</b>
         </span>
       </div>

--- a/src/components/MintDetailsDialog.vue
+++ b/src/components/MintDetailsDialog.vue
@@ -203,10 +203,20 @@
               class="detail-value"
               v-if="!showAllNuts"
               @click="showAllNuts = true"
+              @keyup.enter="showAllNuts = true"
+              tabindex="0"
+              role="button"
             >
               {{ $t("MintDetailsDialog.details.nuts.actions.show.label") }}
             </div>
-            <div class="detail-value" v-else @click="showAllNuts = false">
+            <div
+              class="detail-value"
+              v-else
+              @click="showAllNuts = false"
+              @keyup.enter="showAllNuts = false"
+              tabindex="0"
+              role="button"
+            >
               {{ $t("MintDetailsDialog.details.nuts.actions.hide.label") }}
             </div>
           </div>

--- a/src/components/PaymentRequestDialog.vue
+++ b/src/components/PaymentRequestDialog.vue
@@ -55,7 +55,13 @@
                 <q-icon name="account_balance" size="xs" class="q-mr-sm" />
                 {{ getShortUrl(chosenMintUrl) }}
               </q-chip>
-              <div @click="toggleUnit" class="q-mt-xs q-ml-sm">
+              <div
+                @click="toggleUnit"
+                @keyup.enter="toggleUnit"
+                tabindex="0"
+                role="button"
+                class="q-mt-xs q-ml-sm"
+              >
                 <ToggleUnit class="q-py-none" color="white" />
               </div>
             </div>


### PR DESCRIPTION
## Summary
- add keyboard handlers and ARIA attributes to AnimatedNumber
- add keyboard handlers and ARIA attributes to BalanceView
- make toggle unit button accessible
- add keyboard handlers and ARIA attributes to MintDetailsDialog

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68467aa479488330864dcc770ea66d93