### PR TITLE
Fix wallet page translation crash

### DIFF
--- a/src/components/PaymentRequestDialog.vue
+++ b/src/components/PaymentRequestDialog.vue
@@ -136,7 +136,7 @@ export default defineComponent({
     ToggleUnit,
   },
   data() {
-    const amountLabelDefault = this.$i18n.t(
+    const amountLabelDefault = this.$t(
       "PaymentRequestDialog.actions.add_amount.label"
     );
     return {
@@ -145,7 +145,7 @@ export default defineComponent({
       amountInputValue: "",
       amountLabelDefault,
       amountLabel: amountLabelDefault,
-      defaultAnyMint: this.$i18n.t(
+      defaultAnyMint: this.$t(
         "PaymentRequestDialog.actions.use_active_mint.label"
       ),
       chosenMintUrl: undefined,


### PR DESCRIPTION
## Summary
- fix PaymentRequestDialog translation calls to avoid runtime error

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f29dad0588330928ae540afa6da77