### PR TITLE
Rename variable in P2PK claim

### DIFF
--- a/src/stores/p2pk.ts
+++ b/src/stores/p2pk.ts
@@ -303,14 +303,14 @@ export const useP2PKStore = defineStore("p2pk", {
       const bucketId = entry?.tierId ?? DEFAULT_BUCKET_ID;
       const label = entry?.label ?? "";
 
-      const privkey = this.getPrivateKeyForP2PKEncodedToken(encodedToken);
-      if (!privkey) {
-        throw new Error("no private key found for locked token");
+      const p2pkPriv = this.getPrivateKeyForP2PKEncodedToken(encodedToken);
+      if (!p2pkPriv) {
+        throw new Error("no P2PK private key found for locked token");
       }
 
       const receivedProofs = await wallet.receive(encodedToken, {
         counter,
-        privkey,
+        privkey: p2pkPriv,
         proofsWeHave: mintsStore.mintUnitProofs(mint, unit),
       });
 


### PR DESCRIPTION
## Summary
- rename `privkey` local variable in claimLockedToken to `p2pkPriv`
- pass the renamed variable to `wallet.receive`
- adjust the error message

## Testing
- `npm test` *(fails: getActivePinia errors)*

------
https://chatgpt.com/codex/tasks/task_e_685532bcbfbc8330a1e5d7e180578d13