### PR TITLE
Improve token redemption logging

### DIFF
--- a/src/stores/lockedTokensRedeemWorker.ts
+++ b/src/stores/lockedTokensRedeemWorker.ts
@@ -66,7 +66,10 @@ export const useLockedTokensRedeemWorker = defineStore(
               !mint ||
               !proofs.every((p) => mint.keysets.some((k) => k.id === p.id))
             ) {
-              console.error("Mint or keyset mismatch for locked token", entry.id);
+              console.error(
+                "Mint or keyset mismatch for locked token",
+                entry.id
+              );
               await cashuDb.lockedTokens.delete(entry.id);
               continue;
             }

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -614,6 +614,9 @@ export const useWalletStore = defineStore("wallet", {
       if (!mint) {
         throw new Error("mint not found");
       }
+      if (!proofs.every((p) => mint.keysets.some((k) => k.id === p.id))) {
+        throw new Error("Keyset mismatch for token proofs");
+      }
       await uIStore.lockMutex();
       try {
         // redeem
@@ -666,6 +669,8 @@ export const useWalletStore = defineStore("wallet", {
               proofs,
             })
           : receiveStore.receiveData.tokensBase64;
+
+        debug("redeem: sending proofs", proofs);
 
         let receivedProofs: Proof[];
         try {


### PR DESCRIPTION
## Summary
- add debug log when redeeming in wallet store
- verify locked token mint/keyset before redeeming and log proofs

## Testing
- `npm test` *(fails: getActivePinia errors)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684d58c18700833096c970effb2b7b93