### PR TITLE
Fix messenger relays initialization

### DIFF
--- a/src/stores/messenger.ts
+++ b/src/stores/messenger.ts
@@ -26,7 +26,7 @@ export type MessengerMessage = {
 
 export const useMessengerStore = defineStore("messenger", {
   state: () => ({
-    relays: useSettingsStore().defaultNostrRelays,
+    relays: useSettingsStore().defaultNostrRelays.value,
     conversations: useLocalStorage<Record<string, MessengerMessage[]>>(
       "cashu.messenger.conversations",
       {} as Record<string, MessengerMessage[]>


### PR DESCRIPTION
## Summary
- initialize `relays` with array rather than a ref

## Testing
- `pnpm test` *(fails: Failed to resolve import `@scure/bip32` ...)*

------
https://chatgpt.com/codex/tasks/task_e_686378772a5c8330832f5892bfdb612a