### PR TITLE
Fix ESLint lifecycle rule in profile page

### DIFF
--- a/src/pages/MyProfilePage.vue
+++ b/src/pages/MyProfilePage.vue
@@ -132,8 +132,9 @@ export default defineComponent({
       if (p) profile.value = { ...p };
     }
 
-    await initProfile();
-    onMounted(() => {});
+    onMounted(async () => {
+      await initProfile();
+    });
 
     function renderMarkdown(text: string): string {
       return renderMarkdownFn(text || "");


### PR DESCRIPTION
## Summary
- move profile initialization into `onMounted` to satisfy `vue/no-lifecycle-after-await`

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856f09911d08330851193dd70aeb767