### PR TITLE
Remove event log from messenger

### DIFF
--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -50,15 +50,6 @@
       <ActiveChatHeader :pubkey="selected" />
       <MessageList :messages="messages" class="col" />
       <MessageInput @send="sendMessage" @sendToken="openSendTokenDialog" />
-      <q-expansion-item
-        class="q-mt-md"
-        dense
-        dense-toggle
-        label="Event Log"
-        v-model="showEventLog"
-      >
-        <EventLog :events="eventLog" />
-      </q-expansion-item>
     </div>
   </q-page>
 </template>
@@ -76,7 +67,6 @@ import ConversationList from "components/ConversationList.vue";
 import ActiveChatHeader from "components/ActiveChatHeader.vue";
 import MessageList from "components/MessageList.vue";
 import MessageInput from "components/MessageInput.vue";
-import EventLog from "components/EventLog.vue";
 import { useSendTokensStore } from "src/stores/sendTokensStore";
 
 const messenger = useMessengerStore();
@@ -102,11 +92,6 @@ const drawer = computed({
 });
 const selected = ref("");
 const messages = computed(() => messenger.conversations[selected.value] || []);
-const eventLog = computed(() => messenger.eventLog);
-const showEventLog = useLocalStorage<boolean>(
-  "cashu.messenger.showEventLog",
-  false,
-);
 const showRelays = useLocalStorage<boolean>("cashu.messenger.showRelays", true);
 
 watch(


### PR DESCRIPTION
## Summary
- remove Event Log expansion from NostrMessenger page

## Testing
- `npm run lint`
- `npm test` *(fails: cannot run due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_684687c2585c8330ac313cfe9093bbc6