### PR TITLE
Fix local signer retrieval

### DIFF
--- a/src/boot/ndk.ts
+++ b/src/boot/ndk.ts
@@ -31,9 +31,12 @@ let ndkInstance: NDK | undefined;
 let ndkPromise: Promise<NDK> | undefined;
 
 async function resolveSigner(): Promise<NDKSigner> {
-  const nsec = localStorage.getItem("nsec");
-  if (nsec?.trim().startsWith("nsec")) {
-    return NDKPrivateKeySigner.fromNsec(nsec.trim());
+  // 1 ─ local nsec (strip legacy JSON quotes if present)
+  const raw = window.localStorage.getItem('nsec') ?? ''
+  const clean = raw.replace(/^"+|"+$/g, '').trim()        // "nsec…"
+  // TODO: sanitize quoted legacy values once
+  if (clean.startsWith('nsec')) {
+    return NDKPrivateKeySigner.fromNsec(clean)
   }
 
   if (typeof window !== "undefined" && (window as any).nostr) {
@@ -54,7 +57,7 @@ async function resolveSigner(): Promise<NDKSigner> {
     }
   }
 
-  throw new NdkBootError("no-signer", "No available Nostr signer");
+  throw new NdkBootError('no-signer', 'No available Nostr signer')
 }
 
 async function createNdk(): Promise<NDK> {

--- a/src/components/NdkErrorDialog.vue
+++ b/src/components/NdkErrorDialog.vue
@@ -50,7 +50,6 @@
 
 <script setup lang="ts">
 import { computed, ref } from 'vue'
-import { LocalStorage } from 'quasar'
 import { useBootErrorStore } from 'stores/bootError'
 
 const errStore   = useBootErrorStore()
@@ -63,7 +62,7 @@ const nsec = ref('')
 
 function saveNsec () {
   if (!nsec.value.startsWith('nsec')) return
-  LocalStorage.set('nsec', nsec.value.trim())
+  window.localStorage.setItem('nsec', nsec.value.trim())
   errStore.clear()
   location.reload()
 }

--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -625,10 +625,6 @@ export default {
       }
     },
     async initPage() {
-      await useNdk();
-      // generate NPC connection
-      this.generateNPCConnection();
-      this.claimAllTokens();
 
       // Initialize and run migrations
       const migrationsStore = useMigrationsStore();
@@ -709,6 +705,11 @@ export default {
   watch: {},
 
   mounted() {
+    const ndkReady = useNdk();
+    ndkReady.then(() => {
+      this.generateNPCConnection();
+      this.claimAllTokens();
+    });
     this.initPage();
   },
 


### PR DESCRIPTION
## Summary
- store pasted nsec directly in localStorage
- sanitize quotes when reading the key
- delay WalletPage actions until NDK is ready

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68570143b4188330802f996feb572716