### PR TITLE
Guard nostr extension usage

### DIFF
--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -512,10 +512,11 @@ export const useNostrStore = defineStore("nostr", {
       if (
         (!privKey || privKey.length === 0) &&
         (this.signerType === SignerType.NIP07 ||
-          this.signerType === SignerType.NIP46) &&
-        (window as any)?.nostr?.nip04?.encrypt
+          this.signerType === SignerType.NIP46)
       ) {
-        return await (window as any).nostr.nip04.encrypt(recipient, message);
+        if ((window as any)?.nostr?.nip04?.encrypt) {
+          return await (window as any).nostr.nip04.encrypt(recipient, message);
+        }
       }
       if (!privKey) {
         throw new Error("No private key for encryption");
@@ -530,10 +531,11 @@ export const useNostrStore = defineStore("nostr", {
       if (
         (!privKey || privKey.length === 0) &&
         (this.signerType === SignerType.NIP07 ||
-          this.signerType === SignerType.NIP46) &&
-        (window as any)?.nostr?.nip04?.decrypt
+          this.signerType === SignerType.NIP46)
       ) {
-        return await (window as any).nostr.nip04.decrypt(sender, content);
+        if ((window as any)?.nostr?.nip04?.decrypt) {
+          return await (window as any).nostr.nip04.decrypt(sender, content);
+        }
       }
       if (!privKey) {
         throw new Error("No private key for decryption");

--- a/src/stores/signer.ts
+++ b/src/stores/signer.ts
@@ -39,8 +39,8 @@ export const useSignerStore = defineStore("signer", {
     hasSigner(state): boolean {
       return (
         !!state.privkeyHex ||
-        (typeof window !== "undefined" &&
-          !!(window as any).nostr?.signSchnorr)
+        typeof window !== "undefined" &&
+        !!(window as any)?.nostr?.signSchnorr
       );
     },
   },
@@ -73,7 +73,13 @@ export const useSignerStore = defineStore("signer", {
         throw new Error("signData expects 32‑byte hash");
 
       /* 1️⃣ NIP‑07 browser extension */
-      const ext = typeof window !== "undefined" && (window as any).nostr;
+      let ext: any = undefined;
+      if (
+        typeof window !== "undefined" &&
+        (window as any)?.nostr?.signSchnorr
+      ) {
+        ext = (window as any).nostr;
+      }
       if (ext?.signSchnorr) {
         try {
           const sig: string = await ext.signSchnorr(bytesToHex(bytes));

--- a/src/stores/workers.ts
+++ b/src/stores/workers.ts
@@ -82,9 +82,14 @@ export const useWorkersStore = defineStore("workers", {
         const key = nip19.decode(signerStore.nsec).data as Uint8Array;
         signSchnorr = async (h: string) => schnorr.sign(h, key);
       } else if (method === "nip07") {
-        signSchnorr =
-          (window as any)?.nostr?.signSchnorr ||
-          (nostr.signer as any)?.signSchnorr;
+        if (
+          typeof window !== "undefined" &&
+          (window as any)?.nostr?.signSchnorr
+        ) {
+          signSchnorr = (window as any).nostr.signSchnorr;
+        } else {
+          signSchnorr = (nostr.signer as any)?.signSchnorr;
+        }
       } else if (method === "nip46") {
         signSchnorr = (nostr.signer as any)?.signSchnorr;
       }


### PR DESCRIPTION
## Summary
- check for `window.nostr` before calling nip-04 encrypt/decrypt
- guard NIP-07 signing calls with `window.nostr` existence checks
- verify nostr extension before selecting schnorr signing

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685147f3b3b48330930c5d6452f9ee41