### PR TITLE
Fix token usage in Nutzap store

### DIFF
--- a/src/stores/nutzap.ts
+++ b/src/stores/nutzap.ts
@@ -50,7 +50,7 @@ export const useNutzapStore = defineStore("nutzap", {
           const mint = wallet.findSpendableMint(amount, trustedMints);
           if (!mint) throw new Error("Insufficient balance in recipient-trusted mints");
 
-          const { proofs } = await p2pk.lockToPubKey({
+          const { token } = await p2pk.lockToPubKey({
             mintUrl: mint.url,
             amount,
             pubKey: p2pkPubkey,
@@ -59,7 +59,7 @@ export const useNutzapStore = defineStore("nutzap", {
 
           // store locally for UI (buckets flow)
           lockedTokens.push({
-            proofs,
+            token,
             mintUrl: mint.url,
             timelock: unlockDate,
             receiver: npub,
@@ -67,7 +67,7 @@ export const useNutzapStore = defineStore("nutzap", {
 
           // Publish Nutzap (one event per period)
           await publishNutzap({
-            content: proofs, // ← token string per NUT-11
+            content: token, // ← token string per NUT-11
             receiverHex: profile.hexPub,
             relayHints: profile.relays,
           });


### PR DESCRIPTION
## Summary
- update Nutzap store to use `token` returned from `lockToPubKey`

## Testing
- `npm test` *(fails: getActivePinia not found, missing modules, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6853b8e3d678833098853d17e468c4e4