### PR TITLE
Improve token icon visibility

### DIFF
--- a/src/components/MessageInput.vue
+++ b/src/components/MessageInput.vue
@@ -2,13 +2,9 @@
   <div class="row no-wrap items-center q-pa-sm">
     <q-input v-model="text" class="col" dense outlined @keyup.enter="send">
       <template v-slot:append>
-        <q-btn
-          flat
-          round
-          icon="account-balance-wallet"
-          color="primary"
-          @click="sendToken"
-        />
+        <q-btn flat round color="primary" @click="sendToken">
+          <NutIcon />
+        </q-btn>
         <q-btn
           flat
           round
@@ -25,6 +21,7 @@
 
 <script lang="ts" setup>
 import { ref } from 'vue';
+import { Nut as NutIcon } from 'lucide-vue-next';
 
 const emit = defineEmits(['send', 'sendToken']);
 const text = ref('');


### PR DESCRIPTION
## Summary
- replace Material wallet icon with nut icon in chat message input

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846a50069888330a850545b4262265f