### PR TITLE
Add signer setup in tests

### DIFF
--- a/test/vitest/__tests__/donationPresets.spec.ts
+++ b/test/vitest/__tests__/donationPresets.spec.ts
@@ -3,6 +3,7 @@ import { useDonationPresetsStore } from "../../../src/stores/donationPresets";
 import { useWalletStore } from "../../../src/stores/wallet";
 import { useProofsStore } from "../../../src/stores/proofs";
 import { useMintsStore } from "../../../src/stores/mints";
+import { useSignerStore } from "../../../src/stores/signer";
 
 beforeEach(() => {
   localStorage.clear();
@@ -41,6 +42,9 @@ describe("Donation presets", () => {
   it("calls sendToLock with sequential locktimes", async () => {
     const store = useDonationPresetsStore();
     const wallet = useWalletStore();
+    const signer = useSignerStore();
+    signer.method = 'local';
+    signer.nsec = 'nsec123';
     const spy = wallet.sendToLock as any;
     await store.createDonationPreset(3, 1, "pk", "b");
     expect(spy).toHaveBeenCalledTimes(3);
@@ -54,6 +58,9 @@ describe("Donation presets", () => {
   it("skips schedule when months is 0 and returns token", async () => {
     const store = useDonationPresetsStore();
     const wallet = useWalletStore();
+    const signer = useSignerStore();
+    signer.method = 'local';
+    signer.nsec = 'nsec123';
     const spy = wallet.sendToLock as any;
     const token = await store.createDonationPreset(0, 5, "pk", "b");
     expect(spy).toHaveBeenCalledTimes(1);
@@ -64,6 +71,9 @@ describe("Donation presets", () => {
   it("uses provided startDate for locktimes", async () => {
     const store = useDonationPresetsStore();
     const wallet = useWalletStore();
+    const signer = useSignerStore();
+    signer.method = 'local';
+    signer.nsec = 'nsec123';
     const spy = wallet.sendToLock as any;
     const start = 1000;
     await store.createDonationPreset(3, 1, "pk", "b", start);
@@ -75,6 +85,9 @@ describe("Donation presets", () => {
 
   it("returns locked token data when detailed is true", async () => {
     const store = useDonationPresetsStore();
+    const signer = useSignerStore();
+    signer.method = 'local';
+    signer.nsec = 'nsec123';
     const res = (await store.createDonationPreset(
       2,
       1,

--- a/test/vitest/__tests__/missingSignerModal.spec.ts
+++ b/test/vitest/__tests__/missingSignerModal.spec.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import MissingSignerModal from '../../src/components/MissingSignerModal.vue'
+import { useSignerStore } from '../../src/stores/signer'
+import { useWalletStore } from '../../src/stores/wallet'
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+describe('MissingSignerModal', () => {
+  it('allows redeem after selecting each signing option', async () => {
+    const signer = useSignerStore()
+    const wallet = useWalletStore()
+    wallet.redeem = vi.fn(async () => true)
+
+    const testOption = async (action: (wrapper: any) => Promise<void> | void, method: any) => {
+      signer.reset()
+      const wrapper = mount(MissingSignerModal)
+      if (method === 'local') {
+        ;(wrapper.vm as any).nsec = 'nsec123'
+      }
+      await action(wrapper)
+      expect(signer.method).toBe(method)
+      if (method === 'local') expect(signer.nsec).toBe('nsec123')
+      await expect(wallet.redeem()).resolves.toBe(true)
+    }
+
+    await testOption((w) => (w.vm as any).chooseLocal(), 'local')
+    await testOption((w) => (w.vm as any).chooseNip07(), 'nip07')
+    await testOption((w) => (w.vm as any).chooseNip46(), 'nip46')
+  })
+})

--- a/test/vitest/__tests__/p2pk.spec.ts
+++ b/test/vitest/__tests__/p2pk.spec.ts
@@ -4,6 +4,7 @@ import { useWalletStore } from '../../src/stores/wallet'
 import { useProofsStore } from '../../src/stores/proofs'
 import { generateSecretKey, getPublicKey, nip19 } from 'nostr-tools'
 import { bytesToHex } from '@noble/hashes/utils'
+import { useSignerStore } from '../../src/stores/signer'
 
 beforeEach(() => {
   localStorage.clear()
@@ -40,6 +41,10 @@ describe('P2PK store', () => {
     vi.spyOn(proofsStore, 'removeProofs').mockResolvedValue()
     vi.spyOn(proofsStore, 'addProofs').mockResolvedValue()
 
+    const signer = useSignerStore()
+    signer.method = 'local'
+    signer.nsec = 'nsec123'
+
     walletStore.spendableProofs = vi.fn(() => [{ secret: 's', amount: 1, id: 'a', C: 'c' } as any])
     walletStore.coinSelect = vi.fn(() => [{ secret: 's', amount: 1, id: 'a', C: 'c' } as any])
     walletStore.getKeyset = vi.fn(() => 'kid')
@@ -73,6 +78,10 @@ describe('P2PK store', () => {
     const proofsStore = useProofsStore()
     vi.spyOn(proofsStore, 'removeProofs').mockResolvedValue()
     vi.spyOn(proofsStore, 'addProofs').mockResolvedValue()
+
+    const signer = useSignerStore()
+    signer.method = 'local'
+    signer.nsec = 'nsec123'
 
     walletStore.spendableProofs = vi.fn(() => [{ secret: 's', amount: 1, id: 'a', C: 'c' } as any])
     walletStore.coinSelect = vi.fn(() => [{ secret: 's', amount: 1, id: 'a', C: 'c' } as any])

--- a/test/vitest/__tests__/timelock.spec.ts
+++ b/test/vitest/__tests__/timelock.spec.ts
@@ -3,6 +3,7 @@ import { useSendTokensStore } from '../../src/stores/sendTokensStore'
 import { useWalletStore } from '../../src/stores/wallet'
 import { useProofsStore } from '../../src/stores/proofs'
 import { useP2PKStore } from '../../src/stores/p2pk'
+import { useSignerStore } from '../../src/stores/signer'
 
 beforeEach(() => {
   localStorage.clear()
@@ -22,6 +23,10 @@ describe('Timelock', () => {
     const proofsStore = useProofsStore()
     vi.spyOn(proofsStore, 'removeProofs').mockResolvedValue()
     vi.spyOn(proofsStore, 'addProofs').mockResolvedValue()
+
+    const signer = useSignerStore()
+    signer.method = 'local'
+    signer.nsec = 'nsec123'
 
     walletStore.spendableProofs = vi.fn(() => [{ secret: 's', amount: 1, id: 'a', C: 'c' } as any])
     walletStore.coinSelect = vi.fn(() => [{ secret: 's', amount: 1, id: 'a', C: 'c' } as any])


### PR DESCRIPTION
## Summary
- update p2pk, timelock and donation preset tests to configure signer store
- add MissingSignerModal unit test

## Testing
- `npm run test:ci` *(fails: getActivePinia not found and other path errors)*

------
https://chatgpt.com/codex/tasks/task_e_684a7b33517c8330a65167d3d50dd365