### PR TITLE
Fix P2PK auto redeem loop

### DIFF
--- a/src/components/LockedTokensTable.vue
+++ b/src/components/LockedTokensTable.vue
@@ -55,6 +55,17 @@
               $t("LockedTokensTable.actions.copy.tooltip_text")
             }}</q-tooltip>
           </q-btn>
+          <q-btn
+            flat
+            dense
+            icon="lock_open"
+            v-if="isP2PK(token.token)"
+            @click="unlockP2PKToken(token)"
+            aria-label="Unlock"
+            title="Unlock"
+          >
+            <q-tooltip>Unlock</q-tooltip>
+          </q-btn>
         </q-item-section>
       </q-item>
     </q-list>
@@ -83,6 +94,9 @@ import { formatDistanceToNow, parseISO } from "date-fns";
 import { shortenString } from "src/js/string-utils";
 import { useLockedTokensStore } from "stores/lockedTokens";
 import { useMintsStore } from "stores/mints";
+import { useReceiveTokensStore } from "stores/receiveTokensStore";
+import { useWalletStore } from "stores/wallet";
+import { useP2PKStore } from "stores/p2pk";
 import { nip19 } from "nostr-tools";
 
 export default defineComponent({
@@ -126,6 +140,18 @@ export default defineComponent({
       } catch (e) {
         return hex;
       }
+    },
+    isP2PK(tokenStr) {
+      return !!useP2PKStore().getTokenPubkey(tokenStr)
+    },
+    async unlockP2PKToken(token) {
+      const receiveStore = useReceiveTokensStore()
+      const wallet = useWalletStore()
+      const lockedStore = useLockedTokensStore()
+      receiveStore.receiveData.tokensBase64 = token.token
+      receiveStore.receiveData.bucketId = token.bucketId
+      await wallet.redeem(token.bucketId)
+      lockedStore.deleteLockedToken(token.id)
     },
   },
 });

--- a/src/stores/lockedTokensRedeemWorker.ts
+++ b/src/stores/lockedTokensRedeemWorker.ts
@@ -45,6 +45,16 @@ export const useLockedTokensRedeemWorker = defineStore('lockedTokensRedeemWorker
       for (const entry of entries) {
         try {
           const decoded = token.decode(entry.tokenString)
+          if (
+            decoded.proofs.some(
+              p => typeof p.secret === 'string' && p.secret.startsWith('["P2PK"')
+            )
+          ) {
+            console.debug(
+              `lockedTokensRedeemWorker: skip P2PK token ${entry.id}`
+            )
+            continue
+          }
           // normalise secret before redeem
           decoded.proofs.forEach(p => {
             if (typeof p.secret === 'string' && p.secret.startsWith('["P2PK"')) {


### PR DESCRIPTION
## Summary
- skip P2PK tokens in the locked tokens redeem worker
- allow manual unlock of P2PK tokens in LockedTokensTable

## Testing
- `npm test` *(fails: getActivePinia not found, import resolution errors)*

------
https://chatgpt.com/codex/tasks/task_e_684a9521fb2483309a178ae1be461001