### PR TITLE
Improve tier publishing checks

### DIFF
--- a/src/components/AddTierDialog.vue
+++ b/src/components/AddTierDialog.vue
@@ -130,7 +130,9 @@ export default defineComponent({
       try {
         await nostr.initSignerIfNotSet();
         if (!nostr.signer) {
-          notifyError("Please login to Nostr (Nos2x/Alby) before saving tiers");
+          notifyError(
+            "Please unlock or connect your Nostr signer before saving tiers",
+          );
           return;
         }
         await creatorHub.addOrUpdateTier({ ...localTier });

--- a/src/stores/creatorHub.ts
+++ b/src/stores/creatorHub.ts
@@ -26,6 +26,11 @@ const TIER_DEFINITIONS_KIND = 30000;
 export async function maybeRepublishNutzapProfile() {
   const nostrStore = useNostrStore();
   await nostrStore.initSignerIfNotSet();
+  if (!nostrStore.signer) {
+    throw new Error(
+      "No Nostr signer available. Unlock or connect a signer add-on (Nos2x/Alby) first.",
+    );
+  }
   const ndk = await useNdk();
   if (!ndk) {
     throw new Error(
@@ -149,13 +154,20 @@ export const useCreatorHubStore = defineStore("creatorHub", {
     async publishTierDefinitions() {
       const tiersArray = this.getTierArray();
       const nostr = useNostrStore();
+
+      // ensure user has granted a signer
       await nostr.initSignerIfNotSet();
-      const ndk = await useNdk();
-      if (!ndk) {
+      if (!nostr.signer) {
         throw new Error(
-          "You need to connect a Nostr signer before publishing tiers",
+          "No Nostr signer available. Unlock or connect a signer add-on (Nos2x/Alby) first.",
         );
       }
+
+      const ndk = await useNdk();
+      if (!ndk) {
+        throw new Error("NDK not initialised – cannot publish tiers");
+      }
+
       const ev = new NDKEvent(ndk);
       ev.kind = TIER_DEFINITIONS_KIND as unknown as NDKKind;
       ev.tags = [["d", "tiers"]];


### PR DESCRIPTION
## Summary
- ensure Nostr signer availability when republishing Nutzap profile
- validate signer and NDK before publishing tier definitions
- update AddTierDialog messaging when signer is missing

## Testing
- `pnpm dev`

------
https://chatgpt.com/codex/tasks/task_e_6862bd04fe98833087aa72516df12dca