### PR TITLE
Update cashu-ts dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@capacitor/core": "^6.2.0",
         "@capacitor/haptics": "^6.0.2",
         "@capacitor/ios": "^6.0.0",
-        "@cashu/cashu-ts": "^2.0.0-rc3",
+        "@cashu/cashu-ts": "0.14.1",
         "@cashu/crypto": "^0.3.4",
         "@chenfengyuan/vue-qrcode": "^2.0.0",
         "@gandlaf21/bc-ur": "^1.1.12",
@@ -2040,7 +2040,7 @@
       }
     },
     "node_modules/@cashu/cashu-ts": {
-      "version": "2.0.0-rc3",
+      "version": "0.14.1",
       "license": "MIT",
       "dependencies": {
         "@cashu/crypto": "^0.3.4",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@capacitor/core": "^6.2.0",
     "@capacitor/haptics": "^6.0.2",
     "@capacitor/ios": "^6.0.0",
-    "@cashu/cashu-ts": "^2.0.0-rc3",
+    "@cashu/cashu-ts": "0.14.1",
     "@cashu/crypto": "^0.3.4",
     "@chenfengyuan/vue-qrcode": "^2.0.0",
     "@gandlaf21/bc-ur": "^1.1.12",


### PR DESCRIPTION
## Summary
- update `@cashu/cashu-ts` to version `0.14.1` in package.json
- refresh `package-lock.json` accordingly

## Testing
- `npm install` *(fails: No matching version found)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ef6e543308330809683f624136092