### PR TITLE
Refactor clipboard and NDK init

### DIFF
--- a/src/boot/base.js
+++ b/src/boot/base.js
@@ -1,4 +1,3 @@
-import { copyToClipboard } from "quasar";
 import { useUiStore } from "stores/ui";
 import { Clipboard } from "@capacitor/clipboard";
 import { SafeArea } from "capacitor-plugin-safe-area";

--- a/src/components/SettingsView.vue
+++ b/src/components/SettingsView.vue
@@ -1794,7 +1794,6 @@ import { useI18n } from "vue-i18n";
 
 export default defineComponent({
   name: "SettingsView",
-  mixins: [windowMixin],
   components: {
     P2PKDialog,
     NWCDialog,

--- a/src/composables/useClipboard.ts
+++ b/src/composables/useClipboard.ts
@@ -1,25 +1,30 @@
-import { copyToClipboard, useQuasar } from "quasar";
-import { useI18n } from "vue-i18n";
+import { useQuasar } from 'quasar'
+import { useI18n } from 'vue-i18n'
 
 export function useClipboard() {
-  const $q = useQuasar();
-  const { t } = useI18n();
+  const $q = useQuasar()
+  const { t } = useI18n()
 
-  const copy = async (text: string, message?: string) => {
-    try {
-      await copyToClipboard(text);
-      $q.notify({
-        message: message ?? t("copied_to_clipboard"),
-        position: "bottom",
-      });
-    } catch (e) {
-      $q.notify({
-        type: "negative",
-        message: t("copy_failed"),
-        position: "bottom",
-      });
-    }
-  };
+  const copy = (text: string, message?: string) => {
+    navigator.clipboard.writeText(text).then(
+      () => {
+        $q.notify({
+          type: 'positive',
+          message: message || t('copied_to_clipboard'),
+          timeout: 1000,
+          position: 'top',
+        })
+      },
+      () => {
+        $q.notify({
+          type: 'negative',
+          message: t('copy_failed'),
+          timeout: 1000,
+          position: 'top',
+        })
+      }
+    )
+  }
 
-  return { copy };
+  return { copy }
 }


### PR DESCRIPTION
## Summary
- modern clipboard composable
- remove broken global mixin references
- robust NDK initialization using reconnect logic
- move async logic from `created` to `mounted` in wallet page
- clean up settings view mixin usage

## Testing
- `npm test` *(fails: getActivePinia not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856613c49dc83308a7947d5360cb889