### PR TITLE
Implement subscriptions store and overview enhancements

### DIFF
--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1478,6 +1478,10 @@ export default {
     columns: {
       creator: "Creator",
       bucket: "Bucket",
+      tierName: "Tier",
+      benefits: "Benefits",
+      frequency: "Frequency",
+      tokensRemaining: "Remaining",
       monthly: "Monthly",
       total: "Total",
       start: "Start",

--- a/src/pages/FindCreators.vue
+++ b/src/pages/FindCreators.vue
@@ -167,7 +167,12 @@ async function confirmSubscribe({
       dialogPubkey.value,
       undefined,
       startDate,
-      true
+      true,
+      {
+        tierName: selectedTier.value?.name,
+        benefits: selectedTier.value?.benefits || [],
+        frequency: 'monthly',
+      }
     )) as any[];
     let supporterName = nostr.pubkey;
     try {

--- a/src/pages/PublicCreatorProfilePage.vue
+++ b/src/pages/PublicCreatorProfilePage.vue
@@ -162,7 +162,12 @@ export default defineComponent({
           creatorNpub,
           undefined,
           startDate,
-          true
+          true,
+          {
+            tierName: selectedTier.value?.name,
+            benefits: selectedTier.value?.benefits || [],
+            frequency: 'monthly',
+          }
         )) as any[];
         let supporterName = nostr.pubkey;
         try {

--- a/src/stores/subscriptions.ts
+++ b/src/stores/subscriptions.ts
@@ -1,0 +1,41 @@
+import { defineStore } from 'pinia';
+import { cashuDb } from './dexie';
+import type { Subscription } from './dexie';
+import { liveQuery } from 'dexie';
+import { ref } from 'vue';
+import { v4 as uuidv4 } from 'uuid';
+
+export const useSubscriptionsStore = defineStore('subscriptions', () => {
+  const subscriptions = ref<Subscription[]>([]);
+
+  liveQuery(() => cashuDb.subscriptions.toArray()).subscribe({
+    next: (rows) => {
+      subscriptions.value = rows;
+    },
+    error: (err) => {
+      console.error(err);
+    },
+  });
+
+  async function addSubscription(data: Omit<Subscription, 'id' | 'createdAt' | 'updatedAt'> & { id?: string }) {
+    const now = Math.floor(Date.now() / 1000);
+    const entry: Subscription = {
+      id: data.id ?? uuidv4(),
+      ...data,
+      createdAt: now,
+      updatedAt: now,
+    } as Subscription;
+    await cashuDb.subscriptions.put(entry);
+    return entry;
+  }
+
+  async function updateSubscription(id: string, updates: Partial<Subscription>) {
+    await cashuDb.subscriptions.update(id, { ...updates, updatedAt: Math.floor(Date.now() / 1000) });
+  }
+
+  async function deleteSubscription(id: string) {
+    await cashuDb.subscriptions.delete(id);
+  }
+
+  return { subscriptions, addSubscription, updateSubscription, deleteSubscription };
+});


### PR DESCRIPTION
## Summary
- add a new subscriptions Pinia store backed by Dexie
- store subscription data when creating donation presets
- use subscriptions in SubscriptionsOverview and display extra fields
- update table columns and i18n labels
- extend subscription creation calls with tier info

## Testing
- `npm test --silent` *(fails: getActivePinia not found and other module resolution errors)*

------
https://chatgpt.com/codex/tasks/task_e_6847201ea8608330a1369ae9f49362b7