### PR TITLE
Validate tokens before redemption

### DIFF
--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -72,6 +72,8 @@ export default {
       please_try_again: "يرجى المحاولة مرة أخرى.",
       nostr_dm_sent: "تم إرسال رسالة Nostr",
       nostr_dm_failed: "فشل إرسال رسالة Nostr",
+      proofs_spent_refresh_token:
+        "Some proofs in this token were already spent. Ask the sender for a refreshed token",
     },
     mint: {
       notifications: {

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -73,6 +73,8 @@ export default {
       please_try_again: "Bitte versuchen Sie es erneut.",
       nostr_dm_sent: "Nostr-DM gesendet",
       nostr_dm_failed: "Nostr-DM konnte nicht gesendet werden",
+      proofs_spent_refresh_token:
+        "Some proofs in this token were already spent. Ask the sender for a refreshed token",
     },
     mint: {
       notifications: {

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -73,6 +73,8 @@ export default {
       please_try_again: "Παρακαλώ προσπαθήστε ξανά.",
       nostr_dm_sent: "Το Nostr DM στάλθηκε",
       nostr_dm_failed: "Αποτυχία αποστολής Nostr DM",
+      proofs_spent_refresh_token:
+        "Some proofs in this token were already spent. Ask the sender for a refreshed token",
     },
     mint: {
       notifications: {

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -79,6 +79,8 @@ export default {
       lock_not_supported: "Mint does not support locking (NUT-10/11)",
       nostr_dm_sent: "Nostr DM sent",
       nostr_dm_failed: "Failed to send Nostr DM",
+      proofs_spent_refresh_token:
+        "Some proofs in this token were already spent. Ask the sender for a refreshed token",
     },
     mint: {
       notifications: {

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -73,6 +73,8 @@ export default {
       please_try_again: "Por favor, inténtelo de nuevo.",
       nostr_dm_sent: "DM de Nostr enviado",
       nostr_dm_failed: "Fallo al enviar DM de Nostr",
+      proofs_spent_refresh_token:
+        "Some proofs in this token were already spent. Ask the sender for a refreshed token",
     },
     mint: {
       notifications: {

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -73,6 +73,8 @@ export default {
       please_try_again: "Veuillez réessayer.",
       nostr_dm_sent: "DM Nostr envoyé",
       nostr_dm_failed: "Échec de l'envoi du DM Nostr",
+      proofs_spent_refresh_token:
+        "Some proofs in this token were already spent. Ask the sender for a refreshed token",
     },
     mint: {
       notifications: {

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -73,6 +73,8 @@ export default {
       please_try_again: "Si prega di riprovare.",
       nostr_dm_sent: "DM Nostr inviato",
       nostr_dm_failed: "Invio DM Nostr fallito",
+      proofs_spent_refresh_token:
+        "Some proofs in this token were already spent. Ask the sender for a refreshed token",
     },
     mint: {
       notifications: {

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -73,6 +73,8 @@ export default {
       please_try_again: "もう一度お試しください。",
       nostr_dm_sent: "Nostr DMを送信しました",
       nostr_dm_failed: "Nostr DMの送信に失敗しました",
+      proofs_spent_refresh_token:
+        "Some proofs in this token were already spent. Ask the sender for a refreshed token",
     },
     mint: {
       notifications: {

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -72,6 +72,8 @@ export default {
       please_try_again: "Försök igen.",
       nostr_dm_sent: "Nostr-DM skickat",
       nostr_dm_failed: "Kunde inte skicka Nostr-DM",
+      proofs_spent_refresh_token:
+        "Some proofs in this token were already spent. Ask the sender for a refreshed token",
     },
     mint: {
       notifications: {

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -73,6 +73,8 @@ export default {
       please_try_again: "โปรดลองอีกครั้ง",
       nostr_dm_sent: "ส่ง Nostr DM แล้ว",
       nostr_dm_failed: "ส่ง Nostr DM ไม่สำเร็จ",
+      proofs_spent_refresh_token:
+        "Some proofs in this token were already spent. Ask the sender for a refreshed token",
     },
     mint: {
       notifications: {

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -73,6 +73,8 @@ export default {
       please_try_again: "Lütfen tekrar deneyin.",
       nostr_dm_sent: "Nostr DM gönderildi",
       nostr_dm_failed: "Nostr DM gönderilemedi",
+      proofs_spent_refresh_token:
+        "Some proofs in this token were already spent. Ask the sender for a refreshed token",
     },
     mint: {
       notifications: {

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -72,6 +72,8 @@ export default {
       please_try_again: "请重试。",
       nostr_dm_sent: "Nostr DM 已发送",
       nostr_dm_failed: "Nostr DM 发送失败",
+      proofs_spent_refresh_token:
+        "Some proofs in this token were already spent. Ask the sender for a refreshed token",
     },
     mint: {
       notifications: {


### PR DESCRIPTION
## Summary
- detect partially spent tokens before redeeming
- add warning translation for partially spent tokens

## Testing
- `npx prettier -w src/stores/receiveTokensStore.ts src/i18n/en-US/index.ts src/i18n/ar-SA/index.ts src/i18n/de-DE/index.ts src/i18n/el-GR/index.ts src/i18n/es-ES/index.ts src/i18n/fr-FR/index.ts src/i18n/it-IT/index.ts src/i18n/ja-JP/index.ts src/i18n/sv-SE/index.ts src/i18n/th-TH/index.ts src/i18n/tr-TR/index.ts src/i18n/zh-CN/index.ts`
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68524d89a4ac8330ab6125aaccebd204