### PR TITLE
Return Nutzap subscription

### DIFF
--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -13,6 +13,7 @@ import NDK, {
   NDKRelay,
   NDKTag,
   ProfilePointer,
+  NDKSubscription,
 } from "@nostr-dev-kit/ndk";
 import {
   nip04,
@@ -134,11 +135,13 @@ export async function publishNutzap(opts: {
 export function subscribeToNutzaps(
   myHex: string,
   onZap: (ev: NostrEvent) => void
-) {
-  ndk.subscribe({
+): NDKSubscription {
+  const sub = ndk.subscribe({
     kinds: [9321],
     "#p": [myHex],
-  }).on("event", onZap);
+  });
+  sub.on("event", onZap);
+  return sub;
 }
 
 type MintRecommendation = {

--- a/src/stores/nutzap.ts
+++ b/src/stores/nutzap.ts
@@ -7,7 +7,7 @@ import {
   publishNutzap,
   subscribeToNutzaps,
 } from "./nostr";
-import type { NostrEvent } from "@nostr-dev-kit/ndk";
+import type { NostrEvent, NDKSubscription } from "@nostr-dev-kit/ndk";
 import dayjs from "dayjs";
 
 interface SendParams {
@@ -21,12 +21,13 @@ export const useNutzapStore = defineStore("nutzap", {
     incoming: [] as NostrEvent[], // raw kind:9321 events waiting to be claimed
     loading: false,
     error: null as string | null,
+    subscription: null as NDKSubscription | null,
   }),
 
   actions: {
     /** Called once on app start (e.g. from MainLayout.vue) */
     initListener(myHex: string) {
-      subscribeToNutzaps(myHex, (ev: NostrEvent) => {
+      this.subscription = subscribeToNutzaps(myHex, (ev: NostrEvent) => {
         this.incoming.push(ev);
       });
     },


### PR DESCRIPTION
## Summary
- export `NDKSubscription` in nostr store and return subscription
- capture returned subscription in Nutzap store so callers can stop it

## Testing
- `npm test` *(fails: invalid pubkey format)*

------
https://chatgpt.com/codex/tasks/task_e_6853b47923588330abbbde476e02d296