### PR TITLE
Implement chat token dialog

### DIFF
--- a/src/components/ActiveChatHeader.vue
+++ b/src/components/ActiveChatHeader.vue
@@ -41,15 +41,19 @@
       <template v-else>
         <div class="text-grey-6">Select a conversation to start chatting.</div>
       </template>
-    </div>
-    <q-btn
-      flat
-      dense
-      round
-      :icon="$q.dark.isActive ? 'wb_sunny' : 'brightness_3'"
-      @click="$q.dark.toggle()"
-    />
   </div>
+  <q-btn
+    flat
+    dense
+    round
+    :icon="$q.dark.isActive ? 'wb_sunny' : 'brightness_3'"
+    @click="$q.dark.toggle()"
+  />
+  <ChatSendTokenDialog
+    ref="chatSendTokenDialogRef"
+    :recipient="props.pubkey"
+  />
+</div>
 </template>
 
 <script lang="ts" setup>
@@ -57,7 +61,7 @@ import { ref, watch, computed } from 'vue';
 import { useQuasar } from 'quasar';
 import { useNostrStore } from 'src/stores/nostr';
 import { useMessengerStore } from 'src/stores/messenger';
-import { useSendTokensStore } from 'src/stores/sendTokensStore';
+import ChatSendTokenDialog from './ChatSendTokenDialog.vue';
 import { nip19 } from 'nostr-tools';
 import ProfileInfoDialog from './ProfileInfoDialog.vue';
 
@@ -105,15 +109,12 @@ const initials = computed(() => {
   return name.slice(0, 2).toUpperCase();
 });
 
-const sendTokensStore = useSendTokensStore();
+const chatSendTokenDialogRef = ref<InstanceType<typeof ChatSendTokenDialog> | null>(null);
 const showProfileDialog = ref(false);
 
 function openSendTokenDialog() {
   if (!props.pubkey) return;
-  sendTokensStore.clearSendData();
-  sendTokensStore.recipientPubkey = props.pubkey;
-  sendTokensStore.sendViaNostr = true;
-  sendTokensStore.showSendTokens = true;
+  (chatSendTokenDialogRef.value as any)?.show();
 }
 
 

--- a/src/components/ChatSendTokenDialog.vue
+++ b/src/components/ChatSendTokenDialog.vue
@@ -1,0 +1,93 @@
+<template>
+  <q-dialog v-model="show" persistent ref="dialog">
+    <q-card class="q-pa-md qcard" style="min-width: 300px">
+      <q-card-section class="text-h6">Send Tokens</q-card-section>
+      <q-card-section>
+        <q-select
+          v-model="bucketId"
+          :options="bucketOptions"
+          emit-value
+          map-options
+          label="Bucket"
+          outlined
+          dense
+        />
+        <q-input
+          v-model.number="amount"
+          type="number"
+          label="Amount"
+          outlined
+          dense
+          class="q-mt-md"
+        />
+        <q-input
+          v-model="memo"
+          label="Memo"
+          outlined
+          dense
+          class="q-mt-md"
+        />
+      </q-card-section>
+      <q-card-actions align="right">
+        <q-btn flat color="primary" @click="cancel">Cancel</q-btn>
+        <q-btn flat color="primary" :disable="!amount" @click="confirm">Send</q-btn>
+      </q-card-actions>
+    </q-card>
+  </q-dialog>
+</template>
+
+<script lang="ts" setup>
+import { ref, computed, defineExpose } from 'vue';
+import { useBucketsStore } from 'src/stores/buckets';
+import { useMessengerStore } from 'src/stores/messenger';
+
+const props = defineProps<{ recipient: string }>();
+
+const bucketsStore = useBucketsStore();
+const messenger = useMessengerStore();
+
+const show = ref(false);
+const amount = ref<number | null>(null);
+const memo = ref('');
+const bucketId = ref('');
+
+const bucketOptions = computed(() =>
+  bucketsStore.bucketList.map((b) => ({ label: b.name, value: b.id }))
+);
+
+function reset() {
+  amount.value = null;
+  memo.value = '';
+  bucketId.value = bucketsStore.bucketList[0]?.id || '';
+}
+
+function showDialog() {
+  reset();
+  show.value = true;
+}
+
+function hideDialog() {
+  show.value = false;
+}
+
+defineExpose({ show: showDialog, hide: hideDialog });
+
+function cancel() {
+  hideDialog();
+}
+
+async function confirm() {
+  if (!props.recipient || !amount.value) {
+    hideDialog();
+    return;
+  }
+  await messenger.sendToken(
+    props.recipient,
+    amount.value,
+    bucketId.value,
+    memo.value.trim() || undefined
+  );
+  hideDialog();
+}
+</script>
+


### PR DESCRIPTION
## Summary
- add a minimal `ChatSendTokenDialog` for quick token sending
- use the new dialog in `ActiveChatHeader`
- remove usage of `useSendTokensStore`

## Testing
- `npm run lint` *(fails: command not found)*
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68468dd4f3c48330be853f0ec02fbca6