### PR TITLE
Add 15s timeout for Cashu mint requests

### DIFF
--- a/src/boot/cashu.js
+++ b/src/boot/cashu.js
@@ -1,11 +1,11 @@
-/**
- * Configures the Cashu-ts library axios client
- */
-// import { setupAxios } from "@cashu/cashu-ts";
+// src/boot/cashu.js
+// Quasar boot file that configures axios used by @cashu/cashu-ts.
+// Runs once on app start.
 
-// export default () => {
-//   setupAxios({
-//     // Default timeout for any interaction using the cashu-ts library to interact with a mint
-//     timeout: 15 * 1000, // 15 seconds
-//   });
-// };
+import { boot } from 'quasar/wrappers';
+import { setupAxios } from '@cashu/cashu-ts';
+
+export default boot(() => {
+  // 15-second network timeout for all Cashu mint requests.
+  setupAxios({ timeout: 15_000 });
+});


### PR DESCRIPTION
## Summary
- configure the Cashu boot file to set a 15-second axios timeout for all mint requests

## Testing
- `npm run test:ci` *(fails: getActivePinia errors and missing imports)*

------
https://chatgpt.com/codex/tasks/task_e_684e9d7f199c8330aca7932ff71336fa