### PR TITLE
Update locked token redeem

### DIFF
--- a/src/stores/lockedTokensRedeemWorker.ts
+++ b/src/stores/lockedTokensRedeemWorker.ts
@@ -7,6 +7,7 @@ import { useMintsStore } from "./mints";
 import token from "src/js/token";
 import { ensureCompressed } from "src/utils/ecash";
 import { debug } from "src/js/logger";
+import { getEncodedToken } from "@cashu/cashu-ts";
 
 export const useLockedTokensRedeemWorker = defineStore(
   "lockedTokensRedeemWorker",
@@ -91,7 +92,12 @@ export const useLockedTokensRedeemWorker = defineStore(
                 p.secret = JSON.stringify(s);
               }
             });
-            receiveStore.receiveData.tokensBase64 = entry.tokenString;
+            const normalized = getEncodedToken({
+              mint: mintUrl,
+              unit,
+              proofs: decoded.proofs,
+            });
+            receiveStore.receiveData.tokensBase64 = normalized;
             receiveStore.receiveData.bucketId = entry.tierId;
             debug("locked token redeem: sending proofs", proofs);
             try {


### PR DESCRIPTION
## Summary
- reconstruct locked token base64 data using `getEncodedToken`
- normalize each proof's secret before redeeming

## Testing
- `npm test` *(fails: Cannot set property permissions of [object Object] which has only a getter)*

------
https://chatgpt.com/codex/tasks/task_e_684e4ca7e8488330b85a45862c9f45bb