### PR TITLE
Handle 64-char P2PK secrets

### DIFF
--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -7,7 +7,7 @@ import { useProofsStore } from "./proofs";
 import { HistoryToken, useTokensStore } from "./tokens";
 import { useReceiveTokensStore } from "./receiveTokensStore";
 import { useUiStore } from "src/stores/ui";
-import { useP2PKStore, ensureCompressed } from "src/stores/p2pk";
+import { useP2PKStore } from "src/stores/p2pk";
 import { useSendTokensStore } from "src/stores/sendTokensStore";
 import { usePRStore } from "./payment-request";
 import { useWorkersStore } from "./workers";
@@ -561,16 +561,7 @@ export const useWalletStore = defineStore("wallet", {
       if (tokenJson == undefined) {
         throw new Error("no tokens provided.");
       }
-      let proofs = token.getProofs(tokenJson);
-      // Normalize legacy P2PK secrets
-      proofs = proofs.map((p) => {
-        if (typeof p.secret === "string" && p.secret.startsWith("[\"P2PK")) {
-          const sec = JSON.parse(p.secret);
-          sec[1].data = ensureCompressed(sec[1].data);
-          p.secret = JSON.stringify(sec);
-        }
-        return p;
-      });
+      const proofs = token.getProofs(tokenJson);
       if (proofs.length == 0) {
         throw new Error("no proofs found.");
       }


### PR DESCRIPTION
## Summary
- import `ensureCompressed` in `token.ts`
- normalize P2PK secrets when decoding tokens
- convert 64 character P2PK keys while parsing secrets
- remove legacy normalization step in wallet store

## Testing
- `npm test` *(fails: Failed to resolve import "fake-indexeddb/auto")*

------
https://chatgpt.com/codex/tasks/task_e_684968e3575083308ccb44b79977e222