### PR TITLE
Implement P2PK proof signing

### DIFF
--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -39,6 +39,7 @@ import {
   decodePaymentRequest,
   MintQuoteResponse,
   ProofState,
+  getSignedProofs,
 } from "@cashu/cashu-ts";
 import { hashToCurve } from "@cashu/crypto/modules/common";
 // @ts-ignore
@@ -55,6 +56,7 @@ import { wordlist } from "@scure/bip39/wordlists/english";
 import { useSettingsStore } from "./settings";
 import { usePriceStore } from "./price";
 import { i18n } from "src/boot/i18n";
+import { useNostrStore } from "./nostr";
 // HACK: this is a workaround so that the catch block in the melt function does not throw an error when the user exits the app
 // before the payment is completed. This is necessary because the catch block in the melt function would otherwise remove all
 // quotes from the invoiceHistory and the user would not be able to pay the invoice again after reopening the app.
@@ -230,6 +232,20 @@ export const useWalletStore = defineStore("wallet", {
       } else {
         const newCounter = { id, counter: by } as KeysetCounter;
         this.keysetCounters.push(newCounter);
+      }
+    },
+    signP2PKIfNeeded: function <T extends Proof>(proofs: T[]): T[] {
+      if (!proofs.some((p) => typeof p.secret === "string" && p.secret.startsWith("P2PK:"))) {
+        return proofs;
+      }
+      const privKey = useNostrStore().privKeyHex;
+      if (!privKey) return proofs;
+      try {
+        const signed = getSignedProofs(proofs as unknown as Proof[], privKey);
+        return proofs.map((p, idx) => ({ ...(p as any), ...(signed[idx] as any) })) as T[];
+      } catch (e) {
+        console.error(e);
+        return proofs;
       }
     },
     getKeyset(
@@ -452,6 +468,7 @@ export const useWalletStore = defineStore("wallet", {
           includeFees,
           bucketId,
         );
+        proofsToSend = this.signP2PKIfNeeded(proofsToSend);
         const totalAmount = proofsToSend.reduce((s, t) => (s += t.amount), 0);
         const fees = includeFees ? wallet.getFeesForProofs(proofsToSend) : 0;
         const targetAmount = amount + fees;
@@ -468,6 +485,7 @@ export const useWalletStore = defineStore("wallet", {
             true,
             bucketId,
           );
+          proofsToSend = this.signP2PKIfNeeded(proofsToSend);
           ({ keep: keepProofs, send: sendProofs } = await wallet.send(
             targetAmount,
             proofsToSend,
@@ -487,7 +505,7 @@ export const useWalletStore = defineStore("wallet", {
           await proofsStore.removeProofs(proofsToSendNotReturned);
         } else if (totalAmount == targetAmount) {
           keepProofs = [];
-          sendProofs = proofsToSend;
+          sendProofs = this.signP2PKIfNeeded(proofsToSend);
         } else {
           throw new Error("could not split proofs.");
         }
@@ -866,6 +884,7 @@ export const useWalletStore = defineStore("wallet", {
 
         // NOTE: if the user exits the app while we're in the API call, JS will emit an error that we would catch below!
         // We have to handle that case in the catch block below
+        sendProofs = this.signP2PKIfNeeded(sendProofs);
         const data = await mintWallet.meltProofs(quote, sendProofs, {
           keysetId,
           counter,


### PR DESCRIPTION
## Summary
- add `getSignedProofs` usage to sign P2PK proofs
- sign proofs before mint interactions in `send` and `melt`
- helper `signP2PKIfNeeded` uses nostr private key

## Testing
- `npm test` *(fails: vitest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6848785b9fc88330995cbef68f925d2e