### PR TITLE
Add bucket info to subscriptions overview

### DIFF
--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1477,6 +1477,7 @@ export default {
     },
     columns: {
       creator: "Creator",
+      bucket: "Bucket",
       monthly: "Monthly",
       total: "Total",
       start: "Start",


### PR DESCRIPTION
## Summary
- show bucket names in `SubscriptionsOverview` rows using each token's bucketId
- display bucket column in the subscriptions table
- list bucket in the creator cell and as its own column
- add translation for new bucket column

## Testing
- `npm test --silent` *(fails: "Cannot set property permissions ..." and other unit test errors)*

------
https://chatgpt.com/codex/tasks/task_e_6846c04873c483309b9056f50f3b59c2