### PR TITLE
Fix sendTokens validation

### DIFF
--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -1335,17 +1335,18 @@ export default defineComponent({
           console.error(e);
         }
       }
-      if (!nostrDm) {
-        this.sendData.p2pkPubkey = this.maybeConvertNpub(
-          this.sendData.p2pkPubkey
-        );
-        if (
-          this.sendData.p2pkPubkey &&
-          this.isValidPubkey(this.sendData.p2pkPubkey)
-        ) {
-          await this.lockTokens();
+
+      if (this.showLockInput || (p2pkInput && p2pkInput.trim() !== "")) {
+        if (!p2pkInput || p2pkInput.trim() === "") {
+          notifyWarning("A public key is required for a locked token.");
           return;
         }
+        if (!this.isValidPubkey(p2pkInput)) {
+          notifyError("The entered public key or npub is not valid.");
+          return;
+        }
+        await this.lockTokens();
+        return;
       }
 
       try {


### PR DESCRIPTION
## Summary
- fix P2PK validation logic in SendTokenDialog

## Testing
- `npm test` *(fails: getActivePinia() error, missing components, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68530c683ae083309663c261c9290c32