### PR TITLE
Refactor async hook usage

### DIFF
--- a/src/pages/MyProfilePage.vue
+++ b/src/pages/MyProfilePage.vue
@@ -100,7 +100,7 @@ import { renderMarkdown as renderMarkdownFn } from "src/js/simple-markdown";
 
 export default defineComponent({
   name: "MyProfilePage",
-  async setup() {
+  setup() {
     const $q = useQuasar();
     const { t } = useI18n();
     const { copy } = useClipboard();
@@ -132,8 +132,8 @@ export default defineComponent({
       if (p) profile.value = { ...p };
     }
 
-    onMounted(async () => {
-      await initProfile();
+    onMounted(() => {
+      initProfile();
     });
 
     function renderMarkdown(text: string): string {

--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -77,12 +77,12 @@ import MessageList from "components/MessageList.vue";
 import MessageInput from "components/MessageInput.vue";
 import ChatSendTokenDialog from "components/ChatSendTokenDialog.vue";
 
-await useNdk();
+const ndkPromise = useNdk();
 
 const messenger = useMessengerStore();
 messenger.loadIdentity();
 onMounted(() => {
-  messenger.start();
+  ndkPromise.then(() => messenger.start());
 });
 
 const router = useRouter();

--- a/src/pages/PublicCreatorProfilePage.vue
+++ b/src/pages/PublicCreatorProfilePage.vue
@@ -106,7 +106,7 @@ import PaywalledContent from "components/PaywalledContent.vue";
 export default defineComponent({
   name: "PublicCreatorProfilePage",
   components: { PaywalledContent, SubscriptionReceipt },
-  async setup() {
+  setup() {
     const route = useRoute();
     const creatorNpub = route.params.npub as string;
     const creators = useCreatorsStore();
@@ -132,10 +132,8 @@ export default defineComponent({
       followers.value = await nostr.fetchFollowerCount(creatorNpub);
       following.value = await nostr.fetchFollowingCount(creatorNpub);
     };
-    await loadProfile();
-    onMounted(() => {});
-
-    await useNdk();
+    loadProfile();
+    useNdk();
 
     const openSubscribe = (tier: any) => {
       selectedTier.value = tier;


### PR DESCRIPTION
## Summary
- avoid async setup and awaits in page lifecycle hooks
- call `useNdk` without awaiting
- run async initialization functions without awaiting inside `onMounted`

## Testing
- `pnpm lint` *(fails: ESLint couldn't find config)*
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856fecd63588330a1aeefc2af04339b