### PR TITLE
Add early stop when privkey missing

### DIFF
--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -653,6 +653,13 @@ export const useWalletStore = defineStore("wallet", {
           receiveStore.receiveData.p2pkPrivateKey ||
           nostrStore.activePrivkeyHex;
 
+        if (!privkey) {
+          notifyError(
+            'Cannot redeem – no matching P2PK key (unlock or import one)'
+          );
+          return;
+        }
+
         /* ---------- P2PK remote-sign fall-back ------------ */
         const needsSig = proofs.some(
           (p) => typeof p.secret === "string" && p.secret.startsWith('["P2PK"')


### PR DESCRIPTION
## Summary
- stop redemption if a matching privkey isn't found

## Testing
- `npm test` *(fails: Cannot set property permissions of [object Object] which has only a getter)*

------
https://chatgpt.com/codex/tasks/task_e_684ef37d8af88330af7717dccef98d35