### PR TITLE
Fix messenger relay null-safety

### DIFF
--- a/src/components/RelayManager.vue
+++ b/src/components/RelayManager.vue
@@ -21,20 +21,20 @@ import { notifySuccess, notifyError } from "src/js/notify";
 
 const messenger = useMessengerStore();
 
-const relayText = ref(messenger.relays.join("\n"));
+const relayText = ref((messenger.relays ?? []).join("\n"));
 
 watch(
   () => messenger.relays,
   (r) => {
-    relayText.value = r.join("\n");
+    relayText.value = (r ?? []).join("\n");
   }
 );
 
 const connect = async () => {
-  const relays = relayText.value
-    .split(/\n|\r/)
+  const relays = (relayText.value || "")
+    .split(/\r?\n/)
     .map((r) => r.trim())
-    .filter((r) => r.length);
+    .filter(Boolean);
   try {
     await messenger.connect(relays);
     notifySuccess("Connected to relays");

--- a/src/stores/messenger.ts
+++ b/src/stores/messenger.ts
@@ -26,7 +26,7 @@ export type MessengerMessage = {
 
 export const useMessengerStore = defineStore("messenger", {
   state: () => ({
-    relays: useSettingsStore().defaultNostrRelays.value,
+    relays: useSettingsStore().defaultNostrRelays.value ?? [] as string[],
     conversations: useLocalStorage<Record<string, MessengerMessage[]>>(
       "cashu.messenger.conversations",
       {} as Record<string, MessengerMessage[]>


### PR DESCRIPTION
## Summary
- default messenger relays always return an array
- guard RelayManager relay text from null

## Testing
- `npm run dev` *(fails: `quasar` not found)*
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68639be4fa088330b7019047e14ccf59