### PR TITLE
Fix secp256k1 import for P2PK operations

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "vue": "^3.4.27",
     "vue-i18n": "^11.1.3",
     "vue-router": "^4.3.2",
-    "@noble/curves": "^1.6.0"
+    "@noble/curves": "^1.6.0",
+    "@noble/secp256k1": "^2.1.0"
   },
   "devDependencies": {
     "@capacitor/assets": "^3.0.5",

--- a/src/stores/p2pk.ts
+++ b/src/stores/p2pk.ts
@@ -3,8 +3,7 @@ import { defineStore } from "pinia";
 import { useLocalStorage } from "@vueuse/core";
 import { generateSecretKey, getPublicKey, nip19 } from "nostr-tools";
 import { bytesToHex, hexToBytes } from "@noble/hashes/utils"; // already an installed dependency
-import { secp256k1 } from "@noble/curves/secp256k1";
-const { Point } = secp256k1;
+import { Point } from "@noble/secp256k1";
 import { WalletProof } from "stores/mints";
 import token from "src/js/token";
 


### PR DESCRIPTION
## Summary
- update P2PK store to import `Point` from `@noble/secp256k1`
- add missing dependency for `@noble/secp256k1`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68494cf6471c833099b1fbd6bd6d3e3f