### PR TITLE
Add view profile button to subscriptions

### DIFF
--- a/src/pages/SubscriptionsOverview.vue
+++ b/src/pages/SubscriptionsOverview.vue
@@ -131,6 +131,15 @@
           dense
           size="sm"
           class="q-ml-xs"
+          :to="`/creator/${pubkeyNpub(props.row.creator)}`"
+        >
+          {{ $t('FindCreators.actions.view_profile') }}
+        </q-btn>
+        <q-btn
+          flat
+          dense
+          size="sm"
+          class="q-ml-xs"
           @click="sendMessage(props.row.creator)"
         >
           {{ $t('SubscriptionsOverview.message') }}


### PR DESCRIPTION
## Summary
- link to creator profile in the subscriptions table

## Testing
- `npm test` *(fails: getActivePinia not active et al.)*

------
https://chatgpt.com/codex/tasks/task_e_6847286a83708330b973ad6746baaa2c