### PR TITLE
Handle NDK connection failures

### DIFF
--- a/src/boot/ndk.ts
+++ b/src/boot/ndk.ts
@@ -115,12 +115,13 @@ async function filterHealthyRelays(relays: string[]): Promise<string[]> {
   return results.filter((u): u is string => !!u)
 }
 
-async function safeConnect(ndk: NDK) {
+export async function safeConnect(ndk: NDK): Promise<Error | null> {
   try {
-    await ndk.connect({ timeoutMs: 10_000 });
+    await ndk.connect({ timeoutMs: 10_000 })
+    return null
   } catch (e: any) {
     console.warn('[NDK] connect failed, continuing in offline mode:', e?.message)
-    // swallow error to allow offline usage
+    return e as Error
   }
 }
 


### PR DESCRIPTION
## Summary
- export `safeConnect()` and return the underlying error
- keep the last connection error in the nostr store
- surface relay connection failures with a toast

## Testing
- `npx vitest run` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686422894de4833096b4c53c6078dcf2