### PR TITLE
Add test for getEncodedTokenV3 helper

### DIFF
--- a/test/vitest/__tests__/getEncodedTokenV3.spec.ts
+++ b/test/vitest/__tests__/getEncodedTokenV3.spec.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest'
+import { getEncodedToken, getEncodedTokenV3 } from '@cashu/cashu-ts'
+import type { Token } from '@cashu/cashu-ts/dist/lib/es6/model/types/wallet/tokens'
+
+
+describe('getEncodedTokenV3', () => {
+  it('encodes to the same value as getEncodedToken(token, { version: 3 })', () => {
+    const token: Token = {
+      mint: 'https://example.com',
+      proofs: [{ id: '00', amount: 1, secret: 's', C: 'c' }],
+      unit: 'sat',
+      memo: 'test'
+    }
+    const expected = getEncodedToken(token, { version: 3 })
+    expect(getEncodedTokenV3(token)).toBe(expected)
+  })
+})


### PR DESCRIPTION
## Summary
- add vitest test for `getEncodedTokenV3`

## Testing
- `pnpm test` *(fails: Failed Suites 19)*

------
https://chatgpt.com/codex/tasks/task_e_684cfc0d4dbc8330909c6fd98700eaa9