### PR TITLE
Implement interactive P2PK unlocking

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "light-bolt11-decoder": "^3.1.1",
     "lucide-vue-next": "^0.453.0",
     "nostr-tools": "^2.5.2",
+    "@cashu/token": "^0.8.0",
+    "@noble/secp256k1": "^2.3.0",
     "pinia": "^2.1.7",
     "qr-scanner": "^1.4.2",
     "qrcode": "^1.5.3",

--- a/src/components/CreatorLockedTokensTable.vue
+++ b/src/components/CreatorLockedTokensTable.vue
@@ -116,8 +116,11 @@ export default defineComponent({
       await useDexieLockedTokensStore().deleteLockedToken(token.id)
     },
     async redeemP2PK(token) {
-      const wallet = useWalletStore()
-      await wallet.redeemP2PK(token)
+      await useP2PKStore().redeemP2PKTokenInteractive({
+        id: token.id,
+        token: token.tokenString,
+        bucketId: token.tierId
+      })
     }
   }
 })

--- a/src/components/LockedTokensTable.vue
+++ b/src/components/LockedTokensTable.vue
@@ -16,7 +16,7 @@
           <q-item-label caption>
             {{
               $t("LockedTokensTable.row.receiver_label", {
-                value: shortenString(pubkeyNpub(token.pubkey), 15, 6),
+                value: shortenString(pubkeyNpub(getPK(token)), 15, 6),
               })
             }}
           </q-item-label>
@@ -55,6 +55,19 @@
               $t("LockedTokensTable.actions.copy.tooltip_text")
             }}</q-tooltip>
           </q-btn>
+          <q-btn
+            flat
+            dense
+            icon="key"
+            v-if="getPK(token)"
+            @click="unlock(token)"
+            :aria-label="$t('LockedTokensTable.actions.unlock.tooltip_text')"
+            :title="$t('LockedTokensTable.actions.unlock.tooltip_text')"
+          >
+            <q-tooltip>{{
+              $t('LockedTokensTable.actions.unlock.tooltip_text')
+            }}</q-tooltip>
+          </q-btn>
         </q-item-section>
       </q-item>
     </q-list>
@@ -84,6 +97,7 @@ import { shortenString } from "src/js/string-utils";
 import { useLockedTokensStore } from "stores/lockedTokens";
 import { useMintsStore } from "stores/mints";
 import { nip19 } from "nostr-tools";
+import { useP2PKStore } from "stores/p2pk";
 
 export default defineComponent({
   name: "LockedTokensTable",
@@ -126,6 +140,20 @@ export default defineComponent({
       } catch (e) {
         return hex;
       }
+    },
+    getPK(token) {
+      try {
+        return useP2PKStore().getTokenPubkey(token.token);
+      } catch {
+        return token.pubkey;
+      }
+    },
+    async unlock(token) {
+      await useP2PKStore().redeemP2PKTokenInteractive({
+        id: token.id,
+        token: token.token,
+        bucketId: token.bucketId,
+      });
     },
   },
 });

--- a/src/stores/signer.ts
+++ b/src/stores/signer.ts
@@ -2,6 +2,11 @@ import { defineStore } from 'pinia';
 import { Dialog } from 'quasar';
 import MissingSignerModal from 'src/components/MissingSignerModal.vue';
 import { useWorkersStore } from './workers';
+import { decodeToken } from '@cashu/token';
+import { schnorr } from '@noble/secp256k1';
+import { sha256 } from '@noble/hashes/sha256';
+import { bytesToHex } from '@noble/hashes/utils';
+import { nip19 } from 'nostr-tools';
 import type { Proof } from '@cashu/cashu-ts';
 
 export type SignerMethod = 'local' | 'nip07' | 'nip46' | null;
@@ -36,6 +41,52 @@ export const useSignerStore = defineStore('signer', {
       }
       this.requesting = false;
       return signed;
+    },
+
+    async createP2PKWitness(tokenString: string): Promise<{ signatures: string[] } | null> {
+      const decoded = decodeToken(tokenString);
+      if (!decoded || !decoded.token?.length) return null;
+      const proofs = decoded.token[0].proofs;
+      if (!proofs?.length) return null;
+
+      const secrets = proofs
+        .map((p: any) => p.secret)
+        .filter((s: any) => typeof s === 'string');
+      if (!secrets.length) return null;
+
+      let method = this.method;
+      let signSchnorr: ((h: string) => Promise<string>) | undefined;
+      const loadSigner = () => {
+        if (method === 'local' && this.nsec) {
+          const key = nip19.decode(this.nsec).data as Uint8Array;
+          signSchnorr = async (h: string) => schnorr.sign(h, key);
+        } else if (method === 'nip07') {
+          signSchnorr = (window as any)?.nostr?.signSchnorr;
+        } else if (method === 'nip46') {
+          signSchnorr = (window as any)?.nostr?.signSchnorr;
+        }
+      };
+      loadSigner();
+      if (!signSchnorr) {
+        const dlg = Dialog.create({ component: MissingSignerModal });
+        const ok = await new Promise<boolean>((resolve) => {
+          dlg.onOk(() => resolve(true));
+          dlg.onCancel(() => resolve(false));
+          dlg.onDismiss(() => resolve(false));
+        });
+        if (!ok) return null;
+        method = this.method;
+        loadSigner();
+        if (!signSchnorr) return null;
+      }
+
+      const signatures: string[] = [];
+      for (const s of secrets) {
+        const h = sha256(new TextEncoder().encode(s));
+        const sig = await signSchnorr(bytesToHex(h));
+        signatures.push(sig);
+      }
+      return { signatures };
     },
   },
 });


### PR DESCRIPTION
## Summary
- support interactive P2PK token redemption
- expose witness creation in signer store
- show locked npubs and unlock button
- wire CreatorLockedTokensTable to new P2PK redemption flow
- add missing dependencies

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b220256d4833082a0f58ce9616032