### PR TITLE
Enhance subscriptions table

### DIFF
--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1481,6 +1481,8 @@ export default {
       monthly: "Monthly",
       total: "Total",
       start: "Start",
+      end: "Ends",
+      total_months: "Total months",
       next_unlock: "Next unlock",
       status: "Status",
       remaining: "Months left",


### PR DESCRIPTION
## Summary
- add filtering input, sorting hook and progress color classes
- show total months and ending date
- display progress percentage
- style table with padding and theme colors
- extend i18n translations

## Testing
- `npm test` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68470bdb65dc83308397965ab92fe161