### PR TITLE
Fix lightning address notification text

### DIFF
--- a/src/stores/npubcash.ts
+++ b/src/stores/npubcash.ts
@@ -80,9 +80,10 @@ export const useNPCStore = defineStore("npc", {
         return;
       }
       const walletPublicKeyHex = nostrStore.pubkey;
-      notify(
-        "Lightning address for wallet:",
-        nip19.npubEncode(walletPublicKeyHex) + "@" + this.npcDomain
+      notifySuccess(
+        `Lightning address for wallet: ${
+          nip19.npubEncode(walletPublicKeyHex)
+        }@${this.npcDomain}`
       );
       this.baseURL = `https://${this.npcDomain}`;
       const previousAddress = this.npcAddress;


### PR DESCRIPTION
## Summary
- show lightning address as text in the NPC connection notification

## Testing
- `npm test` *(fails: getActivePinia not set)*

------
https://chatgpt.com/codex/tasks/task_e_684d12cffea08330a78a9dce362c005f