### PR TITLE
Add sendToken vitest spec

### DIFF
--- a/test/vitest/__tests__/messenger-send-token.spec.ts
+++ b/test/vitest/__tests__/messenger-send-token.spec.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+var sendDm: any
+var walletSend: any
+var walletMintWallet: any
+var serializeProofs: any
+var addPending: any
+
+vi.mock('../../../src/stores/nostr', () => {
+  sendDm = vi.fn(async () => ({ success: true, event: { id: '1', created_at: 0 } }))
+  return { useNostrStore: () => ({
+    sendNip04DirectMessage: sendDm,
+    initSignerIfNotSet: vi.fn(),
+    privateKeySignerPrivateKey: 'priv',
+    seedSignerPrivateKey: '',
+    pubkey: 'pub',
+    signerType: 'seed',
+    connected: true,
+    relays: [] as string[],
+    get privKeyHex() { return this.privateKeySignerPrivateKey }
+  }) }
+})
+
+vi.mock('../../../src/stores/wallet', () => {
+  walletSend = vi.fn(async () => ({ sendProofs: [{ secret: 's1', amount: 1 }] }))
+  walletMintWallet = vi.fn(() => ({}))
+  return { useWalletStore: () => ({ send: walletSend, mintWallet: walletMintWallet }) }
+})
+
+vi.mock('../../../src/stores/mints', () => ({
+  useMintsStore: () => ({
+    activeUnitCurrencyMultiplyer: 1,
+    activeMintUrl: 'mint',
+    activeUnit: 'sat',
+    activeProofs: [
+      { secret: 'a', amount: 1, id: 'id', bucketId: 'b' },
+    ],
+  })
+}))
+
+vi.mock('../../../src/stores/proofs', () => {
+  serializeProofs = vi.fn(() => 'TOKEN')
+  return { useProofsStore: () => ({ serializeProofs }) }
+})
+
+vi.mock('../../../src/stores/settings', () => ({
+  useSettingsStore: () => ({ includeFeesInSendAmount: false })
+}))
+
+vi.mock('../../../src/stores/tokens', () => {
+  addPending = vi.fn()
+  return { useTokensStore: () => ({ addPendingToken: addPending }) }
+})
+
+vi.mock('../../../src/js/message-utils', () => ({
+  sanitizeMessage: vi.fn((s: string) => s)
+}))
+
+import { useMessengerStore } from '../../../src/stores/messenger'
+
+beforeEach(() => {
+  localStorage.clear()
+  vi.clearAllMocks()
+})
+
+describe('messenger.sendToken', () => {
+  it('sends token DM and logs message', async () => {
+    const store = useMessengerStore()
+    const success = await store.sendToken('receiver', 1, 'b', 'note')
+    expect(success).toBe(true)
+    expect(walletMintWallet).toHaveBeenCalledWith('mint', 'sat')
+    expect(walletSend).toHaveBeenCalled()
+    expect(sendDm).toHaveBeenCalledWith('receiver', 'note\nTOKEN', 'priv', 'pub')
+    expect(addPending).toHaveBeenCalledWith({
+      amount: -1,
+      token: 'TOKEN',
+      unit: 'sat',
+      mint: 'mint',
+      bucketId: 'b'
+    })
+    expect(store.conversations.receiver.length).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary
- add messenger-send-token spec

## Testing
- `npx vitest run test/vitest/__tests__/messenger-send-token.spec.ts`
- `npm run test:ci` *(fails: Cannot access 'sendDm' before initialization, missing modules, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_684698332cf8833086252514611c3a38