### PR TITLE
Move welcome page init to mounted

### DIFF
--- a/src/pages/WelcomePage.vue
+++ b/src/pages/WelcomePage.vue
@@ -122,6 +122,9 @@ export default {
     },
   },
   created() {
+    // Keep synchronous: event listeners could be added here in the future
+  },
+  async mounted() {
     // Set the initial selected language based on the current locale or from storage
     const stored = localStorage.getItem("cashu.language");
     const initLocale =


### PR DESCRIPTION
## Summary
- follow Vue lifecycle best practice by keeping `created()` sync
- initialize language selection in new `async mounted()` hook

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685656af5fa083309f8d693ec2507ff8