### PR TITLE
Check wallet initKeys

### DIFF
--- a/src/boot/cashu.js
+++ b/src/boot/cashu.js
@@ -16,5 +16,7 @@ export default boot(async () => {
     });
     throw new Error("Unsupported mint");
   }
-  await walletStore.wallet.initKeys();
+  if (typeof walletStore.initKeys === "function") {
+    await walletStore.initKeys();
+  }
 });


### PR DESCRIPTION
## Summary
- ensure the boot wallet uses `initKeys` directly if the method exists

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ceb42da788330a01ce3497f8154d1