### PR TITLE
Fix remote signing for P2PK colon prefix

### DIFF
--- a/src/stores/workers.ts
+++ b/src/stores/workers.ts
@@ -95,7 +95,10 @@ export const useWorkersStore = defineStore("workers", {
 
       return Promise.all(
         proofs.map(async (p) => {
-          if (typeof p.secret === "string" && p.secret.startsWith('["P2PK"')) {
+          if (
+            typeof p.secret === "string" &&
+            (p.secret.startsWith('["P2PK"') || p.secret.startsWith("P2PK:"))
+          ) {
             const h = sha256(new TextEncoder().encode(p.secret));
             const sig = await signSchnorr(bytesToHex(h));
             return { ...p, witness: { signatures: [sig] } } as Proof;


### PR DESCRIPTION
## Summary
- handle tokens that use the `P2PK:` prefix in `signWithRemote`

## Testing
- `npm run test:ci` *(fails: getActivePinia() was called but there was no active Pinia, plus other suite failures)*

------
https://chatgpt.com/codex/tasks/task_e_684e73fe1e1c8330addb4b325cf80da3