### PR TITLE
Fix vue-qrcode setup

### DIFF
--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -640,7 +640,7 @@
   </q-dialog>
 </template>
 <script lang="ts">
-import { defineComponent } from "vue";
+import { defineComponent, defineAsyncComponent } from "vue";
 import { debug } from "src/js/logger";
 import { useSendTokensStore } from "src/stores/sendTokensStore";
 import { useWalletStore } from "src/stores/wallet";
@@ -684,6 +684,10 @@ import {
 } from "src/js/notify.ts";
 import { Dialog } from "quasar";
 import { useDmChatsStore } from "src/stores/dmChats";
+
+const VueQrcode = defineAsyncComponent(
+  () => import("@chenfengyuan/vue-qrcode")
+);
 export default defineComponent({
   name: "SendTokenDialog",
   mixins: [windowMixin],
@@ -694,6 +698,7 @@ export default defineComponent({
     NumericKeyboard,
     ScanIcon,
     NfcIcon,
+    VueQrcode,
   },
   props: {},
   data: function () {


### PR DESCRIPTION
## Summary
- register `<vue-qrcode>` async component in SendTokenDialog

## Testing
- `npm run lint` *(fails: couldn't find eslint config)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d056b002083308e84b7fe2d0c5923