### PR TITLE
Fix Nutzap unlock timing

### DIFF
--- a/src/stores/nutzap.ts
+++ b/src/stores/nutzap.ts
@@ -106,7 +106,7 @@ export const useNutzapStore = defineStore("nutzap", {
         for (let i = 0; i < months; i++) {
           const unlockDate = dayjs(startDate)
             .add(i, "month")
-            .startOf("day")
+            .add(10, "minute")
             .unix();
           const mint = wallet.findSpendableMint(amount, trustedMints);
           if (!mint)


### PR DESCRIPTION
## Summary
- keep custom unlock time in Nutzap pledges
- ensure unlocks are at least 10 minutes in the future

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854f18aab8483308d0343d9c826c0cd