### PR TITLE
Handle expired invoices

### DIFF
--- a/src/components/PayInvoiceDialog.vue
+++ b/src/components/PayInvoiceDialog.vue
@@ -91,7 +91,9 @@
             rounded
             color="primary"
             :disabled="
-              payInvoiceData.blocking || payInvoiceData.meltQuote.error != ''
+              payInvoiceData.blocking ||
+              payInvoiceData.meltQuote.error != '' ||
+              payInvoiceData.invoice.expired
             "
             @click="handleMeltButton"
             :label="
@@ -108,6 +110,21 @@
               <q-spinner-hourglass />
             </template>
           </q-btn>
+          <q-btn v-close-popup flat color="grey" class="q-ml-auto">{{
+            $t("PayInvoiceDialog.invoice.actions.close.label")
+          }}</q-btn>
+        </div>
+        <div v-else-if="payInvoiceData.invoice.expired" class="row q-mt-lg">
+          <q-btn
+            unelevated
+            rounded
+            disabled
+            color="yellow"
+            text-color="black"
+            >{{
+              $t("PayInvoiceDialog.invoice.expired_warning_text")
+            }}</q-btn
+          >
           <q-btn v-close-popup flat color="grey" class="q-ml-auto">{{
             $t("PayInvoiceDialog.invoice.actions.close.label")
           }}</q-btn>

--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -1220,6 +1220,7 @@ export default {
       },
       processing_info_text: "جاري المعالجة…",
       balance_too_low_warning_text: "الرصيد منخفض جدًا",
+      expired_warning_text: "Invoice expired"
       actions: {
         close: {
           label: "@:global.actions.close.label",

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -1227,6 +1227,7 @@ export default {
       },
       processing_info_text: "Wird verarbeitet…",
       balance_too_low_warning_text: "Guthaben zu niedrig",
+      expired_warning_text: "Invoice expired"
       actions: {
         close: {
           label: "@:global.actions.close.label",

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -1230,6 +1230,7 @@ export default {
       },
       processing_info_text: "Επεξεργασία…",
       balance_too_low_warning_text: "Το υπόλοιπο είναι πολύ χαμηλό",
+      expired_warning_text: "Invoice expired"
       actions: {
         close: {
           label: "@:global.actions.close.label",

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1297,6 +1297,7 @@ export default {
       },
       processing_info_text: "Processing…",
       balance_too_low_warning_text: "Balance too low",
+      expired_warning_text: "Invoice expired"
       actions: {
         close: {
           label: "@:global.actions.close.label",

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -1228,6 +1228,7 @@ export default {
       },
       processing_info_text: "Procesando…",
       balance_too_low_warning_text: "Saldo demasiado bajo",
+      expired_warning_text: "Invoice expired"
       actions: {
         close: {
           label: "@:global.actions.close.label",

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -1226,6 +1226,7 @@ export default {
       },
       processing_info_text: "Traitement…",
       balance_too_low_warning_text: "Solde trop faible",
+      expired_warning_text: "Invoice expired"
       actions: {
         close: {
           label: "@:global.actions.close.label",

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -1220,6 +1220,7 @@ export default {
       },
       processing_info_text: "Elaborazione…",
       balance_too_low_warning_text: "Saldo troppo basso",
+      expired_warning_text: "Invoice expired"
       actions: {
         close: {
           label: "@:global.actions.close.label",

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -1220,6 +1220,7 @@ export default {
       },
       processing_info_text: "処理中…",
       balance_too_low_warning_text: "残高不足",
+      expired_warning_text: "Invoice expired"
       actions: {
         close: {
           label: "@:global.actions.close.label",

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -1220,6 +1220,7 @@ export default {
       },
       processing_info_text: "Bearbetar…",
       balance_too_low_warning_text: "Saldot för lågt",
+      expired_warning_text: "Invoice expired"
       actions: {
         close: {
           label: "@:global.actions.close.label",

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -1217,6 +1217,7 @@ export default {
       },
       processing_info_text: "กำลังประมวลผล…",
       balance_too_low_warning_text: "ยอดเงินคงเหลือต่ำเกินไป",
+      expired_warning_text: "Invoice expired"
       actions: {
         close: {
           label: "@:global.actions.close.label",

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -1222,6 +1222,7 @@ export default {
       },
       processing_info_text: "İşleniyor…",
       balance_too_low_warning_text: "Bakiye yetersiz",
+      expired_warning_text: "Invoice expired"
       actions: {
         close: {
           label: "@:global.actions.close.label",

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -1209,6 +1209,7 @@ export default {
       },
       processing_info_text: "正在处理…",
       balance_too_low_warning_text: "余额不足",
+      expired_warning_text: "Invoice expired"
       actions: {
         close: {
           label: "@:global.actions.close.label",

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -1510,6 +1510,7 @@ export const useWalletStore = defineStore("wallet", {
         expireDate: "",
         expired: false,
       };
+      let expiry = 3600;
       _.each(invoice.sections, (tag) => {
         if (_.isObject(tag) && _.has(tag, "name")) {
           if (tag.name === "amount") {
@@ -1523,17 +1524,18 @@ export const useWalletStore = defineStore("wallet", {
           } else if (tag.name === "timestamp") {
             cleanInvoice.timestamp = tag.value;
           } else if (tag.name === "expiry") {
-            var expireDate = new Date(
-              (cleanInvoice.timestamp + tag.value) * 1000
-            );
-            cleanInvoice.expireDate = date.formatDate(
-              expireDate,
-              "YYYY-MM-DDTHH:mm:ss.SSSZ"
-            );
-            cleanInvoice.expired = false; // TODO
+            expiry = tag.value;
           }
         }
       });
+      if (cleanInvoice.timestamp) {
+        const expDate = new Date((cleanInvoice.timestamp + expiry) * 1000);
+        cleanInvoice.expireDate = date.formatDate(
+          expDate,
+          "YYYY-MM-DDTHH:mm:ss.SSSZ"
+        );
+        cleanInvoice.expired = Date.now() > expDate.getTime();
+      }
 
       this.payInvoiceData.invoice = Object.freeze(cleanInvoice);
       // get quote for this request


### PR DESCRIPTION
## Summary
- compute invoice expired status when parsing
- disable payment button for expired invoices
- show an "Invoice expired" warning
- add translation key for the new warning

## Testing
- `pnpm test` *(fails: Failed to resolve imports)*

------
https://chatgpt.com/codex/tasks/task_e_6851176e4324833083e8fc3d3e840dfa