### PR TITLE
Update comment for early NDK check

### DIFF
--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -69,9 +69,11 @@ interface NutzapProfile {
 async function urlsToRelaySet(urls?: string[]): Promise<NDKRelaySet | undefined> {
   if (!urls?.length) return undefined;
 
+  // NOTE: during very early boot `getNdk?.()` may return `undefined`
+  // because the NDK store hasn't been initialized yet.
   const ndk = await getNdk?.();
   if (!ndk) {
-    console.warn("[urlsToRelaySet] NDK not ready \u2013 skip");
+    console.warn("[urlsToRelaySet] NDK not ready \u2013 skipping relay-set build");
     return undefined;
   }
 


### PR DESCRIPTION
## Summary
- document `getNdk?.()` possibly returning `undefined` early in boot
- adjust warning text when skipping relay-set build

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68618225936c83308887387f33edc6ef