### PR TITLE
Enable composition API in i18n boot

### DIFF
--- a/src/boot/base.js
+++ b/src/boot/base.js
@@ -2,6 +2,7 @@ import { copyToClipboard } from "quasar";
 import { useUiStore } from "stores/ui";
 import { Clipboard } from "@capacitor/clipboard";
 import { SafeArea } from "capacitor-plugin-safe-area";
+import { i18n } from "./i18n";
 
 window.LOCALE = "en";
 // window.EventHub = new Vue();
@@ -35,12 +36,11 @@ window.windowMixin = {
     },
     copyText: function (text, message, position) {
       let notify = this.$q.notify;
-      let i18n = this.$i18n;
       copyToClipboard(text).then(function () {
         notify({
           message:
             message ||
-            (i18n && i18n.t("global.copy_to_clipboard.success")) ||
+            i18n.global.t("global.copy_to_clipboard.success") ||
             "Copied to clipboard!",
           position: position || "bottom",
         });
@@ -229,7 +229,7 @@ window.windowMixin = {
 
     const language = this.$q.localStorage.getItem("cashu.language");
     if (language) {
-      this.$i18n.locale = language === "en" ? "en-US" : language;
+      i18n.global.locale.value = language === "en" ? "en-US" : language;
     }
 
     // only for iOS

--- a/src/boot/i18n.js
+++ b/src/boot/i18n.js
@@ -16,6 +16,7 @@ if (storedLocale !== "en-US") {
 }
 
 export const i18n = createI18n({
+  legacy: false,
   locale: storedLocale,
   fallbackLocale: "en-US",
   globalInjection: true,

--- a/src/components/HistoryTable.vue
+++ b/src/components/HistoryTable.vue
@@ -180,6 +180,7 @@ import { useSendTokensStore } from "src/stores/sendTokensStore";
 import token from "../js/token";
 import { notify } from "src/js/notify";
 import { DEFAULT_COLOR } from "src/js/constants";
+import { i18n } from "../boot/i18n";
 
 export default defineComponent({
   name: "HistoryTable",
@@ -263,7 +264,7 @@ export default defineComponent({
     },
     showTokenDialog: function (historyToken) {
       if (historyToken.token === undefined) {
-        notify(this.$i18n.t("HistoryTable.old_token_not_found_error_text"));
+        notify(i18n.global.t("HistoryTable.old_token_not_found_error_text"));
         return;
       }
       const tokensBase64 = historyToken.token;

--- a/src/components/MintDetailsDialog.vue
+++ b/src/components/MintDetailsDialog.vue
@@ -350,6 +350,7 @@ import EditMintDialog from "src/components/EditMintDialog.vue";
 import RemoveMintDialog from "src/components/RemoveMintDialog.vue";
 import MintMotdMessage from "src/components/MintMotdMessage.vue";
 import MintAuditInfo from "src/components/MintAuditInfo.vue";
+import { i18n } from "../boot/i18n";
 import {
   X as CloseIcon,
   QrCode as QrCodeIcon,
@@ -474,7 +475,7 @@ export default defineComponent({
     copyText(text) {
       navigator.clipboard.writeText(text);
       this.$q.notify({
-        message: this.$i18n.t("global.copy_to_clipboard.success"),
+        message: i18n.global.t("global.copy_to_clipboard.success"),
         color: "positive",
         position: "top",
         timeout: 1000,

--- a/src/components/MintSettings.vue
+++ b/src/components/MintSettings.vue
@@ -472,6 +472,7 @@ import { useWorkersStore } from "src/stores/workers";
 import { useSwapStore } from "src/stores/swap";
 import { useUiStore } from "src/stores/ui";
 import { notifyError, notifyWarning } from "src/js/notify";
+import { i18n } from "../boot/i18n";
 import MintDetailsDialog from "src/components/MintDetailsDialog.vue";
 import { EventBus } from "../js/eventBus";
 import AddMintDialog from "src/components/AddMintDialog.vue";
@@ -605,7 +606,7 @@ export default defineComponent({
       }
       if (!this.validateMintUrl(this.addMintData.url)) {
         notifyError(
-          this.$i18n.t("MintSettings.add.actions.add_mint.error_invalid_url")
+          i18n.global.t("MintSettings.add.actions.add_mint.error_invalid_url")
         );
         return;
       }
@@ -670,11 +671,11 @@ export default defineComponent({
       }
       if (mintUrls.length == 0) {
         this.notifyError(
-          this.$i18n.t("MintSettings.discover.actions.discover.error_no_mints")
+          i18n.global.t("MintSettings.discover.actions.discover.error_no_mints")
         );
       } else {
         this.notifySuccess(
-          this.$i18n.t("MintSettings.discover.actions.discover.success", {
+          i18n.global.t("MintSettings.discover.actions.discover.success", {
             length: mintUrls.length,
           })
         );

--- a/src/components/NumericKeyboard.vue
+++ b/src/components/NumericKeyboard.vue
@@ -49,6 +49,7 @@ import { useUiStore } from "../stores/ui";
 import { mapWritableState } from "pinia";
 import { useSettingsStore } from "../stores/settings";
 import { notify } from "src/js/notify";
+import { i18n } from "../boot/i18n";
 
 export default defineComponent({
   name: "NumericKeyboard",
@@ -84,7 +85,7 @@ export default defineComponent({
       this.useNumericKeyboard = false;
       this.showNumericKeyboard = false;
       notify(
-        this.$i18n.t("NumericKeyboard.actions.close.closed_info_text"),
+        i18n.global.t("NumericKeyboard.actions.close.closed_info_text"),
         "bottom"
       );
     },

--- a/src/components/PaymentRequestDialog.vue
+++ b/src/components/PaymentRequestDialog.vue
@@ -127,6 +127,7 @@ import { useMintsStore } from "../stores/mints";
 import { getShortUrl } from "src/js/wallet-helpers";
 import { useUiStore } from "../stores/ui";
 import ToggleUnit from "./ToggleUnit.vue";
+import { i18n } from "../boot/i18n";
 
 export default defineComponent({
   name: "PRDialog",
@@ -136,7 +137,7 @@ export default defineComponent({
     ToggleUnit,
   },
   data() {
-    const amountLabelDefault = this.$i18n.t(
+    const amountLabelDefault = i18n.global.t(
       "PaymentRequestDialog.actions.add_amount.label"
     );
     return {
@@ -145,7 +146,7 @@ export default defineComponent({
       amountInputValue: "",
       amountLabelDefault,
       amountLabel: amountLabelDefault,
-      defaultAnyMint: this.$i18n.t(
+      defaultAnyMint: i18n.global.t(
         "PaymentRequestDialog.actions.use_active_mint.label"
       ),
       chosenMintUrl: undefined,

--- a/src/components/ReceiveDialog.vue
+++ b/src/components/ReceiveDialog.vue
@@ -102,6 +102,7 @@ import {
   notify,
   notifyWarning,
 } from "src/js/notify.ts";
+import { i18n } from "../boot/i18n";
 import {
   X as XIcon,
   Coins as CoinsIcon,
@@ -187,7 +188,7 @@ export default defineComponent({
     showInvoiceCreateDialog: async function () {
       if (!this.canReceivePayments) {
         notifyWarning(
-          this.$i18n.t("ReceiveDialog.actions.lightning.error_no_mints")
+          i18n.global.t("ReceiveDialog.actions.lightning.error_no_mints")
         );
         this.showReceiveDialog = false;
         return;

--- a/src/components/ReceiveTokenDialog.vue
+++ b/src/components/ReceiveTokenDialog.vue
@@ -333,6 +333,7 @@ import {
   notifyWarning,
   notify,
 } from "../js/notify";
+import { i18n } from "../boot/i18n";
 import MintSettings from "./MintSettings.vue";
 
 export default defineComponent({
@@ -569,7 +570,7 @@ export default defineComponent({
     addPendingTokenToHistory: function (tokenStr) {
       if (this.tokenAlreadyInHistory(tokenStr)) {
         this.notifySuccess(
-          this.$i18n.t(
+          i18n.global.t(
             "ReceiveTokenDialog.actions.later.already_in_history_success_text"
           )
         );
@@ -597,7 +598,7 @@ export default defineComponent({
       this.showReceiveTokens = false;
       // show success notification
       this.notifySuccess(
-        this.$i18n.t(
+        i18n.global.t(
           "ReceiveTokenDialog.actions.later.added_to_history_success_text"
         )
       );

--- a/src/components/RestoreView.vue
+++ b/src/components/RestoreView.vue
@@ -179,6 +179,7 @@ import { useRestoreStore } from "src/stores/restore";
 import { useWalletStore } from "src/stores/wallet";
 import { useUiStore } from "src/stores/ui";
 import { notifyError, notifySuccess } from "src/js/notify";
+import { i18n } from "../boot/i18n";
 
 export default defineComponent({
   name: "RestoreView",
@@ -186,7 +187,7 @@ export default defineComponent({
   data() {
     return {
       mnemonicError: "",
-      restoreAllMintsText: this.$i18n.t(
+      restoreAllMintsText: i18n.global.t(
         "RestoreView.actions.restore_all_mints.label"
       ),
     };
@@ -221,7 +222,7 @@ export default defineComponent({
       // Simple validation: check if mnemonicToRestore has at least 12 words
       const words = this.mnemonicToRestore.trim().split(/\s+/);
       if (words.length < 12) {
-        this.mnemonicError = this.$i18n.t("RestoreView.actions.validate.error");
+        this.mnemonicError = i18n.global.t("RestoreView.actions.validate.error");
         return false;
       }
       this.mnemonicError = "";
@@ -232,19 +233,19 @@ export default defineComponent({
         return;
       }
       try {
-        this.restoreAllMintsText = this.$i18n.t(
+        this.restoreAllMintsText = i18n.global.t(
           "RestoreView.actions.restore.in_progress"
         );
         await this.restoreMint(mintUrl);
       } catch (error) {
         console.error("Error restoring mint:", error);
         notifyError(
-          this.$i18n.t("RestoreView.actions.restore.error", {
+          i18n.global.t("RestoreView.actions.restore.error", {
             error: error.message || error,
           })
         );
       } finally {
-        this.restoreAllMintsText = this.$i18n.t(
+        this.restoreAllMintsText = i18n.global.t(
           "RestoreView.actions.restore_all_mints.label"
         );
       }
@@ -254,7 +255,7 @@ export default defineComponent({
         const text = await this.pasteFromClipboard();
         this.mnemonicToRestore = text.trim();
       } catch (error) {
-        notifyError(this.$i18n.t("RestoreView.actions.paste.error"));
+        notifyError(i18n.global.t("RestoreView.actions.paste.error"));
       }
     },
     async restoreAllMints() {
@@ -264,7 +265,7 @@ export default defineComponent({
       }
       try {
         for (const mint of this.mints) {
-          this.restoreAllMintsText = this.$i18n.t(
+          this.restoreAllMintsText = i18n.global.t(
             "RestoreView.actions.restore_all_mints.in_progress",
             {
               index: ++i,
@@ -274,17 +275,17 @@ export default defineComponent({
           await this.restoreMint(mint.url);
         }
         notifySuccess(
-          this.$i18n.t("RestoreView.actions.restore_all_mints.success")
+          i18n.global.t("RestoreView.actions.restore_all_mints.success")
         );
       } catch (error) {
         console.error("Error restoring mints:", error);
         notifyError(
-          this.$i18n.t("RestoreView.actions.restore_all_mints.error", {
+          i18n.global.t("RestoreView.actions.restore_all_mints.error", {
             error: error.message || error,
           })
         );
       } finally {
-        this.restoreAllMintsText = this.$i18n.t(
+        this.restoreAllMintsText = i18n.global.t(
           "RestoreView.actions.restore_all_mints.label"
         );
       }

--- a/src/components/SendDialog.vue
+++ b/src/components/SendDialog.vue
@@ -88,6 +88,7 @@ import { useCameraStore } from "src/stores/camera";
 import { useSendTokensStore } from "src/stores/sendTokensStore";
 import { useSettingsStore } from "../stores/settings";
 import { useMintsStore } from "src/stores/mints";
+import { i18n } from "../boot/i18n";
 import {
   X as XIcon,
   Banknote as BanknoteIcon,
@@ -155,7 +156,7 @@ export default defineComponent({
     showParseDialog: function () {
       if (!this.canMakePayments) {
         notifyWarning(
-          this.$i18n.t("SendDialog.actions.lightning.error_no_mints")
+          i18n.global.t("SendDialog.actions.lightning.error_no_mints")
         );
         this.showSendDialog = false;
         return;
@@ -174,7 +175,7 @@ export default defineComponent({
     showSendTokensDialog: function () {
       debug("##### showSendTokensDialog");
       if (!this.canMakePayments) {
-        notifyWarning(this.$i18n.t("SendDialog.actions.ecash.error_no_mints"));
+        notifyWarning(i18n.global.t("SendDialog.actions.ecash.error_no_mints"));
         this.showSendDialog = false;
         return;
       }

--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -656,6 +656,7 @@ import { usePriceStore } from "src/stores/price";
 import { useNostrStore } from "src/stores/nostr";
 import token from "src/js/token";
 import { Buffer } from "buffer";
+import { i18n } from "../boot/i18n";
 // Ensure Buffer is globally available for dependencies
 globalThis.Buffer = globalThis.Buffer || Buffer;
 import { useCameraStore } from "src/stores/camera";
@@ -1251,13 +1252,13 @@ export default defineComponent({
             if (success && event) {
               useDmChatsStore().addOutgoing(event);
               Dialog.create({
-                message: this.$t(
+                message: i18n.global.t(
                   "wallet.notifications.nostr_dm_sent"
                 ) as string,
               });
             } else {
               Dialog.create({
-                message: this.$t(
+                message: i18n.global.t(
                   "wallet.notifications.nostr_dm_failed"
                 ) as string,
               });
@@ -1265,7 +1266,7 @@ export default defineComponent({
           } catch (e) {
             console.error(e);
             Dialog.create({
-              message: this.$t(
+              message: i18n.global.t(
                 "wallet.notifications.nostr_dm_failed"
               ) as string,
             });
@@ -1294,11 +1295,11 @@ export default defineComponent({
         this.addPendingToken(historyToken);
         this.sendData.historyToken = historyToken;
         Dialog.create({
-          message: this.$t(
+          message: i18n.global.t(
             "FindCreators.notifications.donation_sent"
           ) as string,
           ok: {
-            label: this.$t("FindCreators.actions.back_to_search") as string,
+            label: i18n.global.t("FindCreators.actions.back_to_search") as string,
           },
         }).onOk(() => {
           this.showSendTokens = false;
@@ -1401,13 +1402,13 @@ export default defineComponent({
             if (success && event) {
               useDmChatsStore().addOutgoing(event);
               Dialog.create({
-                message: this.$t(
+                message: i18n.global.t(
                   "wallet.notifications.nostr_dm_sent"
                 ) as string,
               });
             } else {
               Dialog.create({
-                message: this.$t(
+                message: i18n.global.t(
                   "wallet.notifications.nostr_dm_failed"
                 ) as string,
               });
@@ -1415,7 +1416,7 @@ export default defineComponent({
           } catch (e) {
             console.error(e);
             Dialog.create({
-              message: this.$t(
+              message: i18n.global.t(
                 "wallet.notifications.nostr_dm_failed"
               ) as string,
             });

--- a/src/components/SettingsView.vue
+++ b/src/components/SettingsView.vue
@@ -1768,6 +1768,7 @@ import { useUiStore } from "../stores/ui";
 import { useWorkersStore } from "src/stores/workers";
 import { useProofsStore } from "src/stores/proofs";
 import { usePRStore } from "../stores/payment-request";
+import { i18n } from "../boot/i18n";
 import { useRestoreStore } from "src/stores/restore";
 import { useDexieStore } from "../stores/dexie";
 import { useReceiveTokensStore } from "../stores/receiveTokensStore";
@@ -2092,7 +2093,7 @@ export default defineComponent({
         locale = "en-US";
       }
       // Set the i18n locale
-      this.$i18n.locale = locale;
+      i18n.global.locale.value = locale;
 
       // Store the selected language in localStorage
       localStorage.setItem("cashu.language", locale);
@@ -2108,7 +2109,7 @@ export default defineComponent({
     debug("Nip07 signer available", this.nip07SignerAvailable);
     // Set the initial selected language based on the current locale
     const currentLocale =
-      this.$i18n.locale === "en" ? "en-US" : this.$i18n.locale;
+      i18n.global.locale.value === "en" ? "en-US" : i18n.global.locale.value;
     this.selectedLanguage = currentLocale;
   },
 });

--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -246,6 +246,7 @@ import ActivityOrb from "components/ActivityOrb.vue";
 import BucketManager from "components/BucketManager.vue";
 import MissingSignerModal from "src/components/MissingSignerModal.vue";
 import { Dialog } from "quasar";
+import { i18n } from "../boot/i18n";
 
 // pinia stores
 import { mapActions, mapState, mapWritableState } from "pinia";
@@ -712,7 +713,9 @@ export default {
       await this.initNip07Signer();
     } else {
       await this.initSigner();
-      this.notifyWarning(this.$t("settings.nostr.signing_extension.not_found"));
+      this.notifyWarning(
+        i18n.global.t("settings.nostr.signing_extension.not_found")
+      );
     }
 
     // show welcome dialog

--- a/src/pages/WelcomePage.vue
+++ b/src/pages/WelcomePage.vue
@@ -77,6 +77,7 @@
 import { onMounted, ref } from "vue";
 import { useWelcomeStore } from "src/stores/welcome";
 import { useStorageStore } from "src/stores/storage";
+import { i18n } from "../boot/i18n";
 import WelcomeSlidePrivacy from "./welcome/WelcomeSlidePrivacy.vue";
 import WelcomeSlideMints from "./welcome/WelcomeSlideMints.vue";
 import WelcomeSlideProofs from "./welcome/WelcomeSlideProofs.vue";
@@ -115,7 +116,7 @@ export default {
         locale = "en-US";
       }
       // Set the i18n locale
-      this.$i18n.locale = locale;
+      i18n.global.locale.value = locale;
 
       // Store the selected language in localStorage
       localStorage.setItem("cashu.language", locale);
@@ -125,7 +126,7 @@ export default {
     // Set the initial selected language based on the current locale or from storage
     const stored = localStorage.getItem("cashu.language");
     const initLocale =
-      stored || this.$i18n.locale || navigator.language || "en-US";
+      stored || i18n.global.locale.value || navigator.language || "en-US";
     this.selectedLanguage = initLocale === "en" ? "en-US" : initLocale;
   },
   setup() {


### PR DESCRIPTION
## Summary
- configure `createI18n` to use composition mode
- use `i18n.global` instead of `this.$i18n`/`this.$t`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852e1734bc483309b5de02ee9c0f4c6