### PR TITLE
Remove nut support check for subscribe dialog

### DIFF
--- a/src/pages/FindCreators.vue
+++ b/src/pages/FindCreators.vue
@@ -144,14 +144,6 @@ async function onMessage(ev: MessageEvent) {
 }
 
 function openSubscribe(tier: any) {
-  const info = mintsStore.activeInfo || {};
-  const nuts = Array.isArray(info.nut_supports)
-    ? info.nut_supports
-    : Object.keys(info.nuts || {}).map((n) => Number(n));
-  if (!(nuts.includes(10) && nuts.includes(11))) {
-    notifyError(t("wallet.notifications.lock_not_supported"));
-    return;
-  }
   selectedTier.value = tier;
   showSubscribeDialog.value = true;
 }

--- a/src/pages/PublicCreatorProfilePage.vue
+++ b/src/pages/PublicCreatorProfilePage.vue
@@ -131,14 +131,6 @@ export default defineComponent({
     });
 
     const openSubscribe = (tier: any) => {
-      const info = mintsStore.activeInfo || {};
-      const nuts = Array.isArray(info.nut_supports)
-        ? info.nut_supports
-        : Object.keys(info.nuts || {}).map((n) => Number(n));
-      if (!(nuts.includes(10) && nuts.includes(11))) {
-        notifyError(t("wallet.notifications.lock_not_supported"));
-        return;
-      }
       selectedTier.value = tier;
       showSubscribeDialog.value = true;
     };


### PR DESCRIPTION
## Summary
- remove mint capability check before opening subscribe dialog

## Testing
- `pnpm test` *(fails: Cannot set property permissions of [object Object] which has only a getter)*

------
https://chatgpt.com/codex/tasks/task_e_68544d7b08788330965bdcf408750492