### PR TITLE
Implement P2PK compatibility and locked tokens

### DIFF
--- a/src/stores/donationPresets.ts
+++ b/src/stores/donationPresets.ts
@@ -3,7 +3,7 @@ import { useLocalStorage } from "@vueuse/core";
 import { useWalletStore } from "./wallet";
 import { useMintsStore } from "./mints";
 import { useProofsStore } from "./proofs";
-import { useLockedTokensStore, LockedToken } from "./lockedTokens";
+import { LockedToken } from "./lockedTokens";
 import { useSubscriptionsStore } from "./subscriptions";
 import { useP2PKStore } from "./p2pk";
 import { DEFAULT_BUCKET_ID } from "./buckets";
@@ -48,7 +48,6 @@ export const useDonationPresetsStore = defineStore("donationPresets", {
       const walletStore = useWalletStore();
       const proofsStore = useProofsStore();
       const mintsStore = useMintsStore();
-      const lockedStore = useLockedTokensStore();
       const subscriptionsStore = useSubscriptionsStore();
       const p2pkStore = useP2PKStore();
 
@@ -65,32 +64,19 @@ export const useDonationPresetsStore = defineStore("donationPresets", {
         throw new Error('Insufficient balance');
       }
 
+      const tokens: LockedToken[] = [];
+
       if (!months || months <= 0) {
-        const { sendProofs } = await walletStore.sendToLock(
+        const { locked } = await walletStore.sendToLock(
           proofs,
           wallet,
           amount,
           convertedPubkey,
           bucketId
         );
-        const token = proofsStore.serializeProofs(sendProofs);
-        if (detailed) {
-          return [
-            lockedStore.addLockedToken({
-              amount,
-              token,
-              pubkey: convertedPubkey,
-              bucketId,
-              label: subscription?.tierName
-                ? `Subscription: ${subscription.tierName}`
-                : undefined,
-            }),
-          ];
-        }
-        return token;
+        tokens.push(locked);
+        return detailed ? tokens : locked.token;
       }
-
-      const tokens: LockedToken[] = [];
       const base = startDate ?? Math.floor(Date.now() / 1000);
       for (let i = 0; i < months; i++) {
         const locktime = base + i * 30 * 24 * 60 * 60;

--- a/test/p2pk-compat.spec.ts
+++ b/test/p2pk-compat.spec.ts
@@ -1,0 +1,11 @@
+import { ensureCompressed } from '../src/utils/ecash';
+import { describe, it, expect } from 'vitest';
+
+describe('ensureCompressed', () => {
+  it('converts 64-hex to 66-hex', () => {
+    const raw = '1'.repeat(64);
+    const out = ensureCompressed(raw);
+    expect(out.length).toBe(66);
+    expect(out.startsWith('02') || out.startsWith('03')).toBe(true);
+  });
+});

--- a/test/vitest/__tests__/donationPresets.spec.ts
+++ b/test/vitest/__tests__/donationPresets.spec.ts
@@ -2,7 +2,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useDonationPresetsStore } from "../../../src/stores/donationPresets";
 import { useWalletStore } from "../../../src/stores/wallet";
 import { useProofsStore } from "../../../src/stores/proofs";
-import { useLockedTokensStore } from "../../../src/stores/lockedTokens";
 import { useMintsStore } from "../../../src/stores/mints";
 
 beforeEach(() => {
@@ -12,7 +11,7 @@ beforeEach(() => {
 vi.mock("../../../src/stores/wallet", () => ({
   useWalletStore: () => ({
     wallet: {},
-    sendToLock: vi.fn(async () => ({ sendProofs: [] })),
+    sendToLock: vi.fn(async () => ({ locked: { id: "id", token: "tok" } })),
   }),
 }));
 
@@ -23,11 +22,6 @@ vi.mock("../../../src/stores/proofs", () => ({
   }),
 }));
 
-vi.mock("../../../src/stores/lockedTokens", () => ({
-  useLockedTokensStore: () => ({
-    addLockedToken: vi.fn((d: any) => ({ id: "id", date: "d", ...d })),
-  }),
-}));
 
 vi.mock("../../../src/stores/mints", () => ({
   useMintsStore: () => ({
@@ -81,12 +75,6 @@ describe("Donation presets", () => {
 
   it("returns locked token data when detailed is true", async () => {
     const store = useDonationPresetsStore();
-    const locked = useLockedTokensStore();
-    (locked.addLockedToken as any).mockImplementation((d: any) => ({
-      id: "id" + (locked.addLockedToken as any).mock.calls.length,
-      date: "d",
-      ...d,
-    }));
     const res = (await store.createDonationPreset(
       2,
       1,


### PR DESCRIPTION
## Summary
- add new `ensureCompressed` helper
- compress pubkeys when locking coins
- normalize proofs in `redeem` and in locked token worker
- persist locked tokens from `sendToLock`
- adjust donation preset logic for returned locked tokens
- update tests and add new `p2pk-compat` test

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849d3406d9483308bfa3a201f218c61