### PR TITLE
Auto-use P2PK key when redeeming

### DIFF
--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -600,6 +600,14 @@ export const useWalletStore = defineStore("wallet", {
       let proofs = token.getProofs(tokenJson);
       if (!proofs.length) throw new Error("no proofs");
 
+      /* ---------- ensure signer has local key if available ---------- */
+      if (
+        receiveStore.receiveData.p2pkPrivateKey &&
+        !signer.privkeyHex
+      ) {
+        signer.setLocalPrivkey(receiveStore.receiveData.p2pkPrivateKey);
+      }
+
       /* ---------- auto‑sign if locked ---------- */
       try {
         proofs = await unlockProofs(proofs, async (h) => signer.signData(h));


### PR DESCRIPTION
## Summary
- load available P2PK private key into signer before redeeming tokens

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850f6de982c8330801fb34bd82a4527