### PR TITLE
Fix ensureCompressed hex encoding

### DIFF
--- a/src/stores/p2pk.ts
+++ b/src/stores/p2pk.ts
@@ -14,9 +14,9 @@ export function ensureCompressed(pk: string): string {
     return pk;
   if (/^[0-9a-f]{64}$/.test(pk)) {
     try {
-      return Point.fromHex("02" + pk).toRawBytes(true).toString("hex");
+      return bytesToHex(Point.fromHex("02" + pk).toRawBytes(true));
     } catch {
-      return Point.fromHex("03" + pk).toRawBytes(true).toString("hex");
+      return bytesToHex(Point.fromHex("03" + pk).toRawBytes(true));
     }
   }
   throw new Error("invalid pubkey format");


### PR DESCRIPTION
## Summary
- fix byte-to-hex encoding in `ensureCompressed` helper

## Testing
- `npm test` *(fails: Cannot set property permissions of [object Object])*

------
https://chatgpt.com/codex/tasks/task_e_684994868bac8330a990a9e7ff470751