### PR TITLE
use correct privkey for p2pk tokens

### DIFF
--- a/src/stores/p2pk.ts
+++ b/src/stores/p2pk.ts
@@ -303,9 +303,14 @@ export const useP2PKStore = defineStore("p2pk", {
       const bucketId = entry?.tierId ?? DEFAULT_BUCKET_ID;
       const label = entry?.label ?? "";
 
+      const privkey = this.getPrivateKeyForP2PKEncodedToken(encodedToken);
+      if (!privkey) {
+        throw new Error("no private key found for locked token");
+      }
+
       const receivedProofs = await wallet.receive(encodedToken, {
         counter,
-        privkey: wallet.privkey,
+        privkey,
         proofsWeHave: mintsStore.mintUnitProofs(mint, unit),
       });
 


### PR DESCRIPTION
## Summary
- fetch private key for locked token and pass to wallet.receive

## Testing
- `npm test` *(fails: getActivePinia errors)*

------
https://chatgpt.com/codex/tasks/task_e_68551576e428833092fffa01da11bb40