### PR TITLE
Move token state mapping to computed

### DIFF
--- a/src/components/ReceiveEcashDrawer.vue
+++ b/src/components/ReceiveEcashDrawer.vue
@@ -220,10 +220,6 @@ export default defineComponent({
       "toggleScanner",
       "pasteToParseDialog",
     ]),
-    ...mapWritableState(useReceiveTokensStore, [
-      "showReceiveTokens",
-      "receiveData",
-    ]),
     isiOsSafari() {
       const userAgent = window.navigator.userAgent.toLowerCase();
       const match =


### PR DESCRIPTION
## Summary
- remove mapWritableState for receive tokens from methods
- rely on computed mapping instead

## Testing
- `npm test` *(fails: vitest could not run successfully)*

------
https://chatgpt.com/codex/tasks/task_e_684d0389e69c8330a88ebf11fb02fdc1