### PR TITLE
Fix p2pk Point alias

### DIFF
--- a/src/stores/p2pk.ts
+++ b/src/stores/p2pk.ts
@@ -4,7 +4,7 @@ import { useLocalStorage } from "@vueuse/core";
 import { generateSecretKey, getPublicKey, nip19 } from "nostr-tools";
 import { bytesToHex, hexToBytes } from "@noble/hashes/utils"; // already an installed dependency
 import { secp256k1 } from "@noble/curves/secp256k1";
-const { Point } = secp256k1;
+const Point = secp256k1.ProjectivePoint;
 import { WalletProof } from "stores/mints";
 import token from "src/js/token";
 


### PR DESCRIPTION
## Summary
- update `Point` alias to use `secp256k1.ProjectivePoint`

## Testing
- `npm run dev`
- `npm test` *(fails: Failed to resolve import "fake-indexeddb/auto")*

------
https://chatgpt.com/codex/tasks/task_e_68495756a38c8330a1aa3d030245dac2