### PR TITLE
Fix ESLint rule warning

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,6 +36,9 @@ module.exports = {
     // required to lint *.vue files
     "vue",
 
+    // enables rules from @typescript-eslint/eslint-plugin
+    "@typescript-eslint",
+
     // https://github.com/typescript-eslint/typescript-eslint/issues/389#issuecomment-509292674
     // Prettier has not been included as plugin to avoid performance impact
     // add it as an extension for your IDE


### PR DESCRIPTION
## Summary
- register `@typescript-eslint` plugin in `.eslintrc.js` so ESLint recognizes rules such as `@typescript-eslint/no-explicit-any`

## Testing
- `npm run lint`
- `npm run test` *(fails: Cannot set property permissions of [object Object] which has only a getter)*

------
https://chatgpt.com/codex/tasks/task_e_6855a4360090833082f30b3d8398de6e