### PR TITLE
Allow sendProofs reassignment

### DIFF
--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -469,11 +469,12 @@ export const useWalletStore = defineStore("wallet", {
         refund: refundPubkey ? ensureCompressed(refundPubkey) : undefined,
       };
 
-      const { keep: keepProofs, send: sendProofs } = await wallet.send(
+      const { keep: keepProofs, send: sendProofsTmp } = await wallet.send(
         amount,
         proofsToSend,
         sendOpts
       );
+      let sendProofs = sendProofsTmp;
 
       /* sendProofs currently unsigned → add witness */
       sendProofs = await this.signP2PKIfNeeded(sendProofs);


### PR DESCRIPTION
## Summary
- make only `sendProofs` mutable when locking tokens so it can be signed later

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851c0c517008330bb23cceb6df1d3cc