### PR TITLE
Fix onMounted location

### DIFF
--- a/src/pages/WelcomePage.vue
+++ b/src/pages/WelcomePage.vue
@@ -74,7 +74,7 @@
 </template>
 
 <script>
-import { onMounted, ref } from "vue";
+import { ref } from "vue";
 import { useWelcomeStore } from "src/stores/welcome";
 import { useStorageStore } from "src/stores/storage";
 import WelcomeSlidePrivacy from "./welcome/WelcomeSlidePrivacy.vue";
@@ -153,9 +153,6 @@ export default {
       if (file) readFile(file);
     };
 
-    onMounted(() => {
-      welcomeStore.initializeWelcome();
-    });
 
     return {
       welcomeStore,
@@ -165,6 +162,16 @@ export default {
     };
   },
 };
+</script>
+<script setup>
+import { onMounted } from "vue";
+import { useWelcomeStore } from "src/stores/welcome";
+
+const welcomeStoreSetup = useWelcomeStore();
+
+onMounted(() => {
+  welcomeStoreSetup.initializeWelcome();
+});
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Summary
- move `onMounted` hook to a `<script setup>` block in `WelcomePage.vue`

## Testing
- `npx vitest run` *(fails: vitest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684ea312fb188330a89f94ae856f8608