### PR TITLE
Fix repeated logged errors when redeeming invalid tokens

### DIFF
--- a/src/stores/lockedTokensRedeemWorker.ts
+++ b/src/stores/lockedTokensRedeemWorker.ts
@@ -113,7 +113,19 @@ export const useLockedTokensRedeemWorker = defineStore(
                   tokenId: entry.id,
                 });
               } else {
-                throw err;
+                if (
+                  typeof err?.message === "string" &&
+                  err.message.includes("proofs could not be verified")
+                ) {
+                  console.error(
+                    "Removing invalid locked token",
+                    entry.id,
+                    err.message
+                  );
+                  await cashuDb.lockedTokens.delete(entry.id);
+                } else {
+                  throw err;
+                }
               }
             }
           } catch (e) {


### PR DESCRIPTION
## Summary
- handle invalid proofs in the locked token redeem worker
- remove offending tokens instead of rethrowing

## Testing
- `npx --yes vitest run` *(fails: Cannot find module 'vitest/config')*

------
https://chatgpt.com/codex/tasks/task_e_684e56c76b28833082112e34a1e53444