### PR TITLE
Fix extraneous icons in messenger input

### DIFF
--- a/src/components/MessageInput.vue
+++ b/src/components/MessageInput.vue
@@ -2,8 +2,6 @@
   <div class="row no-wrap items-center q-pa-sm">
     <q-input v-model="text" class="col" dense outlined @keyup.enter="send">
       <template v-slot:append>
-        <q-btn flat round icon="emoji-emotions-outline" @click="toggleEmojiPicker" />
-        <q-btn flat round icon="attach-file" @click="onAttachFile" />
         <q-btn flat round icon="account-balance-wallet" @click="sendToken" />
         <q-btn
           flat
@@ -37,6 +35,4 @@ const sendToken = () => {
   emit('sendToken');
 };
 
-const toggleEmojiPicker = () => {};
-const onAttachFile = () => {};
 </script>

--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -49,7 +49,7 @@
       </q-header>
       <ActiveChatHeader :pubkey="selected" />
       <MessageList :messages="messages" class="col" />
-      <MessageInput @send="sendMessage" />
+      <MessageInput @send="sendMessage" @sendToken="openSendTokenDialog" />
       <q-expansion-item
         class="q-mt-md"
         dense
@@ -77,8 +77,10 @@ import ActiveChatHeader from "components/ActiveChatHeader.vue";
 import MessageList from "components/MessageList.vue";
 import MessageInput from "components/MessageInput.vue";
 import EventLog from "components/EventLog.vue";
+import { useSendTokensStore } from "src/stores/sendTokensStore";
 
 const messenger = useMessengerStore();
+const sendTokensStore = useSendTokensStore();
 messenger.loadIdentity();
 onMounted(() => {
   messenger.start();
@@ -132,6 +134,14 @@ const sendMessage = (text: string) => {
   if (!selected.value) return;
   messenger.sendDm(selected.value, text);
 };
+
+function openSendTokenDialog() {
+  if (!selected.value) return;
+  sendTokensStore.clearSendData();
+  sendTokensStore.recipientPubkey = selected.value;
+  sendTokensStore.sendViaNostr = true;
+  sendTokensStore.showSendTokens = true;
+}
 
 let touchStartX = 0;
 const onTouchStart = (e: TouchEvent) => {


### PR DESCRIPTION
## Summary
- keep only the relevant icons in `MessageInput`
- connect the Send Token button with the token dialog logic

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684682f9729083309d2cc2250159b86b