### PR TITLE
Improve mutex lock handling

### DIFF
--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -45,7 +45,8 @@ export const useUiStore = defineStore("ui", {
       this.showReceiveEcashDrawer = false;
     },
     async lockMutex() {
-      const nRetries = 10;
+      // allow longer operations to finish by waiting up to 30s
+      const nRetries = 60;
       const retryInterval = 500;
       let retries = 0;
 

--- a/src/stores/workers.ts
+++ b/src/stores/workers.ts
@@ -132,7 +132,11 @@ export const useWorkersStore = defineStore("workers", {
             this.clearAllWorkers();
             sendTokensStore.showSendTokens = false;
           }
-        } catch (error) {
+        } catch (error: any) {
+          if (error?.message?.includes("Failed to acquire global mutex lock")) {
+            debug("checkTokenSpendableWorker: mutex locked, retrying later");
+            return;
+          }
           debug("checkTokenSpendableWorker: some error", error);
           this.clearAllWorkers();
         }


### PR DESCRIPTION
## Summary
- increase allowed wait time for acquiring the global mutex
- skip worker cancellation when the mutex is still locked

## Testing
- `npm test` *(fails: vitest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684d16a8bf30833084abb5c0058991b1