### PR TITLE
Update relay hint usage

### DIFF
--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -110,7 +110,10 @@ export async function publishNutzap(opts: {
     created_at: Math.floor(Date.now() / 1000),
   } as NostrEvent;
   const signed = await ndk.sign(ev);
-  await ndk.publish(signed, opts.relayHints);
+  await ndk.publish(
+    signed,
+    opts.relayHints?.length ? opts.relayHints : undefined
+  );
   return signed.id;
 }
 


### PR DESCRIPTION
## Summary
- handle empty relay hints when publishing

## Testing
- `npm install`
- `npm test` *(fails: `invalid pubkey format` and others)*

------
https://chatgpt.com/codex/tasks/task_e_6853b3831f78833094a0f1c11717fdb9