### PR TITLE
Fix ndk init and add Nutzap profile composer

### DIFF
--- a/src/js/notify.ts
+++ b/src/js/notify.ts
@@ -53,10 +53,11 @@ async function notifySuccess(
   });
 }
 
-async function notifyError(message: string, caption?: any) {
+async function notifyError(msg: any, caption?: any) {
   Notify.create({
     color: "red",
-    message: message,
+    message:
+      typeof msg === "string" ? msg : msg?.message ?? JSON.stringify(msg),
     caption: caption !== undefined ? String(caption) : undefined,
     position: "top",
     progress: true,


### PR DESCRIPTION
## Summary
- fix check for NDK connection and signer initialization
- sanitize notifyError so it can handle Pinia proxy objects
- add a simple composer in Creator dashboard to publish Nutzap profile

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_6855ae78d0dc83308bcf20887eb1bb9d