### PR TITLE
Add token export to subscription overview

### DIFF
--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1496,6 +1496,7 @@ export default {
     view: "View",
     message: "Message",
     extend: "Extend",
+    export: "Export",
     cancel: "Cancel",
     cancel_confirm_title: "Cancel subscription",
     cancel_confirm_text: "Delete all future locked tokens?",


### PR DESCRIPTION
## Summary
- add export button to subscription rows
- implement `exportTokens` to aggregate proofs and open the send token dialog
- add translation for new export action

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot set property permissions and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68470bb761788330824434fb6dd9930a