### PR TITLE
Add nip44 fallback in decryptNip04

### DIFF
--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -626,7 +626,12 @@ export const useNostrStore = defineStore("nostr", {
       if (!privKey) {
         throw new Error("No private key for decryption");
       }
-      return await nip04.decrypt(privKey, sender, content);
+      try {
+        return await nip04.decrypt(privKey, sender, content);
+      } catch (e) {
+        const key = nip44.v2.utils.getConversationKey(privKey, sender);
+        return await nip44.v2.decrypt(content, key);
+      }
     },
     sendNip04DirectMessage: async function (
       recipient: string,


### PR DESCRIPTION
## Summary
- handle nip04 decrypt failure by falling back to nip44

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854f056e16483309a7343ba023e1464