### PR TITLE
Fix Nostr error dialog for locked signer

### DIFF
--- a/src/components/NdkErrorDialog.vue
+++ b/src/components/NdkErrorDialog.vue
@@ -1,67 +1,79 @@
 <template>
-  <q-dialog v-model="model" persistent>
-    <q-card class="q-pa-md" style="min-width: 300px">
+  <q-dialog v-model="show" persistent>
+    <q-card>
       <q-card-section class="text-h6">Nostr Error</q-card-section>
+
+      <!-- Message -->
       <q-card-section>
-        <template v-if="error?.reason === 'nip07-locked'">
-          <p>Please unlock your NIP-07 signer extension and retry.</p>
-        </template>
-        <template v-else-if="error?.reason === 'no-signer'">
-          <p>No available Nostr signer found. Please enter your nsec key.</p>
-          <q-input v-model="nsec" label="nsec" type="text" dense autofocus />
-        </template>
-        <template v-else>
-          <p>An unknown error occurred while starting Nostr.</p>
-        </template>
+        <p v-if="isLocked">
+          Please unlock your NIP‑07 signer extension and click <b>Retry</b>,
+          or paste an <code>nsec</code> below.
+        </p>
+        <p v-else-if="reason === 'no-signer'">
+          No Nostr signer found. Paste an <code>nsec</code> to continue.
+        </p>
+        <p v-else>
+          An unknown error occurred while starting Nostr.
+        </p>
       </q-card-section>
+
+      <!-- nsec input (for both locked + no‑signer) -->
+      <q-card-section v-if="allowPaste">
+        <q-input
+          v-model="nsec"
+          type="password"
+          label="nsec (private key)"
+          dense
+          autofocus
+        />
+      </q-card-section>
+
+      <!-- actions -->
       <q-card-actions align="right">
+        <q-btn flat label="Close" @click="closeDialog" />
         <q-btn
-          v-if="error?.reason === 'no-signer'"
-          flat
+          v-if="allowPaste"
           color="primary"
+          label="Continue"
           @click="saveNsec"
-          >Continue</q-btn
-        >
+        />
         <q-btn
           v-else
-          flat
           color="primary"
+          label="Retry"
           @click="retry"
-          >Retry</q-btn
-        >
-        <q-btn flat label="Close" @click="errStore.clear()" v-close-popup />
+        />
       </q-card-actions>
     </q-card>
   </q-dialog>
 </template>
 
-<script lang="ts" setup>
-import { ref, computed } from 'vue'
-import { storeToRefs } from 'pinia'
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { LocalStorage } from 'quasar'
 import { useBootErrorStore } from 'stores/bootError'
 
-const errStore = useBootErrorStore()
-const { error } = storeToRefs(errStore)
+const errStore   = useBootErrorStore()
+const show       = computed(() => !!errStore.error)
+const reason     = computed(() => errStore.error?.reason ?? 'unknown')
+const isLocked   = computed(() => reason.value === 'nip07-locked')
+const allowPaste = computed(() => isLocked.value || reason.value === 'no-signer')
 
 const nsec = ref('')
 
-const model = computed({
-  get: () => error.value !== null,
-  set: (v: boolean) => {
-    if (!v) errStore.clear()
-  }
-})
-
-function saveNsec() {
-  const key = nsec.value.trim()
-  if (!key) return
-  localStorage.setItem('nsec', key)
+function saveNsec () {
+  if (!nsec.value.startsWith('nsec')) return
+  LocalStorage.set('nsec', nsec.value.trim())
   errStore.clear()
   location.reload()
 }
 
-function retry() {
+function retry () {
   errStore.clear()
   location.reload()
+}
+
+function closeDialog () {
+  errStore.clear()
 }
 </script>


### PR DESCRIPTION
## Summary
- improve the Nostr error dialog UI
- allow pasting an nsec key when the NIP-07 signer is locked
- simplify dialog script using Quasar `LocalStorage`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856f218d3d88330bbc3509d833a95b8