### PR TITLE
Fix missing dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@cashu/crypto": "^0.3.4",
     "@chenfengyuan/vue-qrcode": "^2.0.0",
     "@gandlaf21/bc-ur": "^1.1.12",
+    "@noble/hashes": "^1.8.0",
     "@nostr-dev-kit/ndk": "^2.8.1",
     "@quasar/extras": "^1.16.11",
     "@quasar/icongenie": "^4.0.0",
@@ -46,6 +47,7 @@
     "qrcode": "^1.5.3",
     "quasar": "^2.16.2",
     "underscore": "^1.13.6",
+    "uuid": "^11.1.0",
     "vue": "^3.4.27",
     "vue-i18n": "^11.1.3",
     "vue-router": "^4.3.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@gandlaf21/bc-ur':
         specifier: ^1.1.12
         version: 1.1.12
+      '@noble/hashes':
+        specifier: ^1.8.0
+        version: 1.8.0
       '@nostr-dev-kit/ndk':
         specifier: ^2.8.1
         version: 2.14.30(nostr-tools@2.15.0(typescript@5.1.6))
@@ -95,6 +98,9 @@ importers:
       underscore:
         specifier: ^1.13.6
         version: 1.13.7
+      uuid:
+        specifier: ^11.1.0
+        version: 11.1.0
       vue:
         specifier: ^3.4.27
         version: 3.5.17(typescript@5.1.6)
@@ -6111,6 +6117,10 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
+  uuid@11.1.0:
+    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+    hasBin: true
+
   uuid@3.4.0:
     resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
     deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
@@ -8252,7 +8262,7 @@ snapshots:
   '@scure/bip32@1.3.1':
     dependencies:
       '@noble/curves': 1.1.0
-      '@noble/hashes': 1.3.1
+      '@noble/hashes': 1.3.2
       '@scure/base': 1.1.1
 
   '@scure/bip32@1.7.0':
@@ -8263,7 +8273,7 @@ snapshots:
 
   '@scure/bip39@1.2.1':
     dependencies:
-      '@noble/hashes': 1.3.1
+      '@noble/hashes': 1.3.2
       '@scure/base': 1.1.1
 
   '@scure/bip39@1.6.0':
@@ -13287,6 +13297,8 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   utils-merge@1.0.1: {}
+
+  uuid@11.1.0: {}
 
   uuid@3.4.0: {}
 


### PR DESCRIPTION
## Summary
- add runtime dependency on `@noble/hashes` and `uuid`
- update lock file

## Testing
- `pnpm run test` *(fails: Failed to resolve import "@noble/curves/secp256k1")*

------
https://chatgpt.com/codex/tasks/task_e_68545da8845c8330bbf82d4599583517