### PR TITLE
Add runtime fallback for NDK relays

### DIFF
--- a/src/boot/ndk.ts
+++ b/src/boot/ndk.ts
@@ -30,6 +30,11 @@ export const DEFAULT_RELAYS = [
   "wss://relay.primal.net/",
 ];
 
+// ensure there is at least one relay configured at runtime
+if (DEFAULT_RELAYS.length === 0) {
+  DEFAULT_RELAYS.push("wss://relay.damus.io/")
+}
+
 let ndkInstance: NDK | undefined;
 let ndkPromise: Promise<NDK> | undefined;
 


### PR DESCRIPTION
## Summary
- ensure that at least one NDK relay is configured at runtime

## Testing
- `npm test` *(fails: vitest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68611ed4ff988330b67b37b6accfcce3