### PR TITLE
Validate relay setting before connecting NDK

### DIFF
--- a/src/boot/ndk.ts
+++ b/src/boot/ndk.ts
@@ -132,9 +132,13 @@ export async function safeConnect(ndk: NDK): Promise<Error | null> {
 
 async function createReadOnlyNdk(): Promise<NDK> {
   const settings = useSettingsStore();
-  const relays = settings.defaultNostrRelays.value.length
+  if (!Array.isArray(settings.defaultNostrRelays?.value)) {
+    settings.defaultNostrRelays.value = DEFAULT_RELAYS;
+  }
+  const userRelays = Array.isArray(settings.defaultNostrRelays?.value)
     ? settings.defaultNostrRelays.value
-    : DEFAULT_RELAYS;
+    : [];
+  const relays = userRelays.length ? userRelays : DEFAULT_RELAYS;
   const healthy = await filterHealthyRelays(relays);
   const relayUrls = healthy.length ? healthy : [relays[0]];
   const ndk = new NDK({ explicitRelayUrls: relayUrls });
@@ -167,9 +171,13 @@ export async function createNdk(): Promise<NDK> {
   }
 
   const settings = useSettingsStore();
-  const relays = settings.defaultNostrRelays.value.length
+  if (!Array.isArray(settings.defaultNostrRelays?.value)) {
+    settings.defaultNostrRelays.value = DEFAULT_RELAYS;
+  }
+  const userRelays = Array.isArray(settings.defaultNostrRelays?.value)
     ? settings.defaultNostrRelays.value
-    : DEFAULT_RELAYS;
+    : [];
+  const relays = userRelays.length ? userRelays : DEFAULT_RELAYS;
   const healthy = await filterHealthyRelays(relays);
   const relayUrls = healthy.length ? healthy : [relays[0]];
   const ndk = new NDK({ signer, explicitRelayUrls: relayUrls });

--- a/src/composables/useNdk.ts
+++ b/src/composables/useNdk.ts
@@ -23,9 +23,13 @@ export async function useNdk(
     cached = await createNdk();
   } catch (e: any) {
     if (!requireSigner) {
-      const relays = settings.defaultNostrRelays.value.length
+      if (!Array.isArray(settings.defaultNostrRelays?.value)) {
+        settings.defaultNostrRelays.value = DEFAULT_RELAYS;
+      }
+      const userRelays = Array.isArray(settings.defaultNostrRelays?.value)
         ? settings.defaultNostrRelays.value
-        : DEFAULT_RELAYS;
+        : [];
+      const relays = userRelays.length ? userRelays : DEFAULT_RELAYS;
       cached = new NDK({ explicitRelayUrls: relays });
       await cached.connect();
     } else {

--- a/src/stores/messenger.ts
+++ b/src/stores/messenger.ts
@@ -5,6 +5,7 @@ import { Event as NostrEvent } from "nostr-tools";
 import { useNostrStore, SignerType } from "./nostr";
 import { v4 as uuidv4 } from "uuid";
 import { useSettingsStore } from "./settings";
+import { DEFAULT_RELAYS } from "boot/ndk";
 import { sanitizeMessage } from "src/js/message-utils";
 import { notifySuccess, notifyError } from "src/js/notify";
 import { useWalletStore } from "./wallet";
@@ -25,8 +26,17 @@ export type MessengerMessage = {
 };
 
 export const useMessengerStore = defineStore("messenger", {
-  state: () => ({
-    relays: useSettingsStore().defaultNostrRelays.value ?? [] as string[],
+  state: () => {
+    const settings = useSettingsStore();
+    if (!Array.isArray(settings.defaultNostrRelays?.value)) {
+      settings.defaultNostrRelays.value = DEFAULT_RELAYS;
+    }
+    const userRelays = Array.isArray(settings.defaultNostrRelays?.value)
+      ? settings.defaultNostrRelays.value
+      : [];
+    const relays = userRelays.length ? userRelays : DEFAULT_RELAYS;
+    return {
+      relays,
     conversations: useLocalStorage<Record<string, MessengerMessage[]>>(
       "cashu.messenger.conversations",
       {} as Record<string, MessengerMessage[]>


### PR DESCRIPTION
## Summary
- ensure the default relay list is an array before connecting to NDK
- apply the same validation in composables and messenger store

## Testing
- `pnpm install`
- `npm run test:ci` *(fails: several suites failed)*

------
https://chatgpt.com/codex/tasks/task_e_686430ca13f083309063a0984a48830c