### PR TITLE
Add P2PK keypair management

### DIFF
--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -211,6 +211,9 @@ export const useNostrStore = defineStore("nostr", {
       this.ndk = new NDK(opts);
       this.ndk.connect();
       this.connected = true;
+      if (this.activePrivkeyHex) {
+        useP2PKStore().addKeyPair(this.activePrivkeyHex);
+      }
     },
     initSignerIfNotSet: async function () {
       if (!this.initialized) {

--- a/src/stores/p2pk.ts
+++ b/src/stores/p2pk.ts
@@ -2,7 +2,7 @@ import { debug } from "src/js/logger";
 import { defineStore } from "pinia";
 import { useLocalStorage } from "@vueuse/core";
 import { generateSecretKey, getPublicKey, nip19 } from "nostr-tools";
-import { bytesToHex } from "@noble/hashes/utils"; // already an installed dependency
+import { bytesToHex, hexToBytes } from "@noble/hashes/utils"; // already an installed dependency
 import { WalletProof } from "stores/mints";
 import token from "src/js/token";
 
@@ -96,6 +96,23 @@ export const useP2PKStore = defineStore("p2pk", {
         usedCount: 0,
       };
       this.p2pkKeys = this.p2pkKeys.concat(keyPair);
+    },
+    addKeyPair: function (privateKeyHex: string) {
+      try {
+        const publicKey = "02" + getPublicKey(hexToBytes(privateKeyHex));
+        if (this.haveThisKey(publicKey)) {
+          return;
+        }
+        const keyPair: P2PKKey = {
+          publicKey,
+          privateKey: privateKeyHex,
+          used: false,
+          usedCount: 0,
+        };
+        this.p2pkKeys = this.p2pkKeys.concat(keyPair);
+      } catch (e) {
+        console.error(e);
+      }
     },
     getSecretP2PKInfo: function (
       secret: string,


### PR DESCRIPTION
## Summary
- support adding private keys directly to P2PK store
- ensure nostr connect stores active private key in P2PK store

## Testing
- `npm test` *(fails: Failed to resolve import `fake-indexeddb/auto`)*

------
https://chatgpt.com/codex/tasks/task_e_684927b34eb4833085a4d5bbb9e5c028