### PR TITLE
Fix redeem error notification

### DIFF
--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -708,6 +708,7 @@ export const useWalletStore = defineStore("wallet", {
       } catch (e: any) {
         console.error(e);
         notifyApiError(e);
+        notifyError(e.message ?? "Redeem failed");
         return false;
       }
     },


### PR DESCRIPTION
## Summary
- show a user-facing error message if `attemptRedeem` fails

## Testing
- `pnpm test` *(fails: Failed to resolve import "@noble/hashes/sha256" from "src/stores/workers.ts". Does the file exist?)*

------
https://chatgpt.com/codex/tasks/task_e_68513593fa488330993ffdd419efb3e4