### PR TITLE
Handle spent tokens gracefully

### DIFF
--- a/src/stores/receiveTokensStore.ts
+++ b/src/stores/receiveTokensStore.ts
@@ -37,6 +37,12 @@ export const useReceiveTokensStore = defineStore("receiveTokensStore", {
     scanningCard: false,
   }),
   actions: {
+    clearReceiveData() {
+      this.receiveData.tokensBase64 = "";
+      this.receiveData.p2pkPrivateKey = "";
+      this.receiveData.bucketId = DEFAULT_BUCKET_ID;
+      this.receiveData.label = "";
+    },
     decodeToken: function (encodedToken: string) {
       encodedToken = encodedToken.replace(/\s+/g, "").trim();
       if (!isValidTokenString(encodedToken)) {

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -42,6 +42,7 @@ import {
   decodePaymentRequest,
   MintQuoteResponse,
   ProofState,
+  MintOperationError,
   getEncodedToken,
 } from "@cashu/cashu-ts";
 import { getSignedProofs } from "@cashu/crypto/modules/client/NUT11";
@@ -716,6 +717,15 @@ export const useWalletStore = defineStore("wallet", {
         return true;
       } catch (e: any) {
         console.error(e);
+        const spent =
+          (e instanceof MintOperationError && e.status === "spent") ||
+          (typeof e.message === "string" &&
+            e.message.includes("Token already spent"));
+        if (spent) {
+          notifyError(e.message ?? "Token already spent");
+          useReceiveTokensStore().clearReceiveData();
+          return null;
+        }
         notifyApiError(e);
         notifyError(e.message ?? "Redeem failed");
         return false;


### PR DESCRIPTION
## Summary
- add clearReceiveData() to receiveTokensStore
- detect spent tokens in wallet.attemptRedeem and clear receive data

## Testing
- `npm install`
- `npm test` *(fails: `[🍍]: "getActivePinia()" was called but there was no active Pinia`)*

------
https://chatgpt.com/codex/tasks/task_e_6852431d68408330829d0aa122b53fac