### PR TITLE
Fix Nutzap locked token typing

### DIFF
--- a/src/stores/nutzap.ts
+++ b/src/stores/nutzap.ts
@@ -43,7 +43,13 @@ export const useNutzapStore = defineStore("nutzap", {
         const { p2pkPubkey, trustedMints } = profile;
         const wallet = useWalletStore();
         const p2pk = useP2PKStore();
-        const lockedTokens = [] as any[];
+        interface LockedTokenPayload {
+          token: string;
+          mintUrl: string;
+          timelock: number;
+          receiver: string;
+        }
+        const lockedTokens: LockedTokenPayload[] = [];
 
         for (let i = 0; i < months; i++) {
           const unlockDate = dayjs().add(i, "month").startOf("day").unix();


### PR DESCRIPTION
## Summary
- add `LockedTokenPayload` type in Nutzap store
- store locked tokens with typed structure

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853bad178548330a7b82d591f9ac263