### PR TITLE
Fix Buffer polyfill for Vite/Quasar

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "dexie": "^4.0.9",
     "light-bolt11-decoder": "^3.1.1",
     "lucide-vue-next": "^0.453.0",
+    "buffer": "^6.0.3",
     "nostr-tools": "^2.5.2",
     "pinia": "^2.1.7",
     "qr-scanner": "^1.4.2",
@@ -52,6 +53,7 @@
   "devDependencies": {
     "@capacitor/assets": "^3.0.5",
     "@capacitor/cli": "^6.2.0",
+    "vite-plugin-node-polyfills": "^0.23.0",
     "@quasar/app-vite": "^1.9.3",
     "@types/node": "^20.12.11",
     "@types/underscore": "^1.11.15",

--- a/quasar.config.js
+++ b/quasar.config.js
@@ -9,6 +9,7 @@
 // https://v2.quasar.dev/quasar-cli-vite/quasar-config-js
 
 const { configure } = require("quasar/wrappers");
+const { nodePolyfills } = require("vite-plugin-node-polyfills");
 
 module.exports = configure(function (/* ctx */) {
   return {
@@ -58,7 +59,10 @@ module.exports = configure(function (/* ctx */) {
       // polyfillModulePreload: true,
       // distDir
 
-      // extendViteConf (viteConf) {},
+      extendViteConf(viteConf) {
+        viteConf.plugins = viteConf.plugins || [];
+        viteConf.plugins.push(nodePolyfills());
+      },
       // viteVuePluginOptions: {},
 
       // vitePlugins: [

--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -656,6 +656,8 @@ import { usePriceStore } from "src/stores/price";
 import { useNostrStore } from "src/stores/nostr";
 import token from "src/js/token";
 import { Buffer } from "buffer";
+// Ensure Buffer is globally available for dependencies
+globalThis.Buffer = globalThis.Buffer || Buffer;
 import { useCameraStore } from "src/stores/camera";
 import { useP2PKStore } from "src/stores/p2pk";
 import { nip19, ProfilePointer } from "nostr-tools";


### PR DESCRIPTION
## Summary
- add `buffer` package and node polyfill plugin to package.json
- enable node polyfills in Vite via `quasar.config.js`
- expose `Buffer` globally for SendTokenDialog

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852a3a026408330b6221014f4d1ced7