### PR TITLE
Fix locked token condition

### DIFF
--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -965,7 +965,11 @@ export const useNostrStore = defineStore("nostr", {
         }
 
         // check for locked token format
-        if (payload && payload.token && payload.referenceId) {
+        if (
+          payload.token &&
+          payload.bucketId &&
+          payload.unlockTime !== undefined
+        ) {
           const buckets = useBucketsStore();
           if (!buckets.bucketList.find((b) => b.id === payload.bucketId)) {
             buckets.buckets.push({


### PR DESCRIPTION
## Summary
- handle locked token messages based on bucketId and unlockTime

## Testing
- `pnpm install`
- `npm test` *(fails: Cannot set property permissions of [object Object] which has only a getter)*


------
https://chatgpt.com/codex/tasks/task_e_6854f80a0f788330be73f88ef9ee33d2