### PR TITLE
Fix getSignedProofs import

### DIFF
--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -41,8 +41,8 @@ import {
   decodePaymentRequest,
   MintQuoteResponse,
   ProofState,
-  getSignedProofs,
 } from "@cashu/cashu-ts";
+import { getSignedProofs } from "@cashu/crypto/modules/client/NUT11";
 import { hashToCurve } from "@cashu/crypto/modules/common";
 // @ts-ignore
 import * as bolt11Decoder from "light-bolt11-decoder";


### PR DESCRIPTION
## Summary
- adjust wallet store to import `getSignedProofs` from the `@cashu/crypto` package

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849b525a2008330957323fdde9b2917