### PR TITLE
Refactor onMounted async usage

### DIFF
--- a/src/components/ConversationList.vue
+++ b/src/components/ConversationList.vue
@@ -72,7 +72,8 @@ const loadProfiles = async () => {
   }
 };
 
-onMounted(loadProfiles);
+await loadProfiles();
+onMounted(() => {});
 watch(uniqueConversations, loadProfiles);
 
 const select = (pubkey: string) => emit("select", pubkey);

--- a/src/components/QrcodeReader.vue
+++ b/src/components/QrcodeReader.vue
@@ -20,12 +20,15 @@ export default {
       urDecoderProgress: 0,
     };
   },
-  setup() {
+  async setup() {
     const instance = getCurrentInstance();
-    onMounted(async () => {
+    async function initScanner() {
       QrScanner = (await import("qr-scanner")).default;
       URDecoder = (await import("@gandlaf21/bc-ur")).URDecoder;
+    }
 
+    await initScanner();
+    onMounted(() => {
       if (!instance) return;
       const vm: any = instance.proxy;
       vm.qrScanner = new QrScanner(

--- a/src/pages/CreatorDashboardPage.vue
+++ b/src/pages/CreatorDashboardPage.vue
@@ -224,7 +224,7 @@ export default defineComponent({
       { immediate: true, deep: true }
     );
 
-    onMounted(async () => {
+    async function initPage() {
       if (!store.loggedInNpub) {
         router.push("/creator/login");
         return;
@@ -234,7 +234,10 @@ export default defineComponent({
       const npub = nostr.pubkey;
       const existing = await fetchNutzapProfile(npub);
       needsProfile.value = !existing;
-    });
+    }
+
+    await initPage();
+    onMounted(() => {});
 
     const logout = () => {
       store.logout();

--- a/src/pages/MyProfilePage.vue
+++ b/src/pages/MyProfilePage.vue
@@ -126,11 +126,14 @@ export default defineComponent({
       uiStore.formatCurrency(walletBalance.value, activeUnit.value)
     );
 
-    onMounted(async () => {
+    async function initProfile() {
       if (!npub.value) return;
       const p = await nostr.getProfile(npub.value);
       if (p) profile.value = { ...p };
-    });
+    }
+
+    await initProfile();
+    onMounted(() => {});
 
     function renderMarkdown(text: string): string {
       return renderMarkdownFn(text || "");

--- a/src/pages/PublicCreatorProfilePage.vue
+++ b/src/pages/PublicCreatorProfilePage.vue
@@ -132,7 +132,8 @@ export default defineComponent({
       followers.value = await nostr.fetchFollowerCount(creatorNpub);
       following.value = await nostr.fetchFollowingCount(creatorNpub);
     };
-    onMounted(loadProfile);
+    await loadProfile();
+    onMounted(() => {});
 
     await useNdk();
 

--- a/src/pages/SubscriptionsOverview.vue
+++ b/src/pages/SubscriptionsOverview.vue
@@ -781,17 +781,18 @@ function copyToken(token: string) {
   copy(token);
 }
 
-function updateProfiles() {
-  subscriptionsStore.subscriptions.forEach(async (sub) => {
+async function updateProfiles() {
+  for (const sub of subscriptionsStore.subscriptions) {
     const pk = sub.creatorNpub;
     if (!profiles.value[pk]) {
       const p = await nostr.getProfile(pk);
       if (p) profiles.value[pk] = p;
     }
-  });
+  }
 }
 
-onMounted(updateProfiles);
+await updateProfiles();
+onMounted(() => {});
 watch(() => subscriptionsStore.subscriptions, updateProfiles);
 
 const columns = computed(() => [


### PR DESCRIPTION
## Summary
- move awaited logic out of `onMounted`
- import QR code scanner before mounting
- load conversation profiles before mount
- fetch creator profile data before mount
- prefetch user profile data in MyProfilePage
- load subscriptions profiles before mount

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856964ec01483308e0eb470713d3a55