### PR TITLE
Fix i18n calls

### DIFF
--- a/src/boot/base.js
+++ b/src/boot/base.js
@@ -2,6 +2,7 @@ import { copyToClipboard } from "quasar";
 import { useUiStore } from "stores/ui";
 import { Clipboard } from "@capacitor/clipboard";
 import { SafeArea } from "capacitor-plugin-safe-area";
+import { i18n } from "./i18n";
 
 window.LOCALE = "en";
 // window.EventHub = new Vue();
@@ -35,12 +36,11 @@ window.windowMixin = {
     },
     copyText: function (text, message, position) {
       let notify = this.$q.notify;
-      let i18n = this.$i18n;
       copyToClipboard(text).then(function () {
         notify({
           message:
             message ||
-            (i18n && i18n.t("global.copy_to_clipboard.success")) ||
+            i18n.global.t("global.copy_to_clipboard.success") ||
             "Copied to clipboard!",
           position: position || "bottom",
         });
@@ -229,7 +229,7 @@ window.windowMixin = {
 
     const language = this.$q.localStorage.getItem("cashu.language");
     if (language) {
-      this.$i18n.locale = language === "en" ? "en-US" : language;
+      i18n.global.locale = language === "en" ? "en-US" : language;
     }
 
     // only for iOS

--- a/src/components/HistoryTable.vue
+++ b/src/components/HistoryTable.vue
@@ -263,7 +263,7 @@ export default defineComponent({
     },
     showTokenDialog: function (historyToken) {
       if (historyToken.token === undefined) {
-        notify(this.$i18n.t("HistoryTable.old_token_not_found_error_text"));
+        notify(this.$t("HistoryTable.old_token_not_found_error_text"));
         return;
       }
       const tokensBase64 = historyToken.token;

--- a/src/components/MintDetailsDialog.vue
+++ b/src/components/MintDetailsDialog.vue
@@ -474,7 +474,7 @@ export default defineComponent({
     copyText(text) {
       navigator.clipboard.writeText(text);
       this.$q.notify({
-        message: this.$i18n.t("global.copy_to_clipboard.success"),
+        message: this.$t("global.copy_to_clipboard.success"),
         color: "positive",
         position: "top",
         timeout: 1000,

--- a/src/components/MintSettings.vue
+++ b/src/components/MintSettings.vue
@@ -605,7 +605,7 @@ export default defineComponent({
       }
       if (!this.validateMintUrl(this.addMintData.url)) {
         notifyError(
-          this.$i18n.t("MintSettings.add.actions.add_mint.error_invalid_url")
+          this.$t("MintSettings.add.actions.add_mint.error_invalid_url")
         );
         return;
       }
@@ -670,11 +670,11 @@ export default defineComponent({
       }
       if (mintUrls.length == 0) {
         this.notifyError(
-          this.$i18n.t("MintSettings.discover.actions.discover.error_no_mints")
+          this.$t("MintSettings.discover.actions.discover.error_no_mints")
         );
       } else {
         this.notifySuccess(
-          this.$i18n.t("MintSettings.discover.actions.discover.success", {
+          this.$t("MintSettings.discover.actions.discover.success", {
             length: mintUrls.length,
           })
         );

--- a/src/components/NumericKeyboard.vue
+++ b/src/components/NumericKeyboard.vue
@@ -84,7 +84,7 @@ export default defineComponent({
       this.useNumericKeyboard = false;
       this.showNumericKeyboard = false;
       notify(
-        this.$i18n.t("NumericKeyboard.actions.close.closed_info_text"),
+        this.$t("NumericKeyboard.actions.close.closed_info_text"),
         "bottom"
       );
     },

--- a/src/components/PaymentRequestDialog.vue
+++ b/src/components/PaymentRequestDialog.vue
@@ -136,7 +136,7 @@ export default defineComponent({
     ToggleUnit,
   },
   data() {
-    const amountLabelDefault = this.$i18n.t(
+    const amountLabelDefault = this.$t(
       "PaymentRequestDialog.actions.add_amount.label"
     );
     return {
@@ -145,7 +145,7 @@ export default defineComponent({
       amountInputValue: "",
       amountLabelDefault,
       amountLabel: amountLabelDefault,
-      defaultAnyMint: this.$i18n.t(
+      defaultAnyMint: this.$t(
         "PaymentRequestDialog.actions.use_active_mint.label"
       ),
       chosenMintUrl: undefined,

--- a/src/components/ReceiveDialog.vue
+++ b/src/components/ReceiveDialog.vue
@@ -187,7 +187,7 @@ export default defineComponent({
     showInvoiceCreateDialog: async function () {
       if (!this.canReceivePayments) {
         notifyWarning(
-          this.$i18n.t("ReceiveDialog.actions.lightning.error_no_mints")
+          this.$t("ReceiveDialog.actions.lightning.error_no_mints")
         );
         this.showReceiveDialog = false;
         return;

--- a/src/components/ReceiveTokenDialog.vue
+++ b/src/components/ReceiveTokenDialog.vue
@@ -569,9 +569,9 @@ export default defineComponent({
     addPendingTokenToHistory: function (tokenStr) {
       if (this.tokenAlreadyInHistory(tokenStr)) {
         this.notifySuccess(
-        this.$t(
-          "ReceiveTokenDialog.actions.later.already_in_history_success_text"
-        )
+          this.$t(
+            "ReceiveTokenDialog.actions.later.already_in_history_success_text"
+          )
         );
         this.showReceiveTokens = false;
         return;

--- a/src/components/ReceiveTokenDialog.vue
+++ b/src/components/ReceiveTokenDialog.vue
@@ -569,9 +569,9 @@ export default defineComponent({
     addPendingTokenToHistory: function (tokenStr) {
       if (this.tokenAlreadyInHistory(tokenStr)) {
         this.notifySuccess(
-          this.$i18n.t(
-            "ReceiveTokenDialog.actions.later.already_in_history_success_text"
-          )
+        this.$t(
+          "ReceiveTokenDialog.actions.later.already_in_history_success_text"
+        )
         );
         this.showReceiveTokens = false;
         return;
@@ -597,7 +597,7 @@ export default defineComponent({
       this.showReceiveTokens = false;
       // show success notification
       this.notifySuccess(
-        this.$i18n.t(
+        this.$t(
           "ReceiveTokenDialog.actions.later.added_to_history_success_text"
         )
       );

--- a/src/components/RestoreView.vue
+++ b/src/components/RestoreView.vue
@@ -186,7 +186,7 @@ export default defineComponent({
   data() {
     return {
       mnemonicError: "",
-      restoreAllMintsText: this.$i18n.t(
+      restoreAllMintsText: this.$t(
         "RestoreView.actions.restore_all_mints.label"
       ),
     };
@@ -221,7 +221,7 @@ export default defineComponent({
       // Simple validation: check if mnemonicToRestore has at least 12 words
       const words = this.mnemonicToRestore.trim().split(/\s+/);
       if (words.length < 12) {
-        this.mnemonicError = this.$i18n.t("RestoreView.actions.validate.error");
+        this.mnemonicError = this.$t("RestoreView.actions.validate.error");
         return false;
       }
       this.mnemonicError = "";
@@ -232,19 +232,19 @@ export default defineComponent({
         return;
       }
       try {
-        this.restoreAllMintsText = this.$i18n.t(
+        this.restoreAllMintsText = this.$t(
           "RestoreView.actions.restore.in_progress"
         );
         await this.restoreMint(mintUrl);
       } catch (error) {
         console.error("Error restoring mint:", error);
         notifyError(
-          this.$i18n.t("RestoreView.actions.restore.error", {
+          this.$t("RestoreView.actions.restore.error", {
             error: error.message || error,
           })
         );
       } finally {
-        this.restoreAllMintsText = this.$i18n.t(
+        this.restoreAllMintsText = this.$t(
           "RestoreView.actions.restore_all_mints.label"
         );
       }
@@ -254,7 +254,7 @@ export default defineComponent({
         const text = await this.pasteFromClipboard();
         this.mnemonicToRestore = text.trim();
       } catch (error) {
-        notifyError(this.$i18n.t("RestoreView.actions.paste.error"));
+        notifyError(this.$t("RestoreView.actions.paste.error"));
       }
     },
     async restoreAllMints() {
@@ -264,7 +264,7 @@ export default defineComponent({
       }
       try {
         for (const mint of this.mints) {
-          this.restoreAllMintsText = this.$i18n.t(
+          this.restoreAllMintsText = this.$t(
             "RestoreView.actions.restore_all_mints.in_progress",
             {
               index: ++i,
@@ -274,17 +274,17 @@ export default defineComponent({
           await this.restoreMint(mint.url);
         }
         notifySuccess(
-          this.$i18n.t("RestoreView.actions.restore_all_mints.success")
+          this.$t("RestoreView.actions.restore_all_mints.success")
         );
       } catch (error) {
         console.error("Error restoring mints:", error);
         notifyError(
-          this.$i18n.t("RestoreView.actions.restore_all_mints.error", {
+          this.$t("RestoreView.actions.restore_all_mints.error", {
             error: error.message || error,
           })
         );
       } finally {
-        this.restoreAllMintsText = this.$i18n.t(
+        this.restoreAllMintsText = this.$t(
           "RestoreView.actions.restore_all_mints.label"
         );
       }

--- a/src/components/RestoreView.vue
+++ b/src/components/RestoreView.vue
@@ -273,9 +273,7 @@ export default defineComponent({
           );
           await this.restoreMint(mint.url);
         }
-        notifySuccess(
-          this.$t("RestoreView.actions.restore_all_mints.success")
-        );
+        notifySuccess(this.$t("RestoreView.actions.restore_all_mints.success"));
       } catch (error) {
         console.error("Error restoring mints:", error);
         notifyError(

--- a/src/components/SendDialog.vue
+++ b/src/components/SendDialog.vue
@@ -155,7 +155,7 @@ export default defineComponent({
     showParseDialog: function () {
       if (!this.canMakePayments) {
         notifyWarning(
-          this.$i18n.t("SendDialog.actions.lightning.error_no_mints")
+          this.$t("SendDialog.actions.lightning.error_no_mints")
         );
         this.showSendDialog = false;
         return;
@@ -174,7 +174,7 @@ export default defineComponent({
     showSendTokensDialog: function () {
       debug("##### showSendTokensDialog");
       if (!this.canMakePayments) {
-        notifyWarning(this.$i18n.t("SendDialog.actions.ecash.error_no_mints"));
+        notifyWarning(this.$t("SendDialog.actions.ecash.error_no_mints"));
         this.showSendDialog = false;
         return;
       }

--- a/src/components/SendDialog.vue
+++ b/src/components/SendDialog.vue
@@ -154,9 +154,7 @@ export default defineComponent({
     ...mapActions(useCameraStore, ["closeCamera", "showCamera"]),
     showParseDialog: function () {
       if (!this.canMakePayments) {
-        notifyWarning(
-          this.$t("SendDialog.actions.lightning.error_no_mints")
-        );
+        notifyWarning(this.$t("SendDialog.actions.lightning.error_no_mints"));
         this.showSendDialog = false;
         return;
       }

--- a/src/components/SettingsView.vue
+++ b/src/components/SettingsView.vue
@@ -1774,6 +1774,7 @@ import { useReceiveTokensStore } from "../stores/receiveTokensStore";
 import { useWelcomeStore } from "src/stores/welcome";
 import { useStorageStore } from "src/stores/storage";
 import { useI18n } from "vue-i18n";
+import { i18n } from "src/boot/i18n";
 
 export default defineComponent({
   name: "SettingsView",
@@ -2092,7 +2093,7 @@ export default defineComponent({
         locale = "en-US";
       }
       // Set the i18n locale
-      this.$i18n.locale = locale;
+      i18n.global.locale = locale;
 
       // Store the selected language in localStorage
       localStorage.setItem("cashu.language", locale);
@@ -2108,7 +2109,7 @@ export default defineComponent({
     debug("Nip07 signer available", this.nip07SignerAvailable);
     // Set the initial selected language based on the current locale
     const currentLocale =
-      this.$i18n.locale === "en" ? "en-US" : this.$i18n.locale;
+      i18n.global.locale === "en" ? "en-US" : i18n.global.locale;
     this.selectedLanguage = currentLocale;
   },
 });

--- a/src/pages/WelcomePage.vue
+++ b/src/pages/WelcomePage.vue
@@ -81,6 +81,7 @@ import WelcomeSlidePrivacy from "./welcome/WelcomeSlidePrivacy.vue";
 import WelcomeSlideMints from "./welcome/WelcomeSlideMints.vue";
 import WelcomeSlideProofs from "./welcome/WelcomeSlideProofs.vue";
 import WelcomeSlideBuckets from "./welcome/WelcomeSlideBuckets.vue";
+import { i18n } from "../boot/i18n";
 
 export default {
   name: "WelcomePage",
@@ -115,7 +116,7 @@ export default {
         locale = "en-US";
       }
       // Set the i18n locale
-      this.$i18n.locale = locale;
+      i18n.global.locale = locale;
 
       // Store the selected language in localStorage
       localStorage.setItem("cashu.language", locale);
@@ -125,7 +126,7 @@ export default {
     // Set the initial selected language based on the current locale or from storage
     const stored = localStorage.getItem("cashu.language");
     const initLocale =
-      stored || this.$i18n.locale || navigator.language || "en-US";
+      stored || i18n.global.locale || navigator.language || "en-US";
     this.selectedLanguage = initLocale === "en" ? "en-US" : initLocale;
   },
   setup() {


### PR DESCRIPTION
## Summary
- access i18n using `$t` or the exported instance
- clean up mint settings messages
- update restore and receive dialogs
- update numeric keyboard and history table
- fix locale handling in settings and welcome pages
- use global i18n instance inside boot

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.js)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684db22131fc8330bd997335726b4913