### PR TITLE
Remove invalid mapWritableState from methods

### DIFF
--- a/quasar.config.js
+++ b/quasar.config.js
@@ -64,12 +64,18 @@ module.exports = configure(function (/* ctx */) {
 
       extendViteConf(viteConf) {
         viteConf.resolve = viteConf.resolve || {};
-        const alias = viteConf.resolve.alias || [];
-        alias.push({
-          find: /^@cashu\/cashu-ts$/,
-          replacement: path.resolve(__dirname, 'src/compat/cashu-ts.ts'),
-        });
-        viteConf.resolve.alias = alias;
+        const replacement = path.resolve(__dirname, 'src/compat/cashu-ts.ts');
+        if (Array.isArray(viteConf.resolve.alias)) {
+          viteConf.resolve.alias.push({
+            find: /^@cashu\/cashu-ts$/,
+            replacement,
+          });
+        } else {
+          viteConf.resolve.alias = {
+            ...(viteConf.resolve.alias || {}),
+            '@cashu/cashu-ts': replacement,
+          };
+        }
 
         // Exclude the package from dependency pre-bundling so the alias takes effect
         viteConf.optimizeDeps = viteConf.optimizeDeps || {};

--- a/src/components/ReceiveEcashDrawer.vue
+++ b/src/components/ReceiveEcashDrawer.vue
@@ -220,10 +220,6 @@ export default defineComponent({
       "toggleScanner",
       "pasteToParseDialog",
     ]),
-    ...mapWritableState(useReceiveTokensStore, [
-      "showReceiveTokens",
-      "receiveData",
-    ]),
     isiOsSafari() {
       const userAgent = window.navigator.userAgent.toLowerCase();
       const match =


### PR DESCRIPTION
## Summary
- fix alias setup in `quasar.config.js` so dev server can run
- remove `mapWritableState` from the `methods` of `ReceiveEcashDrawer`

## Testing
- `npm run lint`
- `npm run test` *(fails: Failed to resolve import)*
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_684cf5e6ce98833089f798d78edde781