### PR TITLE
Handle nip04 decryption errors

### DIFF
--- a/src/stores/nwc.ts
+++ b/src/stores/nwc.ts
@@ -526,13 +526,24 @@ export const useNWCStore = defineStore("nwc", {
 
         debug("### NWC request!");
         debug("### event", event);
-        const decryptedContent = await nip04.decrypt(
-          conn.connectionSecret,
-          conn.walletPublicKey,
-          event.content
-        );
-        // debug("### decryptedContent", decryptedContent)
-        await this.parseNWCCommand(decryptedContent, event, conn);
+        try {
+          const decryptedContent = await nip04.decrypt(
+            conn.connectionSecret,
+            conn.walletPublicKey,
+            event.content
+          );
+          // debug("### decryptedContent", decryptedContent)
+          await this.parseNWCCommand(decryptedContent, event, conn);
+        } catch (e) {
+          if (
+            e instanceof Error &&
+            e.message.toLowerCase().includes("operation")
+          ) {
+            return;
+          }
+          console.error("Failed to decrypt NWC request", e);
+          notifyError("Failed to decrypt NWC request");
+        }
       });
     },
     unsubscribeNWC: function () {


### PR DESCRIPTION
## Summary
- guard nip04 decrypt calls against errors
- ignore decrypt errors marked as operation-specific
- log or notify unexpected decrypt failures

## Testing
- `npm test` *(fails: cannot set permissions, missing components)*

------
https://chatgpt.com/codex/tasks/task_e_68525f0b230c8330ada87e890ccaf92c