### PR TITLE
Fix maybeConvertNpub null check

### DIFF
--- a/src/stores/p2pk.ts
+++ b/src/stores/p2pk.ts
@@ -32,7 +32,8 @@ export const useP2PKStore = defineStore("p2pk", {
     maybeConvertNpub: function (key: string) {
       // Check and convert npub to P2PK.
       // Always normalise with ensureCompressed() before use.
-      if (key && key.startsWith("npub1")) {
+      if (!key) return "";
+      if (key.startsWith("npub1")) {
         const { type, data } = nip19.decode(key);
         if (type === "npub" && data.length === 64) {
           key = "02" + data;


### PR DESCRIPTION
## Summary
- guard empty key in maybeConvertNpub
- build the project

## Testing
- `npm run build`
- `npm test` *(fails: invalid pubkey format, missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_684fba1a2fc88330bd07e333e19d9201