### PR TITLE
Fix subscribe dialog notification

### DIFF
--- a/src/components/SubscribeDialog.vue
+++ b/src/components/SubscribeDialog.vue
@@ -64,6 +64,7 @@ import { useBucketsStore, DEFAULT_BUCKET_ID } from "stores/buckets";
 import { useMintsStore } from "stores/mints";
 import { useUiStore } from "stores/ui";
 import { fetchNutzapProfile } from "stores/nostr";
+import { notifyError } from "src/js/notify";
 import { storeToRefs } from "pinia";
 
 export default defineComponent({
@@ -164,9 +165,7 @@ export default defineComponent({
       }
       const profile = await fetchNutzapProfile(props.creatorPubkey);
       if (!profile) {
-        uiStore.notifyError(
-          "Creator has not published a Nutzap profile (kind-10019)",
-        );
+        notifyError("Creator has not published a Nutzap profile (kind-10019)");
         return;
       }
       const ts = Math.floor(new Date(startDate.value).getTime() / 1000);


### PR DESCRIPTION
## Summary
- update SubscribeDialog to use notifyError
- ensure Nutzap profile check remains before closing dialog

## Testing
- `npm test` *(fails: "Error: [🍍]: \"getActivePinia()\" was called but there was no active Pinia" and others)*

------
https://chatgpt.com/codex/tasks/task_e_68552bd66fec833091349139df96027b