### PR TITLE
Move setup init code to mounted

### DIFF
--- a/src/components/QrcodeReader.vue
+++ b/src/components/QrcodeReader.vue
@@ -1,5 +1,4 @@
 <script lang="ts">
-import { onMounted, getCurrentInstance } from "vue";
 import { useCameraStore } from "src/stores/camera";
 import { mapActions, mapState, mapWritableState } from "pinia";
 import { useUiStore } from "src/stores/ui";
@@ -20,29 +19,26 @@ export default {
       urDecoderProgress: 0,
     };
   },
-  setup() {
-    const instance = getCurrentInstance();
-    onMounted(async () => {
-      QrScanner = (await import("qr-scanner")).default;
-      URDecoder = (await import("@gandlaf21/bc-ur")).URDecoder;
+  async mounted() {
+    QrScanner = (await import("qr-scanner")).default;
+    URDecoder = (await import("@gandlaf21/bc-ur")).URDecoder;
 
-      if (!instance) return;
-      const vm: any = instance.proxy;
-      vm.qrScanner = new QrScanner(
-        vm.$refs.cameraEl as HTMLVideoElement,
-        (result: any) => {
-          vm.handleResult(result);
-        },
-        {
-          returnDetailedScanResult: true,
-          highlightScanRegion: true,
-          highlightCodeOutline: true,
-          onDecodeError: () => {},
-        }
-      );
-      vm.qrScanner.start();
-      vm.urDecoder = new URDecoder();
-    });
+    this.qrScanner = new QrScanner(
+      this.$refs.cameraEl as HTMLVideoElement,
+      (result: any) => {
+        this.handleResult(result);
+      },
+      {
+        returnDetailedScanResult: true,
+        highlightScanRegion: true,
+        highlightCodeOutline: true,
+        onDecodeError: () => {},
+      }
+    );
+    this.qrScanner.start();
+    this.urDecoder = new URDecoder();
+  },
+  setup() {
     return {};
   },
   computed: {

--- a/src/pages/WelcomePage.vue
+++ b/src/pages/WelcomePage.vue
@@ -74,7 +74,7 @@
 </template>
 
 <script>
-import { onMounted, ref } from "vue";
+import { ref } from "vue";
 import { useWelcomeStore } from "src/stores/welcome";
 import { useStorageStore } from "src/stores/storage";
 import WelcomeSlidePrivacy from "./welcome/WelcomeSlidePrivacy.vue";
@@ -128,6 +128,9 @@ export default {
       stored || this.$i18n.locale || navigator.language || "en-US";
     this.selectedLanguage = initLocale === "en" ? "en-US" : initLocale;
   },
+  mounted() {
+    this.welcomeStore.initializeWelcome();
+  },
   setup() {
     const welcomeStore = useWelcomeStore();
     const storageStore = useStorageStore();
@@ -152,9 +155,6 @@ export default {
       if (file) readFile(file);
     };
 
-    onMounted(() => {
-      welcomeStore.initializeWelcome();
-    });
 
     return {
       welcomeStore,


### PR DESCRIPTION
## Summary
- drop unused `onMounted` imports
- shift initialization logic into standard `mounted` lifecycle hook

## Testing
- `npm test` *(fails: getActivePinia errors)*

------
https://chatgpt.com/codex/tasks/task_e_685143e621a48330a8b6a0fe1b016d35