### PR TITLE
Update Vitest setup

### DIFF
--- a/test/vitest/setup-file.js
+++ b/test/vitest/setup-file.js
@@ -1,23 +1,12 @@
-import "happy-dom";
-import "fake-indexeddb/auto";
-import { vi, beforeEach } from "vitest";
-import { createPinia, setActivePinia } from "pinia";
+import { setActivePinia, createPinia } from 'pinia';
+import { beforeAll } from 'vitest';
+import { Quasar, Dialog } from 'quasar';
+import { createI18n } from 'vue-i18n';
+import { config } from '@vue/test-utils';
 
-vi.mock("quasar", () => ({
-  Notify: { create: vi.fn() },
-}));
-
-// polyfill navigator.permissions for camera checks
-if (typeof navigator !== "undefined") {
-  if (!navigator.permissions) navigator.permissions = {};
-  if (!navigator.permissions.query) {
-    navigator.permissions.query = async ({ name }) => {
-      if (name === "camera") return { state: "granted" };
-      return { state: "prompt" };
-    };
-  }
-}
-
-beforeEach(() => {
-  setActivePinia(createPinia());
-});
+beforeAll(() => setActivePinia(createPinia()));
+config.global.plugins = [
+  [Quasar, { plugins: { Dialog } }],
+  createI18n({ legacy: false, locale: 'en', messages: { en: {} } }),
+];
+config.global.stubs = { 'router-link': { template: '<a><slot/></a>' }, InfoTooltip: true };


### PR DESCRIPTION
## Summary
- replace `test/vitest/setup-file.js` with new bootstrap
- keep vitest config pointing to the setup file

## Testing
- `pnpm install` *(fails: No matching version for `@nostr-dev-kit/ndk`)*
- `npx vitest run` *(fails: requires package installation)*

------
https://chatgpt.com/codex/tasks/task_e_685e73b8039c8330add88d4d99136d1a