### PR TITLE
Fix build error by pinning cashu-ts v2.0.0-rc3

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@capacitor/core": "^6.2.0",
     "@capacitor/haptics": "^6.0.2",
     "@capacitor/ios": "^6.0.0",
-    "@cashu/cashu-ts": "^2.0.0-rc3",
+    "@cashu/cashu-ts": "2.0.0-rc3",
     "@cashu/crypto": "^0.3.4",
     "@chenfengyuan/vue-qrcode": "^2.0.0",
     "@gandlaf21/bc-ur": "^1.1.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^6.0.0
         version: 6.2.1(@capacitor/core@6.2.1)
       '@cashu/cashu-ts':
-        specifier: ^2.0.0-rc3
-        version: 2.5.2
+        specifier: 2.0.0-rc3
+        version: 2.0.0-rc3
       '@cashu/crypto':
         specifier: ^0.3.4
         version: 0.3.4
@@ -737,8 +737,8 @@ packages:
     peerDependencies:
       '@capacitor/core': ^6.2.0
 
-  '@cashu/cashu-ts@2.5.2':
-    resolution: {integrity: sha512-AjfDOZKb3RWWhmpHABC4KJxwJs3wp6eOFg6U3S6d3QOqtSoNkceMTn6lLN4/bYQarLR19rysbrIJ8MHsSwNxeQ==}
+  '@cashu/cashu-ts@2.0.0-rc3':
+    resolution: {integrity: sha512-KXH3Zi9JZe5Ylc6PyfO2OxErjKzu7pwTudYQ/3tsunLmqaTQadtlf2JPTcpGOo/O2yLhleryx7l4JgoitWvgSw==}
 
   '@cashu/crypto@0.3.4':
     resolution: {integrity: sha512-mfv1Pj4iL1PXzUj9NKIJbmncCLMqYfnEDqh/OPxAX0nNBt6BOnVJJLjLWFlQeYxlnEfWABSNkrqPje1t5zcyhA==}
@@ -3247,7 +3247,6 @@ packages:
   esbuild-linux-64@0.15.18:
     resolution: {integrity: sha512-hNSeP97IviD7oxLKFuii5sDPJ+QHeiFTFLoLm7NZQligur8poNOWGIgpQ7Qf8Balb69hptMZzyOBIPtY09GZYw==}
     engines: {node: '>=12'}
-    cpu: [x64]
     os: [linux]
 
   esbuild-linux-arm64@0.14.51:
@@ -7427,8 +7426,9 @@ snapshots:
     dependencies:
       '@capacitor/core': 6.2.1
 
-  '@cashu/cashu-ts@2.5.2':
+  '@cashu/cashu-ts@2.0.0-rc3':
     dependencies:
+      '@cashu/crypto': 0.3.4
       '@noble/curves': 1.9.2
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
@@ -8502,7 +8502,7 @@ snapshots:
   '@scure/bip32@1.3.1':
     dependencies:
       '@noble/curves': 1.1.0
-      '@noble/hashes': 1.3.1
+      '@noble/hashes': 1.3.2
       '@scure/base': 1.1.1
 
   '@scure/bip32@1.7.0':
@@ -8513,7 +8513,7 @@ snapshots:
 
   '@scure/bip39@1.2.1':
     dependencies:
-      '@noble/hashes': 1.3.1
+      '@noble/hashes': 1.3.2
       '@scure/base': 1.1.1
 
   '@scure/bip39@1.6.0':


### PR DESCRIPTION
## Summary
- pin `@cashu/cashu-ts` to `2.0.0-rc3` in package.json and pnpm lock file

## Testing
- `pnpm test:ci` *(fails: Failed to resolve import "@noble/hashes/sha256"...)*

------
https://chatgpt.com/codex/tasks/task_e_684c7b4663908330b469966681c9ccce