### PR TITLE
Remove unused import in ChatSendTokenDialog

### DIFF
--- a/src/components/ChatSendTokenDialog.vue
+++ b/src/components/ChatSendTokenDialog.vue
@@ -37,7 +37,7 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, computed, defineExpose } from 'vue';
+import { ref, computed } from 'vue';
 import { useBucketsStore } from 'src/stores/buckets';
 import { useMessengerStore } from 'src/stores/messenger';
 


### PR DESCRIPTION
## Summary
- tidy up imports in ChatSendTokenDialog

## Testing
- `npm test` *(fails: Cannot set property permissions of [object Object] which has only a getter)*

------
https://chatgpt.com/codex/tasks/task_e_6846a089171c83308493b6083fa89eca