### PR TITLE
Improve offline handling for Nostr messenger

### DIFF
--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -321,9 +321,14 @@ export const useNostrStore = defineStore("nostr", {
   actions: {
     initNdkReadOnly: async function () {
       if (this.connected) return;
-      const ndk = await useNdk();
-      await ndk.connect();
-      this.connected = true;
+      const ndk = await useNdk({ requireSigner: false });
+      try {
+        await ndk.connect();
+        this.connected = true;
+      } catch (e) {
+        console.warn("[nostr] read-only connect failed", e);
+        this.connected = false;
+      }
     },
     disconnect: async function () {
       const ndk = await useNdk();


### PR DESCRIPTION
## Summary
- avoid throwing when messenger identity is missing
- ensure messenger `start()` always resolves and logs offline mode
- show offline banner and enforce 10s init timeout
- connect to Nostr read-only in a safe manner

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68638c71e7a88330a1cee56088361ed8