### PR TITLE
Fix npub decode helper

### DIFF
--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -70,7 +70,20 @@ interface NutzapProfile {
 export async function fetchNutzapProfile(
   npubOrHex: string
 ): Promise<NutzapProfile | null> {
-  const hex = ndk.utils.note.npubToHex(npubOrHex);
+  let hex: string;
+  if (/^[0-9a-fA-F]{64}$/.test(npubOrHex)) {
+    hex = npubOrHex.toLowerCase();
+  } else {
+    try {
+      if (ndk.utils.hexFromBech32) {
+        hex = ndk.utils.hexFromBech32(npubOrHex) as string;
+      } else {
+        hex = ndk.utils.nip19.decode(npubOrHex).data as string;
+      }
+    } catch {
+      hex = npubOrHex;
+    }
+  }
   const sub = ndk.subscribe({
     kinds: [10019],
     authors: [hex],


### PR DESCRIPTION
## Summary
- handle npub inputs using `ndk.utils.hexFromBech32` with fallback logic

## Testing
- `npm install`
- `npm test` *(fails: getActivePinia error and module resolution issues)*

------
https://chatgpt.com/codex/tasks/task_e_6853b11960948330874e4805a8dfb904