### PR TITLE
Improve mint URL handling

### DIFF
--- a/src/components/ChooseMint.vue
+++ b/src/components/ChooseMint.vue
@@ -25,7 +25,9 @@
                 <q-item-label
                   class="text-body1 q-pt-xs"
                   :style="
-                    activeMintUrl === scope.opt.url ? 'font-weight: bold' : ''
+                    devAlias(activeMintUrl) === devAlias(scope.opt.url)
+                      ? 'font-weight: bold'
+                      : ''
                   "
                   >{{ scope.opt.nickname || scope.opt.shorturl }}</q-item-label
                 >
@@ -40,7 +42,9 @@
                     v-for="unit in scope.opt.units"
                     :key="unit"
                     :color="
-                      scope.opt.url === activeMintUrl ? 'primary' : 'grey'
+                      devAlias(scope.opt.url) === devAlias(activeMintUrl)
+                        ? 'primary'
+                        : 'grey'
                     "
                     :label="formatCurrency(scope.opt.balances[unit], unit)"
                     class="q-mr-xs q-mb-xs"
@@ -93,8 +97,7 @@
 import { defineComponent } from "vue";
 import { getShortUrl } from "src/js/wallet-helpers";
 import { mapActions, mapState, mapWritableState } from "pinia";
-import { useMintsStore } from "stores/mints";
-import { MintClass } from "stores/mints";
+import { useMintsStore, MintClass, devAlias } from "stores/mints";
 import { i18n } from "../boot/i18n";
 import { title } from "process";
 
@@ -121,7 +124,9 @@ export default defineComponent({
     };
   },
   mounted() {
-    const m = this.mints.find((m) => m.url === this.activeMintUrl);
+    const m = this.mints.find(
+      (m) => devAlias(m.url) === devAlias(this.activeMintUrl)
+    );
     const mint = new MintClass(m);
     this.chosenMint = {
       url: this.activeMintUrl,

--- a/src/components/MintSettings.vue
+++ b/src/components/MintSettings.vue
@@ -15,7 +15,7 @@
         <!-- <q-item-label header>Your mints</q-item-label> -->
         <div v-for="mint in mints" :key="mint.url" class="q-px-md">
           <q-item
-            :active="mint.url == activeMintUrl"
+            :active="devAlias(mint.url) == devAlias(activeMintUrl)"
             active-class="text-weight-bold text-primary"
             clickable
             @click="activateMintUrlInternal(mint.url)"
@@ -23,7 +23,7 @@
             :style="{
               'border-radius': '10px',
               border:
-                mint.url == activeMintUrl
+                devAlias(mint.url) == devAlias(activeMintUrl)
                   ? '1px solid var(--q-primary)'
                   : '1px solid rgba(128, 128, 128, 0.2)',
               padding: '0px',
@@ -460,7 +460,7 @@ import { debug } from "src/js/logger";
 import { ref, defineComponent, onMounted, onBeforeUnmount } from "vue";
 import { getShortUrl } from "src/js/wallet-helpers";
 import { mapActions, mapState, mapWritableState } from "pinia";
-import { useMintsStore, MintClass } from "src/stores/mints";
+import { useMintsStore, MintClass, devAlias } from "src/stores/mints";
 import { useWalletStore } from "src/stores/wallet";
 import { useCameraStore } from "src/stores/camera";
 import { map } from "underscore";
@@ -696,7 +696,9 @@ export default defineComponent({
 
       this.fetchMintInfo(mint).then((newMintInfo) => {
         this.triggerMintInfoMotdChanged(newMintInfo, mint);
-        this.mints.filter((m) => m.url === mint.url)[0].info = newMintInfo;
+        this.mints.filter(
+          (m) => devAlias(m.url) === devAlias(mint.url)
+        )[0].info = newMintInfo;
         this.showMintInfoData = mint;
       });
     },

--- a/src/components/PaymentRequestDialog.vue
+++ b/src/components/PaymentRequestDialog.vue
@@ -123,7 +123,7 @@ const VueQrcode = defineAsyncComponent(() =>
 );
 
 import { usePRStore } from "src/stores/payment-request";
-import { useMintsStore } from "../stores/mints";
+import { useMintsStore, devAlias } from "../stores/mints";
 import { getShortUrl } from "src/js/wallet-helpers";
 import { useUiStore } from "../stores/ui";
 import ToggleUnit from "./ToggleUnit.vue";
@@ -186,7 +186,7 @@ export default defineComponent({
       return getShortUrl(url);
     },
     setActiveMintUrl() {
-      if (this.activeMintUrl == this.chosenMintUrl) {
+      if (devAlias(this.activeMintUrl) == devAlias(this.chosenMintUrl)) {
         return;
       }
       this.chosenMintUrl = this.activeMintUrl;

--- a/src/components/ReceiveTokenDialog.vue
+++ b/src/components/ReceiveTokenDialog.vue
@@ -260,7 +260,7 @@
               rounded
               class="q-pr-md"
               :loading="swapBlocking"
-              :disabled="activeMintUrl == tokenMint"
+              :disabled="devAlias(activeMintUrl) == devAlias(tokenMint)"
             >
               <q-icon name="swap_horiz" class="q-pr-sm" />
               {{ $t("ReceiveTokenDialog.actions.confirm_swap.label") }}
@@ -298,7 +298,7 @@ import { defineComponent } from "vue";
 import { useReceiveTokensStore } from "src/stores/receiveTokensStore";
 import { useWalletStore } from "src/stores/wallet";
 import { useUiStore } from "src/stores/ui";
-import { useMintsStore } from "src/stores/mints";
+import { useMintsStore, devAlias } from "src/stores/mints";
 import { useTokensStore } from "src/stores/tokens";
 import { useCameraStore } from "src/stores/camera";
 import { useP2PKStore } from "src/stores/p2pk";

--- a/src/js/token.ts
+++ b/src/js/token.ts
@@ -1,5 +1,5 @@
 import { type Token, getDecodedToken } from "@cashu/cashu-ts";
-import { useMintsStore, WalletProof } from "src/stores/mints";
+import { useMintsStore, WalletProof, devAlias } from "src/stores/mints";
 import { useProofsStore } from "src/stores/proofs";
 export default { decode, getProofs, getMint, getUnit, getMemo };
 
@@ -46,7 +46,7 @@ function getUnit(decoded_token: Token) {
     const mintStore = useMintsStore();
     const mint = getMint(decoded_token);
     const keysets = mintStore.mints
-      .filter((m) => m.url === mint)
+      .filter((m) => devAlias(m.url) === devAlias(mint))
       .flatMap((m) => m.keysets);
     if (keysets.length > 0) {
       return keysets[0].unit;

--- a/src/stores/lockedTokensRedeemWorker.ts
+++ b/src/stores/lockedTokensRedeemWorker.ts
@@ -3,7 +3,7 @@ import { cashuDb } from "./dexie";
 import { useWalletStore } from "./wallet";
 import { useReceiveTokensStore } from "./receiveTokensStore";
 import { useSettingsStore } from "./settings";
-import { useMintsStore } from "./mints";
+import { useMintsStore, devAlias } from "./mints";
 import token from "src/js/token";
 import { ensureCompressed } from "src/utils/ecash";
 import { debug } from "src/js/logger";
@@ -61,7 +61,9 @@ export const useLockedTokensRedeemWorker = defineStore(
             const mintUrl = token.getMint(decoded);
             const unit = token.getUnit(decoded);
             const proofs = token.getProofs(decoded);
-            const mint = mintStore.mints.find((m) => m.url === mintUrl);
+            const mint = mintStore.mints.find(
+              (m) => devAlias(m.url) === devAlias(mintUrl)
+            );
             if (
               !mint ||
               !proofs.every((p) => mint.keysets.some((k) => k.id === p.id))

--- a/src/stores/proofs.ts
+++ b/src/stores/proofs.ts
@@ -1,7 +1,7 @@
 import { debug } from "src/js/logger";
 import { ref } from "vue";
 import { defineStore } from "pinia";
-import { useMintsStore, WalletProof } from "./mints";
+import { useMintsStore, WalletProof, devAlias } from "./mints";
 import { cashuDb, CashuDexie, useDexieStore } from "./dexie";
 import { useBucketsStore, DEFAULT_BUCKET_ID } from "./buckets";
 import { useTokensStore } from "./tokens";
@@ -31,7 +31,7 @@ export const useProofsStore = defineStore("proofs", {
     const updateActiveProofs = async () => {
       const mintStore = useMintsStore();
       const currentMint = mintStore.mints.find(
-        (m) => m.url === mintStore.activeMintUrl
+        (m) => devAlias(m.url) === devAlias(mintStore.activeMintUrl)
       );
       if (!currentMint) {
         mintStore.activeProofs = [];

--- a/src/stores/swap.ts
+++ b/src/stores/swap.ts
@@ -2,7 +2,7 @@ import { useLocalStorage } from "@vueuse/core";
 import { date } from "quasar";
 import { defineStore } from "pinia";
 import { PaymentRequest, Proof, Token } from "@cashu/cashu-ts";
-import { Mint, useMintsStore } from "./mints";
+import { Mint, useMintsStore, devAlias } from "./mints";
 import { useWalletStore } from "./wallet";
 import { DEFAULT_BUCKET_ID } from "./buckets";
 import { useProofsStore } from "./proofs";
@@ -73,7 +73,7 @@ export const useSwapStore = defineStore("swap", {
           mintQuote.request
         );
         const mint = mintStore.mints.find(
-          (m) => m.url === swapAmountData.fromUrl
+          (m) => devAlias(m.url) === devAlias(swapAmountData.fromUrl)
         );
         if (!mint) {
           throw new Error("mint not found");

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -2,7 +2,7 @@ import { unlockProofs, ensureCompressed } from "src/utils/ecash";
 import { debug } from "src/js/logger";
 import { defineStore } from "pinia";
 import { currentDateStr } from "src/js/utils";
-import { useMintsStore, WalletProof, MintClass, Mint } from "./mints";
+import { useMintsStore, WalletProof, MintClass, Mint, devAlias } from "./mints";
 import { useLocalStorage } from "@vueuse/core";
 import { useProofsStore } from "./proofs";
 import { HistoryToken, useTokensStore } from "./tokens";
@@ -166,10 +166,7 @@ export const useWalletStore = defineStore("wallet", {
   getters: {
     wallet() {
       const mints = useMintsStore();
-      let url = mints.activeMintUrl;
-      if (import.meta.env.DEV && url === "https://mint.minibits.cash/Bitcoin") {
-        url = "/Bitcoin";
-      }
+      const url = devAlias(mints.activeMintUrl);
       const mint = new CashuMint(url);
       if (this.mnemonic == "") {
         this.mnemonic = generateMnemonic(wordlist);
@@ -195,15 +192,14 @@ export const useWalletStore = defineStore("wallet", {
       // note: the unit of the wallet will be activeUnit by default,
       // overwrite wallet.unit if needed
       const mints = useMintsStore();
-      const storedMint = mints.mints.find((m) => m.url === url);
+      const storedMint = mints.mints.find(
+        (m) => devAlias(m.url) === devAlias(url)
+      );
       if (!storedMint) {
         throw new Error("mint not found");
       }
       const unitKeysets = mints.mintUnitKeysets(storedMint, unit);
-      if (import.meta.env.DEV && url === "https://mint.minibits.cash/Bitcoin") {
-        url = "/Bitcoin";
-      }
-      const mint = new CashuMint(url);
+      const mint = new CashuMint(devAlias(url));
       if (this.mnemonic == "") {
         this.mnemonic = generateMnemonic(wordlist);
       }
@@ -285,14 +281,10 @@ export const useWalletStore = defineStore("wallet", {
       unit: string | null = null
     ): string {
       unit = unit || useMintsStore().activeUnit;
-      mintUrl = mintUrl || useMintsStore().activeMintUrl;
-      if (
-        import.meta.env.DEV &&
-        mintUrl === "https://mint.minibits.cash/Bitcoin"
-      ) {
-        mintUrl = "/Bitcoin";
-      }
-      const mint = useMintsStore().mints.find((m) => m.url === mintUrl);
+      mintUrl = devAlias(mintUrl || useMintsStore().activeMintUrl);
+      const mint = useMintsStore().mints.find(
+        (m) => devAlias(m.url) === mintUrl
+      );
       if (!mint) {
         throw new Error("mint not found");
       }
@@ -688,7 +680,7 @@ export const useWalletStore = defineStore("wallet", {
         const received = await mintWallet.receive(tokenToRedeem, {
           counter,
           proofsWeHave: mints.mintUnitProofs(
-            mints.mints.find((m) => m.url === mintUrl)!,
+            mints.mints.find((m) => devAlias(m.url) === devAlias(mintUrl))!,
             unit
           ),
         });
@@ -778,7 +770,9 @@ export const useWalletStore = defineStore("wallet", {
       const uIStore = useUiStore();
       const keysetId = this.getKeyset(invoice.mint, invoice.unit);
       const mintWallet = this.mintWallet(invoice.mint, invoice.unit);
-      const mint = mintStore.mints.find((m) => m.url === invoice.mint);
+      const mint = mintStore.mints.find(
+        (m) => devAlias(m.url) === devAlias(invoice.mint)
+      );
       if (!mint) {
         throw new Error("mint not found");
       }
@@ -1120,7 +1114,9 @@ export const useWalletStore = defineStore("wallet", {
       const proofs = token.getProofs(tokenJson);
       const mintWallet = this.mintWallet(historyToken.mint, historyToken.unit);
 
-      const mint = mintStore.mints.find((m) => m.url === historyToken.mint);
+      const mint = mintStore.mints.find(
+        (m) => devAlias(m.url) === devAlias(historyToken.mint)
+      );
       if (!mint) {
         throw new Error("mint not found");
       }
@@ -1200,7 +1196,9 @@ export const useWalletStore = defineStore("wallet", {
         throw new Error("invoice not found");
       }
       const mintWallet = this.mintWallet(invoice.mint, invoice.unit);
-      const mint = mintStore.mints.find((m) => m.url === invoice.mint);
+      const mint = mintStore.mints.find(
+        (m) => devAlias(m.url) === devAlias(invoice.mint)
+      );
       if (!mint) {
         throw new Error("mint not found");
       }
@@ -1245,7 +1243,9 @@ export const useWalletStore = defineStore("wallet", {
         throw new Error("invoice not found");
       }
       const mintWallet = this.mintWallet(invoice.mint, invoice.unit);
-      const mint = mintStore.mints.find((m) => m.url === invoice.mint);
+      const mint = mintStore.mints.find(
+        (m) => devAlias(m.url) === devAlias(invoice.mint)
+      );
       if (!mint) {
         throw new Error("mint not found");
       }
@@ -1308,7 +1308,9 @@ export const useWalletStore = defineStore("wallet", {
         );
         return;
       }
-      const mint = mintStore.mints.find((m) => m.url === historyToken.mint);
+      const mint = mintStore.mints.find(
+        (m) => devAlias(m.url) === devAlias(historyToken.mint)
+      );
       if (!mint) {
         throw new Error("mint not found");
       }
@@ -1382,7 +1384,9 @@ export const useWalletStore = defineStore("wallet", {
         throw new Error("invoice not found");
       }
       const mintWallet = this.mintWallet(invoice.mint, invoice.unit);
-      const mint = mintStore.mints.find((m) => m.url === invoice.mint);
+      const mint = mintStore.mints.find(
+        (m) => devAlias(m.url) === devAlias(invoice.mint)
+      );
 
       if (!mint) {
         throw new Error("mint not found");


### PR DESCRIPTION
## Summary
- add `devAlias` helper to simplify special-case dev URLs
- alias mint URL comparisons in stores and components
- remove scattered `import.meta.env.DEV` checks

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685133a7aff88330a037ca0b8b234dc5