### PR TITLE
Add alias for local cashu-ts library

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -10,7 +10,8 @@
       "assets/*": ["src/assets/*"],
       "boot/*": ["src/boot/*"],
       "stores/*": ["src/stores/*"],
-      "vue$": ["node_modules/vue/dist/vue.runtime.esm-bundler.js"]
+      "vue$": ["node_modules/vue/dist/vue.runtime.esm-bundler.js"],
+      "@cashu/cashu-ts": ["src/lib/cashu-ts/src/index.ts"]
     }
   },
   "exclude": ["dist", ".quasar", "node_modules", "android", "ios"]

--- a/quasar.config.js
+++ b/quasar.config.js
@@ -9,6 +9,7 @@
 // https://v2.quasar.dev/quasar-cli-vite/quasar-config-js
 
 const { configure } = require("quasar/wrappers");
+const path = require("path");
 
 module.exports = configure(function (/* ctx */) {
   return {
@@ -58,7 +59,13 @@ module.exports = configure(function (/* ctx */) {
       // polyfillModulePreload: true,
       // distDir
 
-      // extendViteConf (viteConf) {},
+      extendViteConf(viteConf) {
+        viteConf.resolve = viteConf.resolve || {};
+        viteConf.resolve.alias = {
+          ...(viteConf.resolve.alias || {}),
+          "@cashu/cashu-ts": path.resolve(__dirname, "src/lib/cashu-ts/src/index.ts"),
+        };
+      },
       // viteVuePluginOptions: {},
 
       // vitePlugins: [

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -32,6 +32,7 @@ export default defineConfig({
       assets: path.resolve(__dirname, "src/assets"),
       boot: path.resolve(__dirname, "src/boot"),
       stores: path.resolve(__dirname, "src/stores"),
+      "@cashu/cashu-ts": path.resolve(__dirname, "src/lib/cashu-ts/src/index.ts"),
     },
   },
   plugins: [


### PR DESCRIPTION
## Summary
- ensure Quasar and Vitest resolve `@cashu/cashu-ts` to the local copy
- add same alias in `jsconfig.json` for editor support

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e46809c4c8330884313827f11c610