### PR TITLE
Add tokenString index in Dexie store

### DIFF
--- a/src/stores/dexie.ts
+++ b/src/stores/dexie.ts
@@ -129,6 +129,25 @@ export class CashuDexie extends Dexie {
       lockedTokens:
         "&id, owner, tierId, intervalKey, unlockTs, refundUnlockTs, status, subscriptionEventId",
     });
+    this.version(6)
+      .stores({
+        proofs: "secret, id, C, amount, reserved, quote, bucketId, label",
+        profiles: "pubkey",
+        creatorsTierDefinitions: "&creatorNpub, eventId, updatedAt",
+        subscriptions: "&id, creatorNpub, tierId, status, createdAt, updatedAt",
+        lockedTokens:
+          "&id, tokenString, owner, tierId, intervalKey, unlockTs, refundUnlockTs, status, subscriptionEventId",
+      })
+      .upgrade(async (tx) => {
+        await tx
+          .table("lockedTokens")
+          .toCollection()
+          .modify((entry: any) => {
+            if (entry.tokenString === undefined && entry.token) {
+              entry.tokenString = entry.token;
+            }
+          });
+      });
   }
 }
 


### PR DESCRIPTION
## Summary
- extend Dexie schema with database version 6
- index `tokenString` on `lockedTokens` table and include upgrade logic

## Testing
- `npm install`
- `npm test` *(fails: getActivePinia error & other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68545143868083308736345b4778f417