### PR TITLE
Fix hex encode

### DIFF
--- a/src/utils/ecash.ts
+++ b/src/utils/ecash.ts
@@ -1,4 +1,5 @@
 import { secp256k1 } from '@noble/curves/secp256k1';
+import { bytesToHex } from '@noble/hashes/utils';
 const Point = secp256k1.ProjectivePoint;
 
 /**
@@ -11,11 +12,11 @@ export function ensureCompressed(hex: string): string {
   hex = hex.toLowerCase().replace(/^0x/, '');
   if (/^(02|03)[0-9a-f]{64}$/.test(hex)) return hex;      // already good
   if (/^[0-9a-f]{64}$/.test(hex)) {
-    try { return Point.fromHex('02' + hex).toRawBytes(true).toString('hex'); }
-    catch { return Point.fromHex('03' + hex).toRawBytes(true).toString('hex'); }
+    try { return bytesToHex(Point.fromHex('02' + hex).toRawBytes(true)); }
+    catch { return bytesToHex(Point.fromHex('03' + hex).toRawBytes(true)); }
   }
   if (/^04[0-9a-f]{128}$/.test(hex)) {
-    return Point.fromHex(hex).toRawBytes(true).toString('hex');
+    return bytesToHex(Point.fromHex(hex).toRawBytes(true));
   }
   throw new Error(`invalid pubkey format: ${hex}`);
 }


### PR DESCRIPTION
## Summary
- use `bytesToHex` for public key hex encoding

## Testing
- `npm test` *(fails: Test Files 17 failed)*

------
https://chatgpt.com/codex/tasks/task_e_684a823bcfe883309e6887e40d748ec0