### PR TITLE
fix urlsToRelaySet uses ndk

### DIFF
--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -74,7 +74,7 @@ async function urlsToRelaySet(urls?: string[]): Promise<NDKRelaySet | undefined>
     throw new Error('NDK instance unavailable');
   }
 
-  const set = new NDKRelaySet();
+  const set = new NDKRelaySet(ndk);
   for (const u of urls) {
     let relay: NDKRelay | undefined;
     try {


### PR DESCRIPTION
## Summary
- connect NDKRelaySet to NDK instance

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e5de0e4cc8330b0d1d66b765c9c39