### PR TITLE
Implement clipboard composable

### DIFF
--- a/src/boot/base.js
+++ b/src/boot/base.js
@@ -33,19 +33,6 @@ window.windowMixin = {
       this.$q.dark.toggle();
       this.$q.localStorage.set("cashu.darkMode", this.$q.dark.isActive);
     },
-    copyText: function (text, message, position) {
-      let notify = this.$q.notify;
-      let i18n = this.$i18n;
-      copyToClipboard(text).then(function () {
-        notify({
-          message:
-            message ||
-            (i18n && i18n.t("global.copy_to_clipboard.success")) ||
-            "Copied to clipboard!",
-          position: position || "bottom",
-        });
-      });
-    },
     pasteFromClipboard: async function () {
       let text = "";
       if (window?.Capacitor) {

--- a/src/components/InvoiceDetailDialog.vue
+++ b/src/components/InvoiceDetailDialog.vue
@@ -156,7 +156,7 @@
             class="q-mx-xs"
             size="md"
             flat
-            @click="copyText(invoiceData.bolt11)"
+            @click="copy(invoiceData.bolt11)"
             >{{ $t("InvoiceDetailDialog.invoice.actions.copy.label") }}</q-btn
           >
           <q-btn v-close-popup flat color="grey" class="q-ml-auto">{{
@@ -171,6 +171,7 @@
 import { debug } from "src/js/logger";
 import { defineComponent } from "vue";
 import { mapActions, mapState, mapWritableState } from "pinia";
+import { useClipboard } from "src/composables/useClipboard";
 import { defineAsyncComponent } from "vue";
 const VueQrcode = defineAsyncComponent(() =>
   import("@chenfengyuan/vue-qrcode")
@@ -192,6 +193,10 @@ export default defineComponent({
     ChooseMint,
     VueQrcode,
     NumericKeyboard,
+  },
+  setup() {
+    const { copy } = useClipboard();
+    return { copy };
   },
   props: {},
   data: function () {

--- a/src/components/LockedTokensTable.vue
+++ b/src/components/LockedTokensTable.vue
@@ -49,7 +49,7 @@
             flat
             dense
             icon="content_copy"
-            @click="copyText(token.token)"
+            @click="copy(token.token)"
             :aria-label="$t('LockedTokensTable.actions.copy.tooltip_text')"
             :title="$t('LockedTokensTable.actions.copy.tooltip_text')"
           >
@@ -81,6 +81,7 @@
 <script>
 import { defineComponent } from "vue";
 import { mapState } from "pinia";
+import { useClipboard } from "src/composables/useClipboard";
 import { formatDistanceToNow, parseISO } from "date-fns";
 import { shortenString } from "src/js/string-utils";
 import { useLockedTokensStore } from "stores/lockedTokens";
@@ -92,6 +93,10 @@ export default defineComponent({
   mixins: [windowMixin],
   props: {
     bucketId: { type: String, required: true },
+  },
+  setup() {
+    const { copy } = useClipboard();
+    return { copy };
   },
   data() {
     return { currentPage: 1, pageSize: 5 };

--- a/src/components/MintDetailsDialog.vue
+++ b/src/components/MintDetailsDialog.vue
@@ -156,7 +156,7 @@
             </div>
             <div class="contact-text">{{ contactInfo.info }}</div>
             <copy-icon
-              @click="copyText(contactInfo.info)"
+              @click="copy(contactInfo.info)"
               size="20"
               color="#9E9E9E"
               class="copy-icon cursor-pointer"
@@ -185,7 +185,7 @@
             </div>
             <div
               class="detail-value items-center"
-              @click="copyText(showMintInfoData.url)"
+              @click="copy(showMintInfoData.url)"
             >
               {{ showMintInfoData.url }}
             </div>
@@ -313,7 +313,7 @@
 
             <div
               class="action-button cursor-pointer"
-              @click="copyText(showMintInfoData.url)"
+              @click="copy(showMintInfoData.url)"
             >
               <copy-icon size="20" color="#9E9E9E" class="action-icon" />
               <div class="action-label">
@@ -350,6 +350,7 @@ import EditMintDialog from "src/components/EditMintDialog.vue";
 import RemoveMintDialog from "src/components/RemoveMintDialog.vue";
 import MintMotdMessage from "src/components/MintMotdMessage.vue";
 import MintAuditInfo from "src/components/MintAuditInfo.vue";
+import { useClipboard } from "src/composables/useClipboard";
 import {
   X as CloseIcon,
   QrCode as QrCodeIcon,
@@ -385,6 +386,10 @@ export default defineComponent({
     RemoveMintDialog,
     MintMotdMessage,
     MintAuditInfo,
+  },
+  setup() {
+    const { copy } = useClipboard();
+    return { copy };
   },
   data: function () {
     return {
@@ -470,15 +475,6 @@ export default defineComponent({
         return text.substring(0, maxLength) + "...";
       }
       return text;
-    },
-    copyText(text) {
-      navigator.clipboard.writeText(text);
-      this.$q.notify({
-        message: this.$i18n.t("global.copy_to_clipboard.success"),
-        color: "positive",
-        position: "top",
-        timeout: 1000,
-      });
     },
     openEditMintDialog() {
       this.mintToEdit = Object.assign({}, this.showMintInfoData);

--- a/src/components/MintSettings.vue
+++ b/src/components/MintSettings.vue
@@ -328,7 +328,7 @@
               >
                 <q-icon
                   name="content_copy"
-                  @click="copyText(mint.url)"
+                  @click="copy(mint.url)"
                   size="1em"
                   color="grey"
                   class="q-mr-xs cursor-pointer"
@@ -458,6 +458,7 @@
 <script>
 import { debug } from "src/js/logger";
 import { ref, defineComponent, onMounted, onBeforeUnmount } from "vue";
+import { useClipboard } from "src/composables/useClipboard";
 import { getShortUrl } from "src/js/wallet-helpers";
 import { mapActions, mapState, mapWritableState } from "pinia";
 import { useMintsStore, MintClass } from "src/stores/mints";
@@ -486,6 +487,7 @@ export default defineComponent({
   props: {},
   setup() {
     const addMintDiv = ref(null);
+    const { copy } = useClipboard();
 
     const scrollToAddMintDiv = () => {
       if (addMintDiv.value) {
@@ -508,6 +510,7 @@ export default defineComponent({
     });
     return {
       addMintDiv,
+      copy,
     };
   },
   data: function () {

--- a/src/components/NWCDialog.vue
+++ b/src/components/NWCDialog.vue
@@ -48,7 +48,7 @@
             class="q-mx-xs"
             size="md"
             flat
-            @click="copyText(showNWCData.connectionString)"
+            @click="copy(showNWCData.connectionString)"
             >{{ $t("NWCDialog.actions.copy.label") }}</q-btn
           >
           <q-btn v-close-popup flat color="grey" class="q-ml-auto">{{
@@ -62,6 +62,7 @@
 <script>
 import { defineComponent } from "vue";
 import { mapActions, mapState, mapWritableState } from "pinia";
+import { useClipboard } from "src/composables/useClipboard";
 import { defineAsyncComponent } from "vue";
 const VueQrcode = defineAsyncComponent(() =>
   import("@chenfengyuan/vue-qrcode")
@@ -74,6 +75,10 @@ export default defineComponent({
   mixins: [windowMixin],
   components: {
     VueQrcode,
+  },
+  setup() {
+    const { copy } = useClipboard();
+    return { copy };
   },
   data: function () {
     return {};

--- a/src/components/P2PKDialog.vue
+++ b/src/components/P2PKDialog.vue
@@ -56,7 +56,7 @@
             class="q-mx-xs"
             size="md"
             flat
-            @click="copyText(showP2PKData.publicKey)"
+            @click="copy(showP2PKData.publicKey)"
             >{{ $t("P2PKDialog.actions.copy.label") }}</q-btn
           >
           <q-btn v-close-popup flat color="grey" class="q-ml-auto">{{
@@ -70,6 +70,7 @@
 <script>
 import { defineComponent } from "vue";
 import { mapActions, mapState, mapWritableState } from "pinia";
+import { useClipboard } from "src/composables/useClipboard";
 import { defineAsyncComponent } from "vue";
 const VueQrcode = defineAsyncComponent(() =>
   import("@chenfengyuan/vue-qrcode")
@@ -82,6 +83,10 @@ export default defineComponent({
   mixins: [windowMixin],
   components: {
     VueQrcode,
+  },
+  setup() {
+    const { copy } = useClipboard();
+    return { copy };
   },
   data: function () {
     return {};

--- a/src/components/PaymentRequestDialog.vue
+++ b/src/components/PaymentRequestDialog.vue
@@ -102,7 +102,7 @@
             class="q-mx-xs"
             size="md"
             flat
-            @click="copyText(showPRKData)"
+            @click="copy(showPRKData)"
             >{{ $t("PaymentRequestDialog.actions.copy.label") }}</q-btn
           >
           <q-btn v-close-popup flat color="grey" class="q-ml-auto">{{
@@ -117,6 +117,7 @@
 <script>
 import { defineComponent } from "vue";
 import { mapActions, mapState, mapWritableState } from "pinia";
+import { useClipboard } from "src/composables/useClipboard";
 import { defineAsyncComponent } from "vue";
 const VueQrcode = defineAsyncComponent(() =>
   import("@chenfengyuan/vue-qrcode")
@@ -134,6 +135,10 @@ export default defineComponent({
   components: {
     VueQrcode,
     ToggleUnit,
+  },
+  setup() {
+    const { copy } = useClipboard();
+    return { copy };
   },
   data() {
     const amountLabelDefault = this.$t(

--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -321,7 +321,7 @@
                 :value="qrCodeFragment"
                 :options="{ width: 400 }"
                 class="rounded-borders"
-                @click="copyText(sendData.tokensBase64)"
+                @click="copy(sendData.tokensBase64)"
               >
               </vue-qrcode>
             </q-responsive>
@@ -442,7 +442,7 @@
                   size="md"
                   flat
                   dense
-                  @click="copyText(sendData.tokensBase64)"
+                  @click="copy(sendData.tokensBase64)"
                   >{{ $t("SendTokenDialog.actions.copy_tokens.label") }}</q-btn
                 >
                 <q-btn
@@ -465,7 +465,7 @@
                     size="md"
                     flat
                     dense
-                    @click="copyText(encodeToPeanut(sendData.tokensBase64))"
+                    @click="copy(encodeToPeanut(sendData.tokensBase64))"
                     >{{ $t("SendTokenDialog.actions.copy_emoji.label") }}
                     <q-tooltip>{{
                       $t("SendTokenDialog.actions.copy_emoji.tooltip_text")
@@ -479,7 +479,7 @@
                     icon="link"
                     flat
                     @click="
-                      copyText(baseURL + '#token=' + sendData.tokensBase64)
+                      copy(baseURL + '#token=' + sendData.tokensBase64)
                     "
                     :aria-label="
                       $t('SendTokenDialog.actions.copy_link.tooltip_text')
@@ -641,6 +641,7 @@
 </template>
 <script lang="ts">
 import { defineComponent, defineAsyncComponent } from "vue";
+import { useClipboard } from "src/composables/useClipboard";
 import { debug } from "src/js/logger";
 import { useSendTokensStore } from "src/stores/sendTokensStore";
 import { useWalletStore } from "src/stores/wallet";
@@ -703,6 +704,10 @@ export default defineComponent({
     ScanIcon,
     NfcIcon,
     VueQrcode,
+  },
+  setup() {
+    const { copy } = useClipboard();
+    return { copy };
   },
   props: {},
   data: function () {

--- a/src/components/SettingsView.vue
+++ b/src/components/SettingsView.vue
@@ -48,7 +48,7 @@
                       icon="content_copy"
                       color="primary"
                       class="cursor-pointer q-mt-md"
-                      @click="copyText(mnemonic)"
+                      @click="copy(mnemonic)"
                       :aria-label="$t('global.actions.copy.label')"
                       :title="$t('global.actions.copy.label')"
                     ></q-btn>
@@ -134,7 +134,7 @@
                     <q-spinner-hourglass size="sm" v-if="npcLoading" />
                     <q-icon
                       name="content_copy"
-                      @click="copyText(npcAddress)"
+                      @click="copy(npcAddress)"
                       size="xs"
                       color="grey"
                       class="q-mr-sm cursor-pointer"
@@ -224,7 +224,7 @@
               >
                 <q-badge
                   class="cursor-pointer q-mt-xs"
-                  @click="copyText(seedSignerPrivateKeyNsecComputed)"
+                  @click="copy(seedSignerPrivateKeyNsecComputed)"
                   outline
                   color="grey"
                 >
@@ -426,7 +426,7 @@
             >
               <q-icon
                 name="content_copy"
-                @click="copyText(relay)"
+                @click="copy(relay)"
                 size="xs"
                 color="grey"
                 class="q-mr-sm cursor-pointer"
@@ -568,7 +568,7 @@
             >
               <q-icon
                 name="content_copy"
-                @click="copyText(getConnectionString(connection))"
+                @click="copy(getConnectionString(connection))"
                 size="xs"
                 color="grey"
                 class="q-mr-sm cursor-pointer"
@@ -687,7 +687,7 @@
               >
                 <q-icon
                   name="content_copy"
-                  @click="copyText(relay)"
+                  @click="copy(relay)"
                   size="xs"
                   color="grey"
                   class="q-mr-sm cursor-pointer"
@@ -931,7 +931,7 @@
                 >
                   <q-icon
                     name="content_copy"
-                    @click="copyText(key.publicKey)"
+                    @click="copy(key.publicKey)"
                     size="1.2em"
                     color="grey"
                     class="q-mr-xs cursor-pointer"
@@ -1173,7 +1173,7 @@
                   dense
                   flat
                   icon="content_copy"
-                  @click="copyText(auditorUrl)"
+                  @click="copy(auditorUrl)"
                   size="sm"
                   color="grey"
                 />
@@ -1197,7 +1197,7 @@
                   dense
                   flat
                   icon="content_copy"
-                  @click="copyText(auditorApiUrl)"
+                  @click="copy(auditorApiUrl)"
                   size="sm"
                   color="grey"
                 />
@@ -1764,6 +1764,7 @@
 <script>
 import { debug } from "src/js/logger";
 import { defineComponent } from "vue";
+import { useClipboard } from "src/composables/useClipboard";
 import P2PKDialog from "./P2PKDialog.vue";
 import NWCDialog from "./NWCDialog.vue";
 
@@ -1797,6 +1798,10 @@ export default defineComponent({
   components: {
     P2PKDialog,
     NWCDialog,
+  },
+  setup() {
+    const { copy } = useClipboard();
+    return { copy };
   },
   props: {},
   data: function () {
@@ -2033,7 +2038,7 @@ export default defineComponent({
     exportActiveProofs: async function () {
       // export active proofs
       const token = await this.serializeProofs(this.activeProofs);
-      this.copyText(token);
+      this.copy(token);
     },
     publishMyNutzapProfile: async function () {
       try {

--- a/src/components/SubscriptionReceipt.vue
+++ b/src/components/SubscriptionReceipt.vue
@@ -82,6 +82,7 @@
 
 <script lang="ts">
 import { defineComponent } from "vue";
+import { useClipboard } from "src/composables/useClipboard";
 
 export default defineComponent({
   name: "SubscriptionReceipt",
@@ -94,6 +95,10 @@ export default defineComponent({
     },
   },
   emits: ["update:modelValue"],
+  setup() {
+    const { copy } = useClipboard();
+    return { copy };
+  },
   data() {
     return {
       expanded: {} as Record<string, boolean>,
@@ -111,7 +116,7 @@ export default defineComponent({
   },
   methods: {
     copyToken(token: string) {
-      this.copyText(token);
+      this.copy(token);
     },
     saveToken(token: string) {
       const blob = new Blob([token], { type: "text/plain" });

--- a/src/components/WelcomeDialog.vue
+++ b/src/components/WelcomeDialog.vue
@@ -64,7 +64,7 @@
             flat
             size="0.6rem"
             class="q-mx-xs q-px-none"
-            @click="copyText(baseURL)"
+            @click="copy(baseURL)"
             >Copy URL</q-btn
           >
           <q-btn
@@ -99,6 +99,7 @@
 <script>
 import { defineComponent } from "vue";
 import { mapActions, mapState } from "pinia";
+import { useClipboard } from "src/composables/useClipboard";
 import { useWalletStore } from "src/stores/wallet";
 import { useStorageStore } from "src/stores/storage";
 
@@ -111,6 +112,10 @@ export default defineComponent({
     setTab: Function,
     getPwaDisplayMode: Function,
     setWelcomeDialogSeen: Function,
+  },
+  setup() {
+    const { copy } = useClipboard();
+    return { copy };
   },
   data: function () {
     return {};

--- a/src/composables/useClipboard.ts
+++ b/src/composables/useClipboard.ts
@@ -1,0 +1,25 @@
+import { copyToClipboard, useQuasar } from "quasar";
+import { useI18n } from "vue-i18n";
+
+export function useClipboard() {
+  const $q = useQuasar();
+  const { t } = useI18n();
+
+  const copy = async (text: string, message?: string) => {
+    try {
+      await copyToClipboard(text);
+      $q.notify({
+        message: message ?? t("copied_to_clipboard"),
+        position: "bottom",
+      });
+    } catch (e) {
+      $q.notify({
+        type: "negative",
+        message: t("copy_failed"),
+        position: "bottom",
+      });
+    }
+  };
+
+  return { copy };
+}

--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -1,4 +1,6 @@
 export default {
+  copied_to_clipboard: "Copied to clipboard!",
+  copy_failed: "Copy failed",
   global: {
     copy_to_clipboard: {
       success: "تم النسخ إلى الحافظة!",

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -1,4 +1,6 @@
 export default {
+  copied_to_clipboard: "Copied to clipboard!",
+  copy_failed: "Copy failed",
   global: {
     copy_to_clipboard: {
       success: "In die Zwischenablage kopiert!",

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -1,4 +1,6 @@
 export default {
+  copied_to_clipboard: "Copied to clipboard!",
+  copy_failed: "Copy failed",
   global: {
     copy_to_clipboard: {
       success: "Αντιγράφηκε στο πρόχειρο!",

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1,4 +1,6 @@
 export default {
+  copied_to_clipboard: "Copied to clipboard!",
+  copy_failed: "Copy failed",
   global: {
     copy_to_clipboard: {
       success: "Copied to clipboard!",

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -1,4 +1,6 @@
 export default {
+  copied_to_clipboard: "Copied to clipboard!",
+  copy_failed: "Copy failed",
   global: {
     copy_to_clipboard: {
       success: "¡Copiado al portapapeles!",

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -1,4 +1,6 @@
 export default {
+  copied_to_clipboard: "Copied to clipboard!",
+  copy_failed: "Copy failed",
   global: {
     copy_to_clipboard: {
       success: "Copié dans le presse-papiers !",

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -1,4 +1,6 @@
 export default {
+  copied_to_clipboard: "Copied to clipboard!",
+  copy_failed: "Copy failed",
   global: {
     copy_to_clipboard: {
       success: "Copiato negli appunti!",

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -1,4 +1,6 @@
 export default {
+  copied_to_clipboard: "Copied to clipboard!",
+  copy_failed: "Copy failed",
   global: {
     copy_to_clipboard: {
       success: "クリップボードにコピーしました！",

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -1,4 +1,6 @@
 export default {
+  copied_to_clipboard: "Copied to clipboard!",
+  copy_failed: "Copy failed",
   global: {
     copy_to_clipboard: {
       success: "Kopierat till urklipp!",

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -1,4 +1,6 @@
 export default {
+  copied_to_clipboard: "Copied to clipboard!",
+  copy_failed: "Copy failed",
   global: {
     copy_to_clipboard: {
       success: "คัดลอกไปยังคลิปบอร์ดแล้ว!",

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -1,4 +1,6 @@
 export default {
+  copied_to_clipboard: "Copied to clipboard!",
+  copy_failed: "Copy failed",
   global: {
     copy_to_clipboard: {
       success: "Panoya kopyalandı!",

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -1,4 +1,6 @@
 export default {
+  copied_to_clipboard: "Copied to clipboard!",
+  copy_failed: "Copy failed",
   global: {
     copy_to_clipboard: {
       success: "已复制到剪贴板！",

--- a/src/pages/MyProfilePage.vue
+++ b/src/pages/MyProfilePage.vue
@@ -24,7 +24,7 @@
           flat
           dense
           icon="content_copy"
-          @click="copyText(npub)"
+          @click="copy(npub)"
         />
       </div>
       <div
@@ -36,7 +36,7 @@
           flat
           dense
           icon="content_copy"
-          @click="copyText(seedSignerPrivateKeyNsecComputed)"
+          @click="copy(seedSignerPrivateKeyNsecComputed)"
         />
       </div>
       <div
@@ -48,7 +48,7 @@
           flat
           dense
           icon="content_copy"
-          @click="copyText(privateKeySignerPrivateKey)"
+          @click="copy(privateKeySignerPrivateKey)"
         />
       </div>
       <div class="q-mt-sm">
@@ -87,7 +87,8 @@
 <script lang="ts">
 import { defineComponent, ref, onMounted, computed } from "vue";
 import { storeToRefs } from "pinia";
-import { useQuasar, copyToClipboard } from "quasar";
+import { useQuasar } from "quasar";
+import { useClipboard } from "src/composables/useClipboard";
 import { useI18n } from "vue-i18n";
 import { useNostrStore } from "stores/nostr";
 import { useCreatorHubStore, Tier } from "stores/creatorHub";
@@ -102,6 +103,7 @@ export default defineComponent({
   setup() {
     const $q = useQuasar();
     const { t } = useI18n();
+    const { copy } = useClipboard();
 
     const nostr = useNostrStore();
     const {
@@ -153,14 +155,6 @@ export default defineComponent({
       }
     }
 
-    function copyText(text: string) {
-      copyToClipboard(text).then(() => {
-        $q.notify({
-          message: t("global.copy_to_clipboard.success"),
-          position: "bottom",
-        });
-      });
-    }
 
     return {
       npub,
@@ -175,7 +169,7 @@ export default defineComponent({
       walletBalanceFormatted,
       renderMarkdown,
       formatFiat,
-      copyText,
+      copy,
       supportTier,
     };
   },

--- a/src/pages/welcome/WelcomeSlide3.vue
+++ b/src/pages/welcome/WelcomeSlide3.vue
@@ -37,7 +37,7 @@
             dense
             icon="content_copy"
             class="cursor-pointer q-mt-md"
-            @click="copyText(walletStore.mnemonic)"
+            @click="copy(walletStore.mnemonic)"
             :aria-label="$t('global.actions.copy.label')"
             :title="$t('global.actions.copy.label')"
           ></q-btn>
@@ -61,6 +61,7 @@ import { useWelcomeStore } from "src/stores/welcome";
 import { useWalletStore } from "src/stores/wallet";
 import { ref, computed } from "vue";
 import { useQuasar } from "quasar";
+import { useClipboard } from "src/composables/useClipboard";
 
 export default {
   name: "WelcomeSlide3",
@@ -69,6 +70,7 @@ export default {
     const welcomeStore = useWelcomeStore();
     const walletStore = useWalletStore();
     const $q = useQuasar();
+    const { copy } = useClipboard();
     let hideMnemonic = ref(true);
 
     const hiddenMnemonic = computed(() => {
@@ -95,6 +97,7 @@ export default {
       proceed,
       toggleMnemonicVisibility,
       hiddenMnemonic,
+      copy,
     };
   },
 };


### PR DESCRIPTION
## Summary
- add new `useClipboard` composable for copy notifications
- replace global `copyText` mixin usage with the new composable
- remove `copyText` method from `base.js`
- provide default clipboard messages in every locale

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68564e89f7dc833094e7329b9120ca1e