### PR TITLE
Remove event log from Nostr Messenger

### DIFF
--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -50,15 +50,6 @@
       <ActiveChatHeader :pubkey="selected" />
       <MessageList :messages="messages" class="col" />
       <MessageInput @send="sendMessage" />
-      <q-expansion-item
-        class="q-mt-md"
-        dense
-        dense-toggle
-        label="Event Log"
-        v-model="showEventLog"
-      >
-        <EventLog :events="eventLog" />
-      </q-expansion-item>
     </div>
   </q-page>
 </template>
@@ -76,7 +67,6 @@ import ConversationList from "components/ConversationList.vue";
 import ActiveChatHeader from "components/ActiveChatHeader.vue";
 import MessageList from "components/MessageList.vue";
 import MessageInput from "components/MessageInput.vue";
-import EventLog from "components/EventLog.vue";
 
 const messenger = useMessengerStore();
 messenger.loadIdentity();
@@ -100,11 +90,6 @@ const drawer = computed({
 });
 const selected = ref("");
 const messages = computed(() => messenger.conversations[selected.value] || []);
-const eventLog = computed(() => messenger.eventLog);
-const showEventLog = useLocalStorage<boolean>(
-  "cashu.messenger.showEventLog",
-  false,
-);
 const showRelays = useLocalStorage<boolean>("cashu.messenger.showRelays", true);
 
 watch(


### PR DESCRIPTION
## Summary
- remove the Event Log UI from `NostrMessenger.vue`

## Testing
- `npm run lint`
- `npm test` *(fails: "expected \"spy\" to be called" etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6846828df98c8330952d75055a516479