### PR TITLE
Add active key getters

### DIFF
--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -168,6 +168,19 @@ export const useNostrStore = defineStore("nostr", {
           return "";
       }
     },
+    activePrivkeyHex(state): string | null {
+      switch (state.signerType) {
+        case SignerType.PRIVATEKEY:
+          return state.privateKeySignerPrivateKey || null;
+        case SignerType.SEED:
+          return state.seedSignerPrivateKey || null;
+        default:
+          return null; // NIP-07/46 keep keys remote
+      }
+    },
+    activePubkeyHex(state): string | null {
+      return state.pubkey || null;
+    },
   },
   actions: {
     initNdkReadOnly: function () {


### PR DESCRIPTION
## Summary
- expose getters for active private and public keys

## Testing
- `npm test` *(fails: Failed to resolve import "fake-indexeddb/auto" from `test/vitest/setup-file.js`)*

------
https://chatgpt.com/codex/tasks/task_e_684925af4f6883308f5bd6969fee3f2d