### PR TITLE
fix(A-2-final-cleanup): relay list, duplicate line, modal watcher

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,3 @@
+export default {
+  extends: ["./.eslintrc.js"],
+};

--- a/src/boot/ndk.ts
+++ b/src/boot/ndk.ts
@@ -24,9 +24,7 @@ export class NdkBootError extends Error {
 }
 
 export const DEFAULT_RELAYS = [
-  "wss://relay.f7z.io/",
   "wss://relay.damus.io/",
-  "wss://relay.nostr.band/",
   "wss://relay.primal.net/",
 ];
 

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -1,11 +1,13 @@
 <template>
   <q-layout view="lHh Lpr lFf">
+    <!-- global utility dialogs – mount once -->
+    <MissingSignerModal />
+    <NdkErrorDialog />
+
     <MainHeader />
     <q-page-container>
       <router-view />
     </q-page-container>
-    <NdkErrorDialog />
-    <MissingSignerModal />
   </q-layout>
 </template>
 

--- a/src/pages/CreatorDashboardPage.vue
+++ b/src/pages/CreatorDashboardPage.vue
@@ -296,8 +296,15 @@ export default defineComponent({
       try {
         await nostr.initSignerIfNotSet();
       } catch (e) {
-        uiStore.showMissingSignerModal = true;
-        return;
+        const ui = useUiStore();
+        ui.showMissingSignerModal = true;
+        await new Promise<void>(resolve => {
+          const stop = watch(
+            () => ui.showMissingSignerModal,
+            v => { if (!v) { stop(); resolve(); } }
+          );
+        });
+        if (!useSignerStore().method) { return; }
       }
       try {
         await publishNutzapProfile({

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -77,7 +77,7 @@ async function urlsToRelaySet(urls?: string[]): Promise<NDKRelaySet | undefined>
     return undefined;
   }
 
-  const set = new NDKRelaySet(ndk);
+  const set = new NDKRelaySet(ndk);      // single declaration, keep
   for (const u of urls) {
     let relay: NDKRelay | undefined;
     try {

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -714,23 +714,17 @@ export const useWalletStore = defineStore("wallet", {
         }
 
         if (!privkey && needsSig && !remoteSigned) {
-          const signerStore = useSignerStore();
-          const uiStore = useUiStore();
-          signerStore.reset();
-          uiStore.showMissingSignerModal = true;
-          const ok = await new Promise<boolean>((resolve) => {
+          useSignerStore().reset();
+          const ui = useUiStore();
+          ui.showMissingSignerModal = true;
+          await new Promise<void>(resolve => {
             const stop = watch(
-              () => uiStore.showMissingSignerModal,
-              (val) => {
-                if (!val) {
-                  stop();
-                  resolve(!!signerStore.method);
-                }
-              }
+              () => ui.showMissingSignerModal,
+              v => { if (!v) { stop(); resolve(); } }
             );
           });
-          if (ok) {
-            return false;
+          if (!useSignerStore().method) {
+            throw new Error("User cancelled signer setup");
           }
           throw new Error(
             "No private key or remote signer available for P2PK unlock"


### PR DESCRIPTION
## Summary
- clean up default relay list in NDK boot
- clarify comment in nostr relay set helper
- rearrange global dialogs in `MainLayout`
- improve signer modal handling in wallet and creator dashboard
- provide `eslint.config.js` for tooling compatibility

## Testing
- `pnpm install`
- `npm run test:ci` *(fails: Cannot resolve @scure/bip32 and other test errors)*

------
https://chatgpt.com/codex/tasks/task_e_686232cc830483308cba4893785c03d9