### PR TITLE
Update CreatorDashboardPage publish logic

### DIFF
--- a/src/pages/CreatorDashboardPage.vue
+++ b/src/pages/CreatorDashboardPage.vue
@@ -275,6 +275,7 @@ export default defineComponent({
         return;
       }
       try {
+        await nostr.initSignerIfNotSet();
         await publishNutzapProfile({
           p2pkPub: first.publicKey,
           mints: mintsStore.mints.map((m) => m.url),


### PR DESCRIPTION
## Summary
- initialize Nostr signer before publishing Nutzap profile

## Testing
- `npm test` *(fails: getActivePinia() was called but there was no active Pinia)*

------
https://chatgpt.com/codex/tasks/task_e_6855684ca5b48330a62ccbdf1d356b3a