### PR TITLE
Add Nutzap send step after DM receipts

### DIFF
--- a/src/pages/FindCreators.vue
+++ b/src/pages/FindCreators.vue
@@ -77,6 +77,7 @@ import { useNostrStore } from "stores/nostr";
 import { useMintsStore } from "stores/mints";
 import { notifyError, notifySuccess, notifyWarning } from "src/js/notify";
 import { useDmChatsStore } from "stores/dmChats";
+import { useNutzapStore } from "stores/nutzap";
 import { useI18n } from "vue-i18n";
 import {
   QDialog,
@@ -102,6 +103,7 @@ const lockedStore = useLockedTokensStore();
 const creators = useCreatorsStore();
 const nostr = useNostrStore();
 const mintsStore = useMintsStore();
+const nutzap = useNutzapStore();
 const { t } = useI18n();
 const tiers = computed(() => creators.tiersMap[dialogPubkey.value] || []);
 const showSubscribeDialog = ref(false);
@@ -186,6 +188,12 @@ async function confirmSubscribe({
       );
       if (event) useDmChatsStore().addOutgoing(event);
       if (!success) dmSuccess = false;
+      await nutzap.send({
+        npub: dialogPubkey.value,
+        months: 1,
+        amount: r.amount,
+        startDate: r.locktime,
+      });
     }
     if (dmSuccess) {
       notifySuccess(t("FindCreators.notifications.subscription_success"));

--- a/src/pages/PublicCreatorProfilePage.vue
+++ b/src/pages/PublicCreatorProfilePage.vue
@@ -93,6 +93,7 @@ import SubscriptionReceipt from "components/SubscriptionReceipt.vue";
 import { useMintsStore } from "stores/mints";
 import { notifyError, notifySuccess, notifyWarning } from "src/js/notify";
 import { useDmChatsStore } from "stores/dmChats";
+import { useNutzapStore } from "stores/nutzap";
 import { useI18n } from "vue-i18n";
 import { Loading } from "quasar";
 import { renderMarkdown as renderMarkdownFn } from "src/js/simple-markdown";
@@ -112,6 +113,7 @@ export default defineComponent({
     const priceStore = usePriceStore();
     const uiStore = useUiStore();
     const mintsStore = useMintsStore();
+    const nutzap = useNutzapStore();
     const { t } = useI18n();
     const bitcoinPrice = computed(() => priceStore.bitcoinPrice);
     const profile = ref<any>({});
@@ -181,6 +183,12 @@ export default defineComponent({
           );
           if (event) useDmChatsStore().addOutgoing(event);
           if (!success) dmSuccess = false;
+          await nutzap.send({
+            npub: creatorNpub,
+            months: 1,
+            amount: r.amount,
+            startDate: r.locktime,
+          });
         }
         if (dmSuccess) {
           notifySuccess(t("FindCreators.notifications.subscription_success"));


### PR DESCRIPTION
## Summary
- send Nutzap subscriptions after each DM receipt in subscription flows
- import and instantiate `useNutzapStore` in relevant pages

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint couldn't find config file)*
- `npx tsc --noEmit` *(fails: many modules not found)*

------
https://chatgpt.com/codex/tasks/task_e_68544e796adc83308733378f06a121a4