### PR TITLE
Fix duplicate relays

### DIFF
--- a/src/boot/ndk.ts
+++ b/src/boot/ndk.ts
@@ -31,9 +31,7 @@ export const DEFAULT_RELAYS = [
   "wss://nos.lol/",
   "wss://nostr-pub.wellorder.net/",
   "wss://nostr.bitcoiner.social/",
-  "wss://offchain.pub/",
   "wss://relay.nostr.band/",
-  "wss://relay.primal.net/",
   "wss://relay.snort.social/",
 ];
 


### PR DESCRIPTION
## Summary
- dedupe `DEFAULT_RELAYS` in NDK boot file and remove bad relay entry

## Testing
- `pnpm install`
- `npm test` *(fails: Tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68642716b8d88330a018b11eaec6e92e