### PR TITLE
Improve messenger token UI

### DIFF
--- a/src/components/MessageInput.vue
+++ b/src/components/MessageInput.vue
@@ -2,7 +2,13 @@
   <div class="row no-wrap items-center q-pa-sm">
     <q-input v-model="text" class="col" dense outlined @keyup.enter="send">
       <template v-slot:append>
-        <q-btn flat round icon="account-balance-wallet" @click="sendToken" />
+        <q-btn
+          flat
+          round
+          icon="account-balance-wallet"
+          color="primary"
+          @click="sendToken"
+        />
         <q-btn
           flat
           round


### PR DESCRIPTION
## Summary
- show the total balance when sending tokens in messenger
- list bucket balances in the bucket selector
- color the send-token icon so it stands out

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846a3697d548330ad64db4dadf4f149