### PR TITLE
Normalize public keys before P2PK use

### DIFF
--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -23,6 +23,7 @@ import {
   finalizeEvent,
 } from "nostr-tools";
 import { bytesToHex, hexToBytes } from "@noble/hashes/utils"; // already an installed dependency
+import { ensureCompressed } from "src/utils/ecash";
 import { useWalletStore } from "./wallet";
 import { generateSecretKey, getPublicKey } from "nostr-tools";
 import { useLocalStorage } from "@vueuse/core";
@@ -239,7 +240,8 @@ export const useNostrStore = defineStore("nostr", {
         const privKey = this.privKeyHex;
         if (privKey && privKey.length) {
           const p2pkStore = useP2PKStore();
-          const pk66 = "02" + getPublicKey(hexToBytes(privKey));
+          // ensureCompressed() so P2PK keys are always in SEC form
+          const pk66 = ensureCompressed("02" + getPublicKey(hexToBytes(privKey)));
           if (!p2pkStore.haveThisKey(pk66)) {
             const keyPair = {
               publicKey: pk66,

--- a/src/utils/ecash.ts
+++ b/src/utils/ecash.ts
@@ -4,8 +4,9 @@ const Point = secp256k1.ProjectivePoint;
 /**
  * Ensure a hex pubkey is 33-byte SEC-compressed (66 hex chars 02/03…).
  * Accepts raw 32-byte hex, 65-byte uncompressed hex (prefix 04), or
- * already-compressed hex.
- */
+ * already-compressed hex. Always run user-provided keys through this
+ * helper before they are stored or used in P2PK operations.
+*/
 export function ensureCompressed(hex: string): string {
   hex = hex.toLowerCase().replace(/^0x/, '');
   if (/^(02|03)[0-9a-f]{64}$/.test(hex)) return hex;      // already good


### PR DESCRIPTION
## Summary
- normalize hex keys with `ensureCompressed` helper
- keep P2PK store keys compressed when generating/importing
- ensure decoded secrets and internal pubkeys are compressed
- store Nostr signer pubkeys compressed

## Testing
- `npm test` *(fails: Cannot set property permissions of [object Object] which has only a getter)*

------
https://chatgpt.com/codex/tasks/task_e_684a7ec3302883309e278808be4e537b