### PR TITLE
Add spendable mint lookup

### DIFF
--- a/src/stores/nutzap.ts
+++ b/src/stores/nutzap.ts
@@ -47,7 +47,7 @@ export const useNutzapStore = defineStore("nutzap", {
 
         for (let i = 0; i < months; i++) {
           const unlockDate = dayjs().add(i, "month").startOf("day").unix();
-          const mint = wallet.pickMint(amount, trustedMints);
+          const mint = wallet.findSpendableMint(amount, trustedMints);
           if (!mint) throw new Error("Insufficient balance in recipient-trusted mints");
 
           const { proofs } = await p2pk.lockToPubKey({

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -240,6 +240,34 @@ export const useWalletStore = defineStore("wallet", {
         this.keysetCounters.push(newCounter);
       }
     },
+    findSpendableMint: function (
+      amount: number,
+      preferred: string[] = []
+    ): Mint | null {
+      const mintsStore = useMintsStore();
+      const unit = mintsStore.activeUnit;
+      const checked = new Set<string>();
+
+      for (const url of preferred) {
+        const mint = mintsStore.mints.find((m) => m.url === url);
+        if (!mint) continue;
+        checked.add(url);
+        const mintClass = new MintClass(mint);
+        if (mintClass.unitBalance(unit) >= amount) {
+          return mint;
+        }
+      }
+
+      for (const mint of mintsStore.mints) {
+        if (checked.has(mint.url)) continue;
+        const mintClass = new MintClass(mint);
+        if (mintClass.unitBalance(unit) >= amount) {
+          return mint;
+        }
+      }
+
+      return null;
+    },
     signP2PKIfNeeded: function <T extends Proof>(proofs: T[]): T[] {
       if (
         !proofs.some(


### PR DESCRIPTION
## Summary
- add `findSpendableMint` to wallet store
- use `findSpendableMint` when locking tokens in Nutzap store

## Testing
- `npm test` *(fails: getActivePinia error and other suite failures)*

------
https://chatgpt.com/codex/tasks/task_e_6853b60e4ddc83308cc9945296923f6d