### PR TITLE
Fix nutzap bucket persisting

### DIFF
--- a/src/stores/nutzap.ts
+++ b/src/stores/nutzap.ts
@@ -82,7 +82,7 @@ export const useNutzapStore = defineStore("nutzap", {
 
         // Persist into bucket store for progress UI
         const buckets = useLockedTokensStore();
-        buckets.addMany(lockedTokens as any);
+        await buckets.addMany(lockedTokens as any);
       } catch (e: any) {
         this.error = e.message;
         throw e;


### PR DESCRIPTION
## Summary
- await persisting locked tokens to ensure DB writes finish

## Testing
- `npm run test` *(fails: 'Cannot set property permissions of [object Object] which has only a getter', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_6853d21b077c8330aa96101fd52bc2c5