### PR TITLE
Migrate to eslint.config.js

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,9 +1,0 @@
-/dist
-/src-bex/www
-/src-capacitor
-/src-cordova
-/.quasar
-/node_modules
-.eslintrc.js
-babel.config.js
-**/cashu-ts/dist/**

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,57 @@
+const { FlatCompat } = require('@eslint/eslintrc');
+const compat = new FlatCompat({ baseDirectory: __dirname });
+
+module.exports = [
+  {
+    ignores: [
+      '/dist',
+      '/src-bex/www',
+      '/src-capacitor',
+      '/src-cordova',
+      '/.quasar',
+      '/node_modules',
+      '.eslintrc.js',
+      'babel.config.js',
+      '**/cashu-ts/dist/**',
+    ],
+  },
+  ...compat.config({
+    parserOptions: {
+      parser: require.resolve('@typescript-eslint/parser'),
+      ecmaVersion: 2021,
+    },
+    env: {
+      browser: true,
+      'vue/setup-compiler-macros': true,
+    },
+    extends: [
+      'plugin:vue/vue3-essential',
+      'prettier',
+    ],
+    plugins: [
+      'vue',
+    ],
+    globals: {
+      ga: 'readonly',
+      cordova: 'readonly',
+      __statics: 'readonly',
+      __QUASAR_SSR__: 'readonly',
+      __QUASAR_SSR_SERVER__: 'readonly',
+      __QUASAR_SSR_CLIENT__: 'readonly',
+      __QUASAR_SSR_PWA__: 'readonly',
+      process: 'readonly',
+      Capacitor: 'readonly',
+      chrome: 'readonly',
+    },
+    rules: {
+      'prefer-promise-reject-errors': 'off',
+      'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
+    },
+    overrides: [
+      {
+        files: ['**/*.{js,ts}'],
+        rules: { 'vue/no-unused-properties': 'off' },
+      },
+    ],
+  }),
+];

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "quasar build",
     "build:pwa": "quasar build -m pwa",
     "quasar": "quasar",
-    "lint": "eslint --ext .js,.vue ./",
+    "lint": "eslint .",
     "format": "prettier --write .",
     "checkformat": "prettier --check .",
     "test": "vitest",


### PR DESCRIPTION
## Summary
- set up new `eslint.config.js` using FlatCompat
- move ignore patterns from `.eslintignore` into config
- update npm lint script for flat config

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68495bbb98c88330a3ca8e8008c34ece