### PR TITLE
Add ensureCompressed util tests

### DIFF
--- a/test/vitest/__tests__/ecash.spec.ts
+++ b/test/vitest/__tests__/ecash.spec.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import { ensureCompressed } from '../../../src/utils/ecash'
+import { getPublicKey } from '@noble/secp256k1'
+
+describe('ensureCompressed', () => {
+  it('returns the same value for an already compressed key', () => {
+    const priv = new Uint8Array(32).fill(1)
+    const compressed = Buffer.from(getPublicKey(priv, true)).toString('hex')
+    expect(ensureCompressed(compressed)).toBe(compressed)
+  })
+
+  it('compresses an uncompressed key', () => {
+    const priv = new Uint8Array(32).fill(2)
+    const compressed = Buffer.from(getPublicKey(priv, true)).toString('hex')
+    const uncompressed = Buffer.from(getPublicKey(priv, false)).toString('hex')
+    expect(ensureCompressed(uncompressed)).toBe(compressed)
+  })
+
+  it('throws on invalid input', () => {
+    expect(() => ensureCompressed('')).toThrow()
+  })
+})


### PR DESCRIPTION
## Summary
- add tests for `ensureCompressed` utility

## Testing
- `npm test --silent` *(fails: Error: Failed to resolve import "fake-indexeddb/auto" from setup file)*

------
https://chatgpt.com/codex/tasks/task_e_6849ab1512608330a55c62a3d050bcf7