### PR TITLE
Fix i18n translation usage

### DIFF
--- a/src/components/PaymentRequestDialog.vue
+++ b/src/components/PaymentRequestDialog.vue
@@ -136,18 +136,18 @@ export default defineComponent({
     ToggleUnit,
   },
   data() {
-    const amountLabelDefault = this.$i18n.t(
-      "PaymentRequestDialog.actions.add_amount.label"
-    );
+    const amountLabelDefault = this.$t(
+        "PaymentRequestDialog.actions.add_amount.label"
+      );
     return {
       paymentRequestAmount: undefined,
       isEditingAmount: false,
       amountInputValue: "",
       amountLabelDefault,
       amountLabel: amountLabelDefault,
-      defaultAnyMint: this.$i18n.t(
-        "PaymentRequestDialog.actions.use_active_mint.label"
-      ),
+      defaultAnyMint: this.$t(
+          "PaymentRequestDialog.actions.use_active_mint.label"
+        ),
       chosenMintUrl: undefined,
       memo: "",
     };


### PR DESCRIPTION
## Summary
- fix i18n call in `PaymentRequestDialog` to use `$t`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685302e245ac8330a8bfa7e3dc64165a