### PR TITLE
Fix language fallback for 'en' locale

### DIFF
--- a/src/boot/i18n.js
+++ b/src/boot/i18n.js
@@ -3,8 +3,13 @@ import { createI18n } from "vue-i18n";
 import { loadMessages } from "src/i18n";
 
 // Get stored locale from localStorage or fallback to browser language or en-US
-const storedLocale =
+let storedLocale =
   localStorage.getItem("cashu.language") || navigator.language || "en-US";
+
+// Map generic English locale to en-US since no "en" folder exists
+if (storedLocale === "en") {
+  storedLocale = "en-US";
+}
 const messages = { "en-US": await loadMessages("en-US") };
 if (storedLocale !== "en-US") {
   messages[storedLocale] = await loadMessages(storedLocale);


### PR DESCRIPTION
## Summary
- map `navigator.language` value `en` to `en-US` during i18n boot

## Testing
- `npm test` *(fails: vitest not found)*
- `npx prettier --check src/boot/i18n.js`

------
https://chatgpt.com/codex/tasks/task_e_684d0b6b08708330ba194608a77bbee4