### PR TITLE
Fix build error by importing getSignedProofs from crypto

### DIFF
--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -40,8 +40,8 @@ import {
   decodePaymentRequest,
   MintQuoteResponse,
   ProofState,
-  getSignedProofs,
 } from "@cashu/cashu-ts";
+import { getSignedProofs } from "@cashu/crypto/modules/client/NUT11";
 import { hashToCurve } from "@cashu/crypto/modules/common";
 // @ts-ignore
 import * as bolt11Decoder from "light-bolt11-decoder";


### PR DESCRIPTION
## Summary
- fix wallet store build error by importing `getSignedProofs` from `@cashu/crypto/modules/client/NUT11`

## Testing
- `npm run build`
- `npm test` *(fails: Error: Failed to resolve import "fake-indexeddb/auto")*

------
https://chatgpt.com/codex/tasks/task_e_68492ee35a108330b4642185d20f2eed