### PR TITLE
Add bulk token insertion

### DIFF
--- a/src/stores/lockedTokens.ts
+++ b/src/stores/lockedTokens.ts
@@ -1,6 +1,7 @@
 import { defineStore } from "pinia";
 import { useLocalStorage } from "@vueuse/core";
 import { v4 as uuidv4 } from "uuid";
+import { cashuDb } from "./dexie";
 
 export type LockedToken = {
   id: string;
@@ -46,6 +47,10 @@ export const useLockedTokensStore = defineStore("lockedTokens", {
       };
       this.lockedTokens.push(token);
       return token;
+    },
+    async addMany(tokens: LockedToken[]) {
+      this.lockedTokens.push(...tokens);
+      await cashuDb.lockedTokens.bulkAdd(tokens);
     },
     deleteLockedToken(id: string) {
       const idx = this.lockedTokens.findIndex((t) => t.id === id);

--- a/test/vitest/__tests__/lockedTokens.spec.ts
+++ b/test/vitest/__tests__/lockedTokens.spec.ts
@@ -58,4 +58,28 @@ describe("LockedTokens store", () => {
     expect(tokens.length).toBe(1);
     expect(tokens[0].id).toBe(t1.id);
   });
+
+  it("adds many tokens", async () => {
+    const store = useLockedTokensStore();
+    const tokens = [
+      {
+        id: "a",
+        amount: 1,
+        token: "x",
+        pubkey: "pk1",
+        bucketId: "b1",
+        date: new Date().toISOString(),
+      },
+      {
+        id: "b",
+        amount: 2,
+        token: "y",
+        pubkey: "pk2",
+        bucketId: "b2",
+        date: new Date().toISOString(),
+      },
+    ];
+    await store.addMany(tokens);
+    expect(store.lockedTokens.length).toBe(2);
+  });
 });


### PR DESCRIPTION
## Summary
- implement `addMany` in LockedTokens store
- test adding many locked tokens

## Testing
- `npm test` *(fails: getActivePinia error and other suite failures)*

------
https://chatgpt.com/codex/tasks/task_e_6853bcdfd46083308b49b88878367627