### PR TITLE
Fix NDK relay initialization

### DIFF
--- a/src/boot/ndk.ts
+++ b/src/boot/ndk.ts
@@ -134,7 +134,7 @@ async function createReadOnlyNdk(): Promise<NDK> {
 }
 
 export async function createSignedNdk(signer: NDKSigner): Promise<NDK> {
-  const relayUrls = useSettingsStore().defaultNostrRelays
+  const relayUrls = useSettingsStore().defaultNostrRelays.value
   const ndk = new NDK({ explicitRelayUrls: relayUrls })
   ndk.signer = signer
   await ndk.connect()

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -68,7 +68,7 @@ async function urlsToRelaySet(urls?: string[]): Promise<NDKRelaySet | undefined>
   if (!urls?.length) return undefined;
 
   const ndk = await useNdk({ requireSigner: false });
-  const set = new NDKRelaySet([], ndk);
+  const set = new NDKRelaySet(new Set(), ndk);
   urls.forEach((u) =>
     set.addRelay(ndk.pool.getRelay(u) ?? new NDKRelay(u))
   );
@@ -1174,7 +1174,7 @@ export async function signEvent(
 }
 
 export async function publishEvent(event: NostrEvent): Promise<void> {
-  const relays = useSettingsStore().defaultNostrRelays;
+  const relays = useSettingsStore().defaultNostrRelays.value;
   const pool = new SimplePool();
   try {
     await Promise.any(pool.publish(relays, event));
@@ -1184,7 +1184,7 @@ export async function publishEvent(event: NostrEvent): Promise<void> {
 }
 
 export function subscribeToNostr(filter: any, cb: (ev: NostrEvent) => void) {
-  const relays = useSettingsStore().defaultNostrRelays;
+  const relays = useSettingsStore().defaultNostrRelays.value;
   const pool = new SimplePool();
   try {
     pool.subscribeMany(relays, [filter], { onevent: cb });

--- a/src/stores/nwc.ts
+++ b/src/stores/nwc.ts
@@ -84,7 +84,7 @@ export const useNWCStore = defineStore("nwc", {
     ],
     relays: useLocalStorage<string[]>(
       "cashu.nwc.relays",
-      useSettingsStore().defaultNostrRelays
+      useSettingsStore().defaultNostrRelays.value
     ),
     blocking: false,
     subscriptions: [] as NDKSubscription[],


### PR DESCRIPTION
## Summary
- ensure NDKRelaySet is initialized with a `Set`
- unwrap default relay refs when constructing NDK or using SimplePool
- use default relay value when creating nwc relays

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68636e7babec833090bb0435477e54d8