### PR TITLE
Fix NostrMessenger HTML structure

### DIFF
--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -53,6 +53,7 @@
       <MessageList :messages="messages" class="col" />
       <MessageInput @send="sendMessage" @sendToken="openSendTokenDialog" />
       <ChatSendTokenDialog ref="chatSendTokenDialogRef" :recipient="selected" />
+      </div>
       </q-page>
     </template>
     <template #fallback>


### PR DESCRIPTION
## Summary
- close unbalanced `div` in `NostrMessenger.vue`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cf1bc90ec8330abccdd6228da3aa8