### PR TITLE
Fix addMany in lockedTokens store

### DIFF
--- a/src/stores/lockedTokens.ts
+++ b/src/stores/lockedTokens.ts
@@ -48,9 +48,8 @@ export const useLockedTokensStore = defineStore("lockedTokens", {
       this.lockedTokens.push(token);
       return token;
     },
-    async addMany(tokens: LockedToken[]) {
-      this.lockedTokens.push(...tokens);
-      await cashuDb.lockedTokens.bulkAdd(tokens);
+    async addMany(arr: LockedToken[]) {
+      await cashuDb.lockedTokens.bulkAdd(arr);
     },
     deleteLockedToken(id: string) {
       const idx = this.lockedTokens.findIndex((t) => t.id === id);


### PR DESCRIPTION
## Summary
- adjust lockedTokens store `addMany` to only bulk add to Dexie DB

## Testing
- `npm test` *(fails: getActivePinia and other unit test errors)*

------
https://chatgpt.com/codex/tasks/task_e_6853d0d627108330867b8c0ab21728fc