### PR TITLE
Add nip04 decrypt fallback to nip44

### DIFF
--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -621,7 +621,12 @@ export const useNostrStore = defineStore("nostr", {
           this.signerType === SignerType.NIP46) &&
         (window as any)?.nostr?.nip04?.decrypt
       ) {
-        return await (window as any).nostr.nip04.decrypt(sender, content);
+        try {
+          return await (window as any).nostr.nip04.decrypt(sender, content);
+        } catch (e) {
+          const shared = await (window as any).nostr.getSharedSecret(sender);
+          return await nip44.v2.decrypt(content, shared);
+        }
       }
       if (!privKey) {
         throw new Error("No private key for decryption");


### PR DESCRIPTION
## Summary
- handle NIP07/NIP46 decrypt errors by trying nip44

## Testing
- `npm test` *(fails: getActivePinia error, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685510e7e9208330a97cf87f81728e5d