### PR TITLE
Fix SendTokenDialog cashu import

### DIFF
--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -684,7 +684,7 @@ import {
 } from "src/js/notify.ts";
 import { Dialog } from "quasar";
 import { useDmChatsStore } from "src/stores/dmChats";
-import { getEncodedTokenV3 } from "@cashu/cashu-ts/dist/lib/es5/utils";
+import { getEncodedTokenV3 } from "@cashu/cashu-ts";
 export default defineComponent({
   name: "SendTokenDialog",
   mixins: [windowMixin],


### PR DESCRIPTION
## Summary
- import `getEncodedTokenV3` from the public package entry

## Testing
- `npm run lint`
- `npm run test` *(fails: Camera store & donation presets)*
- `npm run dev` *(started without missing export)*

------
https://chatgpt.com/codex/tasks/task_e_684b04a8d1b48330b4f4c6af2f3232ce