### PR TITLE
Handle incoming Nutzap events

### DIFF
--- a/src/stores/nutzap.ts
+++ b/src/stores/nutzap.ts
@@ -3,10 +3,13 @@ import { useWalletStore } from "./wallet";
 import { useP2PKStore } from "./p2pk";
 import { useLockedTokensStore } from "./lockedTokens";
 import { cashuDb } from "./dexie";
+import token from "src/js/token";
+import { v4 as uuidv4 } from "uuid";
 import {
   fetchNutzapProfile,
   publishNutzap,
   subscribeToNutzaps,
+  useNostrStore,
 } from "./nostr";
 import type { NostrEvent, NDKSubscription } from "@nostr-dev-kit/ndk";
 import dayjs from "dayjs";
@@ -24,14 +27,61 @@ export const useNutzapStore = defineStore("nutzap", {
     loading: false,
     error: null as string | null,
     subscription: null as NDKSubscription | null,
+    listenerStarted: false,
   }),
 
   actions: {
     /** Called once on app start (e.g. from MainLayout.vue) */
     initListener(myHex: string) {
+      if (this.listenerStarted) return;
       this.subscription = subscribeToNutzaps(myHex, (ev: NostrEvent) => {
-        this.incoming.push(ev);
+        this._onZap(ev);
       });
+      this.listenerStarted = true;
+    },
+
+    async _onZap(ev: NostrEvent) {
+      if (this.incoming.some((e) => e.id === ev.id)) return;
+
+      const tokenString = ev.content.trim();
+
+      const exists = await cashuDb.lockedTokens
+        .where("tokenString")
+        .equals(tokenString)
+        .first();
+      if (exists) return;
+
+      this.incoming.push(ev);
+
+      try {
+        const decoded = token.decode(tokenString);
+        const amount = decoded
+          ? token.getProofs(decoded).reduce((s, p) => (s += p.amount), 0)
+          : 0;
+        const unlockTs = useP2PKStore().getTokenLocktime(tokenString) || 0;
+        const creator = useNostrStore();
+        const entry = {
+          id: uuidv4(),
+          tokenString,
+          amount,
+          owner: "creator",
+          creatorNpub: creator.pubkey,
+          subscriberNpub: ev.pubkey,
+          tierId: "nutzap",
+          intervalKey: ev.id,
+          unlockTs,
+          refundUnlockTs: 0,
+          status:
+            unlockTs && unlockTs > Math.floor(Date.now() / 1000)
+              ? "pending"
+              : "unlockable",
+          subscriptionEventId: null,
+          label: "Nutzap",
+        } as const;
+        await cashuDb.lockedTokens.put(entry as any);
+      } catch (e) {
+        console.error("Failed to handle zap", e);
+      }
     },
 
     /** High-level entry from UI – fan pledges to creator */
@@ -59,7 +109,8 @@ export const useNutzapStore = defineStore("nutzap", {
             .startOf("day")
             .unix();
           const mint = wallet.findSpendableMint(amount, trustedMints);
-          if (!mint) throw new Error("Insufficient balance in recipient-trusted mints");
+          if (!mint)
+            throw new Error("Insufficient balance in recipient-trusted mints");
 
           const { token } = await p2pk.lockToPubKey({
             mintUrl: mint.url,
@@ -116,4 +167,3 @@ export const useNutzapStore = defineStore("nutzap", {
     },
   },
 });
-


### PR DESCRIPTION
## Summary
- add listenerStarted flag
- ensure incoming Nutzap events are unique
- store received zaps as locked tokens

## Testing
- `pnpm test` *(fails: Failed to resolve imports)*

------
https://chatgpt.com/codex/tasks/task_e_6854483acbc08330aa828c22acab6992