### PR TITLE
Fix npub decode fallback

### DIFF
--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -76,10 +76,10 @@ export async function fetchNutzapProfile(
     hex = npubOrHex.toLowerCase();
   } else {
     try {
-      if (ndk.utils.hexFromBech32) {
-        hex = ndk.utils.hexFromBech32(npubOrHex) as string;
+      if ((ndk as any).utils?.hexFromBech32) {
+        hex = (ndk as any).utils.hexFromBech32(npubOrHex) as string;
       } else {
-        hex = ndk.utils.nip19.decode(npubOrHex).data as string;
+        hex = nip19.decode(npubOrHex).data as string;
       }
     } catch {
       hex = npubOrHex;


### PR DESCRIPTION
## Summary
- fix fallback path when converting npub to hex using `nip19.decode`

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853c77b375c8330a33b310f4d0f7117