### PR TITLE
Add signer modal and store

### DIFF
--- a/src/components/MissingSignerModal.vue
+++ b/src/components/MissingSignerModal.vue
@@ -1,0 +1,50 @@
+<template>
+  <q-dialog ref="dialogRef" @hide="onDialogHide">
+    <q-card class="q-pa-md">
+      <q-card-section>
+        <div class="text-h6">Missing Signer</div>
+        <div class="text-subtitle2">Choose how to sign P2PK proofs</div>
+      </q-card-section>
+      <q-card-section>
+        <q-input v-model="nsec" type="password" label="nsec" dense autofocus />
+      </q-card-section>
+      <q-card-actions vertical class="q-gutter-sm">
+        <q-btn color="primary" @click="chooseLocal">Use pasted nsec</q-btn>
+        <q-btn color="primary" @click="chooseNip07">Use NIP-07</q-btn>
+        <q-btn color="primary" @click="chooseNip46">Use NIP-46</q-btn>
+        <q-btn flat v-close-popup color="grey">Cancel</q-btn>
+      </q-card-actions>
+    </q-card>
+  </q-dialog>
+</template>
+
+<script lang="ts" setup>
+import { ref } from 'vue';
+import { useSignerStore } from 'src/stores/signer';
+
+const props = defineProps<{ dialogRef?: any }>();
+const emit = defineEmits(['ok', 'hide']);
+const dialogRef = props.dialogRef;
+function onDialogHide() {
+  emit('hide');
+}
+const signer = useSignerStore();
+const nsec = ref('');
+
+function chooseLocal() {
+  signer.method = 'local';
+  signer.nsec = nsec.value;
+  emit('ok');
+  dialogRef && dialogRef.hide();
+}
+function chooseNip07() {
+  signer.method = 'nip07';
+  emit('ok');
+  dialogRef && dialogRef.hide();
+}
+function chooseNip46() {
+  signer.method = 'nip46';
+  emit('ok');
+  dialogRef && dialogRef.hide();
+}
+</script>

--- a/src/stores/signer.ts
+++ b/src/stores/signer.ts
@@ -1,0 +1,16 @@
+import { defineStore } from 'pinia';
+
+export type SignerMethod = 'local' | 'nip07' | 'nip46' | null;
+
+export const useSignerStore = defineStore('signer', {
+  state: () => ({
+    method: null as SignerMethod,
+    nsec: '',
+  }),
+  actions: {
+    reset() {
+      this.method = null;
+      this.nsec = '';
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add `MissingSignerModal` component to select a signing method
- implement Pinia `signer` store
- prompt for signer in `wallet.redeem` when none is available
- choose signing method in `workers.signWithRemote`

## Testing
- `npm test` *(fails: No "useDialogPluginComponent" export is defined / missing imports)*

------
https://chatgpt.com/codex/tasks/task_e_684a75884e9c833090b4ff5f3a4965b5