### PR TITLE
Allow sendProofs reassignment

### DIFF
--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -469,7 +469,7 @@ export const useWalletStore = defineStore("wallet", {
         refund: refundPubkey ? ensureCompressed(refundPubkey) : undefined,
       };
 
-      const { keep: keepProofs, send: sendProofs } = await wallet.send(
+      let { keep: keepProofs, send: sendProofs } = await wallet.send(
         amount,
         proofsToSend,
         sendOpts


### PR DESCRIPTION
## Summary
- make `sendProofs` a mutable variable when locking tokens so it can be signed later

## Testing
- `npm test` *(fails: getActivePinia() called with no active Pinia, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6851c0c517008330bb23cceb6df1d3cc