### PR TITLE
Add subscription status filter translations

### DIFF
--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -1344,5 +1344,6 @@ timelock: {
   },
   SubscriptionsOverview: {
     export_csv: "Export CSV",
+    filter: { status: "تصفية حسب الحالة" },
   },
 };

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -1351,5 +1351,6 @@ export default {
   },
   SubscriptionsOverview: {
     export_csv: "Export CSV",
+    filter: { status: "Nach Status filtern" },
   },
 };

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -1354,5 +1354,6 @@ timelock: {
   },
   SubscriptionsOverview: {
     export_csv: "Export CSV",
+    filter: { status: "Φιλτράρισμα κατά κατάσταση" },
   },
 };

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1509,6 +1509,7 @@ export default {
     cancel_confirm_text: "Delete all future locked tokens?",
     extend_dialog_title: "Extend subscription",
     extend_dialog_text: "Number of additional months",
+    filter: { status: "Filter by status" },
     notifications: {
       cancel_success: "Subscription canceled",
       extend_success: "Subscription extended",

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -1352,5 +1352,6 @@ timelock: {
   },
   SubscriptionsOverview: {
     export_csv: "Export CSV",
+    filter: { status: "Filtrar por estado" },
   },
 };

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -1341,5 +1341,6 @@ timelock: {
   },
   SubscriptionsOverview: {
     export_csv: "Export CSV",
+    filter: { status: "Filtrer par statut" },
   },
 };

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -1334,5 +1334,6 @@ timelock: {
   },
   SubscriptionsOverview: {
     export_csv: "Export CSV",
+    filter: { status: "Filtra per stato" },
   },
 };

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -1334,5 +1334,6 @@ timelock: {
   },
   SubscriptionsOverview: {
     export_csv: "Export CSV",
+    filter: { status: "ステータスでフィルタ" },
   },
 };

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -1334,5 +1334,6 @@ timelock: {
   },
   SubscriptionsOverview: {
     export_csv: "Export CSV",
+    filter: { status: "Filtrera efter status" },
   },
 };

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -1331,5 +1331,6 @@ timelock: {
   },
   SubscriptionsOverview: {
     export_csv: "Export CSV",
+    filter: { status: "กรองตามสถานะ" },
   },
 };

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -1336,5 +1336,6 @@ timelock: {
   },
   SubscriptionsOverview: {
     export_csv: "Export CSV",
+    filter: { status: "Duruma göre filtrele" },
   },
 };

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -1324,5 +1324,6 @@ timelock: {
   },
   SubscriptionsOverview: {
     export_csv: "Export CSV",
+    filter: { status: "按状态筛选" },
   },
 };


### PR DESCRIPTION
## Summary
- translate the new status filter for subscriptions overview in all locales
- show status filter text correctly in SubscriptionsOverview.vue

## Testing
- `npm run lint`
- `npm test` *(fails: MISSING DEPENDENCY happy-dom)*

------
https://chatgpt.com/codex/tasks/task_e_6847badf34688330815c700d710a14c0