### PR TITLE
Fix creator dashboard init

### DIFF
--- a/src/pages/CreatorDashboardPage.vue
+++ b/src/pages/CreatorDashboardPage.vue
@@ -236,8 +236,13 @@ export default defineComponent({
       needsProfile.value = !existing;
     }
 
-    await initPage();
-    onMounted(() => {});
+    onMounted(async () => {
+      try {
+        await initPage();
+      } catch (e) {
+        notifyError('Creator dashboard disabled – signer missing');
+      }
+    });
 
     const logout = () => {
       store.logout();


### PR DESCRIPTION
## Summary
- init page inside mounted hook
- show error when signer missing

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: eslint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_685be14c4f64833081cef790c4b1b1b2