### PR TITLE
Fix locked token cleanup

### DIFF
--- a/src/stores/nutzap.ts
+++ b/src/stores/nutzap.ts
@@ -100,14 +100,10 @@ export const useNutzapStore = defineStore("nutzap", {
       await p2pk.claimLockedToken(tokenString); // verifies, swaps, updates proofs store
 
       // delete any matching locked token entries from dexie
-      const matches = await cashuDb.lockedTokens
-        .filter(
-          (t) => t.tokenString === tokenString || t.intervalKey === event.id
-        )
-        .toArray();
-      for (const match of matches) {
-        await cashuDb.lockedTokens.delete(match.id);
-      }
+      await cashuDb.lockedTokens
+        .where("token")
+        .equals(tokenString)
+        .delete();
 
       // Optionally: send receipt (kind:9322) here …
 


### PR DESCRIPTION
## Summary
- remove slow filter loop in `claim`
- directly delete locked token Dexie entries

## Testing
- `npm run test` *(fails: getActivePinia not called, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6853d319f538833098662bd69939b34c