### PR TITLE
Add missing NIP-07 signing extension message

### DIFF
--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -1348,6 +1348,13 @@ export default {
     invalid_swap_data_error_text: "بيانات تبديل غير صالحة",
     swap_error_text: "خطأ في التبديل",
   },
+  settings: {
+    nostr: {
+      signing_extension: {
+        not_found: "لم يتم العثور على ملحق التوقيع NIP-07",
+      },
+    },
+  },
   SubscriptionsOverview: {
     export_csv: "Export CSV",
     filter: {

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -1354,6 +1354,13 @@ export default {
     invalid_swap_data_error_text: "Ungültige Swap-Daten",
     swap_error_text: "Fehler beim Tauschen",
   },
+  settings: {
+    nostr: {
+      signing_extension: {
+        not_found: "Keine NIP-07 Signaturerweiterung gefunden",
+      },
+    },
+  },
   SubscriptionsOverview: {
     export_csv: "Export CSV",
     filter: {

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -1358,6 +1358,13 @@ export default {
     invalid_swap_data_error_text: "Μη έγκυρα δεδομένα ανταλλαγής",
     swap_error_text: "Σφάλμα κατά την ανταλλαγή",
   },
+  settings: {
+    nostr: {
+      signing_extension: {
+        not_found: "Δεν βρέθηκε επέκταση υπογραφής NIP-07",
+      },
+    },
+  },
   SubscriptionsOverview: {
     export_csv: "Export CSV",
     filter: {

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1599,4 +1599,11 @@ export default {
     invalid_swap_data_error_text: "Invalid swap data",
     swap_error_text: "Error swapping",
   },
+  settings: {
+    nostr: {
+      signing_extension: {
+        not_found: "No NIP-07 signing extension found",
+      },
+    },
+  },
 };

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -1355,6 +1355,13 @@ export default {
     invalid_swap_data_error_text: "Datos de intercambio inválidos",
     swap_error_text: "Error al intercambiar",
   },
+  settings: {
+    nostr: {
+      signing_extension: {
+        not_found: "No se encontró ninguna extensión de firma NIP-07",
+      },
+    },
+  },
   SubscriptionsOverview: {
     export_csv: "Export CSV",
     filter: {

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -1345,6 +1345,13 @@ export default {
     invalid_swap_data_error_text: "Données d'échange invalides",
     swap_error_text: "Erreur lors de l'échange",
   },
+  settings: {
+    nostr: {
+      signing_extension: {
+        not_found: "Aucune extension de signature NIP-07 trouvée",
+      },
+    },
+  },
   SubscriptionsOverview: {
     export_csv: "Export CSV",
     filter: {

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -1337,6 +1337,13 @@ export default {
     invalid_swap_data_error_text: "Dati di scambio non validi",
     swap_error_text: "Errore durante lo scambio",
   },
+  settings: {
+    nostr: {
+      signing_extension: {
+        not_found: "Nessuna estensione di firma NIP-07 trovata",
+      },
+    },
+  },
   SubscriptionsOverview: {
     export_csv: "Export CSV",
     filter: {

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -1338,6 +1338,13 @@ export default {
     invalid_swap_data_error_text: "無効なスワップデータ",
     swap_error_text: "スワップエラー",
   },
+  settings: {
+    nostr: {
+      signing_extension: {
+        not_found: "NIP-07署名拡張機能が見つかりません",
+      },
+    },
+  },
   SubscriptionsOverview: {
     export_csv: "Export CSV",
     filter: {

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -1337,6 +1337,13 @@ export default {
     invalid_swap_data_error_text: "Ogiltig bytesdata",
     swap_error_text: "Fel vid byte",
   },
+  settings: {
+    nostr: {
+      signing_extension: {
+        not_found: "Ingen NIP-07 signeringsutökning hittades",
+      },
+    },
+  },
   SubscriptionsOverview: {
     export_csv: "Export CSV",
     filter: {

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -1335,6 +1335,13 @@ export default {
     invalid_swap_data_error_text: "ข้อมูลการแลกเปลี่ยนไม่ถูกต้อง",
     swap_error_text: "ข้อผิดพลาดในการแลกเปลี่ยน",
   },
+  settings: {
+    nostr: {
+      signing_extension: {
+        not_found: "ไม่พบส่วนขยายการลงนาม NIP-07",
+      },
+    },
+  },
   SubscriptionsOverview: {
     export_csv: "Export CSV",
     filter: {

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -1340,6 +1340,13 @@ export default {
     invalid_swap_data_error_text: "Geçersiz takas verisi",
     swap_error_text: "Takas hatası",
   },
+  settings: {
+    nostr: {
+      signing_extension: {
+        not_found: "NIP-07 imzalama uzantısı bulunamadı",
+      },
+    },
+  },
   SubscriptionsOverview: {
     export_csv: "Export CSV",
     filter: {

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -1327,6 +1327,13 @@ export default {
     invalid_swap_data_error_text: "无效的兑换数据",
     swap_error_text: "兑换错误",
   },
+  settings: {
+    nostr: {
+      signing_extension: {
+        not_found: "未找到 NIP-07 签名扩展",
+      },
+    },
+  },
   SubscriptionsOverview: {
     export_csv: "Export CSV",
     filter: {


### PR DESCRIPTION
## Summary
- add `settings.nostr.signing_extension.not_found` message in all locales

## Testing
- `npm test` *(fails: Cannot set property permissions of [object Object]...)*

------
https://chatgpt.com/codex/tasks/task_e_684d5cd19ec083308f5bf87849b6136a