### PR TITLE
Add QIcon stub for tests

### DIFF
--- a/test/vitest/setup-file.js
+++ b/test/vitest/setup-file.js
@@ -1,3 +1,8 @@
+vi.mock('quasar', async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, QIcon: actual.QIcon || { name: 'QIcon', template: '<i />' } };
+});
+
 import { setActivePinia, createPinia } from 'pinia';
 import { beforeAll } from 'vitest';
 import { Quasar, Dialog } from 'quasar';


### PR DESCRIPTION
## Summary
- stub `QIcon` globally for Vitest in `setup-file.js`

## Testing
- `npx vitest` *(fails: package not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685e74f5ba188330aac2f10f375c724c