### PR TITLE
Fix maybeConvertNpub behaviour

### DIFF
--- a/src/stores/p2pk.ts
+++ b/src/stores/p2pk.ts
@@ -38,11 +38,7 @@ export const useP2PKStore = defineStore("p2pk", {
           key = "02" + data;
         }
       }
-      try {
-        return ensureCompressed(key);
-      } catch {
-        return key;
-      }
+      return ensureCompressed(key);
     },
     isValidPubkey: function (key: string) {
       try {


### PR DESCRIPTION
## Summary
- return compressed public keys even when invalid npubs are supplied

## Testing
- `npm test` *(fails: invalid pubkey format)*

------
https://chatgpt.com/codex/tasks/task_e_684a8a88b6808330bfc0ff9d77739ca8