### PR TITLE
Add bucket and frequency filters

### DIFF
--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -1344,6 +1344,10 @@ timelock: {
   },
   SubscriptionsOverview: {
     export_csv: "Export CSV",
-    filter: { status: "تصفية حسب الحالة" },
+    filter: {
+      status: "تصفية حسب الحالة",
+      bucket: "تصفية حسب الحاوية",
+      frequency: "تصفية حسب التكرار",
+    },
   },
 };

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -1351,6 +1351,10 @@ export default {
   },
   SubscriptionsOverview: {
     export_csv: "Export CSV",
-    filter: { status: "Nach Status filtern" },
+    filter: {
+      status: "Nach Status filtern",
+      bucket: "Nach Bucket filtern",
+      frequency: "Nach Frequenz filtern",
+    },
   },
 };

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -1354,6 +1354,10 @@ timelock: {
   },
   SubscriptionsOverview: {
     export_csv: "Export CSV",
-    filter: { status: "Φιλτράρισμα κατά κατάσταση" },
+    filter: {
+      status: "Φιλτράρισμα κατά κατάσταση",
+      bucket: "Φιλτράρισμα ανά κάδο",
+      frequency: "Φιλτράρισμα ανά συχνότητα",
+    },
   },
 };

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1509,7 +1509,11 @@ export default {
     cancel_confirm_text: "Delete all future locked tokens?",
     extend_dialog_title: "Extend subscription",
     extend_dialog_text: "Number of additional months",
-    filter: { status: "Filter by status" },
+    filter: {
+      status: "Filter by status",
+      bucket: "Filter by bucket",
+      frequency: "Filter by frequency",
+    },
     notifications: {
       cancel_success: "Subscription canceled",
       extend_success: "Subscription extended",

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -1352,6 +1352,10 @@ timelock: {
   },
   SubscriptionsOverview: {
     export_csv: "Export CSV",
-    filter: { status: "Filtrar por estado" },
+    filter: {
+      status: "Filtrar por estado",
+      bucket: "Filtrar por bucket",
+      frequency: "Filtrar por frecuencia",
+    },
   },
 };

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -1341,6 +1341,10 @@ timelock: {
   },
   SubscriptionsOverview: {
     export_csv: "Export CSV",
-    filter: { status: "Filtrer par statut" },
+    filter: {
+      status: "Filtrer par statut",
+      bucket: "Filtrer par bucket",
+      frequency: "Filtrer par fréquence",
+    },
   },
 };

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -1334,6 +1334,10 @@ timelock: {
   },
   SubscriptionsOverview: {
     export_csv: "Export CSV",
-    filter: { status: "Filtra per stato" },
+    filter: {
+      status: "Filtra per stato",
+      bucket: "Filtra per bucket",
+      frequency: "Filtra per frequenza",
+    },
   },
 };

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -1334,6 +1334,10 @@ timelock: {
   },
   SubscriptionsOverview: {
     export_csv: "Export CSV",
-    filter: { status: "ステータスでフィルタ" },
+    filter: {
+      status: "ステータスでフィルタ",
+      bucket: "バケットでフィルタ",
+      frequency: "頻度でフィルタ",
+    },
   },
 };

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -1334,6 +1334,10 @@ timelock: {
   },
   SubscriptionsOverview: {
     export_csv: "Export CSV",
-    filter: { status: "Filtrera efter status" },
+    filter: {
+      status: "Filtrera efter status",
+      bucket: "Filtrera efter bucket",
+      frequency: "Filtrera efter frekvens",
+    },
   },
 };

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -1331,6 +1331,10 @@ timelock: {
   },
   SubscriptionsOverview: {
     export_csv: "Export CSV",
-    filter: { status: "กรองตามสถานะ" },
+    filter: {
+      status: "กรองตามสถานะ",
+      bucket: "กรองตามบัคเก็ต",
+      frequency: "กรองตามความถี่",
+    },
   },
 };

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -1336,6 +1336,10 @@ timelock: {
   },
   SubscriptionsOverview: {
     export_csv: "Export CSV",
-    filter: { status: "Duruma göre filtrele" },
+    filter: {
+      status: "Duruma göre filtrele",
+      bucket: "Buckete göre filtrele",
+      frequency: "Sıklığa göre filtrele",
+    },
   },
 };

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -1324,6 +1324,10 @@ timelock: {
   },
   SubscriptionsOverview: {
     export_csv: "Export CSV",
-    filter: { status: "按状态筛选" },
+    filter: {
+      status: "按状态筛选",
+      bucket: "按桶筛选",
+      frequency: "按频率筛选",
+    },
   },
 };

--- a/src/pages/SubscriptionsOverview.vue
+++ b/src/pages/SubscriptionsOverview.vue
@@ -43,6 +43,29 @@
           ]"
           :placeholder="$t('SubscriptionsOverview.filter.status')"
         />
+        <q-select
+          v-model="bucketFilter"
+          dense
+          emit-value
+          map-options
+          clearable
+          :options="bucketsStore.bucketList.map((b) => ({ label: b.name, value: b.name }))"
+          class="q-ml-md"
+          :placeholder="$t('SubscriptionsOverview.filter.bucket')"
+        />
+        <q-select
+          v-model="frequencyFilter"
+          dense
+          emit-value
+          map-options
+          clearable
+          :options="[
+            { label: 'monthly', value: 'monthly' },
+            { label: 'weekly', value: 'weekly' }
+          ]"
+          class="q-ml-md"
+          :placeholder="$t('SubscriptionsOverview.filter.frequency')"
+        />
       </template>
       <template #body-cell-creator="props">
         <div class="row items-center">
@@ -399,15 +422,19 @@ const messageText = ref("");
 const messageRecipient = ref("");
 const filter = ref("");
 const statusFilter = ref<string | null>(null);
+const bucketFilter = ref<string | null>(null);
+const frequencyFilter = ref<string | null>(null);
 const pagination = ref({ page: 1, rowsPerPage: 10 });
 
 const filteredRows = computed(() => {
   const term = filter.value.toLowerCase();
   return rows.value.filter((r) => {
     const matchesStatus = !statusFilter.value || r.status === statusFilter.value;
+    const matchesBucket = !bucketFilter.value || r.bucketName === bucketFilter.value;
+    const matchesFrequency = !frequencyFilter.value || r.frequency === frequencyFilter.value;
     const rowString = JSON.stringify(r).toLowerCase();
     const matchesFilter = !term || rowString.includes(term);
-    return matchesStatus && matchesFilter;
+    return matchesStatus && matchesBucket && matchesFrequency && matchesFilter;
   });
 });
 


### PR DESCRIPTION
## Summary
- add filters for subscription bucket and frequency
- translate placeholders for bucket & frequency filters

## Testing
- `npm run lint`
- `npm run test:ci` *(fails: Cannot find dependency 'happy-dom')*

------
https://chatgpt.com/codex/tasks/task_e_6847c08342d883309a8017e0dfe1cdd1