### PR TITLE
Add Dexie fields for buckets and locked tokens

### DIFF
--- a/src/stores/lockedTokensDexie.ts
+++ b/src/stores/lockedTokensDexie.ts
@@ -15,7 +15,7 @@ export const useDexieLockedTokensStore = defineStore('dexieLockedTokens', () => 
   })
 
   async function addLockedToken(data: Omit<LockedToken, 'id'> & { id?: string }) {
-    const entry: LockedToken = { id: data.id ?? uuidv4(), ...data }
+    const entry: LockedToken = { id: data.id ?? uuidv4(), bucketId: data.bucketId ?? '', ...data }
     await cashuDb.lockedTokens.put(entry)
     return entry
   }


### PR DESCRIPTION
## Summary
- extend locked token records with `bucketId`
- include new `BucketDexie` type
- bump Dexie version and create migration for new fields
- default missing `bucketId` and `creatorPubkey` values on upgrade
- ensure Dexie locked token wrapper sets default bucket id

## Testing
- `npm test` *(fails: Failed to resolve import "fake-indexeddb/auto")*

------
https://chatgpt.com/codex/tasks/task_e_6849376cad4483308a86d70f50b00f35