### PR TITLE
Refactor to global NDK

### DIFF
--- a/src/stores/creatorHub.ts
+++ b/src/stores/creatorHub.ts
@@ -11,6 +11,7 @@ import { useMintsStore } from "./mints";
 import { db } from "./dexie";
 import { v4 as uuidv4 } from "uuid";
 import { notifySuccess } from "src/js/notify";
+import { useNdk } from "src/composables/useNdk";
 
 export interface Tier {
   id: string;
@@ -69,7 +70,8 @@ export const useCreatorHubStore = defineStore("creatorHub", {
     async updateProfile(profile: any) {
       const nostr = useNostrStore();
       await nostr.initSignerIfNotSet();
-      const ev = new NDKEvent(nostr.ndk);
+      const ndk = await useNdk();
+      const ev = new NDKEvent(ndk);
       ev.kind = 0;
       ev.content = JSON.stringify(profile);
       await ev.sign(nostr.signer);
@@ -110,7 +112,8 @@ export const useCreatorHubStore = defineStore("creatorHub", {
         "#d": ["tiers"],
         limit: 1,
       };
-      const events = await nostr.ndk.fetchEvents(filter);
+      const ndk = await useNdk();
+      const events = await ndk.fetchEvents(filter);
       events.forEach((ev) => {
         try {
           const data: Tier[] = JSON.parse(ev.content);
@@ -133,7 +136,8 @@ export const useCreatorHubStore = defineStore("creatorHub", {
       const tiersArray = this.getTierArray();
       const nostr = useNostrStore();
       await nostr.initSignerIfNotSet();
-      const ev = new NDKEvent(nostr.ndk);
+      const ndk = await useNdk();
+      const ev = new NDKEvent(ndk);
       ev.kind = TIER_DEFINITIONS_KIND as unknown as NDKKind;
       ev.tags = [["d", "tiers"]];
       ev.created_at = Math.floor(Date.now() / 1000);

--- a/src/stores/npubcash.ts
+++ b/src/stores/npubcash.ts
@@ -18,6 +18,7 @@ import token from "../js/token";
 import { WalletProof, useMintsStore } from "./mints";
 import { useTokensStore } from "../stores/tokens";
 import { useNostrStore } from "../stores/nostr";
+import { useNdk } from "src/composables/useNdk";
 import { DEFAULT_BUCKET_ID } from "./buckets";
 // type NPCConnection = {
 //   walletPublicKey: string,
@@ -121,7 +122,8 @@ export const useNPCStore = defineStore("npc", {
     ): Promise<string> {
       const nostrStore = useNostrStore();
       await nostrStore.initSignerIfNotSet();
-      const nip98Event = new NDKEvent(new NDK());
+      const ndk = await useNdk();
+      const nip98Event = new NDKEvent(ndk);
       nip98Event.kind = NIP98Kind;
       nip98Event.content = "";
       nip98Event.tags = [


### PR DESCRIPTION
## Summary
- rely on global `useNdk` composable instead of per-store NDK instances
- clean up store state for `ndk`

## Testing
- `npm test` *(fails: vitest not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6856786445548330be3bb05d74b9960f