### PR TITLE
Add getEncodedTokenV3 shim

### DIFF
--- a/quasar.config.js
+++ b/quasar.config.js
@@ -9,6 +9,7 @@
 // https://v2.quasar.dev/quasar-cli-vite/quasar-config-js
 
 const { configure } = require("quasar/wrappers");
+const path = require('path');
 
 module.exports = configure(function (/* ctx */) {
   return {
@@ -61,7 +62,15 @@ module.exports = configure(function (/* ctx */) {
       // polyfillModulePreload: true,
       // distDir
 
-      // extendViteConf (viteConf) {},
+      extendViteConf(viteConf) {
+        viteConf.resolve = viteConf.resolve || {};
+        const alias = viteConf.resolve.alias || [];
+        alias.push({
+          find: '@cashu/cashu-ts',
+          replacement: path.resolve(__dirname, 'src/compat/cashu-ts.ts'),
+        });
+        viteConf.resolve.alias = alias;
+      },
       // viteVuePluginOptions: {},
 
       // vitePlugins: [

--- a/src/compat/cashu-ts.ts
+++ b/src/compat/cashu-ts.ts
@@ -1,0 +1,7 @@
+export * from '@cashu/cashu-ts';
+import type { Token } from '@cashu/cashu-ts';
+import { getEncodedToken } from '@cashu/cashu-ts';
+
+export function getEncodedTokenV3(token: Token) {
+  return getEncodedToken(token, { version: 3 });
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
       "assets/*": ["src/assets/*"],
       "boot/*": ["src/boot/*"],
       "stores/*": ["src/stores/*"],
-      "vue$": ["node_modules/vue/dist/vue.runtime.esm-bundler.js"]
+      "vue$": ["node_modules/vue/dist/vue.runtime.esm-bundler.js"],
+      "@cashu/cashu-ts": ["src/compat/cashu-ts.ts"]
     }
   },
   "exclude": ["node_modules", "test"]

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -32,6 +32,7 @@ export default defineConfig({
       assets: path.resolve(__dirname, 'src/assets'),
       boot: path.resolve(__dirname, 'src/boot'),
       stores: path.resolve(__dirname, 'src/stores'),
+      '@cashu/cashu-ts': path.resolve(__dirname, 'src/compat/cashu-ts.ts'),
     },
   },
   plugins: [


### PR DESCRIPTION
## Summary
- shim getEncodedTokenV3 by wrapping cashu-ts
- alias @cashu/cashu-ts to our shim in Vite, Vitest and TypeScript config

## Testing
- `pnpm test` *(fails: Failed to resolve imports)*

------
https://chatgpt.com/codex/tasks/task_e_684c76f8c35483309ae0c6ffdf0c726a