### PR TITLE
Improve locked token creation flow

### DIFF
--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -408,6 +408,7 @@ export const useWalletStore = defineStore("wallet", {
       bucketId: string = DEFAULT_BUCKET_ID,
       locktime?: number,
       refundPubkey?: string,
+      label?: string,
     ) {
       const mintStore = useMintsStore();
       const info = mintStore.activeInfo || {};
@@ -442,15 +443,17 @@ export const useWalletStore = defineStore("wallet", {
       const creatorBucketId = bucketsStore.ensureCreatorBucket(receiverPubkey);
 
       const tokenStr = useProofsStore().serializeProofs(sendProofs);
-      lockedStore.addLockedToken({
+      const lockedToken = lockedStore.addLockedToken({
         amount,
         token: tokenStr,
         pubkey: receiverPubkey,
         bucketId: creatorBucketId,
         locktime,
+        refundPubkey,
+        label,
       });
       await proofsStore.addProofs(keepProofs, undefined, bucketId, "");
-      return { keepProofs, sendProofs };
+      return { keepProofs, sendProofs, lockedToken };
     },
     send: async function (
       proofs: WalletProof[],

--- a/test/vitest/__tests__/donationPresets.spec.ts
+++ b/test/vitest/__tests__/donationPresets.spec.ts
@@ -2,19 +2,31 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useDonationPresetsStore } from "../../../src/stores/donationPresets";
 import { useWalletStore } from "../../../src/stores/wallet";
 import { useProofsStore } from "../../../src/stores/proofs";
-import { useLockedTokensStore } from "../../../src/stores/lockedTokens";
 import { useMintsStore } from "../../../src/stores/mints";
 
 beforeEach(() => {
   localStorage.clear();
 });
 
-vi.mock("../../../src/stores/wallet", () => ({
-  useWalletStore: () => ({
-    wallet: {},
-    sendToLock: vi.fn(async () => ({ sendProofs: [] })),
-  }),
-}));
+vi.mock("../../../src/stores/wallet", () => {
+  let call = 0;
+  return {
+    useWalletStore: () => ({
+      wallet: {},
+      sendToLock: vi.fn(async () => ({
+        sendProofs: [],
+        lockedToken: {
+          id: `id${++call}`,
+          amount: 1,
+          token: "tok",
+          pubkey: "pk",
+          bucketId: "b",
+          date: "d",
+        },
+      })),
+    }),
+  };
+});
 
 vi.mock("../../../src/stores/proofs", () => ({
   useProofsStore: () => ({
@@ -23,11 +35,6 @@ vi.mock("../../../src/stores/proofs", () => ({
   }),
 }));
 
-vi.mock("../../../src/stores/lockedTokens", () => ({
-  useLockedTokensStore: () => ({
-    addLockedToken: vi.fn((d: any) => ({ id: "id", date: "d", ...d })),
-  }),
-}));
 
 vi.mock("../../../src/stores/mints", () => ({
   useMintsStore: () => ({
@@ -81,12 +88,6 @@ describe("Donation presets", () => {
 
   it("returns locked token data when detailed is true", async () => {
     const store = useDonationPresetsStore();
-    const locked = useLockedTokensStore();
-    (locked.addLockedToken as any).mockImplementation((d: any) => ({
-      id: "id" + (locked.addLockedToken as any).mock.calls.length,
-      date: "d",
-      ...d,
-    }));
     const res = (await store.createDonationPreset(
       2,
       1,


### PR DESCRIPTION
## Summary
- return `lockedToken` info from `wallet.sendToLock`
- use the returned locked token when creating donation presets
- adjust donation presets tests for new API

## Testing
- `npm test` *(fails: Failed to resolve import "fake-indexeddb/auto")*

------
https://chatgpt.com/codex/tasks/task_e_68496db6d54883309515e0e50dd58dd6