### PR TITLE
Update tsconfig and dev types

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@quasar/app-vite": "^1.9.3",
     "@types/node": "^20.12.11",
     "@types/underscore": "^1.11.15",
+    "@types/debug": "^4.1.12",
     "@types/uuid": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,9 @@
   "compilerOptions": {
     "baseUrl": ".",
     "target": "ES2020",
+    "moduleResolution": "nodenext",
+    "types": ["node"],
+    "skipLibCheck": true,
     "paths": {
       "src/*": ["src/*"],
       "app/*": ["*"],
@@ -14,5 +17,6 @@
       "stores/*": ["src/stores/*"],
       "vue$": ["node_modules/vue/dist/vue.runtime.esm-bundler.js"]
     }
-  }
+  },
+  "exclude": ["node_modules", "test"]
 }


### PR DESCRIPTION
## Summary
- enable `nodenext` resolution and skip lib checking
- add Node types and exclude tests
- add missing `@types/debug` entry

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npx tsc --noEmit` *(fails: errors remain)*

------
https://chatgpt.com/codex/tasks/task_e_684a8e3ad2cc8330be7b1c67e613655f