### PR TITLE
Implement P2PK claim function and update redeem

### DIFF
--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -725,7 +725,7 @@ export const useWalletStore = defineStore("wallet", {
         try {
           receivedProofs = await mintWallet.receive(tokenToRedeem, {
             counter,
-            privkey,
+            privkey: privkey || mintWallet.privkey,
             proofsWeHave: mintStore.mintUnitProofs(mint, historyToken.unit),
           });
           await proofsStore.addProofs(


### PR DESCRIPTION
## Summary
- add claimLockedToken action in P2PK store
- include wallet private key when receiving locked ecash

## Testing
- `npm install` *(fails: high vulnerability warnings)*
- `npm test` *(fails to run unit tests due to Pinia initialization and missing component imports)*

------
https://chatgpt.com/codex/tasks/task_e_6854f25f5ad08330ae3c9591e02f9ba2