### PR TITLE
Fix token encoding import

### DIFF
--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -660,7 +660,7 @@ import { useCameraStore } from "src/stores/camera";
 import { useP2PKStore } from "src/stores/p2pk";
 import { nip19, ProfilePointer } from "nostr-tools";
 import TokenInformation from "components/TokenInformation.vue";
-import { getDecodedToken, getEncodedTokenV4 } from "@cashu/cashu-ts";
+import { getDecodedToken, getEncodedTokenV4, getEncodedToken } from "@cashu/cashu-ts";
 import { DEFAULT_BUCKET_ID, useBucketsStore } from "src/stores/buckets";
 
 import { mapActions, mapState, mapWritableState } from "pinia";
@@ -684,7 +684,6 @@ import {
 } from "src/js/notify.ts";
 import { Dialog } from "quasar";
 import { useDmChatsStore } from "src/stores/dmChats";
-import { getEncodedTokenV3 } from "@cashu/cashu-ts/dist/lib/es5/utils.js";
 export default defineComponent({
   name: "SendTokenDialog",
   mixins: [windowMixin],
@@ -1049,10 +1048,10 @@ export default defineComponent({
           this.sendData.tokensBase64 = getEncodedTokenV4(decodedToken);
         } catch {
           debug("### Could not encode token to V4");
-          this.sendData.tokensBase64 = getEncodedTokenV3(decodedToken);
+          this.sendData.tokensBase64 = getEncodedToken(decodedToken, { version: 3 });
         }
       } else {
-        this.sendData.tokensBase64 = getEncodedTokenV3(decodedToken);
+        this.sendData.tokensBase64 = getEncodedToken(decodedToken, { version: 3 });
       }
     },
     deleteThisToken: function () {


### PR DESCRIPTION
## Summary
- use getEncodedToken from `@cashu/cashu-ts` instead of deep import

## Testing
- `npm test` *(fails: Cannot set property permissions of [object Object] which has only a getter)*

------
https://chatgpt.com/codex/tasks/task_e_684b100d8b8c8330932ae94bcd740313