### PR TITLE
Persist locked proofs

### DIFF
--- a/src/stores/buckets.ts
+++ b/src/stores/buckets.ts
@@ -136,6 +136,21 @@ export const useBucketsStore = defineStore("buckets", {
       },
   },
   actions: {
+    /** Ensure we have (or create) a bucket dedicated to a creator npub */
+    ensureCreatorBucket(creatorPubkey: string): string {
+      const existing = this.buckets.find(
+        (b) => b.creatorPubkey === creatorPubkey
+      );
+      if (existing) return existing.id;
+
+      const id = uuidv4();
+      this.buckets.push({
+        id,
+        name: creatorPubkey.slice(0, 8), // short label
+        creatorPubkey,
+      });
+      return id;
+    },
     addBucket(bucket: Omit<Bucket, "id">): Bucket | undefined {
       // basic validation
       if (!bucket.name || bucket.name.trim().length === 0) {


### PR DESCRIPTION
## Summary
- add `ensureCreatorBucket` helper to bucket store
- store locked proofs immediately in `wallet.sendToLock`
- wire up buckets and locked token stores

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849234f864c833093932590a8e95525