### PR TITLE
Fix reload mutex handling

### DIFF
--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -364,7 +364,7 @@ export default defineComponent({
       return location.host.includes("staging");
     };
 
-    const reload = () => {
+    const reload = async () => {
       if (countdown.value > 0) {
         try {
           clearInterval(countdownInterval);
@@ -375,7 +375,7 @@ export default defineComponent({
         return;
       }
       if (uiStore.globalMutexLock) return;
-      uiStore.lockMutex();
+      await uiStore.lockMutex();
       countdown.value = 3;
       countdownInterval = setInterval(() => {
         countdown.value--;


### PR DESCRIPTION
## Summary
- await mutex acquisition before starting reload countdown in MainHeader

## Testing
- `npm test` *(fails: Cannot set property permissions of [object Object])*

------
https://chatgpt.com/codex/tasks/task_e_684e542247c48330ae3750a9a0b706c3