### PR TITLE
Fix locked token ingestion for creators

### DIFF
--- a/src/stores/dexie.ts
+++ b/src/stores/dexie.ts
@@ -55,6 +55,7 @@ export interface Subscription {
 export interface LockedToken {
   id: string;
   tokenString: string;
+  amount: number;
   owner: "subscriber" | "creator";
   subscriberNpub?: string;
   creatorNpub?: string;
@@ -64,6 +65,7 @@ export interface LockedToken {
   refundUnlockTs: number;
   status: "pending" | "unlockable" | "claimed" | "expired";
   subscriptionEventId: string | null;
+  label?: string;
 }
 
 // export interface Proof {


### PR DESCRIPTION
## Summary
- store amount in locked token model
- skip self-sent DMs when parsing for ecash
- create bucket for incoming locked tokens and persist amount info

## Testing
- `npm test` *(fails: Cannot find dependency 'happy-dom')*

------
https://chatgpt.com/codex/tasks/task_e_6847d9144c948330ae1dc86a701789bb