### PR TITLE
Update p2pk mock for nutzap tests

### DIFF
--- a/test/vitest/__tests__/nutzap.spec.ts
+++ b/test/vitest/__tests__/nutzap.spec.ts
@@ -22,6 +22,7 @@ vi.mock("../../../src/stores/p2pk", () => ({
   useP2PKStore: () => ({
     lockToPubKey: (...args: any[]) => lockToPubKey(...args),
     getTokenLocktime: (...args: any[]) => getTokenLocktime(...args),
+    generateRefundSecret: () => ({ preimage: 'pre', hash: 'hash' }),
   }),
 }));
 


### PR DESCRIPTION
## Summary
- extend p2pk mock in nutzap tests to include `generateRefundSecret`

## Testing
- `npm test` *(fails: `vitest` not found)*
- `pnpm install` *(fails: no matching version for @nostr-dev-kit/ndk)*

------
https://chatgpt.com/codex/tasks/task_e_685e7742fc008330984a2c3a54f76077