### PR TITLE
Improve P2PK witness checks

### DIFF
--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -263,6 +263,13 @@ export const useWalletStore = defineStore("wallet", {
         proofs as unknown as Proof[],
         async (hash) => signer.signData(hash)
       );
+      for (const p of signed) {
+        debug("signP2PKIfNeeded proof", p);
+        if (!(p as any).witness) {
+          debug("missing witness after signing", p);
+          throw new Error("P2PK witness missing");
+        }
+      }
       return signed as T[];
     },
 
@@ -647,6 +654,13 @@ export const useWalletStore = defineStore("wallet", {
 
         /* try signing again */
         proofs = await unlockProofs(proofs, async (h) => signer.signData(h));
+        for (const p of proofs) {
+          debug("attemptRedeem signed proof", p);
+          if (!(p as any).witness) {
+            debug("missing witness after second sign", p);
+            throw new Error("P2PK witness missing");
+          }
+        }
       }
 
       /* ---------- re‑encode token if we added witness ---------- */


### PR DESCRIPTION
## Summary
- validate that P2PK-locked proofs contain Schnorr witnesses
- stop redemption if proofs remain unsigned after user interaction

## Testing
- `npm test --silent` *(fails: `Failed Suites 15`, `Failed Tests 6`)*

------
https://chatgpt.com/codex/tasks/task_e_685113f61e088330b3d5b5e271512fd7