### PR TITLE
Fix P2PK locked token redemption

### DIFF
--- a/src/stores/lockedTokensRedeemWorker.ts
+++ b/src/stores/lockedTokensRedeemWorker.ts
@@ -3,6 +3,7 @@ import { cashuDb } from './dexie'
 import { useWalletStore } from './wallet'
 import { useReceiveTokensStore } from './receiveTokensStore'
 import { useSettingsStore } from './settings'
+import { useP2PKStore } from './p2pk'
 
 export const useLockedTokensRedeemWorker = defineStore('lockedTokensRedeemWorker', {
   state: () => ({
@@ -33,11 +34,15 @@ export const useLockedTokensRedeemWorker = defineStore('lockedTokensRedeemWorker
       if (!entries.length) return
       const wallet = useWalletStore()
       const receiveStore = useReceiveTokensStore()
+      const p2pkStore = useP2PKStore()
       for (const entry of entries) {
         try {
           receiveStore.receiveData.tokensBase64 = entry.tokenString
           receiveStore.receiveData.bucketId = entry.tierId
+          receiveStore.receiveData.p2pkPrivateKey =
+            p2pkStore.getPrivateKeyForP2PKEncodedToken(entry.tokenString)
           await wallet.redeem(entry.tierId)
+          receiveStore.receiveData.p2pkPrivateKey = ''
           await cashuDb.lockedTokens.delete(entry.id)
         } catch (e) {
           console.error('Failed to auto-redeem locked token', e)


### PR DESCRIPTION
## Summary
- import `useP2PKStore` in the locked tokens worker
- inject the proper P2PK private key before calling `wallet.redeem`
- clear the value once the redemption succeeds

## Testing
- `npm test` *(fails: Failed to resolve import "fake-indexeddb/auto")*

------
https://chatgpt.com/codex/tasks/task_e_6847ffa40f5883309d545e7d300c56d8