### PR TITLE
Fix NDK private key initialization

### DIFF
--- a/src/pages/SubscriptionsOverview.vue
+++ b/src/pages/SubscriptionsOverview.vue
@@ -791,8 +791,13 @@ async function updateProfiles() {
   }
 }
 
-await updateProfiles();
-onMounted(() => {});
+onMounted(async () => {
+  try {
+    await updateProfiles();
+  } catch (e: any) {
+    notifyError(e.message);
+  }
+});
 watch(() => subscriptionsStore.subscriptions, updateProfiles);
 
 const columns = computed(() => [


### PR DESCRIPTION
## Summary
- decode `nsec` keys with `nip19.decode` and create `NDKPrivateKeySigner` from hex
- fetch profiles after mount in `SubscriptionsOverview` and surface errors via toast

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bdcf51a5883308597339b77a559cd