### PR TITLE
Add dev proxy for mint

### DIFF
--- a/quasar.config.js
+++ b/quasar.config.js
@@ -71,6 +71,13 @@ module.exports = configure(function (/* ctx */) {
       https: true,
       open: true, // opens browser window automatically
       port: 8080,
+      proxy: {
+        '^/Bitcoin': {
+          target: 'https://mint.minibits.cash',
+          changeOrigin: true,
+          secure: false,
+        },
+      },
     },
 
     // https://v2.quasar.dev/quasar-cli-vite/quasar-config-js#framework

--- a/src/components/MintSettings.vue
+++ b/src/components/MintSettings.vue
@@ -592,6 +592,9 @@ export default defineComponent({
     },
     validateMintUrl: function (url) {
       try {
+        if (url.startsWith("/")) {
+          return true;
+        }
         new URL(url);
         return true;
       } catch (e) {
@@ -599,8 +602,11 @@ export default defineComponent({
       }
     },
     sanitizeMintUrlAndShowAddDialog: function () {
-      // if no protocol is given, add https
-      if (!this.addMintData.url.match(/^[a-zA-Z]+:\/\//)) {
+      // if no protocol is given and not relative, add https
+      if (
+        !this.addMintData.url.match(/^[a-zA-Z]+:\/\//) &&
+        !this.addMintData.url.startsWith("/")
+      ) {
         this.addMintData.url = "https://" + this.addMintData.url;
       }
       if (!this.validateMintUrl(this.addMintData.url)) {
@@ -609,10 +615,12 @@ export default defineComponent({
         );
         return;
       }
-      let urlObj = new URL(this.addMintData.url);
-      urlObj.hostname = urlObj.hostname.toLowerCase();
-      this.addMintData.url = urlObj.toString();
-      this.addMintData.url = this.addMintData.url.replace(/\/$/, "");
+      if (!this.addMintData.url.startsWith("/")) {
+        let urlObj = new URL(this.addMintData.url);
+        urlObj.hostname = urlObj.hostname.toLowerCase();
+        this.addMintData.url = urlObj.toString();
+        this.addMintData.url = this.addMintData.url.replace(/\/$/, "");
+      }
       this.showAddMintDialog = true;
     },
     addMintInternal: function (mintToAdd, verbose) {

--- a/src/stores/mints.ts
+++ b/src/stores/mints.ts
@@ -288,6 +288,9 @@ export const useMintsStore = defineStore("mints", {
         // sanitize url
         const sanitizeUrl = (url: string): string | null => {
           try {
+            if (url.startsWith("/")) {
+              return url;
+            }
             if (!/^[a-zA-Z]+:\/\//.test(url)) {
               url = "https://" + url;
             }


### PR DESCRIPTION
## Summary
- proxy `/Bitcoin` to `https://mint.minibits.cash` in dev server
- allow relative mint URLs in settings

## Testing
- `npm run lint`
- `npm test` *(fails: getActivePinia not set etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68511583f2e48330869071241fa5cf8a