### PR TITLE
Fix missing Buffer polyfill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,8 @@
         "underscore": "^1.13.6",
         "vue": "^3.4.27",
         "vue-i18n": "^11.1.3",
-        "vue-router": "^4.3.2"
+        "vue-router": "^4.3.2",
+        "buffer": "^6.0.3"
       },
       "devDependencies": {
         "@capacitor/assets": "^3.0.5",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "underscore": "^1.13.6",
     "vue": "^3.4.27",
     "vue-i18n": "^11.1.3",
-    "vue-router": "^4.3.2"
+    "vue-router": "^4.3.2",
+    "buffer": "^6.0.3"
   },
   "devDependencies": {
     "@capacitor/assets": "^3.0.5",

--- a/quasar.config.js
+++ b/quasar.config.js
@@ -27,7 +27,7 @@ module.exports = configure(function (/* ctx */) {
     // app boot file (/src/boot)
     // --> boot files are part of "main.js"
     // https://v2.quasar.dev/quasar-cli/boot-files
-    boot: ["base", "global-components", "cashu", "i18n"],
+    boot: ["base", "global-components", "cashu", "i18n", "buffer"],
 
     // https://v2.quasar.dev/quasar-cli-vite/quasar-config-js#css
     css: ["app.scss", "base.scss"],

--- a/src/boot/buffer.js
+++ b/src/boot/buffer.js
@@ -1,0 +1,8 @@
+import { boot } from 'quasar/wrappers'
+import { Buffer } from 'buffer'
+
+export default boot(() => {
+  if (typeof window !== 'undefined' && !window.Buffer) {
+    window.Buffer = Buffer
+  }
+})


### PR DESCRIPTION
## Summary
- add `buffer` to package.json deps and lockfile
- expose Buffer globally via a new Quasar boot file
- load the new boot file in quasar.config.js

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852a3a026408330b6221014f4d1ced7