### PR TITLE
Fix alias normalization in extendViteConf

### DIFF
--- a/quasar.config.js
+++ b/quasar.config.js
@@ -64,18 +64,15 @@ module.exports = configure(function (/* ctx */) {
 
       extendViteConf(viteConf) {
         viteConf.resolve = viteConf.resolve || {};
-        const replacement = path.resolve(__dirname, 'src/compat/cashu-ts.ts');
-        if (Array.isArray(viteConf.resolve.alias)) {
-          viteConf.resolve.alias.push({
-            find: /^@cashu\/cashu-ts$/,
-            replacement,
-          });
-        } else {
-          viteConf.resolve.alias = {
-            ...(viteConf.resolve.alias || {}),
-            '@cashu/cashu-ts': replacement,
-          };
-        }
+        const current = viteConf.resolve.alias || [];
+        const aliasArray = Array.isArray(current)
+          ? current
+          : Object.entries(current).map(([find, replacement]) => ({ find, replacement }));
+        aliasArray.push({
+          find: /^@cashu\/cashu-ts$/,
+          replacement: path.resolve(__dirname, 'src/compat/cashu-ts.ts'),
+        });
+        viteConf.resolve.alias = aliasArray;
 
         // Exclude the package from dependency pre-bundling so the alias takes effect
         viteConf.optimizeDeps = viteConf.optimizeDeps || {};


### PR DESCRIPTION
## Summary
- normalize aliases in `extendViteConf` so both object and array formats work

## Testing
- `pnpm test` *(fails: Failed to resolve imports)*

------
https://chatgpt.com/codex/tasks/task_e_684cf7a444308330a19fe24092df6640