### PR TITLE
Implement refund private key helper

### DIFF
--- a/test/vitest/__tests__/p2pk.spec.ts
+++ b/test/vitest/__tests__/p2pk.spec.ts
@@ -146,4 +146,20 @@ describe("P2PK store", () => {
       "cashuA" + Buffer.from(JSON.stringify(tokenObj)).toString("base64");
     expect(p2pk.getPrivateKeyForP2PKEncodedToken(encoded)).toBe(skHex);
   });
+
+  it("returns refund privkey when expired", () => {
+    const sk = generateSecretKey();
+    const pk = getPublicKey(sk);
+    const skHex = bytesToHex(sk);
+    const npub = nip19.npubEncode(pk);
+
+    const p2pk = useP2PKStore();
+    const pubHex = p2pk.maybeConvertNpub(npub);
+    p2pk.p2pkKeys = [
+      { publicKey: pubHex, privateKey: skHex, used: false, usedCount: 0 },
+    ];
+
+    const result = p2pk.getRefundPrivateKey(true, [pubHex, "02aa"], p2pk.p2pkKeys);
+    expect(result).toBe(skHex);
+  });
 });


### PR DESCRIPTION
## Summary
- add `getRefundPrivateKey` helper to p2pk store
- handle expired locks in `getPrivateKeyForP2PKEncodedToken`
- test refund private key helper

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ef4ef5d8c8330b1636f4fb6043a38