### PR TITLE
Fix extraneous icons in messenger input

### DIFF
--- a/src/components/MessageInput.vue
+++ b/src/components/MessageInput.vue
@@ -2,8 +2,6 @@
   <div class="row no-wrap items-center q-pa-sm">
     <q-input v-model="text" class="col" dense outlined @keyup.enter="send">
       <template v-slot:append>
-        <q-btn flat round icon="emoji-emotions-outline" @click="toggleEmojiPicker" />
-        <q-btn flat round icon="attach-file" @click="onAttachFile" />
         <q-btn flat round icon="account-balance-wallet" @click="sendToken" />
         <q-btn
           flat
@@ -37,6 +35,4 @@ const sendToken = () => {
   emit('sendToken');
 };
 
-const toggleEmojiPicker = () => {};
-const onAttachFile = () => {};
 </script>

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -147,3 +147,9 @@ body.body--dark .received {
   background-color: var(--q-color-grey-8) !important;
   color: #ffffff !important;
 }
+
+
+.no-horizontal-scroll {
+  overflow-x: hidden;
+}
+

--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -1,6 +1,6 @@
 <template>
   <q-page
-    class="row full-height"
+    class="row full-height no-horizontal-scroll"
     :class="[$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark']"
     @touchstart="onTouchStart"
     @touchend="onTouchEnd"
@@ -49,7 +49,7 @@
       </q-header>
       <ActiveChatHeader :pubkey="selected" />
       <MessageList :messages="messages" class="col" />
-      <MessageInput @send="sendMessage" />
+      <MessageInput @send="sendMessage" @sendToken="openSendTokenDialog" />
       <q-expansion-item
         class="q-mt-md"
         dense
@@ -77,8 +77,10 @@ import ActiveChatHeader from "components/ActiveChatHeader.vue";
 import MessageList from "components/MessageList.vue";
 import MessageInput from "components/MessageInput.vue";
 import EventLog from "components/EventLog.vue";
+import { useSendTokensStore } from "src/stores/sendTokensStore";
 
 const messenger = useMessengerStore();
+const sendTokensStore = useSendTokensStore();
 messenger.loadIdentity();
 onMounted(() => {
   messenger.start();
@@ -132,6 +134,14 @@ const sendMessage = (text: string) => {
   if (!selected.value) return;
   messenger.sendDm(selected.value, text);
 };
+
+function openSendTokenDialog() {
+  if (!selected.value) return;
+  sendTokensStore.clearSendData();
+  sendTokensStore.recipientPubkey = selected.value;
+  sendTokensStore.sendViaNostr = true;
+  sendTokensStore.showSendTokens = true;
+}
 
 let touchStartX = 0;
 const onTouchStart = (e: TouchEvent) => {


### PR DESCRIPTION
## Summary
- keep only the relevant icons in `MessageInput`
- connect the Send Token button with the token dialog logic
- prevent horizontal overflow on the messenger page

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm test` *(fails: vitest not found)*


------
https://chatgpt.com/codex/tasks/task_e_684682f9729083309d2cc2250159b86b