### PR TITLE
Implement P2PK unlock flow

### DIFF
--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1537,6 +1537,7 @@ export default {
     },
     actions: {
       copy: { tooltip_text: "Copy" },
+      unlock: { tooltip_text: "Unlock" },
     },
   },
   restore: {

--- a/src/stores/signer.ts
+++ b/src/stores/signer.ts
@@ -1,4 +1,8 @@
 import { defineStore } from 'pinia';
+import { Dialog } from 'quasar';
+import MissingSignerModal from 'src/components/MissingSignerModal.vue';
+import { useWorkersStore } from './workers';
+import type { Proof } from '@cashu/cashu-ts';
 
 export type SignerMethod = 'local' | 'nip07' | 'nip46' | null;
 
@@ -6,11 +10,32 @@ export const useSignerStore = defineStore('signer', {
   state: () => ({
     method: null as SignerMethod,
     nsec: '',
+    requesting: false,
   }),
   actions: {
     reset() {
       this.method = null;
       this.nsec = '';
+      this.requesting = false;
+    },
+    async requestWitness(proofs: Proof[]): Promise<Proof[]> {
+      this.requesting = true;
+      let signed = await useWorkersStore().signWithRemote(proofs);
+      if (!signed.some((p: any) => p.witness?.signatures?.length > 0)) {
+        const dlg = Dialog.create({ component: MissingSignerModal });
+        const ok = await new Promise<boolean>((resolve) => {
+          dlg.onOk(() => resolve(true));
+          dlg.onCancel(() => resolve(false));
+          dlg.onDismiss(() => resolve(false));
+        });
+        if (!ok) {
+          this.requesting = false;
+          throw new Error('No private key or remote signer available for P2PK unlock');
+        }
+        signed = await useWorkersStore().signWithRemote(proofs);
+      }
+      this.requesting = false;
+      return signed;
     },
   },
 });

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -14,6 +14,8 @@ import { useWorkersStore } from "./workers";
 import { useInvoicesWorkerStore } from "./invoicesWorker";
 import { DEFAULT_BUCKET_ID, useBucketsStore } from "./buckets";
 import { useLockedTokensStore } from "./lockedTokens";
+import { useDexieLockedTokensStore } from "./lockedTokensDexie";
+import type { LockedToken as DexieLockedToken } from "./dexie";
 import { v4 as uuidv4 } from "uuid";
 import { ensureCompressed } from "src/utils/ecash";
 
@@ -740,6 +742,14 @@ export const useWalletStore = defineStore("wallet", {
         const res = await this.attemptRedeem(bucketId);
         if (res) break;
       }
+    },
+
+    redeemP2PK: async function (token: DexieLockedToken) {
+      const receiveStore = useReceiveTokensStore();
+      receiveStore.receiveData.tokensBase64 = token.tokenString;
+      receiveStore.receiveData.bucketId = token.tierId;
+      await this.redeem(token.tierId);
+      await useDexieLockedTokensStore().deleteLockedToken(token.id);
     },
 
     // /mint


### PR DESCRIPTION
## Summary
- add signer store flow to request witnesses
- allow creators to unlock P2PK tokens
- expose redeemP2PK action in wallet
- add translation for unlock button

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b1e83c05c8330ade390ce31965cca