### PR TITLE
Add dev CORS proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,21 @@ npm install
 npm test
 ```
 
+## Handling CORS Issues
+
+Some mints do not enable CORS which can prevent the wallet from
+redeeming tokens when running in a browser.  A small proxy is provided
+to work around this during development:
+
+```bash
+npm run proxy
+```
+
+The proxy forwards requests to `https://mint.minibits.cash` with CORS
+headers enabled.  When using the proxy, configure your mint URL as
+`http://localhost:3001/Bitcoin`.
+
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE.md).

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "format": "prettier --write .",
     "checkformat": "prettier --check .",
     "test": "vitest",
-    "test:ci": "vitest run"
+    "test:ci": "vitest run",
+    "proxy": "node proxy.js"
   },
   "dependencies": {
     "@capacitor/android": "^6.2.0",

--- a/proxy.js
+++ b/proxy.js
@@ -1,0 +1,34 @@
+const http = require('http');
+const https = require('https');
+const { URL } = require('url');
+
+const TARGET = 'https://mint.minibits.cash';
+
+function onRequest(req, res) {
+  const url = new URL(req.url, TARGET);
+  const options = {
+    hostname: url.hostname,
+    port: 443,
+    path: url.pathname + url.search,
+    method: req.method,
+    headers: { ...req.headers, host: url.hostname }
+  };
+
+  const proxyReq = https.request(options, (proxyRes) => {
+    const headers = { ...proxyRes.headers, 'access-control-allow-origin': '*' };
+    res.writeHead(proxyRes.statusCode || 500, headers);
+    proxyRes.pipe(res, { end: true });
+  });
+
+  proxyReq.on('error', (err) => {
+    console.error('Proxy error:', err.message);
+    res.writeHead(500);
+    res.end('Proxy error');
+  });
+
+  req.pipe(proxyReq, { end: true });
+}
+
+http.createServer(onRequest).listen(3001, () => {
+  console.log('CORS proxy running on http://localhost:3001');
+});


### PR DESCRIPTION
## Summary
- add a simple Node proxy for CORS
- expose proxy command in package.json
- document how to use the proxy in README

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850fc91fa688330b18dc95d54f6c25b