### PR TITLE
Fix messenger component refs and read‑only ndk init

### DIFF
--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -77,6 +77,16 @@ import ChatSendTokenDialog from "components/ChatSendTokenDialog.vue";
 
 export default defineComponent({
   name: "NostrMessenger",
+  components: {
+    NostrIdentityManager,
+    RelayManager,
+    NewChat,
+    ConversationList,
+    ActiveChatHeader,
+    MessageList,
+    MessageInput,
+    ChatSendTokenDialog,
+  },
   setup() {
     const loading = ref(true);
     const messenger = useMessengerStore();

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -320,8 +320,8 @@ export const useNostrStore = defineStore("nostr", {
   },
   actions: {
     initNdkReadOnly: async function () {
-      if (this.connected) return;
       const ndk = await useNdk({ requireSigner: false });
+      if (this.connected) return;
       try {
         await ndk.connect();
         this.connected = true;


### PR DESCRIPTION
## Summary
- register messenger components when using `defineComponent`
- initialise `initNdkReadOnly` with `requireSigner: false`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68639317f38c8330b4c21f4e6bdec2bd