### PR TITLE
Fix messenger store closure syntax

### DIFF
--- a/src/stores/messenger.ts
+++ b/src/stores/messenger.ts
@@ -53,7 +53,8 @@ export const useMessengerStore = defineStore("messenger", {
     drawerOpen: useLocalStorage<boolean>("cashu.messenger.drawerOpen", true),
     started: false,
     watchInitialized: false,
-  }),
+    };
+  },
   getters: {
     connected(): boolean {
       const nostr = useNostrStore();


### PR DESCRIPTION
## Summary
- correct closing of state function in `messenger.ts`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686432396b4483309d8ff2680903886a