### PR TITLE
Fix auto-redeem loop on P2PK tokens

### DIFF
--- a/src/stores/lockedTokensRedeemWorker.ts
+++ b/src/stores/lockedTokensRedeemWorker.ts
@@ -5,6 +5,7 @@ import { useReceiveTokensStore } from './receiveTokensStore'
 import { useSettingsStore } from './settings'
 import token from 'src/js/token'
 import { ensureCompressed } from 'src/utils/ecash'
+import { debug } from 'src/js/logger'
 
 export const useLockedTokensRedeemWorker = defineStore('lockedTokensRedeemWorker', {
   state: () => ({
@@ -45,6 +46,14 @@ export const useLockedTokensRedeemWorker = defineStore('lockedTokensRedeemWorker
       for (const entry of entries) {
         try {
           const decoded = token.decode(entry.tokenString)
+          if (
+            decoded.proofs.some(
+              (p) => typeof p.secret === 'string' && p.secret.startsWith('["P2PK"')
+            )
+          ) {
+            debug('Skipping auto-redeem for P2PK token')
+            continue
+          }
           // normalise secret before redeem
           decoded.proofs.forEach(p => {
             if (typeof p.secret === 'string' && p.secret.startsWith('["P2PK"')) {


### PR DESCRIPTION
## Summary
- inspect token secrets during auto redeem
- skip redeeming tokens whose proofs start with `["P2PK"`

## Testing
- `npm run test:ci` *(fails: getActivePinia not active and other module issues)*

------
https://chatgpt.com/codex/tasks/task_e_684b14b39e4c833082701043254fdfc9