### PR TITLE
Cleanup relay defaults and watcher logic

### DIFF
--- a/src/boot/ndk.ts
+++ b/src/boot/ndk.ts
@@ -26,6 +26,14 @@ export class NdkBootError extends Error {
 export const DEFAULT_RELAYS = [
   "wss://relay.damus.io/",
   "wss://relay.primal.net/",
+  "wss://eden.nostr.land/",
+  "wss://nos.lol/",
+  "wss://nostr-pub.wellorder.net/",
+  "wss://nostr.bitcoiner.social/",
+  "wss://offchain.pub/",
+  "wss://relay.nostr.band/",
+  "wss://relay.primal.net/",
+  "wss://relay.snort.social/",
 ];
 
 // ensure there is at least one relay configured at runtime

--- a/src/pages/CreatorDashboardPage.vue
+++ b/src/pages/CreatorDashboardPage.vue
@@ -291,7 +291,6 @@ export default defineComponent({
       const first = p2pkStore.firstKey;
       if (!first) {
         notifyError('No P2PK key');
-        return;
       }
       try {
         await nostr.initSignerIfNotSet();


### PR DESCRIPTION
## Summary
- update Nostr relay defaults
- drop stray early return in Creator dashboard

## Testing
- `pnpm run lint --fix` *(fails: ESLint missing deps)*
- `pnpm run test:ci` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686237265a9c83309c8303f46dff39a4