### PR TITLE
Fix MissingSignerModal dialogRef

### DIFF
--- a/src/components/MissingSignerModal.vue
+++ b/src/components/MissingSignerModal.vue
@@ -26,7 +26,8 @@ import { notifyError } from 'src/js/notify';
 
 const props = defineProps<{ dialogRef?: any }>();
 const emit = defineEmits(['ok', 'hide']);
-const dialogRef = props.dialogRef;
+// Ensure dialogRef is always a Vue ref to avoid warnings
+const dialogRef = props.dialogRef ?? ref(null);
 function onDialogHide() {
   emit('hide');
 }
@@ -47,16 +48,16 @@ function chooseLocal() {
   signer.method = 'local';
   signer.nsec = key;
   emit('ok');
-  dialogRef && dialogRef.hide();
+  dialogRef.value?.hide();
 }
 function chooseNip07() {
   signer.method = 'nip07';
   emit('ok');
-  dialogRef && dialogRef.hide();
+  dialogRef.value?.hide();
 }
 function chooseNip46() {
   signer.method = 'nip46';
   emit('ok');
-  dialogRef && dialogRef.hide();
+  dialogRef.value?.hide();
 }
 </script>


### PR DESCRIPTION
## Summary
- ensure `dialogRef` is always a Vue ref
- call `hide()` through the ref value

## Testing
- `npm install`
- `npx vitest run` *(fails: getActivePinia not set, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684d0a5c76ac8330b700fa27e9a43b10