### PR TITLE
Resolve Cashu-ts alias

### DIFF
--- a/quasar.config.js
+++ b/quasar.config.js
@@ -66,7 +66,7 @@ module.exports = configure(function (/* ctx */) {
         viteConf.resolve = viteConf.resolve || {};
         const alias = viteConf.resolve.alias || [];
         alias.push({
-          find: '@cashu/cashu-ts',
+          find: /^@cashu\/cashu-ts$/,
           replacement: path.resolve(__dirname, 'src/compat/cashu-ts.ts'),
         });
         viteConf.resolve.alias = alias;

--- a/src/compat/cashu-ts.ts
+++ b/src/compat/cashu-ts.ts
@@ -1,6 +1,8 @@
-export * from '@cashu/cashu-ts';
-import type { Token } from '@cashu/cashu-ts';
-import { getEncodedToken } from '@cashu/cashu-ts';
+// Re-export the package but add Cashu.me specific helpers.
+// Import from the real package path to avoid alias loops.
+export * from '@cashu/cashu-ts/dist/lib/es6/index.js';
+import type { Token } from '@cashu/cashu-ts/dist/lib/es6/index.js';
+import { getEncodedToken } from '@cashu/cashu-ts/dist/lib/es6/index.js';
 
 export function getEncodedTokenV3(token: Token) {
   return getEncodedToken(token, { version: 3 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,17 +23,17 @@ export default defineConfig({
     ],
   },
   resolve: {
-    alias: {
-      src: path.resolve(__dirname, 'src'),
-      app: path.resolve(__dirname),
-      components: path.resolve(__dirname, 'src/components'),
-      layouts: path.resolve(__dirname, 'src/layouts'),
-      pages: path.resolve(__dirname, 'src/pages'),
-      assets: path.resolve(__dirname, 'src/assets'),
-      boot: path.resolve(__dirname, 'src/boot'),
-      stores: path.resolve(__dirname, 'src/stores'),
-      '@cashu/cashu-ts': path.resolve(__dirname, 'src/compat/cashu-ts.ts'),
-    },
+    alias: [
+      { find: /^@cashu\/cashu-ts$/, replacement: path.resolve(__dirname, 'src/compat/cashu-ts.ts') },
+      { find: 'src', replacement: path.resolve(__dirname, 'src') },
+      { find: 'app', replacement: path.resolve(__dirname) },
+      { find: 'components', replacement: path.resolve(__dirname, 'src/components') },
+      { find: 'layouts', replacement: path.resolve(__dirname, 'src/layouts') },
+      { find: 'pages', replacement: path.resolve(__dirname, 'src/pages') },
+      { find: 'assets', replacement: path.resolve(__dirname, 'src/assets') },
+      { find: 'boot', replacement: path.resolve(__dirname, 'src/boot') },
+      { find: 'stores', replacement: path.resolve(__dirname, 'src/stores') },
+    ],
   },
   plugins: [
     vue({


### PR DESCRIPTION
## Summary
- update compatibility wrapper to import the real `@cashu/cashu-ts` package
- restrict alias in Quasar and Vitest configs so subpaths resolve to the original package

## Testing
- `pnpm install` *(fails: ignored build scripts)*
- `pnpm test` *(fails to run tests)*

------
https://chatgpt.com/codex/tasks/task_e_684c802ba3d48330bd8d5b5a1c8e4c35