### PR TITLE
Fix P2PK signing check

### DIFF
--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -241,11 +241,12 @@ export const useWalletStore = defineStore("wallet", {
       }
     },
     signP2PKIfNeeded: function <T extends Proof>(proofs: T[]): T[] {
-      if (
-        !proofs.some(
-          (p) => typeof p.secret === "string" && p.secret.startsWith("P2PK:")
-        )
-      ) {
+      const needsSignature = proofs.some(
+        (p) =>
+          typeof p.secret === "string" &&
+          (p.secret.startsWith("P2PK:") || p.secret.startsWith('["P2PK"'))
+      );
+      if (!needsSignature) {
         return proofs;
       }
       const privKey = useNostrStore().privKeyHex;


### PR DESCRIPTION
## Summary
- handle JSON-based P2PK secret format in `signP2PKIfNeeded`

## Testing
- `npm test` *(fails: Cannot set property permissions of [object Object]; many tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_684e7115f1b88330989977eced290d24