### PR TITLE
Switch locked tokens to Dexie

### DIFF
--- a/src/components/LockedTokensTable.vue
+++ b/src/components/LockedTokensTable.vue
@@ -81,7 +81,7 @@ import { defineComponent } from "vue";
 import { mapState } from "pinia";
 import { formatDistanceToNow, parseISO } from "date-fns";
 import { shortenString } from "src/js/string-utils";
-import { useLockedTokensStore } from "stores/lockedTokens";
+import { useDexieLockedTokensStore } from "stores/lockedTokensDexie";
 import { useMintsStore } from "stores/mints";
 import { nip19 } from "nostr-tools";
 
@@ -95,10 +95,10 @@ export default defineComponent({
     return { currentPage: 1, pageSize: 5 };
   },
   computed: {
-    ...mapState(useLockedTokensStore, ["lockedTokens"]),
+    ...mapState(useDexieLockedTokensStore, ["lockedTokens"]),
     ...mapState(useMintsStore, ["activeUnit"]),
     filteredTokens() {
-      return this.lockedTokens.filter((t) => t.bucketId === this.bucketId);
+      return this.lockedTokens.filter((t) => t.tierId === this.bucketId);
     },
     maxPages() {
       return Math.ceil(this.filteredTokens.length / this.pageSize);

--- a/src/components/PaywalledContent.vue
+++ b/src/components/PaywalledContent.vue
@@ -13,7 +13,7 @@
 
 <script lang="ts">
 import { defineComponent, computed } from 'vue';
-import { useLockedTokensStore } from 'stores/lockedTokens';
+import { useDexieLockedTokensStore } from 'stores/lockedTokensDexie';
 
 export default defineComponent({
   name: 'PaywalledContent',
@@ -22,10 +22,16 @@ export default defineComponent({
     tierId: { type: String, required: true },
   },
   setup(props) {
-    const store = useLockedTokensStore();
-    const validTokens = computed(() =>
-      store.validTokensForTier(props.creatorNpub, props.tierId)
-    );
+    const store = useDexieLockedTokensStore();
+    const validTokens = computed(() => {
+      const now = Math.floor(Date.now() / 1000);
+      return store.lockedTokens.filter(
+        (t) =>
+          t.tierId === props.tierId &&
+          t.creatorNpub === props.creatorNpub &&
+          (!t.unlockTs || t.unlockTs <= now)
+      );
+    });
     const hasAccess = computed(() => validTokens.value.length > 0);
     return { hasAccess };
   },

--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -648,7 +648,7 @@ import { useUiStore } from "src/stores/ui";
 import { useProofsStore } from "src/stores/proofs";
 import { useMintsStore } from "src/stores/mints";
 import { useTokensStore } from "src/stores/tokens";
-import { useLockedTokensStore } from "src/stores/lockedTokens";
+import { useDexieLockedTokensStore } from "src/stores/lockedTokensDexie";
 import { getShortUrl } from "src/js/wallet-helpers";
 import { useSettingsStore } from "src/stores/settings";
 import { useWorkersStore } from "src/stores/workers";
@@ -1264,13 +1264,22 @@ export default defineComponent({
             this.sendData.memo = "";
           }
         }
-        useLockedTokensStore().addLockedToken({
+        useDexieLockedTokensStore().addLockedToken({
+          tokenString: this.sendData.tokensBase64,
           amount: sendAmount,
-          token: this.sendData.tokensBase64,
-          pubkey: this.sendData.p2pkPubkey,
-          locktime: this.sendData.locktime || undefined,
-          refundPubkey: this.sendData.refundPubkey || undefined,
-          bucketId,
+          owner: 'creator',
+          creatorNpub: this.sendData.p2pkPubkey,
+          tierId: bucketId,
+          intervalKey: '',
+          unlockTs: this.sendData.locktime || 0,
+          refundUnlockTs: 0,
+          status:
+            this.sendData.locktime &&
+            this.sendData.locktime > Math.floor(Date.now() / 1000)
+              ? 'pending'
+              : 'unlockable',
+          subscriptionEventId: null,
+          label: this.sendData.memo || undefined,
         });
         const historyToken = {
           amount: -this.sendData.amount,

--- a/src/pages/BucketDetail.vue
+++ b/src/pages/BucketDetail.vue
@@ -127,7 +127,7 @@ import { useUiStore } from 'stores/ui';
 import { storeToRefs } from 'pinia';
 import { useSendTokensStore } from 'stores/sendTokensStore';
 import { useTokensStore, HistoryToken } from 'stores/tokens';
-import { useLockedTokensStore } from 'stores/lockedTokens';
+import { useDexieLockedTokensStore } from 'stores/lockedTokensDexie';
 import { useNostrStore } from 'stores/nostr';
 import SendTokenDialog from 'components/SendTokenDialog.vue';
 import HistoryTable from 'components/HistoryTable.vue';
@@ -143,13 +143,15 @@ const mintsStore = useMintsStore();
 const uiStore = useUiStore();
 const sendTokensStore = useSendTokensStore();
 const tokensStore = useTokensStore();
-const lockedTokensStore = useLockedTokensStore();
+const lockedTokensStore = useDexieLockedTokensStore();
 
 const bucketId = route.params.id as string;
 const bucket = computed(() => bucketsStore.bucketList.find(b => b.id === bucketId));
 const bucketProofs = computed(() => proofsStore.proofs.filter(p => p.bucketId === bucketId && !p.reserved));
 const bucketBalance = computed(() => bucketProofs.value.reduce((s,p)=>s+p.amount,0));
-const bucketLockedTokens = computed(() => lockedTokensStore.tokensByBucket(bucketId));
+const bucketLockedTokens = computed(() =>
+  lockedTokensStore.lockedTokens.filter((t) => t.tierId === bucketId)
+);
 const { activeUnit } = storeToRefs(mintsStore);
 const showSendTokens = storeToRefs(sendTokensStore).showSendTokens;
 const nostrStore = useNostrStore();

--- a/src/pages/FindCreators.vue
+++ b/src/pages/FindCreators.vue
@@ -71,7 +71,6 @@ import SubscriptionReceipt from "components/SubscriptionReceipt.vue";
 import SendTokenDialog from "components/SendTokenDialog.vue";
 import { useSendTokensStore } from "stores/sendTokensStore";
 import { useDonationPresetsStore } from "stores/donationPresets";
-import { useLockedTokensStore } from "stores/lockedTokens";
 import { useCreatorsStore } from "stores/creators";
 import { useNostrStore } from "stores/nostr";
 import { useMintsStore } from "stores/mints";
@@ -98,7 +97,6 @@ const dialogPubkey = ref("");
 
 const sendTokensStore = useSendTokensStore();
 const donationStore = useDonationPresetsStore();
-const lockedStore = useLockedTokensStore();
 const creators = useCreatorsStore();
 const nostr = useNostrStore();
 const mintsStore = useMintsStore();

--- a/src/pages/PublicCreatorProfilePage.vue
+++ b/src/pages/PublicCreatorProfilePage.vue
@@ -85,7 +85,6 @@ import { useRoute } from "vue-router";
 import { useCreatorsStore } from "stores/creators";
 import { useNostrStore } from "stores/nostr";
 import { useDonationPresetsStore } from "stores/donationPresets";
-import { useLockedTokensStore } from "stores/lockedTokens";
 import { usePriceStore } from "stores/price";
 import { useUiStore } from "stores/ui";
 import SubscribeDialog from "components/SubscribeDialog.vue";
@@ -108,7 +107,6 @@ export default defineComponent({
     const creators = useCreatorsStore();
     const nostr = useNostrStore();
     const donationStore = useDonationPresetsStore();
-    const lockedStore = useLockedTokensStore();
     const priceStore = usePriceStore();
     const uiStore = useUiStore();
     const mintsStore = useMintsStore();

--- a/src/pages/SubscriptionsOverview.vue
+++ b/src/pages/SubscriptionsOverview.vue
@@ -475,7 +475,7 @@
 <script setup lang="ts">
 import { computed, ref, onMounted, onUnmounted, watch } from 'vue';
 import { storeToRefs } from 'pinia';
-import { useLockedTokensStore, type LockedToken } from 'stores/lockedTokens';
+import { useDexieLockedTokensStore, type LockedToken } from 'stores/lockedTokensDexie';
 import { useBucketsStore } from 'stores/buckets';
 import { useMintsStore } from 'stores/mints';
 import { useUiStore } from 'stores/ui';
@@ -495,7 +495,7 @@ import { useProofsStore } from 'stores/proofs';
 import { useSendTokensStore } from 'stores/sendTokensStore';
 import token from 'src/js/token';
 
-const lockedStore = useLockedTokensStore();
+const lockedStore = useDexieLockedTokensStore();
 const bucketsStore = useBucketsStore();
 const mintsStore = useMintsStore();
 const uiStore = useUiStore();

--- a/src/stores/buckets.ts
+++ b/src/stores/buckets.ts
@@ -4,7 +4,6 @@ import { v4 as uuidv4 } from "uuid";
 import { cashuDb } from "./dexie";
 import { useProofsStore } from "./proofs";
 import { useTokensStore } from "./tokens";
-import { useLockedTokensStore } from "./lockedTokens";
 import { ref, watch } from "vue";
 import { notifySuccess } from "src/js/notify";
 
@@ -108,22 +107,6 @@ export const useBucketsStore = defineStore("buckets", {
       });
       return balances;
     },
-    lockedBucketBalance: () => (bucketId: string): number => {
-      const ltStore = useLockedTokensStore();
-      return ltStore.lockedTokens
-        .filter((t) => t.bucketId === bucketId)
-        .reduce((sum, t) => sum + t.amount, 0);
-    },
-    lockedBucketBalances(): Record<string, number> {
-      const ltStore = useLockedTokensStore();
-      const balances: Record<string, number> = {};
-      this.bucketList.forEach((bucket) => {
-        balances[bucket.id] = ltStore.lockedTokens
-          .filter((t) => t.bucketId === bucket.id)
-          .reduce((sum, t) => sum + t.amount, 0);
-      });
-      return balances;
-    },
     autoBucketFor: (state) =>
       (mint?: string, memo?: string): string | undefined => {
         return state.autoAssignRules.find((r) => {
@@ -201,6 +184,26 @@ export const useBucketsStore = defineStore("buckets", {
       const idx = this.autoAssignRules.findIndex((r) => r.id === id);
       if (idx === -1) return;
       this.autoAssignRules[idx] = { ...this.autoAssignRules[idx], ...updates };
+    },
+
+    async lockedBucketBalance(bucketId: string): Promise<number> {
+      const tokens = await cashuDb.lockedTokens
+        .where('tierId')
+        .equals(bucketId)
+        .toArray();
+      return tokens.reduce((sum, t) => sum + t.amount, 0);
+    },
+
+    async lockedBucketBalances(): Promise<Record<string, number>> {
+      const balances: Record<string, number> = {};
+      const tokens = await cashuDb.lockedTokens.toArray();
+      tokens.forEach((t) => {
+        balances[t.tierId] = (balances[t.tierId] || 0) + t.amount;
+      });
+      this.bucketList.forEach((b) => {
+        if (balances[b.id] === undefined) balances[b.id] = 0;
+      });
+      return balances;
     },
   },
 });

--- a/test/vitest/__tests__/donationPresets.spec.ts
+++ b/test/vitest/__tests__/donationPresets.spec.ts
@@ -2,11 +2,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useDonationPresetsStore } from "../../../src/stores/donationPresets";
 import { useWalletStore } from "../../../src/stores/wallet";
 import { useProofsStore } from "../../../src/stores/proofs";
-import { useLockedTokensStore } from "../../../src/stores/lockedTokens";
+import { useDexieLockedTokensStore } from "../../../src/stores/lockedTokensDexie";
+import { cashuDb } from "../../../src/stores/dexie";
 import { useMintsStore } from "../../../src/stores/mints";
 
-beforeEach(() => {
+beforeEach(async () => {
   localStorage.clear();
+  await cashuDb.delete();
+  await cashuDb.open();
 });
 
 vi.mock("../../../src/stores/wallet", () => ({
@@ -23,9 +26,9 @@ vi.mock("../../../src/stores/proofs", () => ({
   }),
 }));
 
-vi.mock("../../../src/stores/lockedTokens", () => ({
-  useLockedTokensStore: () => ({
-    addLockedToken: vi.fn((d: any) => ({ id: "id", date: "d", ...d })),
+vi.mock("../../../src/stores/lockedTokensDexie", () => ({
+  useDexieLockedTokensStore: () => ({
+    addLockedToken: vi.fn(async (d: any) => ({ id: "id", ...d })),
   }),
 }));
 
@@ -81,7 +84,7 @@ describe("Donation presets", () => {
 
   it("returns locked token data when detailed is true", async () => {
     const store = useDonationPresetsStore();
-    const locked = useLockedTokensStore();
+    const locked = useDexieLockedTokensStore();
     (locked.addLockedToken as any).mockImplementation((d: any) => ({
       id: "id" + (locked.addLockedToken as any).mock.calls.length,
       date: "d",

--- a/test/vitest/__tests__/lockedTokens.spec.ts
+++ b/test/vitest/__tests__/lockedTokens.spec.ts
@@ -1,33 +1,98 @@
 import { beforeEach, describe, expect, it } from 'vitest'
-import { useLockedTokensStore } from '../../../src/stores/lockedTokens'
+import { useDexieLockedTokensStore } from '../../../src/stores/lockedTokensDexie'
+import { cashuDb } from '../../../src/stores/dexie'
 
-beforeEach(() => {
+beforeEach(async () => {
   localStorage.clear()
+  await cashuDb.delete()
+  await cashuDb.open()
 })
 
 describe('LockedTokens store', () => {
-  it('adds and retrieves tokens', () => {
-    const store = useLockedTokensStore()
-    const t = store.addLockedToken({ amount: 1, token: 'tok', pubkey: 'pk', bucketId: 'b1' })
+  it('adds and retrieves tokens', async () => {
+    const store = useDexieLockedTokensStore()
+    const t = await store.addLockedToken({
+      tokenString: 'tok',
+      amount: 1,
+      owner: 'creator',
+      creatorNpub: 'pk',
+      tierId: 'b1',
+      intervalKey: '',
+      unlockTs: 0,
+      refundUnlockTs: 0,
+      status: 'unlockable',
+      subscriptionEventId: null,
+    })
+    await Promise.resolve()
     expect(store.lockedTokens.length).toBe(1)
-    expect(store.tokensByBucket('b1')[0].id).toBe(t.id)
+    expect(store.lockedTokens[0].id).toBe(t.id)
   })
 
-  it('deletes token', () => {
-    const store = useLockedTokensStore()
-    const t = store.addLockedToken({ amount: 1, token: 'tok', pubkey: 'pk', bucketId: 'b1' })
-    store.deleteLockedToken(t.id)
+  it('deletes token', async () => {
+    const store = useDexieLockedTokensStore()
+    const t = await store.addLockedToken({
+      tokenString: 'tok',
+      amount: 1,
+      owner: 'creator',
+      creatorNpub: 'pk',
+      tierId: 'b1',
+      intervalKey: '',
+      unlockTs: 0,
+      refundUnlockTs: 0,
+      status: 'unlockable',
+      subscriptionEventId: null,
+    })
+    await store.deleteLockedToken(t.id)
+    await Promise.resolve()
     expect(store.lockedTokens.length).toBe(0)
   })
 
-  it('returns valid tokens for tier', () => {
-    const store = useLockedTokensStore()
+  it('returns valid tokens for tier', async () => {
+    const store = useDexieLockedTokensStore()
     const past = Math.floor(Date.now() / 1000) - 10
     const future = Math.floor(Date.now() / 1000) + 100
-    const t1 = store.addLockedToken({ amount: 1, token: 'a', pubkey: 'pk', bucketId: 'b', locktime: past })
-    store.addLockedToken({ amount: 1, token: 'b', pubkey: 'pk', bucketId: 'b', locktime: future })
-    store.addLockedToken({ amount: 1, token: 'c', pubkey: 'other', bucketId: 'b' })
-    const tokens = store.validTokensForTier('pk', 'b')
+    const t1 = await store.addLockedToken({
+      tokenString: 'a',
+      amount: 1,
+      owner: 'creator',
+      creatorNpub: 'pk',
+      tierId: 'b',
+      intervalKey: '',
+      unlockTs: past,
+      refundUnlockTs: 0,
+      status: 'unlockable',
+      subscriptionEventId: null,
+    })
+    await store.addLockedToken({
+      tokenString: 'b',
+      amount: 1,
+      owner: 'creator',
+      creatorNpub: 'pk',
+      tierId: 'b',
+      intervalKey: '',
+      unlockTs: future,
+      refundUnlockTs: 0,
+      status: 'pending',
+      subscriptionEventId: null,
+    })
+    await store.addLockedToken({
+      tokenString: 'c',
+      amount: 1,
+      owner: 'creator',
+      creatorNpub: 'other',
+      tierId: 'b',
+      intervalKey: '',
+      unlockTs: 0,
+      refundUnlockTs: 0,
+      status: 'unlockable',
+      subscriptionEventId: null,
+    })
+    await Promise.resolve()
+    const now = Math.floor(Date.now() / 1000)
+    const tokens = store.lockedTokens.filter(
+      (t) =>
+        t.tierId === 'b' && t.creatorNpub === 'pk' && (!t.unlockTs || t.unlockTs <= now)
+    )
     expect(tokens.length).toBe(1)
     expect(tokens[0].id).toBe(t1.id)
   })


### PR DESCRIPTION
## Summary
- replace persistent token store with useDexieLockedTokensStore
- compute bucket balances directly from cashuDb.lockedTokens
- update donation preset logic for Dexie
- adjust paywalled access checks
- modify unit tests for Dexie locked tokens

## Testing
- `npm test` *(fails: Error: Failed to resolve import "fake-indexeddb/auto" from "test/vitest/setup-file.js")*

------
https://chatgpt.com/codex/tasks/task_e_6847e5e7e34883308f824fb3748bda2a