### PR TITLE
Implement locked token bucket helper

### DIFF
--- a/src/components/CreatorLockedTokensTable.vue
+++ b/src/components/CreatorLockedTokensTable.vue
@@ -57,13 +57,15 @@ export default defineComponent({
   props: { bucketId: { type: String, required: true } },
   data() { return { currentPage: 1, pageSize: 5 } },
   computed: {
-    ...mapState(useDexieLockedTokensStore, ['lockedTokens']),
     ...mapState(useMintsStore, ['activeUnit']),
     filteredTokens() {
+      const store = useDexieLockedTokensStore()
       const nostrPubkey = useNostrStore().pubkey
-      return this.lockedTokens.filter(
-        t => t.owner === 'creator' && t.creatorNpub === nostrPubkey && t.tierId === this.bucketId
-      )
+      return store
+        .getLockedByBucket(this.bucketId)
+        .filter(
+          t => t.owner === 'creator' && t.creatorNpub === nostrPubkey && t.tierId === this.bucketId
+        )
     },
     maxPages() { return Math.ceil(this.filteredTokens.length / this.pageSize) },
     paginatedTokens() {

--- a/src/stores/lockedTokensDexie.ts
+++ b/src/stores/lockedTokensDexie.ts
@@ -24,5 +24,9 @@ export const useDexieLockedTokensStore = defineStore('dexieLockedTokens', () => 
     await cashuDb.lockedTokens.delete(id)
   }
 
-  return { lockedTokens, addLockedToken, deleteLockedToken }
+  function getLockedByBucket(bucketId: string) {
+    return lockedTokens.value.filter(t => t.bucketId === bucketId)
+  }
+
+  return { lockedTokens, addLockedToken, deleteLockedToken, getLockedByBucket }
 })


### PR DESCRIPTION
## Summary
- extend dexie locked tokens store with `getLockedByBucket`
- use the helper to filter tokens in `CreatorLockedTokensTable`

## Testing
- `npm test` *(fails: Failed to resolve import "fake-indexeddb/auto" during vitest startup)*

------
https://chatgpt.com/codex/tasks/task_e_684973434da48330ad67876ae7ffd5e9