### PR TITLE
Handle missing signer when redeeming locked tokens

### DIFF
--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -246,6 +246,8 @@ import iOSPWAPrompt from "components/iOSPWAPrompt.vue";
 import AndroidPWAPrompt from "components/AndroidPWAPrompt.vue";
 import ActivityOrb from "components/ActivityOrb.vue";
 import BucketManager from "components/BucketManager.vue";
+import MissingSignerModal from "src/components/MissingSignerModal.vue";
+import { Dialog } from "quasar";
 
 // pinia stores
 import { mapActions, mapState, mapWritableState } from "pinia";
@@ -605,6 +607,15 @@ export default {
         }
       };
     },
+    handleLockedTokenMessage(event) {
+      if (event.data?.type === "locked-token-missing-signer") {
+        const tokenId = event.data.tokenId;
+        const dlg = Dialog.create({ component: MissingSignerModal });
+        dlg.onOk(() => {
+          postMessage({ type: "retry-locked-token", tokenId });
+        });
+      }
+    },
   },
   watch: {},
 
@@ -614,7 +625,12 @@ export default {
     this.claimAllTokens();
   },
 
+  unmounted: function () {
+    window.removeEventListener('message', this.handleLockedTokenMessage);
+  },
+
   created: async function () {
+    window.addEventListener('message', this.handleLockedTokenMessage);
     // Initialize and run migrations
     const migrationsStore = useMigrationsStore();
     migrationsStore.initMigrations();


### PR DESCRIPTION
## Summary
- handle missing signer errors when redeeming locked tokens
- notify UI thread so user can select a signer
- retry redeem when signer chosen

## Testing
- `npm test` *(fails: getActivePinia not set, resolve import errors)*

------
https://chatgpt.com/codex/tasks/task_e_684a785f1ad0833086487f20ac0a6cc5