### PR TITLE
Fix Cashu ts alias pre-bundling

### DIFF
--- a/quasar.config.js
+++ b/quasar.config.js
@@ -70,6 +70,13 @@ module.exports = configure(function (/* ctx */) {
           replacement: path.resolve(__dirname, 'src/compat/cashu-ts.ts'),
         });
         viteConf.resolve.alias = alias;
+
+        // Exclude the package from dependency pre-bundling so the alias takes effect
+        viteConf.optimizeDeps = viteConf.optimizeDeps || {};
+        viteConf.optimizeDeps.exclude = [
+          ...(viteConf.optimizeDeps.exclude || []),
+          '@cashu/cashu-ts',
+        ];
       },
       // viteVuePluginOptions: {},
 


### PR DESCRIPTION
## Summary
- disable Vite pre-bundling of `@cashu/cashu-ts` so the alias is used

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm test` *(fails: Failed to resolve imports)*

------
https://chatgpt.com/codex/tasks/task_e_684c8612f38c8330a8d858b36841916b