### PR TITLE
Map en locale to en‑US

### DIFF
--- a/src/boot/base.js
+++ b/src/boot/base.js
@@ -26,7 +26,8 @@ window.windowMixin = {
       this.$q.localStorage.set("cashu.theme", newValue);
     },
     changeLanguage: function (e) {
-      this.$q.localStorage.set("cashu.language", e.target.value);
+      const value = e.target.value === "en" ? "en-US" : e.target.value;
+      this.$q.localStorage.set("cashu.language", value);
     },
     toggleDarkMode: function () {
       this.$q.dark.toggle();
@@ -228,7 +229,7 @@ window.windowMixin = {
 
     const language = this.$q.localStorage.getItem("cashu.language");
     if (language) {
-      this.$i18n.locale = language;
+      this.$i18n.locale = language === "en" ? "en-US" : language;
     }
 
     // only for iOS

--- a/src/components/SettingsView.vue
+++ b/src/components/SettingsView.vue
@@ -2086,6 +2086,9 @@ export default defineComponent({
       );
     },
     changeLanguage(locale) {
+      if (locale === "en") {
+        locale = "en-US";
+      }
       // Set the i18n locale
       this.$i18n.locale = locale;
 
@@ -2102,7 +2105,8 @@ export default defineComponent({
     this.nip07SignerAvailable = await this.checkNip07Signer();
     debug("Nip07 signer available", this.nip07SignerAvailable);
     // Set the initial selected language based on the current locale
-    this.selectedLanguage = this.$i18n.locale;
+    const currentLocale = this.$i18n.locale === "en" ? "en-US" : this.$i18n.locale;
+    this.selectedLanguage = currentLocale;
   },
 });
 </script>

--- a/src/pages/WelcomePage.vue
+++ b/src/pages/WelcomePage.vue
@@ -111,6 +111,9 @@ export default {
   },
   methods: {
     changeLanguage(locale) {
+      if (locale === "en") {
+        locale = "en-US";
+      }
       // Set the i18n locale
       this.$i18n.locale = locale;
 
@@ -120,11 +123,9 @@ export default {
   },
   created() {
     // Set the initial selected language based on the current locale or from storage
-    this.selectedLanguage =
-      localStorage.getItem("cashu.language") ||
-      this.$i18n.locale ||
-      navigator.language ||
-      "en-US";
+    const stored = localStorage.getItem("cashu.language");
+    const initLocale = stored || this.$i18n.locale || navigator.language || "en-US";
+    this.selectedLanguage = initLocale === "en" ? "en-US" : initLocale;
   },
   setup() {
     const welcomeStore = useWelcomeStore();


### PR DESCRIPTION
## Summary
- normalize English locale selection to use `en-US`
- update SettingsView, WelcomePage and base boot script

## Testing
- `npm test` *(fails: Cannot set property permissions of [object Object] which has only a getter)*

------
https://chatgpt.com/codex/tasks/task_e_684d144af1c883309bd056538ff09bc8