### PR TITLE
Update messenger sendToken spec

### DIFF
--- a/test/vitest/__tests__/messenger-send-token.spec.ts
+++ b/test/vitest/__tests__/messenger-send-token.spec.ts
@@ -81,7 +81,7 @@ describe("messenger.sendToken", () => {
     expect(walletSend).toHaveBeenCalled();
     expect(sendDm).toHaveBeenCalledWith(
       "receiver",
-      "note\nTOKEN",
+      expect.stringContaining('\"token\":\"TOKEN\"'),
       "priv",
       "pub"
     );


### PR DESCRIPTION
## Summary
- update test expectation for messenger sendToken

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e7a0a3ef48330b6326d7f39031336