### PR TITLE
Add Nutzap notification component

### DIFF
--- a/src/components/NutzapNotification.vue
+++ b/src/components/NutzapNotification.vue
@@ -1,0 +1,46 @@
+<template>
+  <div v-if="entries.length" class="q-pa-xs" style="max-width: 500px; margin: 0 auto">
+    <q-list bordered>
+      <q-item v-for="entry in entries" :key="entry.ev.id">
+        <q-item-section>
+          <q-item-label class="text-weight-bold">{{ entry.amount }} sats</q-item-label>
+          <q-item-label caption>{{ entry.tier }}</q-item-label>
+        </q-item-section>
+        <q-item-section side>
+          <q-btn flat dense color="primary" label="Claim" @click="claim(entry.ev)" />
+        </q-item-section>
+      </q-item>
+    </q-list>
+  </div>
+</template>
+
+<script lang="ts">
+import { defineComponent, computed } from 'vue';
+import { useNutzapStore } from 'stores/nutzap';
+import token from 'src/js/token';
+
+export default defineComponent({
+  name: 'NutzapNotification',
+  setup() {
+    const store = useNutzapStore();
+    const entries = computed(() => {
+      return store.incoming.map((ev) => {
+        let amount = 0;
+        try {
+          const decoded = token.decode(ev.content.trim());
+          amount = decoded
+            ? token.getProofs(decoded).reduce((s, p) => (s += p.amount), 0)
+            : 0;
+        } catch {}
+        return { ev, amount, tier: 'Nutzap' };
+      });
+    });
+
+    const claim = (ev: any) => {
+      store.claim(ev);
+    };
+
+    return { entries, claim };
+  },
+});
+</script>

--- a/src/pages/CreatorDashboardPage.vue
+++ b/src/pages/CreatorDashboardPage.vue
@@ -12,6 +12,8 @@
       }}</q-btn>
     </div>
 
+    <NutzapNotification class="q-mt-md" />
+
     <div class="q-mt-md">
       <div class="text-h6">{{ $t("CreatorHub.dashboard.edit_profile") }}</div>
       <q-input
@@ -139,6 +141,7 @@
 import { defineComponent, ref, onMounted, computed, watch } from "vue";
 import { useCreatorHubStore, Tier } from "stores/creatorHub";
 import AddTierDialog from "components/AddTierDialog.vue";
+import NutzapNotification from "components/NutzapNotification.vue";
 import { useNostrStore } from "stores/nostr";
 import { useRouter } from "vue-router";
 import { usePriceStore } from "stores/price";
@@ -148,7 +151,7 @@ import { notifySuccess } from "src/js/notify";
 
 export default defineComponent({
   name: "CreatorDashboardPage",
-  components: { AddTierDialog },
+  components: { AddTierDialog, NutzapNotification },
   setup() {
     const store = useCreatorHubStore();
     const nostr = useNostrStore();

--- a/src/pages/CreatorHubPage.vue
+++ b/src/pages/CreatorHubPage.vue
@@ -17,6 +17,7 @@
       </div>
 
       <div v-else>
+        <NutzapNotification class="q-mb-md" />
         <div v-for="tier in tiers" :key="tier.id" class="q-mb-md">
           <q-card flat bordered>
             <q-card-section>
@@ -48,9 +49,11 @@
 import { defineComponent, computed } from "vue";
 import { useCreatorHubStore } from "stores/creatorHub";
 import { renderMarkdown as renderMarkdownFn } from "src/js/simple-markdown";
+import NutzapNotification from "components/NutzapNotification.vue";
 
 export default defineComponent({
   name: "CreatorHubPage",
+  components: { NutzapNotification },
   setup() {
     const store = useCreatorHubStore();
     const tiers = computed(() => store.getTierArray());


### PR DESCRIPTION
## Summary
- show incoming Nutzap events for creators in a new component
- display Nutzap notifications on creator dashboard and hub pages

## Testing
- `npm test` *(fails: getActivePinia() errors and other module resolution issues)*

------
https://chatgpt.com/codex/tasks/task_e_6854533429c08330bf507ccb19f34c18