### PR TITLE
Improve Nostr relay handling

### DIFF
--- a/src/pages/CreatorDashboardPage.vue
+++ b/src/pages/CreatorDashboardPage.vue
@@ -289,7 +289,7 @@ export default defineComponent({
         notifySuccess("Nutzap profile published ✔");
         needsProfile.value = false;
       } catch (e: any) {
-        notifyError("Relays rejected event", String(e));
+        notifyError("Relays rejected event", e?.message ?? String(e));
       }
     }
 

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -67,11 +67,17 @@ interface NutzapProfile {
 
 function urlsToRelaySet(ndk: NDK, urls?: string[]): NDKRelaySet | undefined {
   if (!urls?.length) return undefined;
+
   const set = new NDKRelaySet();
-  urls.forEach((u) => {
-    const r = ndk.getRelay(u);
-    if (r) set.addRelay(r);
-  });
+  for (const u of urls) {
+    // ensure relay object exists in pool
+    let relay = ndk.pool.relays.get(u);
+    if (!relay) {
+      relay = new NDKRelay(u);
+      ndk.pool.addRelay(relay); // read & write by default
+    }
+    set.addRelay(relay);
+  }
   return set;
 }
 


### PR DESCRIPTION
## Summary
- ensure `urlsToRelaySet` creates relays when missing
- update dashboard error toast message for rejected events

## Testing
- `pnpm test` *(fails: Failed to resolve import `@noble/curves/secp256k1` ...)*

------
https://chatgpt.com/codex/tasks/task_e_68558fbd51f48330b795c546de1c779e