### PR TITLE
Enhance chat bubble token display

### DIFF
--- a/src/components/ChatMessageBubble.vue
+++ b/src/components/ChatMessageBubble.vue
@@ -4,7 +4,25 @@
     :class="message.outgoing ? 'items-end' : 'items-start'"
   >
     <div :class="message.outgoing ? 'sent' : 'received'" :style="bubbleStyle">
-      {{ message.content }}
+      <template v-if="tokenPayload">
+        <div class="token-container">
+          <div v-if="tokenPayload.amount !== null && tokenPayload.amount !== undefined">
+            <strong>Amount:</strong> {{ tokenPayload.amount }}
+          </div>
+          <div v-if="tokenPayload.memo">
+            <strong>Memo:</strong> {{ tokenPayload.memo }}
+          </div>
+          <div v-if="unlockDate">
+            <strong>Unlock:</strong> {{ unlockDate }}
+          </div>
+        </div>
+        <q-btn dense color="primary" class="q-mt-sm" @click="receiveToken"
+          >Receive Token</q-btn
+        >
+      </template>
+      <template v-else>
+        {{ message.content }}
+      </template>
     </div>
     <div
       class="text-caption q-mt-xs row items-center"
@@ -31,6 +49,12 @@ import { computed } from "vue";
 import { useQuasar } from "quasar";
 import { mdiCheck, mdiCheckAll } from "@quasar/extras/mdi-v6";
 import type { MessengerMessage } from "src/stores/messenger";
+import {
+  parseFormattedTokenMessage,
+  CASHU_TOKEN_START,
+  CASHU_TOKEN_END,
+} from "src/js/message-utils";
+import { useReceiveTokensStore } from "src/stores/receiveTokensStore";
 
 const props = defineProps<{
   message: MessengerMessage;
@@ -38,6 +62,30 @@ const props = defineProps<{
 }>();
 
 const $q = useQuasar();
+const receiveTokensStore = useReceiveTokensStore();
+
+const tokenPayload = computed(() => {
+  if (
+    !props.message.content.includes(CASHU_TOKEN_START) ||
+    !props.message.content.includes(CASHU_TOKEN_END)
+  )
+    return null;
+  return parseFormattedTokenMessage(props.message.content);
+});
+
+const unlockDate = computed(() => {
+  if (!tokenPayload.value?.unlockTime) return null;
+  return new Date(tokenPayload.value.unlockTime * 1000).toLocaleString();
+});
+
+async function receiveToken() {
+  if (!tokenPayload.value) return;
+  receiveTokensStore.receiveData.tokensBase64 = tokenPayload.value.token;
+  await receiveTokensStore.receiveToken(
+    tokenPayload.value.token,
+    receiveTokensStore.receiveData.bucketId,
+  );
+}
 
 const receivedStyle = computed(() => ({
   backgroundColor: $q.dark.isActive
@@ -78,5 +126,11 @@ const deliveryIcon = computed(() =>
 .received {
   background-color: var(--q-color-grey-2);
   color: #000000;
+}
+
+.token-container {
+  border: 1px solid currentColor;
+  padding: 8px;
+  border-radius: 8px;
 }
 </style>


### PR DESCRIPTION
## Summary
- detect CASHU token markers in `ChatMessageBubble.vue`
- parse token messages and show amount/memo/unlock time
- provide a button to receive the token
- style token display

## Testing
- `npm test` *(fails: Failed to resolve import `fake-indexeddb/auto`)*

------
https://chatgpt.com/codex/tasks/task_e_6848418ae80883308047df7e1c6d4cda