### PR TITLE
Allow relay-set rebuild for NDK

### DIFF
--- a/src/composables/useNdk.ts
+++ b/src/composables/useNdk.ts
@@ -1,9 +1,18 @@
-import NDK from "@nostr-dev-kit/ndk";
+import NDK, { NDKSigner } from "@nostr-dev-kit/ndk";
 import { DEFAULT_RELAYS, createNdk, createSignedNdk } from "boot/ndk";
 import { useNostrStore } from "stores/nostr";
 import { useSettingsStore } from "stores/settings";
 
 let cached: NDK | undefined;
+
+/** Force-rebuild the cached NDK with a new relay set (and optional signer). */
+export async function rebuildNdk(relays: string[], signer?: NDKSigner) {
+  const { default: NDK } = await import("@nostr-dev-kit/ndk");
+  cached = new NDK({ explicitRelayUrls: relays });
+  if (signer) cached.signer = signer;
+  await cached.connect({ timeoutMs: 10_000 });
+  return cached;
+}
 
 export async function useNdk(
   opts: { requireSigner?: boolean } = {},


### PR DESCRIPTION
## Summary
- add `rebuildNdk` helper for rebuilding cached NDK
- rebuild NDK on connect and expose pool events
- remove obsolete safeConnect usage

## Testing
- `npm test` *(fails: vitest not found)*
- `npx tsc --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68643a9964848330abcf4b7f1be35f00