### PR TITLE
Add useNdk composable

### DIFF
--- a/src/composables/useNdk.ts
+++ b/src/composables/useNdk.ts
@@ -1,0 +1,12 @@
+import { getCurrentInstance } from 'vue'
+import type NDK from '@nostr-dev-kit/ndk'
+import { NdkBootError } from 'boot/ndk'
+
+export function useNdk(): Promise<NDK> {
+  const vm = getCurrentInstance()?.proxy as any
+  const ndkPromise: Promise<NDK> | undefined = vm?.$ndkPromise
+  if (!ndkPromise) {
+    return Promise.reject(new NdkBootError('unknown'))
+  }
+  return ndkPromise
+}


### PR DESCRIPTION
## Summary
- provide a `useNdk` composable for retrieving `$ndkPromise`

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Failed to resolve imports when running vitest)*

------
https://chatgpt.com/codex/tasks/task_e_685676b472d0833097aecaa4f6ee4166