### PR TITLE
Set axios timeout for Cashu

### DIFF
--- a/src/boot/cashu.js
+++ b/src/boot/cashu.js
@@ -1,11 +1,11 @@
-/**
- * Configures the Cashu-ts library axios client
- */
-// import { setupAxios } from "@cashu/cashu-ts";
+// src/boot/cashu.js
+// Quasar boot file that configures axios used by @cashu/cashu-ts.
+// Runs once on app start.
 
-// export default () => {
-//   setupAxios({
-//     // Default timeout for any interaction using the cashu-ts library to interact with a mint
-//     timeout: 15 * 1000, // 15 seconds
-//   });
-// };
+import { boot } from 'quasar/wrappers';
+import { setupAxios } from '@cashu/cashu-ts';
+
+export default boot(() => {
+  // 15-second network timeout for all Cashu mint requests.
+  setupAxios({ timeout: 15_000 });
+});


### PR DESCRIPTION
## Summary
- configure `setupAxios` with 15s timeout in boot file

## Testing
- `npm test` *(fails: getActivePinia error during vitest run)*

------
https://chatgpt.com/codex/tasks/task_e_684e84a0a4b883308e6b0c7063fe4fc7