### PR TITLE
Fix token decoding whitespace

### DIFF
--- a/src/stores/receiveTokensStore.ts
+++ b/src/stores/receiveTokensStore.ts
@@ -38,7 +38,7 @@ export const useReceiveTokensStore = defineStore("receiveTokensStore", {
   }),
   actions: {
     decodeToken: function (encodedToken: string) {
-      encodedToken = encodedToken.trim();
+      encodedToken = encodedToken.replace(/\s+/g, "").trim();
       if (!isValidTokenString(encodedToken)) {
         console.error("Invalid token string");
         return undefined;

--- a/src/stores/tokens.ts
+++ b/src/stores/tokens.ts
@@ -216,7 +216,7 @@ export const useTokensStore = defineStore("tokens", {
       return this.historyTokens.find((t) => t.token === tokenStr);
     },
     decodeToken(encodedToken: string): Token | undefined {
-      encodedToken = encodedToken.trim();
+      encodedToken = encodedToken.replace(/\s+/g, "").trim();
       if (!isValidTokenString(encodedToken)) {
         console.error("Invalid token string");
         return undefined;


### PR DESCRIPTION
## Summary
- strip whitespace before validating a token in `receiveTokensStore`
- do the same whitespace cleanup in `tokens` store helper

## Testing
- `npm test` *(fails: getActivePinia not set and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_685111c53d1c833089286602f485b65a