### PR TITLE
Initialize Nutzap listener in MainLayout

### DIFF
--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -10,12 +10,18 @@
 <script>
 import { defineComponent, ref } from "vue";
 import MainHeader from "components/MainHeader.vue";
+import { useNostrStore } from "src/stores/nostr";
+import { useNutzapStore } from "src/stores/nutzap";
 
 export default defineComponent({
   name: "MainLayout",
   mixins: [windowMixin],
   components: {
     MainHeader,
+  },
+  mounted() {
+    const myHex = useNostrStore().pubkey;
+    useNutzapStore().initListener(myHex);
   },
 });
 </script>


### PR DESCRIPTION
## Summary
- start the Nutzap event listener when `MainLayout` mounts

## Testing
- `npm test` *(fails: 19 failed, 5 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68544fb3cb788330b9ebeccaca9181fd