### PR TITLE
Normalize P2PK secrets in token proofs

### DIFF
--- a/src/js/token.ts
+++ b/src/js/token.ts
@@ -1,6 +1,7 @@
 import { type Token, getDecodedToken } from "@cashu/cashu-ts";
 import { useMintsStore, WalletProof } from "src/stores/mints";
 import { useProofsStore } from "src/stores/proofs";
+import { ensureCompressed } from "src/stores/p2pk";
 export default { decode, getProofs, getMint, getUnit, getMemo };
 
 /**
@@ -19,7 +20,29 @@ function getProofs(decoded_token: Token): WalletProof[] {
     throw new Error("Token format wrong");
   }
   const proofs = decoded_token.proofs.flat();
-  return useProofsStore().proofsToWalletProofs(proofs, undefined, "unassigned", "");
+  const normalized = proofs.map((p) => {
+    if (typeof p.secret === "string" && p.secret.startsWith('["P2PK"')) {
+      try {
+        const sec = JSON.parse(p.secret);
+        if (
+          sec &&
+          sec[1] &&
+          typeof sec[1].data === "string" &&
+          /^[0-9a-fA-F]{64}$/.test(sec[1].data)
+        ) {
+          sec[1].data = ensureCompressed(sec[1].data);
+          return { ...p, secret: JSON.stringify(sec) };
+        }
+      } catch {}
+    }
+    return p;
+  });
+  return useProofsStore().proofsToWalletProofs(
+    normalized,
+    undefined,
+    "unassigned",
+    ""
+  );
 }
 
 function getMint(decoded_token: Token) {


### PR DESCRIPTION
## Summary
- normalize P2PK secret pubkeys when decoding tokens

## Testing
- `npm test` *(fails: no tests detected and missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_6849899514a083309d1eb0a6d88176d0