### PR TITLE
Fix translation syntax error

### DIFF
--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -1220,7 +1220,7 @@ export default {
       },
       processing_info_text: "جاري المعالجة…",
       balance_too_low_warning_text: "الرصيد منخفض جدًا",
-      expired_warning_text: "Invoice expired"
+      expired_warning_text: "Invoice expired",
       actions: {
         close: {
           label: "@:global.actions.close.label",

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -1227,7 +1227,7 @@ export default {
       },
       processing_info_text: "Wird verarbeitet…",
       balance_too_low_warning_text: "Guthaben zu niedrig",
-      expired_warning_text: "Invoice expired"
+      expired_warning_text: "Invoice expired",
       actions: {
         close: {
           label: "@:global.actions.close.label",

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -1230,7 +1230,7 @@ export default {
       },
       processing_info_text: "Επεξεργασία…",
       balance_too_low_warning_text: "Το υπόλοιπο είναι πολύ χαμηλό",
-      expired_warning_text: "Invoice expired"
+      expired_warning_text: "Invoice expired",
       actions: {
         close: {
           label: "@:global.actions.close.label",

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1297,7 +1297,7 @@ export default {
       },
       processing_info_text: "Processing…",
       balance_too_low_warning_text: "Balance too low",
-      expired_warning_text: "Invoice expired"
+      expired_warning_text: "Invoice expired",
       actions: {
         close: {
           label: "@:global.actions.close.label",

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -1228,7 +1228,7 @@ export default {
       },
       processing_info_text: "Procesando…",
       balance_too_low_warning_text: "Saldo demasiado bajo",
-      expired_warning_text: "Invoice expired"
+      expired_warning_text: "Invoice expired",
       actions: {
         close: {
           label: "@:global.actions.close.label",

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -1226,7 +1226,7 @@ export default {
       },
       processing_info_text: "Traitement…",
       balance_too_low_warning_text: "Solde trop faible",
-      expired_warning_text: "Invoice expired"
+      expired_warning_text: "Invoice expired",
       actions: {
         close: {
           label: "@:global.actions.close.label",

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -1220,7 +1220,7 @@ export default {
       },
       processing_info_text: "Elaborazione…",
       balance_too_low_warning_text: "Saldo troppo basso",
-      expired_warning_text: "Invoice expired"
+      expired_warning_text: "Invoice expired",
       actions: {
         close: {
           label: "@:global.actions.close.label",

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -1220,7 +1220,7 @@ export default {
       },
       processing_info_text: "処理中…",
       balance_too_low_warning_text: "残高不足",
-      expired_warning_text: "Invoice expired"
+      expired_warning_text: "Invoice expired",
       actions: {
         close: {
           label: "@:global.actions.close.label",

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -1220,7 +1220,7 @@ export default {
       },
       processing_info_text: "Bearbetar…",
       balance_too_low_warning_text: "Saldot för lågt",
-      expired_warning_text: "Invoice expired"
+      expired_warning_text: "Invoice expired",
       actions: {
         close: {
           label: "@:global.actions.close.label",

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -1217,7 +1217,7 @@ export default {
       },
       processing_info_text: "กำลังประมวลผล…",
       balance_too_low_warning_text: "ยอดเงินคงเหลือต่ำเกินไป",
-      expired_warning_text: "Invoice expired"
+      expired_warning_text: "Invoice expired",
       actions: {
         close: {
           label: "@:global.actions.close.label",

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -1222,7 +1222,7 @@ export default {
       },
       processing_info_text: "İşleniyor…",
       balance_too_low_warning_text: "Bakiye yetersiz",
-      expired_warning_text: "Invoice expired"
+      expired_warning_text: "Invoice expired",
       actions: {
         close: {
           label: "@:global.actions.close.label",

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -1209,7 +1209,7 @@ export default {
       },
       processing_info_text: "正在处理…",
       balance_too_low_warning_text: "余额不足",
-      expired_warning_text: "Invoice expired"
+      expired_warning_text: "Invoice expired",
       actions: {
         close: {
           label: "@:global.actions.close.label",


### PR DESCRIPTION
## Summary
- add missing commas after `expired_warning_text` keys

## Testing
- `npm install`
- `npm test` *(fails: getActivePinia() was called but there was no active Pinia)*

------
https://chatgpt.com/codex/tasks/task_e_68511e6fc8588330b1878cb20e2d9275