### PR TITLE
Refactor NDK usage and update tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
   "devDependencies": {
     "@capacitor/assets": "^3.0.5",
     "@capacitor/cli": "^6.2.0",
+    "@noble/curves": "^1.9.2",
+    "@noble/secp256k1": "^2.3.0",
     "@quasar/app-vite": "^1.9.3",
     "@types/node": "^20.12.11",
     "@types/underscore": "^1.11.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,12 @@ importers:
       '@capacitor/cli':
         specifier: ^6.2.0
         version: 6.2.1
+      '@noble/curves':
+        specifier: ^1.9.2
+        version: 1.9.2
+      '@noble/secp256k1':
+        specifier: ^2.3.0
+        version: 2.3.0
       '@quasar/app-vite':
         specifier: ^1.9.3
         version: 1.11.0(electron-packager@15.5.2)(eslint@8.57.1)(pinia@2.3.1(typescript@5.1.6)(vue@3.5.17(typescript@5.1.6)))(quasar@2.18.1)(rollup@2.79.2)(vue-router@4.5.1(vue@3.5.17(typescript@5.1.6)))(vue@3.5.17(typescript@5.1.6))(workbox-build@6.6.1)

--- a/src/stores/nwc.ts
+++ b/src/stores/nwc.ts
@@ -340,7 +340,8 @@ export const useNWCStore = defineStore("nwc", {
       conn: NWCConnection
     ) {
       // reply to NWC with result
-      let replyEvent = new NDKEvent(event.ndk);
+      const ndk = await useNdk();
+      let replyEvent = new NDKEvent(ndk);
       replyEvent.kind = 23195;
       debug("### replying with", JSON.stringify(result));
       const nostr = useNostrStore();

--- a/test/vitest/__tests__/bucketManagerDrag.spec.ts
+++ b/test/vitest/__tests__/bucketManagerDrag.spec.ts
@@ -1,14 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { shallowMount } from "@vue/test-utils";
-import BucketManager from "../../src/components/BucketManager.vue";
+import BucketManager from "../../../src/components/BucketManager.vue";
 
 const moveProofsMock = vi.fn();
 
-vi.mock("../../src/stores/proofs", () => ({
+vi.mock("../../../src/stores/proofs", () => ({
   useProofsStore: () => ({ moveProofs: moveProofsMock }),
 }));
 
-vi.mock("../../src/stores/buckets", () => ({
+vi.mock("../../../src/stores/buckets", () => ({
   useBucketsStore: () => ({
     bucketList: [{ id: "b1", name: "Bucket 1" }],
     bucketBalances: {},
@@ -19,15 +19,15 @@ vi.mock("../../src/stores/buckets", () => ({
   DEFAULT_BUCKET_ID: "b1",
 }));
 
-vi.mock("../../src/stores/mints", () => ({
+vi.mock("../../../src/stores/mints", () => ({
   useMintsStore: () => ({ activeUnit: "sat" }),
 }));
 
-vi.mock("../../src/stores/ui", () => ({
+vi.mock("../../../src/stores/ui", () => ({
   useUiStore: () => ({ formatCurrency: (a: number) => String(a) }),
 }));
 
-vi.mock("../../src/js/notify", () => ({
+vi.mock("../../../src/js/notify", () => ({
   notifyError: vi.fn(),
 }));
 

--- a/test/vitest/__tests__/bucketManagerForm.spec.ts
+++ b/test/vitest/__tests__/bucketManagerForm.spec.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect, vi } from "vitest";
 import { shallowMount } from "@vue/test-utils";
-import BucketManager from "../../src/components/BucketManager.vue";
+import BucketManager from "../../../src/components/BucketManager.vue";
 
-vi.mock("../../src/stores/proofs", () => ({
+vi.mock("../../../src/stores/proofs", () => ({
   useProofsStore: () => ({ moveProofs: vi.fn() }),
 }));
 
-vi.mock("../../src/stores/buckets", () => ({
+vi.mock("../../../src/stores/buckets", () => ({
   useBucketsStore: () => ({
     bucketList: [],
     bucketBalances: {},
@@ -17,15 +17,15 @@ vi.mock("../../src/stores/buckets", () => ({
   DEFAULT_BUCKET_ID: "b1",
 }));
 
-vi.mock("../../src/stores/mints", () => ({
+vi.mock("../../../src/stores/mints", () => ({
   useMintsStore: () => ({ activeUnit: "sat" }),
 }));
 
-vi.mock("../../src/stores/ui", () => ({
+vi.mock("../../../src/stores/ui", () => ({
   useUiStore: () => ({ formatCurrency: (a: number) => String(a) }),
 }));
 
-vi.mock("../../src/js/notify", () => ({
+vi.mock("../../../src/js/notify", () => ({
   notifyError: vi.fn(),
 }));
 

--- a/test/vitest/__tests__/infoTooltip.spec.ts
+++ b/test/vitest/__tests__/infoTooltip.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { mount } from "@vue/test-utils";
-import InfoTooltip from "../../src/components/InfoTooltip.vue";
+import InfoTooltip from "../../../src/components/InfoTooltip.vue";
 
 describe("InfoTooltip", () => {
   it("shows tooltip on hover", async () => {

--- a/test/vitest/__tests__/moveTokens.spec.ts
+++ b/test/vitest/__tests__/moveTokens.spec.ts
@@ -1,14 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { shallowMount } from "@vue/test-utils";
-import MoveTokens from "../../src/pages/MoveTokens.vue";
+import MoveTokens from "../../../src/pages/MoveTokens.vue";
 
 const moveProofsMock = vi.fn();
 
-vi.mock("../../src/stores/proofs", () => ({
+vi.mock("../../../src/stores/proofs", () => ({
   useProofsStore: () => ({ proofs: [], moveProofs: moveProofsMock }),
 }));
 
-vi.mock("../../src/stores/buckets", () => ({
+vi.mock("../../../src/stores/buckets", () => ({
   useBucketsStore: () => ({
     bucketList: [
       { id: "b1", name: "Bucket 1" },
@@ -17,15 +17,15 @@ vi.mock("../../src/stores/buckets", () => ({
   }),
 }));
 
-vi.mock("../../src/stores/mints", () => ({
+vi.mock("../../../src/stores/mints", () => ({
   useMintsStore: () => ({ activeUnit: "sat" }),
 }));
 
-vi.mock("../../src/stores/ui", () => ({
+vi.mock("../../../src/stores/ui", () => ({
   useUiStore: () => ({ formatCurrency: (a: number) => String(a) }),
 }));
 
-vi.mock("../../src/js/notify", () => ({
+vi.mock("../../../src/js/notify", () => ({
   notifyError: vi.fn(),
 }));
 

--- a/test/vitest/__tests__/nostr.spec.ts
+++ b/test/vitest/__tests__/nostr.spec.ts
@@ -2,63 +2,10 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { useNostrStore } from "../../../src/stores/nostr";
 import { NDKKind } from "@nostr-dev-kit/ndk";
 
-vi.mock("@nostr-dev-kit/ndk", () => {
-  class NDKEvent {
-    kind: number | undefined;
-    content: any;
-    tags: any[] = [];
-    created_at: number | undefined;
-    pubkey = "";
-    sig: string | undefined;
-    id = "";
-    constructor(public ndk?: any) {}
-    getEventHash() {
-      return "hash";
-    }
-    async sign(_s?: any) {
-      this.sig = "signature";
-      return this.sig;
-    }
-    async toNostrEvent() {
-      return {
-        kind: this.kind,
-        content: this.content,
-        tags: this.tags,
-        created_at: this.created_at,
-        pubkey: this.pubkey,
-        id: this.id,
-        sig: this.sig,
-      };
-    }
-    async publish() {}
-  }
-  class NDKPrivateKeySigner {
-    constructor(privateKey: string) {
-      this.privateKey = privateKey;
-    }
-  }
-  class NDK {
-    constructor(opts: any) {
-      this.opts = opts;
-    }
-    connect() {}
-  }
-  return {
-    default: NDK,
-    NDKEvent,
-    NDKSigner: class {},
-    NDKNip07Signer: class {},
-    NDKNip46Signer: class {},
-    NDKFilter: class {},
-    NDKPrivateKeySigner,
-    NostrEvent: class {},
-    NDKKind: { EncryptedDirectMessage: 4 },
-    NDKRelaySet: class {},
-    NDKRelay: class {},
-    NDKTag: class {},
-    ProfilePointer: class {},
-  };
-});
+const ndkStub = {};
+vi.mock("../../../src/composables/useNdk", () => ({
+  useNdk: vi.fn().mockResolvedValue(ndkStub),
+}));
 
 const encryptMock = vi.fn((content: string) => content);
 let publishSuccess = true;

--- a/test/vitest/__tests__/p2pk.spec.ts
+++ b/test/vitest/__tests__/p2pk.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { useP2PKStore } from "../../src/stores/p2pk";
-import { useWalletStore } from "../../src/stores/wallet";
-import { useProofsStore } from "../../src/stores/proofs";
+import { useP2PKStore } from "../../../src/stores/p2pk";
+import { useWalletStore } from "../../../src/stores/wallet";
+import { useProofsStore } from "../../../src/stores/proofs";
 import { generateSecretKey, getPublicKey, nip19 } from "nostr-tools";
 import { bytesToHex } from "@noble/hashes/utils";
 

--- a/test/vitest/__tests__/timelock.spec.ts
+++ b/test/vitest/__tests__/timelock.spec.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { useSendTokensStore } from "../../src/stores/sendTokensStore";
-import { useWalletStore } from "../../src/stores/wallet";
-import { useProofsStore } from "../../src/stores/proofs";
-import { useP2PKStore } from "../../src/stores/p2pk";
+import { useSendTokensStore } from "../../../src/stores/sendTokensStore";
+import { useWalletStore } from "../../../src/stores/wallet";
+import { useProofsStore } from "../../../src/stores/proofs";
+import { useP2PKStore } from "../../../src/stores/p2pk";
 
 beforeEach(() => {
   localStorage.clear();


### PR DESCRIPTION
## Summary
- remove remaining references to `event.ndk`
- stub `useNdk` in unit tests instead of globally mocking NDK
- fix broken relative imports in unit tests
- install noble crypto packages needed for tests

## Testing
- `pnpm test:ci` *(fails: Cannot set property permissions of [object Object] which has only a getter)*

------
https://chatgpt.com/codex/tasks/task_e_685682eaea888330b0a03928592d8705