### PR TITLE
Handle NDK boot errors

### DIFF
--- a/src/components/NdkErrorDialog.vue
+++ b/src/components/NdkErrorDialog.vue
@@ -1,0 +1,48 @@
+<template>
+  <q-dialog v-model="model" persistent>
+    <q-card class="q-pa-md" style="min-width: 300px">
+      <q-card-section class="text-h6">Nostr Error</q-card-section>
+      <q-card-section>
+        <p v-if="error?.reason === 'no-signer'">
+          No available Nostr signer was found. Please install a signer extension
+          or provide an nsec key.
+        </p>
+        <p v-else-if="error?.reason === 'connect-failed'">
+          Failed to connect to the configured relays. Check your internet
+          connection and try again.
+        </p>
+        <p v-else>
+          An unknown error occurred while starting Nostr.
+        </p>
+      </q-card-section>
+      <q-card-actions align="right">
+        <q-btn flat color="primary" @click="retry">Retry</q-btn>
+        <q-btn v-close-popup flat color="grey" @click="close">Close</q-btn>
+      </q-card-actions>
+    </q-card>
+  </q-dialog>
+</template>
+
+<script lang="ts" setup>
+import { computed } from 'vue'
+import { storeToRefs } from 'pinia'
+import { useNdkBootStore } from 'src/stores/ndkBoot'
+
+const ndkBoot = useNdkBootStore()
+const { error } = storeToRefs(ndkBoot)
+
+const model = computed({
+  get: () => error.value !== null,
+  set: (v: boolean) => {
+    if (!v) ndkBoot.setError(null)
+  }
+})
+
+function retry() {
+  ndkBoot.retry()
+}
+
+function close() {
+  ndkBoot.setError(null)
+}
+</script>

--- a/src/composables/useNdk.ts
+++ b/src/composables/useNdk.ts
@@ -1,12 +1,23 @@
 import { getCurrentInstance } from 'vue'
 import type NDK from '@nostr-dev-kit/ndk'
 import { NdkBootError } from 'boot/ndk'
+import { useNdkBootStore } from 'src/stores/ndkBoot'
 
 export function useNdk(): Promise<NDK> {
   const vm = getCurrentInstance()?.proxy as any
   const ndkPromise: Promise<NDK> | undefined = vm?.$ndkPromise
+  const store = useNdkBootStore()
   if (!ndkPromise) {
-    return Promise.reject(new NdkBootError('unknown'))
+    const err = new NdkBootError('unknown')
+    store.setError(err)
+    return Promise.reject(err)
   }
-  return ndkPromise
+  return ndkPromise.catch((e) => {
+    if (e instanceof NdkBootError) {
+      store.setError(e)
+    } else {
+      store.setError(new NdkBootError('unknown', (e as any)?.message))
+    }
+    return Promise.reject(e)
+  })
 }

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -4,12 +4,14 @@
     <q-page-container>
       <router-view />
     </q-page-container>
+    <NdkErrorDialog />
   </q-layout>
 </template>
 
 <script>
 import { defineComponent, ref } from "vue";
 import MainHeader from "components/MainHeader.vue";
+import NdkErrorDialog from "components/NdkErrorDialog.vue";
 import { useNostrStore } from "src/stores/nostr";
 import { useNutzapStore } from "src/stores/nutzap";
 
@@ -18,6 +20,7 @@ export default defineComponent({
   mixins: [windowMixin],
   components: {
     MainHeader,
+    NdkErrorDialog,
   },
   async mounted() {
     const myHex = useNostrStore().pubkey;

--- a/src/stores/ndkBoot.ts
+++ b/src/stores/ndkBoot.ts
@@ -1,0 +1,26 @@
+import { defineStore } from 'pinia'
+import { getNdk, NdkBootError } from 'boot/ndk'
+
+export type NdkBootState = {
+  error: NdkBootError | null
+}
+
+export const useNdkBootStore = defineStore('ndkBoot', {
+  state: (): NdkBootState => ({
+    error: null
+  }),
+  actions: {
+    setError(err: NdkBootError | null) {
+      this.error = err
+    },
+    async retry() {
+      try {
+        await getNdk()
+        this.error = null
+      } catch (e) {
+        this.error = e instanceof NdkBootError ? e : new NdkBootError('unknown', (e as any)?.message)
+        throw e
+      }
+    }
+  }
+})


### PR DESCRIPTION
## Summary
- add NdkErrorDialog component to show boot errors
- create store to track and retry NDK boot failures
- enrich NdkBootError with reason and throw on connect failure
- record boot errors in useNdk composable
- show the error dialog from MainLayout

## Testing
- `npm test` *(fails: getActivePinia error and other failing suites)*

------
https://chatgpt.com/codex/tasks/task_e_68567f0a0f2083309c58d93d30fdb785