### PR TITLE
Fix camera permission mocking in tests

### DIFF
--- a/test/vitest/__tests__/camera.spec.ts
+++ b/test/vitest/__tests__/camera.spec.ts
@@ -16,10 +16,15 @@ describe("Camera store", () => {
   });
 
   it("checks camera permission", async () => {
-    const queryMock = vi.fn().mockResolvedValue({ state: "granted" });
-    (navigator as any).permissions = { query: queryMock };
+    const permissionsGetSpy = vi
+      .spyOn(navigator, "permissions", "get")
+      .mockReturnValue({
+        query: vi.fn().mockResolvedValue({ state: "granted" }),
+      });
     const store = useCameraStore();
     await store.hasCamera();
-    expect(queryMock).toHaveBeenCalledWith({ name: "camera" });
+    expect(permissionsGetSpy.mock.results[0].value.query).toHaveBeenCalledWith({
+      name: "camera",
+    });
   });
 });


### PR DESCRIPTION
## Summary
- use `vi.spyOn` on the navigator permission getter
- verify mocked `query` call

## Testing
- `npx vitest run` *(fails: Cannot find module 'vitest/config')*

------
https://chatgpt.com/codex/tasks/task_e_685e78b3010083308b5642ab4fed404a