### PR TITLE
Add MissingSignerModal unit tests

### DIFF
--- a/test/vitest/__tests__/missingSignerModal.spec.ts
+++ b/test/vitest/__tests__/missingSignerModal.spec.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import MissingSignerModal from '../../../src/components/MissingSignerModal.vue'
+import { useSignerStore } from '../../../src/stores/signer'
+
+vi.mock('../../../src/js/notify', () => ({
+  notifyError: vi.fn(),
+}))
+vi.mock('quasar', () => ({ Dialog: { create: vi.fn(() => ({ onOk: vi.fn(), onCancel: vi.fn(), onDismiss: vi.fn() })) }, Notify: { create: vi.fn() } }));
+
+vi.mock('nostr-tools', () => ({
+  nip19: { decode: vi.fn() },
+}))
+
+const { nip19 } = require('nostr-tools')
+const { notifyError } = require('../../../src/js/notify')
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('MissingSignerModal', () => {
+  it('chooses local signer', () => {
+    ;(nip19.decode as any).mockReturnValue({ type: 'nsec', data: 'd' })
+    const wrapper = mount(MissingSignerModal)
+    const vm: any = wrapper.vm
+    vm.nsec = 'nsec123'
+    vm.chooseLocal()
+    const store = useSignerStore()
+    expect(store.method).toBe('local')
+    expect(store.nsec).toBe('nsec123')
+    expect(notifyError).not.toHaveBeenCalled()
+  })
+
+  it('chooses NIP-07 signer', () => {
+    const wrapper = mount(MissingSignerModal)
+    const vm: any = wrapper.vm
+    vm.chooseNip07()
+    const store = useSignerStore()
+    expect(store.method).toBe('nip07')
+  })
+
+  it('chooses NIP-46 signer', () => {
+    const wrapper = mount(MissingSignerModal)
+    const vm: any = wrapper.vm
+    vm.chooseNip46()
+    const store = useSignerStore()
+    expect(store.method).toBe('nip46')
+  })
+})


### PR DESCRIPTION
## Summary
- add vitest spec for MissingSignerModal to exercise signer selection logic

## Testing
- `npm test -- -t missingSignerModal.spec.ts` *(fails: module resolution issues)*

------
https://chatgpt.com/codex/tasks/task_e_684a8c0e82688330a952b85b4b19f3da