### PR TITLE
Fix relay publishing helper

### DIFF
--- a/src/js/notify.ts
+++ b/src/js/notify.ts
@@ -53,11 +53,11 @@ async function notifySuccess(
   });
 }
 
-async function notifyError(message: string, caption?: string) {
+async function notifyError(message: string, caption?: any) {
   Notify.create({
     color: "red",
     message: message,
-    caption,
+    caption: caption !== undefined ? String(caption) : undefined,
     position: "top",
     progress: true,
     actions: [

--- a/src/pages/CreatorDashboardPage.vue
+++ b/src/pages/CreatorDashboardPage.vue
@@ -276,6 +276,11 @@ export default defineComponent({
       }
       try {
         await nostr.initSignerIfNotSet();
+      } catch (e) {
+        notifyError("You declined the Nostr signer popup");
+        return;
+      }
+      try {
         await publishNutzapProfile({
           p2pkPub: first.publicKey,
           mints: mintsStore.mints.map((m) => m.url),
@@ -284,7 +289,7 @@ export default defineComponent({
         notifySuccess("Nutzap profile published ✔");
         needsProfile.value = false;
       } catch (e: any) {
-        notifyError("Publishing failed", String(e));
+        notifyError("Relays rejected event", String(e));
       }
     }
 

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -65,6 +65,16 @@ interface NutzapProfile {
   relays: string[];
 }
 
+function urlsToRelaySet(ndk: NDK, urls?: string[]): NDKRelaySet | undefined {
+  if (!urls?.length) return undefined;
+  const set = new NDKRelaySet();
+  urls.forEach((u) => {
+    const r = ndk.getRelay(u);
+    if (r) set.addRelay(r);
+  });
+  return set;
+}
+
 /**
  * Fetches the receiver’s ‘kind:10019’ Nutzap profile.
  */
@@ -123,7 +133,8 @@ export async function publishNutzapProfile(opts: {
   ev.tags = tags;
   ev.created_at = Math.floor(Date.now() / 1000);
   await ev.sign();
-  await ev.publish(opts.relays?.length ? opts.relays : undefined);
+  const relaySet = urlsToRelaySet(nostr.ndk, opts.relays);
+  await ev.publish(relaySet);
   return ev.id!;
 }
 
@@ -141,7 +152,8 @@ export async function publishNutzap(opts: {
   ev.tags = [["p", opts.receiverHex]];
   ev.created_at = Math.floor(Date.now() / 1000);
   await ev.sign();
-  await ev.publish(opts.relayHints?.length ? opts.relayHints : undefined);
+  const relaySet = urlsToRelaySet(nostr.ndk, opts.relayHints);
+  await ev.publish(relaySet);
   return ev.id!;
 }
 


### PR DESCRIPTION
## Summary
- convert relay URLs to an `NDKRelaySet`
- keep signer cancellation handling when publishing a profile
- stringify notify error captions

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.js)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855705a550483308f0aec7ed2c414d0