### PR TITLE
Add ecash utility helper

### DIFF
--- a/src/utils/ecash.ts
+++ b/src/utils/ecash.ts
@@ -1,0 +1,18 @@
+import * as nobleSecp256k1 from "@noble/secp256k1";
+
+/**
+ * Ensure a public key hex string is compressed.
+ * Returns the compressed representation or throws
+ * if the input is invalid.
+ */
+export function ensureCompressed(pubkey: string): string {
+  if (!pubkey) throw new Error("invalid pubkey");
+  if (
+    pubkey.length === 66 &&
+    (pubkey.startsWith("02") || pubkey.startsWith("03"))
+  ) {
+    return pubkey;
+  }
+  const point = nobleSecp256k1.Point.fromHex(pubkey);
+  return point.toHex(true);
+}


### PR DESCRIPTION
## Summary
- add new `ensureCompressed` helper in `src/utils/ecash.ts`

## Testing
- `npm test` *(fails: Failed to resolve import "fake-indexeddb/auto")*

------
https://chatgpt.com/codex/tasks/task_e_6849a222ab708330951091ff6a831e56