### PR TITLE
Add default NOSTR relays in boot

### DIFF
--- a/src/boot/nostr.ts
+++ b/src/boot/nostr.ts
@@ -7,8 +7,22 @@ export default boot(() => {
   if ((window as any).__NDK_READY) return;
   (window as any).__NDK_READY = true;
 
+  const RELAYS = [
+    "wss://relay.damus.io",
+    "wss://relay.primal.net",
+    "wss://nos.lol",
+    "wss://nostr.wine",
+    "wss://purplepag.es",
+    "wss://relay.nostr.band",
+  ];
+
   const settings = useSettingsStore();
-  const ndk = new NDK({ explicitRelayUrls: settings.defaultNostrRelays });
+  const ndk = new NDK({
+    explicitRelayUrls:
+      settings.defaultNostrRelays.length > 0
+        ? settings.defaultNostrRelays
+        : RELAYS,
+  });
   ndk.connect();
   (window as any).ndk = ndk;
 });


### PR DESCRIPTION
## Summary
- insert a `RELAYS` constant in `src/boot/nostr.ts`
- use the constant when `settings.defaultNostrRelays` is empty

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eef61bfa08330aa95288ca4ca9569