### PR TITLE
Fix token regex and dev mint proxy

### DIFF
--- a/src/stores/receiveTokensStore.ts
+++ b/src/stores/receiveTokensStore.ts
@@ -20,7 +20,7 @@ import { DEFAULT_BUCKET_ID } from "./buckets";
 function isValidTokenString(tokenStr: string): boolean {
   // allow any Cashu token prefix (e.g. cashuA, cashuB, ...)
   // and accept base64/base64url characters in the body
-  const prefixRegex = /^cashu[A-Za-z0-9][A-Za-z0-9_\-+=\/]*$/;
+  const prefixRegex = /^cashu[A-Za-z0-9][A-Za-z0-9_\-+=\/.~]*$/;
   return prefixRegex.test(tokenStr);
 }
 

--- a/src/stores/tokens.ts
+++ b/src/stores/tokens.ts
@@ -242,6 +242,6 @@ function currentDateStr() {
 }
 
 function isValidTokenString(tokenStr: string): boolean {
-  const prefixRegex = /^cashu[A-Za-z0-9][A-Za-z0-9_\-+=\/]*$/;
+  const prefixRegex = /^cashu[A-Za-z0-9][A-Za-z0-9_\-+=\/.~]*$/;
   return prefixRegex.test(tokenStr);
 }

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -166,7 +166,11 @@ export const useWalletStore = defineStore("wallet", {
   getters: {
     wallet() {
       const mints = useMintsStore();
-      const mint = new CashuMint(mints.activeMintUrl);
+      let url = mints.activeMintUrl;
+      if (import.meta.env.DEV && url === "https://mint.minibits.cash/Bitcoin") {
+        url = "/Bitcoin";
+      }
+      const mint = new CashuMint(url);
       if (this.mnemonic == "") {
         this.mnemonic = generateMnemonic(wordlist);
       }
@@ -196,6 +200,9 @@ export const useWalletStore = defineStore("wallet", {
         throw new Error("mint not found");
       }
       const unitKeysets = mints.mintUnitKeysets(storedMint, unit);
+      if (import.meta.env.DEV && url === "https://mint.minibits.cash/Bitcoin") {
+        url = "/Bitcoin";
+      }
       const mint = new CashuMint(url);
       if (this.mnemonic == "") {
         this.mnemonic = generateMnemonic(wordlist);
@@ -279,6 +286,12 @@ export const useWalletStore = defineStore("wallet", {
     ): string {
       unit = unit || useMintsStore().activeUnit;
       mintUrl = mintUrl || useMintsStore().activeMintUrl;
+      if (
+        import.meta.env.DEV &&
+        mintUrl === "https://mint.minibits.cash/Bitcoin"
+      ) {
+        mintUrl = "/Bitcoin";
+      }
       const mint = useMintsStore().mints.find((m) => m.url === mintUrl);
       if (!mint) {
         throw new Error("mint not found");


### PR DESCRIPTION
## Summary
- allow `.` and `~` in token validation regex
- proxy mint API to Vite dev server when mint URL is `mint.minibits.cash`

## Testing
- `pnpm install`
- `pnpm test` *(fails: Failed to resolve imports)*

------
https://chatgpt.com/codex/tasks/task_e_6851228e206c833090240926e2f0918d