### PR TITLE
Fix optional NDK in urlsToRelaySet

### DIFF
--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -69,9 +69,10 @@ interface NutzapProfile {
 async function urlsToRelaySet(urls?: string[]): Promise<NDKRelaySet | undefined> {
   if (!urls?.length) return undefined;
 
-  const ndk = await getNdk();
+  const ndk = await getNdk?.();
   if (!ndk) {
-    throw new Error('NDK instance unavailable');
+    console.warn("[urlsToRelaySet] NDK not ready \u2013 skip");
+    return undefined;
   }
 
   const set = new NDKRelaySet(ndk);


### PR DESCRIPTION
## Summary
- handle missing NDK in `urlsToRelaySet`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68611f89322483309ef3eb5bf7cefa5b