### PR TITLE
Add error handling on token redemption

### DIFF
--- a/src/stores/receiveTokensStore.ts
+++ b/src/stores/receiveTokensStore.ts
@@ -95,11 +95,19 @@ export const useReceiveTokensStore = defineStore("receiveTokensStore", {
         await mintStore.addMint({ url: token.getMint(tokenJson) });
       }
       // redeem the token
-      await walletStore.redeem(bucketId);
-      await cashuDb.lockedTokens
-        .where("tokenString")
-        .equals(receiveStore.receiveData.tokensBase64)
-        .delete();
+      try {
+        await walletStore.redeem(bucketId);
+        await cashuDb.lockedTokens
+          .where("tokenString")
+          .equals(receiveStore.receiveData.tokensBase64)
+          .delete();
+      } catch (error) {
+        await cashuDb.lockedTokens
+          .where("tokenString")
+          .equals(receiveStore.receiveData.tokensBase64)
+          .delete();
+        throw error;
+      }
       receiveStore.showReceiveTokens = false;
       uiStore.closeDialogs();
     },


### PR DESCRIPTION
## Summary
- handle errors in `receiveToken` when redeeming tokens

## Testing
- `npm run test:ci` *(fails: getActivePinia, missing component files, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68551a7a0ef48330ba0e2c0ad66a0717