### PR TITLE
Fix debug import in MintAuditInfo

### DIFF
--- a/src/components/MintAuditInfo.vue
+++ b/src/components/MintAuditInfo.vue
@@ -97,8 +97,9 @@
 </template>
 
 <script lang="ts">
-interface MintRead {
 import { debug } from "src/js/logger";
+
+interface MintRead {
   id: number;
   url: string;
   info?: string;


### PR DESCRIPTION
## Summary
- import `debug` at the top of `<script>` section
- remove misplaced import line inside interface

## Testing
- `npm run test:ci` *(fails: getActivePinia was called but there was no active Pinia, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68469f292b14833089f107c23e50d48e