### PR TITLE
Fix blank-screen freeze after secp256k1 update

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "underscore": "^1.13.6",
     "vue": "^3.4.27",
     "vue-i18n": "^11.1.3",
-    "vue-router": "^4.3.2"
+    "vue-router": "^4.3.2",
+    "@noble/curves": "^1.6.0"
   },
   "devDependencies": {
     "@capacitor/assets": "^3.0.5",

--- a/src/stores/p2pk.ts
+++ b/src/stores/p2pk.ts
@@ -3,7 +3,7 @@ import { defineStore } from "pinia";
 import { useLocalStorage } from "@vueuse/core";
 import { generateSecretKey, getPublicKey, nip19 } from "nostr-tools";
 import { bytesToHex, hexToBytes } from "@noble/hashes/utils"; // already an installed dependency
-import { Point } from "@noble/secp256k1";
+import { Point } from "@noble/curves/secp256k1";
 import { WalletProof } from "stores/mints";
 import token from "src/js/token";
 
@@ -49,10 +49,17 @@ export const useP2PKStore = defineStore("p2pk", {
     },
     maybeConvertNpub: function (key: string) {
       if (!key) return key;
+
+      // npub → 32-byte hex
       if (key.startsWith("npub1")) {
         const { data } = nip19.decode(key);
-        key = typeof data === "string" ? data : bytesToHex(data as Uint8Array);
+        key =
+          typeof data === "string"
+            ? data.toLowerCase()
+            : bytesToHex(data as Uint8Array);
       }
+
+      // Always return compressed SEC format
       return ensureCompressed(key);
     },
     isValidPubkey: function (key: string) {


### PR DESCRIPTION
## Summary
- use `@noble/curves/secp256k1` for `Point` to restore named export
- always compress keys in `maybeConvertNpub`
- include `@noble/curves` dependency

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684945f638648330856824b377366be5