### PR TITLE
Ensure NDK is loaded before page logic

### DIFF
--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -1,10 +1,12 @@
 <template>
-  <q-page
-    class="row full-height no-horizontal-scroll"
-    :class="[$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark']"
-    @touchstart="onTouchStart"
-    @touchend="onTouchEnd"
-  >
+  <Suspense>
+    <template #default>
+      <q-page
+        class="row full-height no-horizontal-scroll"
+        :class="[$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark']"
+        @touchstart="onTouchStart"
+        @touchend="onTouchEnd"
+      >
     <q-responsive>
       <q-drawer
         v-model="drawer"
@@ -51,8 +53,12 @@
       <MessageList :messages="messages" class="col" />
       <MessageInput @send="sendMessage" @sendToken="openSendTokenDialog" />
       <ChatSendTokenDialog ref="chatSendTokenDialogRef" :recipient="selected" />
-    </div>
-  </q-page>
+      </q-page>
+    </template>
+    <template #fallback>
+      <q-skeleton height="100vh" square />
+    </template>
+  </Suspense>
 </template>
 
 <script lang="ts" setup>
@@ -60,6 +66,7 @@ import { computed, ref, onMounted, watch } from "vue";
 import { useRouter } from "vue-router";
 import { useLocalStorage } from "@vueuse/core";
 import { useMessengerStore } from "src/stores/messenger";
+import { useNdk } from "src/composables/useNdk";
 
 import NostrIdentityManager from "components/NostrIdentityManager.vue";
 import RelayManager from "components/RelayManager.vue";
@@ -69,6 +76,8 @@ import ActiveChatHeader from "components/ActiveChatHeader.vue";
 import MessageList from "components/MessageList.vue";
 import MessageInput from "components/MessageInput.vue";
 import ChatSendTokenDialog from "components/ChatSendTokenDialog.vue";
+
+await useNdk();
 
 const messenger = useMessengerStore();
 messenger.loadIdentity();

--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -1,9 +1,11 @@
 <template>
-  <div class="row q-col-gutter-y-md justify-center q-pt-sm q-pb-md">
-    <div class="col-12 col-sm-11 col-md-8 text-center q-gutter-y-md">
-      <ActivityOrb />
-      <NoMintWarnBanner v-if="mints.length == 0" />
-      <BalanceView v-else :set-tab="setTab" />
+  <Suspense>
+    <template #default>
+      <div class="row q-col-gutter-y-md justify-center q-pt-sm q-pb-md">
+        <div class="col-12 col-sm-11 col-md-8 text-center q-gutter-y-md">
+          <ActivityOrb />
+          <NoMintWarnBanner v-if="mints.length == 0" />
+          <BalanceView v-else :set-tab="setTab" />
       <div
         class="wallet-actions row items-center justify-around q-gutter-x-xl q-pt-lg q-pb-md"
       >
@@ -172,7 +174,12 @@
 
     <!-- RECEIVE TOKENS DIALOG  -->
     <ReceiveTokenDialog v-model="showReceiveTokens" />
-  </div>
+      </div>
+    </template>
+    <template #fallback>
+      <q-skeleton height="100vh" square />
+    </template>
+  </Suspense>
 </template>
 <style>
 * {
@@ -246,6 +253,7 @@ import ActivityOrb from "components/ActivityOrb.vue";
 import BucketManager from "components/BucketManager.vue";
 import MissingSignerModal from "src/components/MissingSignerModal.vue";
 import { Dialog } from "quasar";
+import { useNdk } from "src/composables/useNdk";
 
 // pinia stores
 import { mapActions, mapState, mapWritableState } from "pinia";
@@ -620,6 +628,7 @@ export default {
   watch: {},
 
   async mounted() {
+    await useNdk();
     // generate NPC connection
     this.generateNPCConnection();
     this.claimAllTokens();


### PR DESCRIPTION
## Summary
- call `useNdk` at start of NostrMessenger page
- load NDK before other async logic in PublicCreatorProfilePage
- ensure WalletPage waits for NDK before mount
- wrap heavy pages in `<Suspense>`

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68567d8b134883308d60607e073f9910