### PR TITLE
Add missing dev dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@capacitor/core": "^6.2.0",
         "@capacitor/haptics": "^6.0.2",
         "@capacitor/ios": "^6.0.0",
-        "@cashu/cashu-ts": "file:src/lib/cashu-ts",
+        "@cashu/cashu-ts": "file:./src/lib/cashu-ts",
         "@cashu/crypto": "^0.3.4",
         "@chenfengyuan/vue-qrcode": "^2.0.0",
         "@gandlaf21/bc-ur": "^1.1.12",
@@ -59,6 +59,8 @@
         "eslint-plugin-vue": "^9.26.0",
         "fake-indexeddb": "^6.0.1",
         "happy-dom": "^14.3.10",
+        "mock-socket": "^9.3.1",
+        "msw": "^2.6.6",
         "prettier": "^2.8.8",
         "typescript": "5.1.6",
         "vitest": "^1.5.0",
@@ -68,7 +70,8 @@
         "workbox-expiration": "^6.6.1",
         "workbox-precaching": "^6.6.1",
         "workbox-routing": "^6.6.1",
-        "workbox-strategies": "^6.6.1"
+        "workbox-strategies": "^6.6.1",
+        "ws": "^8.16.0"
       },
       "engines": {
         "node": ">=16.11.0",
@@ -2038,7 +2041,7 @@
       }
     },
     "node_modules/@cashu/cashu-ts": {
-      "version": "file:src/lib/cashu-ts",
+      "version": "file:./src/lib/cashu-ts",
       "license": "MIT",
       "dependencies": {
         "@cashu/crypto": "^0.3.4",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "vue": "^3.4.27",
     "vue-i18n": "^11.1.3",
     "vue-router": "^4.3.2",
-    "@cashu/cashu-ts": "file:src/lib/cashu-ts"
+    "@cashu/cashu-ts": "file:./src/lib/cashu-ts"
   },
   "devDependencies": {
     "@capacitor/assets": "^3.0.5",
@@ -73,6 +73,8 @@
     "eslint-plugin-vue": "^9.26.0",
     "fake-indexeddb": "^6.0.1",
     "happy-dom": "^14.3.10",
+    "mock-socket": "^9.3.1",
+    "msw": "^2.6.6",
     "prettier": "^2.8.8",
     "typescript": "5.1.6",
     "vitest": "^1.5.0",
@@ -82,7 +84,8 @@
     "workbox-expiration": "^6.6.1",
     "workbox-precaching": "^6.6.1",
     "workbox-routing": "^6.6.1",
-    "workbox-strategies": "^6.6.1"
+    "workbox-strategies": "^6.6.1",
+    "ws": "^8.16.0"
   },
   "engines": {
     "node": ">=16.11.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,6 +171,12 @@ importers:
       happy-dom:
         specifier: ^14.3.10
         version: 14.12.3
+      mock-socket:
+        specifier: ^9.3.1
+        version: 9.3.1
+      msw:
+        specifier: ^2.6.6
+        version: 2.6.6
       prettier:
         specifier: ^2.8.8
         version: 2.8.8
@@ -201,6 +207,9 @@ importers:
       workbox-strategies:
         specifier: ^6.6.1
         version: 6.6.1
+      ws:
+        specifier: ^8.16.0
+        version: 8.18.0
 
 packages:
 


### PR DESCRIPTION
## Summary
- add `mock-socket`, `msw`, and `ws` to `devDependencies`
- update package- and pnpm-lock files

## Testing
- `npm install --package-lock-only` *(fails: Invalid Version: file:./src/lib/cashu-ts)*
- `pnpm add -D mock-socket msw ws` *(fails: No matching version for @nostr-dev-kit/ndk@^3.2.0)*

------
https://chatgpt.com/codex/tasks/task_e_685e75c4f8208330b7d1bd9cf179830d