### PR TITLE
Fix nostr injection for dashboard

### DIFF
--- a/src/pages/CreatorDashboardPage.vue
+++ b/src/pages/CreatorDashboardPage.vue
@@ -398,6 +398,7 @@ export default defineComponent({
       profileRelays,
       canSaveNutzap,
       publishProfile,
+      nostr,
     };
   },
 });


### PR DESCRIPTION
## Summary
- export nostr store in CreatorDashboardPage so Nostr Signer button works

## Testing
- `pnpm run lint` *(fails: Invalid option '--ext')*
- `pnpm run dev`

------
https://chatgpt.com/codex/tasks/task_e_686368daa44083309206659ba3b0dd30