### PR TITLE
Fix empty pubkey errors in SendTokenDialog

### DIFF
--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -1200,12 +1200,16 @@ export default defineComponent({
             console.error(e);
           }
         }
-        this.sendData.p2pkPubkey = this.maybeConvertNpub(
-          this.sendData.p2pkPubkey
-        );
-        this.sendData.refundPubkey = this.maybeConvertNpub(
-          this.sendData.refundPubkey
-        );
+        if (this.sendData.p2pkPubkey) {
+          this.sendData.p2pkPubkey = this.maybeConvertNpub(
+            this.sendData.p2pkPubkey
+          );
+        }
+        if (this.sendData.refundPubkey) {
+          this.sendData.refundPubkey = this.maybeConvertNpub(
+            this.sendData.refundPubkey
+          );
+        }
         let { _, sendProofs } = await this.sendToLock(
           proofsForBucket,
           mintWallet,
@@ -1339,15 +1343,16 @@ export default defineComponent({
         }
       }
       if (!nostrDm) {
-        this.sendData.p2pkPubkey = this.maybeConvertNpub(
-          this.sendData.p2pkPubkey
-        );
-        if (
-          this.sendData.p2pkPubkey &&
-          this.isValidPubkey(this.sendData.p2pkPubkey)
-        ) {
-          await this.lockTokens();
-          return;
+        if (this.sendData.p2pkPubkey) {
+          this.sendData.p2pkPubkey = this.maybeConvertNpub(
+            this.sendData.p2pkPubkey
+          );
+          if (
+            this.isValidPubkey(this.sendData.p2pkPubkey)
+          ) {
+            await this.lockTokens();
+            return;
+          }
         }
       }
 


### PR DESCRIPTION
## Summary
- avoid converting empty pubkeys in `SendTokenDialog` before lock/send

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852f1b205a083308bc8bc1bd4779cd1