### PR TITLE
Fix Nostr relay defaults and messenger suspense

### DIFF
--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -27,7 +27,14 @@
         </q-expansion-item>
         <NewChat class="q-mb-md" @start="startChat" />
         <q-scroll-area class="col" style="min-height: 0">
-          <ConversationList @select="selectConversation" />
+          <Suspense>
+            <template #default>
+              <ConversationList @select="selectConversation" />
+            </template>
+            <template #fallback>
+              <q-skeleton height="100px" square />
+            </template>
+          </Suspense>
         </q-scroll-area>
       </q-drawer>
     </q-responsive>

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -228,7 +228,7 @@ export const useNostrStore = defineStore("nostr", {
   state: () => ({
     connected: false,
     pubkey: useLocalStorage<string>("cashu.ndk.pubkey", ""),
-    relays: useSettingsStore().defaultNostrRelays,
+    relays: useSettingsStore().defaultNostrRelays.value ?? [] as string[],
     signerType: useLocalStorage<SignerType>(
       "cashu.ndk.signerType",
       SignerType.SEED
@@ -1190,6 +1190,10 @@ export async function publishEvent(event: NostrEvent): Promise<void> {
 
 export function subscribeToNostr(filter: any, cb: (ev: NostrEvent) => void) {
   const relays = useSettingsStore().defaultNostrRelays.value;
+  if (!relays || relays.length === 0) {
+    console.warn('[nostr] subscribeMany called with empty relay list');
+    return;
+  }
   const pool = new SimplePool();
   try {
     pool.subscribeMany(relays, [filter], { onevent: cb });


### PR DESCRIPTION
## Summary
- ensure `relays` state is never undefined
- guard empty relay lists in `subscribeToNostr`
- wrap `ConversationList` in `Suspense` in `NostrMessenger`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863a0a0805883308bbdd783d553a9b3