### PR TITLE
Add benefits cell to subscription table

### DIFF
--- a/src/pages/SubscriptionsOverview.vue
+++ b/src/pages/SubscriptionsOverview.vue
@@ -66,6 +66,18 @@
       <template #body-cell-bucket="props">
         {{ props.row.bucketName || '-' }}
       </template>
+      <template #body-cell-benefits="props">
+        <template v-if="Array.isArray(props.row.benefits)">
+          <ul class="q-my-none q-pl-none">
+            <li v-for="(benefit, idx) in props.row.benefits" :key="idx">
+              {{ benefit }}
+            </li>
+          </ul>
+        </template>
+        <template v-else>
+          {{ props.row.benefits }}
+        </template>
+      </template>
       <template #body-cell-monthly="props">
         {{ formatCurrency(props.row.monthly) }}
       </template>


### PR DESCRIPTION
## Summary
- show subscription benefits in a dedicated column

## Testing
- `npm run lint`
- `npm run test` *(fails: MISSING DEPENDENCY 'happy-dom')*

------
https://chatgpt.com/codex/tasks/task_e_6847be4711948330b4a2795b0652cfb0