### PR TITLE
Validate nsec in signer modal

### DIFF
--- a/src/components/MissingSignerModal.vue
+++ b/src/components/MissingSignerModal.vue
@@ -21,6 +21,8 @@
 <script lang="ts" setup>
 import { ref } from 'vue';
 import { useSignerStore } from 'src/stores/signer';
+import { nip19 } from 'nostr-tools';
+import { notifyError } from 'src/js/notify';
 
 const props = defineProps<{ dialogRef?: any }>();
 const emit = defineEmits(['ok', 'hide']);
@@ -32,8 +34,18 @@ const signer = useSignerStore();
 const nsec = ref('');
 
 function chooseLocal() {
+  const key = nsec.value.trim();
+  try {
+    const decoded = nip19.decode(key);
+    if (decoded.type !== 'nsec') {
+      throw new Error('invalid type');
+    }
+  } catch (e) {
+    notifyError('Invalid nsec');
+    return;
+  }
   signer.method = 'local';
-  signer.nsec = nsec.value;
+  signer.nsec = key;
   emit('ok');
   dialogRef && dialogRef.hide();
 }


### PR DESCRIPTION
## Summary
- verify pasted `nsec` when selecting local signer
- keep dialog open and notify error when invalid

## Testing
- `npm test` *(fails: Cannot set property permissions of [object Object] which has only a getter)*

------
https://chatgpt.com/codex/tasks/task_e_684a835bc7108330a8c2e32fc9cd0384