### PR TITLE
Add Nutzap profile publishing

### DIFF
--- a/src/components/SettingsView.vue
+++ b/src/components/SettingsView.vue
@@ -887,6 +887,19 @@
                 >{{ $t("Settings.p2pk_features.import_button") }}</q-btn
               >
             </q-item>
+            <q-item style="display: inline-block">
+              <q-btn
+                class="q-ml-sm q-px-md"
+                color="primary"
+                size="sm"
+                rounded
+                outline
+                @click="publishMyNutzapProfile"
+                >{{
+                  $t("Settings.p2pk_features.publish_profile_button")
+                }}</q-btn
+              >
+            </q-item>
             <q-item>
               <q-toggle
                 v-model="showP2PkButtonInDrawer"
@@ -1760,7 +1773,10 @@ import { useMintsStore, MintClass } from "src/stores/mints";
 import { useWalletStore } from "src/stores/wallet";
 import { map } from "underscore";
 import { useSettingsStore } from "src/stores/settings";
-import { useNostrStore } from "src/stores/nostr";
+import {
+  useNostrStore,
+  publishNutzapProfile as publishNutzapProfileFn,
+} from "src/stores/nostr";
 import { useNPCStore } from "src/stores/npubcash";
 import { useP2PKStore } from "src/stores/p2pk";
 import { useNWCStore } from "src/stores/nwc";
@@ -2018,6 +2034,22 @@ export default defineComponent({
       // export active proofs
       const token = await this.serializeProofs(this.activeProofs);
       this.copyText(token);
+    },
+    publishMyNutzapProfile: async function () {
+      try {
+        if (!this.p2pkKeys.length) {
+          this.notifyError("No P2PK key available");
+          return;
+        }
+        await publishNutzapProfileFn({
+          p2pkPub: this.p2pkKeys[0].publicKey,
+          mints: this.mints.map((m) => m.url),
+          relays: this.defaultNostrRelays,
+        });
+        this.notifySuccess("Nutzap profile published");
+      } catch (e) {
+        this.notifyError(e.message || "Failed to publish Nutzap profile");
+      }
     },
     handleSeedClick: async function () {
       await this.initWalletSeedPrivateKeySigner();

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -348,6 +348,7 @@ export default {
         "Generate a key pair to receive P2PK-locked ecash. Warning: This feature is experimental. Only use with small amounts. If you lose your private keys, nobody will be able to unlock the ecash locked to it anymore.",
       generate_button: "Generate key",
       import_button: "Import nsec",
+      publish_profile_button: "Publish Nutzap profile",
       quick_access: {
         toggle: "Quick access to lock",
         description:


### PR DESCRIPTION
## Summary
- expose publishNutzapProfile in settings
- add UI button for publishing Nutzap profile
- show success or failure notifications

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855389133ac83308269f14e23616e5a