### PR TITLE
Add cancel and extend subscription actions

### DIFF
--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1495,6 +1495,16 @@ export default {
     discover: "Discover creators",
     view: "View",
     message: "Message",
+    extend: "Extend",
+    cancel: "Cancel",
+    cancel_confirm_title: "Cancel subscription",
+    cancel_confirm_text: "Delete all future locked tokens?",
+    extend_dialog_title: "Extend subscription",
+    extend_dialog_text: "Number of additional months",
+    notifications: {
+      cancel_success: "Subscription canceled",
+      extend_success: "Subscription extended",
+    },
   },
   LockedTokensTable: {
     empty_text: "No locked tokens",


### PR DESCRIPTION
## Summary
- add `Cancel` and `Extend` buttons to subscription table actions
- implement methods to delete future locked tokens or to extend a subscription
- add related i18n strings

## Testing
- `npm run lint`
- `npm test` *(fails: getActivePinia() was called but there was no active Pinia, failed to resolve imports, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6846d0454c908330a1a89ede65192bda