### PR TITLE
Ensure cleanup after redeem fails

### DIFF
--- a/src/stores/receiveTokensStore.ts
+++ b/src/stores/receiveTokensStore.ts
@@ -97,16 +97,11 @@ export const useReceiveTokensStore = defineStore("receiveTokensStore", {
       // redeem the token
       try {
         await walletStore.redeem(bucketId);
+      } finally {
         await cashuDb.lockedTokens
           .where("tokenString")
           .equals(receiveStore.receiveData.tokensBase64)
           .delete();
-      } catch (error) {
-        await cashuDb.lockedTokens
-          .where("tokenString")
-          .equals(receiveStore.receiveData.tokensBase64)
-          .delete();
-        throw error;
       }
       receiveStore.showReceiveTokens = false;
       uiStore.closeDialogs();


### PR DESCRIPTION
## Summary
- always cleanup locked tokens in `receiveToken`

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685537a865308330b4afc59e3bf233be