### PR TITLE
Provide ndk promise via injection

### DIFF
--- a/src/boot/ndk.ts
+++ b/src/boot/ndk.ts
@@ -1,4 +1,5 @@
 import { boot } from "quasar/wrappers";
+import { useBootErrorStore } from 'stores/bootError'
 import NDK, {
   NDKNip07Signer,
   NDKPrivateKeySigner,
@@ -84,5 +85,6 @@ export async function getNdk(): Promise<NDK> {
 
 export default boot(async ({ app }) => {
   ndkPromise = getNdk();
-  app.config.globalProperties.$ndkPromise = ndkPromise;
+  app.provide('$ndkPromise', ndkPromise);
+  ndkPromise.catch((e) => useBootErrorStore().set(e as NdkBootError));
 });

--- a/src/composables/useNdk.ts
+++ b/src/composables/useNdk.ts
@@ -1,11 +1,10 @@
-import { getCurrentInstance } from 'vue'
+import { inject } from 'vue'
 import type NDK from '@nostr-dev-kit/ndk'
 import { NdkBootError } from 'boot/ndk'
 import { useNdkBootStore } from 'src/stores/ndkBoot'
 
 export function useNdk(): Promise<NDK> {
-  const vm = getCurrentInstance()?.proxy as any
-  const ndkPromise: Promise<NDK> | undefined = vm?.$ndkPromise
+  const ndkPromise = inject<Promise<NDK> | undefined>('$ndkPromise')
   const store = useNdkBootStore()
   if (!ndkPromise) {
     const err = new NdkBootError('unknown')

--- a/src/stores/bootError.ts
+++ b/src/stores/bootError.ts
@@ -1,0 +1,16 @@
+import { defineStore } from 'pinia'
+import type { NdkBootError } from 'boot/ndk'
+
+export const useBootErrorStore = defineStore('bootError', {
+  state: () => ({
+    error: null as NdkBootError | null
+  }),
+  actions: {
+    set(error: NdkBootError) {
+      this.error = error
+    },
+    clear() {
+      this.error = null
+    }
+  }
+})


### PR DESCRIPTION
## Summary
- create `bootError` pinia store to save boot errors
- provide `$ndkPromise` using Vue's provider API and record boot failures
- update `useNdk` composable to retrieve promise via `inject`

## Testing
- `pnpm exec vitest run` *(fails: getActivePinia() was called but there was no active Pinia etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685693e5a7e4833094e231f389cfb8ea