### PR TITLE
Ensure mutex release

### DIFF
--- a/src/stores/mints.ts
+++ b/src/stores/mints.ts
@@ -376,24 +376,27 @@ export const useMintsStore = defineStore("mints", {
       }
       const uIStore = useUiStore();
       await uIStore.lockMutex();
-      const mint = this.mints.find((m) => m.url === this.activeMintUrl);
-      if (!mint) {
-        notifyError(
-          this.t("wallet.mint.notifications.no_active_mint"),
-          this.t("wallet.mint.notifications.unit_activation_failed")
-        );
-        return;
+      try {
+        const mint = this.mints.find((m) => m.url === this.activeMintUrl);
+        if (!mint) {
+          notifyError(
+            this.t("wallet.mint.notifications.no_active_mint"),
+            this.t("wallet.mint.notifications.unit_activation_failed")
+          );
+          return;
+        }
+        const mintClass = new MintClass(mint);
+        if (mintClass.units.includes(unit)) {
+          this.activeUnit = unit;
+        } else {
+          notifyError(
+            this.t("wallet.mint.notifications.unit_not_supported"),
+            this.t("wallet.mint.notifications.unit_activation_failed")
+          );
+        }
+      } finally {
+        await uIStore.unlockMutex();
       }
-      const mintClass = new MintClass(mint);
-      if (mintClass.units.includes(unit)) {
-        this.activeUnit = unit;
-      } else {
-        notifyError(
-          this.t("wallet.mint.notifications.unit_not_supported"),
-          this.t("wallet.mint.notifications.unit_activation_failed")
-        );
-      }
-      await uIStore.unlockMutex();
       const worker = useWorkersStore();
       worker.clearAllWorkers();
     },

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -45,6 +45,7 @@ export const useUiStore = defineStore("ui", {
       this.showReceiveEcashDrawer = false;
     },
     async lockMutex() {
+      debug("Attempting to acquire global mutex lock");
       // allow longer operations to finish by waiting up to 30s
       const nRetries = 60;
       const retryInterval = 500;
@@ -60,9 +61,11 @@ export const useUiStore = defineStore("ui", {
       }
 
       this.globalMutexLock = true;
+      debug("Global mutex lock acquired");
     },
     unlockMutex() {
       this.globalMutexLock = false;
+      debug("Global mutex lock released");
     },
     triggerActivityOrb() {
       this.activityOrb = true;


### PR DESCRIPTION
## Summary
- wrap `activateUnit` with try/finally when using the UI mutex
- log acquiring and releasing the mutex

## Testing
- `npm test` *(fails: getActivePinia was called but there was no active Pinia, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684d5792b16c8330a121b17b8a0e3325