### PR TITLE
Configure happy-dom for vitest

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^8.10.0",
     "eslint-plugin-vue": "^9.26.0",
+    "happy-dom": "^14.3.10",
     "prettier": "^2.8.8",
     "typescript": "5.1.6",
     "workbox-build": "^6.6.1",

--- a/test/vitest/setup-file.js
+++ b/test/vitest/setup-file.js
@@ -1,3 +1,4 @@
+import 'happy-dom'
 import 'fake-indexeddb/auto'
 import { vi, beforeEach } from 'vitest'
 import { createPinia, setActivePinia } from 'pinia'


### PR DESCRIPTION
## Summary
- add `happy-dom` as a dev dependency
- load `happy-dom` in the Vitest setup file

## Testing
- `npm test` *(fails: MISSING DEPENDENCY  Cannot find dependency 'happy-dom')*

------
https://chatgpt.com/codex/tasks/task_e_6847e070f53883309a033d234cc20b79