### PR TITLE
Add wallet lightning address notification

### DIFF
--- a/src/stores/npubcash.ts
+++ b/src/stores/npubcash.ts
@@ -80,6 +80,7 @@ export const useNPCStore = defineStore("npc", {
         return;
       }
       const walletPublicKeyHex = nostrStore.pubkey;
+      notify(
         "Lightning address for wallet:",
         nip19.npubEncode(walletPublicKeyHex) + "@" + this.npcDomain
       );


### PR DESCRIPTION
## Summary
- display the Lightning address when generating an NPC connection

## Testing
- `npm run test:ci` *(fails: Failed Suites 14)*

------
https://chatgpt.com/codex/tasks/task_e_68469c2b18cc8330aad85233a58517fc