### PR TITLE
Improve Nutzap profile publishing workflow

### DIFF
--- a/public/find-creators.html
+++ b/public/find-creators.html
@@ -595,13 +595,9 @@
 
         sub.on("eose", (relay) => {
           try {
-            const relayUrl = relay && relay.url ? relay.url : "unknown relay";
-            if (relay && relay.url) activeRelays.add(relay.url);
-            else
-              console.warn(
-                "EOSE received without a valid relay object or relay.url:",
-                relay
-              );
+            if (!relay || !relay.url) return;
+            const relayUrl = relay.url;
+            activeRelays.add(relayUrl);
 
             eoseCount++;
             console.log(

--- a/src/stores/mints.ts
+++ b/src/stores/mints.ts
@@ -24,6 +24,7 @@ import { liveQuery } from "dexie";
 import { ref, computed, watch } from "vue";
 import { useProofsStore } from "./proofs";
 import { useI18n } from "vue-i18n";
+import { maybeRepublishNutzapProfile } from "./creatorHub";
 import { i18n } from "src/boot/i18n";
 
 export type Mint = {
@@ -341,6 +342,7 @@ export const useMintsStore = defineStore("mints", {
         if (verbose) {
           await notifySuccess(this.t("wallet.mint.notifications.added"));
         }
+        await maybeRepublishNutzapProfile();
         return mintToAdd;
       } catch (error) {
         // activation failed, we remove the mint again from local storage
@@ -542,6 +544,7 @@ export const useMintsStore = defineStore("mints", {
         await this.activateMint(this.mints[0], false);
       }
       notifySuccess(this.t("wallet.mint.notifications.removed"));
+      await maybeRepublishNutzapProfile();
     },
     assertMintError: function (response: { error?: any }, verbose = true) {
       if (response.error != null) {

--- a/src/stores/p2pk.ts
+++ b/src/stores/p2pk.ts
@@ -12,6 +12,7 @@ import { useMintsStore } from "./mints";
 import { useTokensStore } from "./tokens";
 import { DEFAULT_BUCKET_ID } from "./buckets";
 import { cashuDb } from "./dexie";
+import { maybeRepublishNutzapProfile } from "./creatorHub";
 
 type P2PKKey = {
   publicKey: string;
@@ -30,7 +31,9 @@ export const useP2PKStore = defineStore("p2pk", {
     showP2PKDialog: false,
     showP2PKData: {} as P2PKKey,
   }),
-  getters: {},
+  getters: {
+    firstKey: (state) => state.p2pkKeys[0] || null,
+  },
   actions: {
     haveThisKey: function (key: string) {
       return this.p2pkKeys.filter((m) => m.publicKey == key).length > 0;
@@ -96,6 +99,7 @@ export const useP2PKStore = defineStore("p2pk", {
         usedCount: 0,
       };
       this.p2pkKeys = this.p2pkKeys.concat(keyPair);
+      maybeRepublishNutzapProfile();
     },
     generateKeypair: function () {
       let sk = generateSecretKey(); // `sk` is a Uint8Array
@@ -109,6 +113,7 @@ export const useP2PKStore = defineStore("p2pk", {
         usedCount: 0,
       };
       this.p2pkKeys = this.p2pkKeys.concat(keyPair);
+      maybeRepublishNutzapProfile();
     },
     getSecretP2PKInfo: function (secret: string): {
       pubkey: string;


### PR DESCRIPTION
## Summary
- show banner on creator dashboard when Nutzap profile is missing
- allow creators to publish profile or generate key directly from banner
- auto re-publish Nutzap profile when tiers, mints or primary P2PK change
- expose first P2PK key in store
- silence undefined relay warnings in `find-creators.html`

## Testing
- `pnpm lint`
- `pnpm format`
- `pnpm test` *(fails: Failed to resolve imports)*

------
https://chatgpt.com/codex/tasks/task_e_68554289aa5883309dc1769fbf7b5eff