### PR TITLE
Fix P2PK auto redeem

### DIFF
--- a/src/components/CreatorLockedTokensTable.vue
+++ b/src/components/CreatorLockedTokensTable.vue
@@ -51,6 +51,7 @@ import { useReceiveTokensStore } from 'stores/receiveTokensStore'
 import { useWalletStore } from 'stores/wallet'
 import { useNostrStore } from 'stores/nostr'
 import { useUiStore } from 'stores/ui'
+import { useP2PKStore } from 'stores/p2pk'
 
 export default defineComponent({
   name: 'CreatorLockedTokensTable',
@@ -91,8 +92,11 @@ export default defineComponent({
     async redeem(token) {
       const receiveStore = useReceiveTokensStore()
       const wallet = useWalletStore()
+      const p2pkStore = useP2PKStore()
       receiveStore.receiveData.tokensBase64 = token.tokenString
       receiveStore.receiveData.bucketId = token.tierId
+      receiveStore.receiveData.p2pkPrivateKey =
+        p2pkStore.getPrivateKeyForP2PKEncodedToken(token.tokenString)
       await wallet.redeem(token.tierId)
       await useDexieLockedTokensStore().deleteLockedToken(token.id)
     }

--- a/src/stores/lockedTokensRedeemWorker.ts
+++ b/src/stores/lockedTokensRedeemWorker.ts
@@ -3,6 +3,7 @@ import { cashuDb } from './dexie'
 import { useWalletStore } from './wallet'
 import { useReceiveTokensStore } from './receiveTokensStore'
 import { useSettingsStore } from './settings'
+import { useP2PKStore } from './p2pk'
 
 export const useLockedTokensRedeemWorker = defineStore('lockedTokensRedeemWorker', {
   state: () => ({
@@ -33,10 +34,13 @@ export const useLockedTokensRedeemWorker = defineStore('lockedTokensRedeemWorker
       if (!entries.length) return
       const wallet = useWalletStore()
       const receiveStore = useReceiveTokensStore()
+      const p2pkStore = useP2PKStore()
       for (const entry of entries) {
         try {
           receiveStore.receiveData.tokensBase64 = entry.tokenString
           receiveStore.receiveData.bucketId = entry.tierId
+          receiveStore.receiveData.p2pkPrivateKey =
+            p2pkStore.getPrivateKeyForP2PKEncodedToken(entry.tokenString)
           await wallet.redeem(entry.tierId)
           await cashuDb.lockedTokens.delete(entry.id)
         } catch (e) {

--- a/src/stores/npubcash.ts
+++ b/src/stores/npubcash.ts
@@ -19,6 +19,7 @@ import { WalletProof, useMintsStore } from "./mints";
 import { useTokensStore } from "../stores/tokens";
 import { useNostrStore } from "../stores/nostr";
 import { DEFAULT_BUCKET_ID } from "./buckets";
+import { useP2PKStore } from "./p2pk";
 // type NPCConnection = {
 //   walletPublicKey: string,
 //   walletPrivateKey: string,
@@ -169,6 +170,8 @@ export const useNPCStore = defineStore("npc", {
           // add token to history first
           this.addPendingTokenToHistory(token);
           receiveStore.receiveData.tokensBase64 = token;
+          receiveStore.receiveData.p2pkPrivateKey =
+            useP2PKStore().getPrivateKeyForP2PKEncodedToken(token);
           if (this.automaticClaim) {
             try {
               // redeem token automatically


### PR DESCRIPTION
## Summary
- automatically fetch P2PK key when redeeming locked tokens
- fetch key when redeeming creator locked tokens
- support automatic P2PK unlock in npub.cash claim flow

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68487b786d38833090d33adcce195212