### PR TITLE
Ensure npub conversion before locking and test redemption

### DIFF
--- a/src/stores/donationPresets.ts
+++ b/src/stores/donationPresets.ts
@@ -5,6 +5,7 @@ import { useMintsStore } from "./mints";
 import { useProofsStore } from "./proofs";
 import { useLockedTokensStore, LockedToken } from "./lockedTokens";
 import { useSubscriptionsStore } from "./subscriptions";
+import { useP2PKStore } from "./p2pk";
 import { DEFAULT_BUCKET_ID } from "./buckets";
 
 export type DonationPreset = {
@@ -49,6 +50,9 @@ export const useDonationPresetsStore = defineStore("donationPresets", {
       const mintsStore = useMintsStore();
       const lockedStore = useLockedTokensStore();
       const subscriptionsStore = useSubscriptionsStore();
+      const p2pkStore = useP2PKStore();
+
+      const convertedPubkey = p2pkStore.maybeConvertNpub(pubkey);
 
       const wallet = walletStore.wallet;
       let proofs = mintsStore.activeProofs.filter(
@@ -66,7 +70,7 @@ export const useDonationPresetsStore = defineStore("donationPresets", {
           proofs,
           wallet,
           amount,
-          pubkey,
+          convertedPubkey,
           bucketId
         );
         const token = proofsStore.serializeProofs(sendProofs);
@@ -75,7 +79,7 @@ export const useDonationPresetsStore = defineStore("donationPresets", {
             lockedStore.addLockedToken({
               amount,
               token,
-              pubkey,
+              pubkey: convertedPubkey,
               bucketId,
               label: subscription?.tierName
                 ? `Subscription: ${subscription.tierName}`
@@ -94,7 +98,7 @@ export const useDonationPresetsStore = defineStore("donationPresets", {
           proofs,
           wallet,
           amount,
-          pubkey,
+          convertedPubkey,
           bucketId,
           locktime
         );
@@ -102,7 +106,7 @@ export const useDonationPresetsStore = defineStore("donationPresets", {
         const locked = lockedStore.addLockedToken({
           amount,
           token,
-          pubkey,
+          pubkey: convertedPubkey,
           locktime,
           bucketId,
           label: subscription?.tierName

--- a/test/vitest/__tests__/p2pk.spec.ts
+++ b/test/vitest/__tests__/p2pk.spec.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { useP2PKStore } from '../../src/stores/p2pk'
 import { useWalletStore } from '../../src/stores/wallet'
 import { useProofsStore } from '../../src/stores/proofs'
+import { generateSecretKey, getPublicKey, nip19 } from 'nostr-tools'
+import { bytesToHex } from '@noble/hashes/utils'
 
 beforeEach(() => {
   localStorage.clear()
@@ -64,5 +66,39 @@ describe('P2PK store', () => {
     const encoded = 'cashuA' + Buffer.from(JSON.stringify(tokenObj)).toString('base64')
     expect(p2pk.getTokenPubkey(encoded)).toBe('02aa')
     expect(p2pk.getTokenRefundPubkey(encoded)).toBe('02bb')
+  })
+
+  it('redeems token locked to converted npub', async () => {
+    const walletStore = useWalletStore()
+    const proofsStore = useProofsStore()
+    vi.spyOn(proofsStore, 'removeProofs').mockResolvedValue()
+    vi.spyOn(proofsStore, 'addProofs').mockResolvedValue()
+
+    walletStore.spendableProofs = vi.fn(() => [{ secret: 's', amount: 1, id: 'a', C: 'c' } as any])
+    walletStore.coinSelect = vi.fn(() => [{ secret: 's', amount: 1, id: 'a', C: 'c' } as any])
+    walletStore.getKeyset = vi.fn(() => 'kid')
+
+    const sk = generateSecretKey()
+    const pk = getPublicKey(sk)
+    const skHex = bytesToHex(sk)
+    const npub = nip19.npubEncode(pk)
+
+    const p2pk = useP2PKStore()
+    const pubHex = p2pk.maybeConvertNpub(npub)
+    p2pk.p2pkKeys = [{ publicKey: pubHex, privateKey: skHex, used: false, usedCount: 0 }]
+
+    const wallet = {
+      mint: { mintUrl: 'm' },
+      unit: 'sat',
+      send: vi.fn(async (_a: number, _p: any, opts: any) => {
+        const secret = JSON.stringify(['P2PK', { data: opts.pubkey }])
+        return { keep: [], send: [{ id: 'a', amount: 1, C: 'c', secret }] }
+      })
+    } as any
+
+    const { sendProofs } = await walletStore.sendToLock([{ secret: 's', amount: 1, id: 'a', C: 'c' } as any], wallet, 1, pubHex, 'b')
+    const tokenObj = { token: [{ proofs: sendProofs, mint: 'm' }] }
+    const encoded = 'cashuA' + Buffer.from(JSON.stringify(tokenObj)).toString('base64')
+    expect(p2pk.getPrivateKeyForP2PKEncodedToken(encoded)).toBe(skHex)
   })
 })


### PR DESCRIPTION
## Summary
- convert npubs to hex before calling `sendToLock`
- keep the converted key when storing locked token metadata
- test that tokens locked using converted keys yield the correct private key

## Testing
- `npm test` *(fails: Failed to resolve import "fake-indexeddb/auto")*

------
https://chatgpt.com/codex/tasks/task_e_6847f4f5d7e083309bd4250d1c7c4ca8