### PR TITLE
Fix NDK hot reload

### DIFF
--- a/quasar.config.js
+++ b/quasar.config.js
@@ -27,7 +27,7 @@ module.exports = configure(function (/* ctx */) {
     // app boot file (/src/boot)
     // --> boot files are part of "main.js"
     // https://v2.quasar.dev/quasar-cli/boot-files
-    boot: ["base", "global-components", "cashu", "i18n"],
+    boot: ["base", "global-components", "cashu", "i18n", "nostr"],
 
     // https://v2.quasar.dev/quasar-cli-vite/quasar-config-js#css
     css: ["app.scss", "base.scss"],

--- a/src/boot/nostr.ts
+++ b/src/boot/nostr.ts
@@ -1,0 +1,14 @@
+import { boot } from "quasar/wrappers";
+import NDK from "@nostr-dev-kit/ndk";
+import { useSettingsStore } from "stores/settings";
+
+export default boot(() => {
+  // Prevent re-initialization during hot-reloads in development.
+  if ((window as any).__NDK_READY) return;
+  (window as any).__NDK_READY = true;
+
+  const settings = useSettingsStore();
+  const ndk = new NDK({ explicitRelayUrls: settings.defaultNostrRelays });
+  ndk.connect();
+  (window as any).ndk = ndk;
+});


### PR DESCRIPTION
## Summary
- add NDK boot file with hot reload guard
- register the new boot file in Quasar config

## Testing
- `npm run lint`
- `npm run test` *(fails: getActivePinia errors, missing components)*

------
https://chatgpt.com/codex/tasks/task_e_684ea2e191e083308683602685356bd5