### PR TITLE
Improve messenger UI

### DIFF
--- a/src/components/ActiveChatHeader.vue
+++ b/src/components/ActiveChatHeader.vue
@@ -19,9 +19,14 @@
         @click="messenger.toggleDrawer()"
       />
       <template v-if="pubkey">
-        <q-avatar size="md" class="q-mr-sm">
+        <q-avatar size="md" class="q-mr-sm relative-position">
           <img v-if="profile?.picture" :src="profile.picture" />
           <span v-else>{{ initials }}</span>
+          <q-badge
+            class="status-dot"
+            rounded
+            :color="messenger.connected ? 'positive' : 'grey'"
+          />
         </q-avatar>
         <div class="text-h6 ellipsis">{{ displayName }}</div>
         <q-btn
@@ -84,7 +89,7 @@ watch(
   () => {
     loadProfile();
   },
-  { immediate: true }
+  { immediate: true },
 );
 
 const displayName = computed(() => {
@@ -125,3 +130,15 @@ function clearChat() {
   messenger.unreadCounts[props.pubkey] = 0;
 }
 </script>
+
+<style scoped>
+.status-dot {
+  position: absolute;
+  bottom: -2px;
+  right: -2px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 2px solid var(--q-color-white);
+}
+</style>

--- a/src/components/ChatMessageBubble.vue
+++ b/src/components/ChatMessageBubble.vue
@@ -41,23 +41,23 @@ const $q = useQuasar();
 
 const receivedStyle = computed(() => ({
   backgroundColor: $q.dark.isActive
-    ? "var(--q-color-grey-8)"
+    ? "var(--q-secondary)"
     : "var(--q-color-grey-2)",
   color: $q.dark.isActive ? "#ffffff" : "#000000",
 }));
 
 const bubbleStyle = computed(() =>
-  props.message.outgoing ? {} : receivedStyle.value
+  props.message.outgoing ? {} : receivedStyle.value,
 );
 
 const time = computed(() =>
-  new Date(props.message.created_at * 1000).toLocaleString()
+  new Date(props.message.created_at * 1000).toLocaleString(),
 );
 const isoTime = computed(() =>
-  new Date(props.message.created_at * 1000).toISOString()
+  new Date(props.message.created_at * 1000).toISOString(),
 );
 const deliveryIcon = computed(() =>
-  props.deliveryStatus === "delivered" ? mdiCheckAll : mdiCheck
+  props.deliveryStatus === "delivered" ? mdiCheckAll : mdiCheck,
 );
 </script>
 
@@ -71,12 +71,12 @@ const deliveryIcon = computed(() =>
 }
 
 .sent {
-  background-color: var(--q-color-primary);
+  background-color: var(--q-primary);
   color: #ffffff;
 }
 
 .received {
-  background-color: var(--q-color-grey-2);
+  background-color: var(--q-secondary);
   color: #000000;
 }
 </style>

--- a/src/components/ConversationList.vue
+++ b/src/components/ConversationList.vue
@@ -17,7 +17,9 @@
         :key="item.pubkey"
         :pubkey="item.pubkey"
         :lastMsg="item.lastMsg"
+        :selected="item.pubkey === selectedPubkey"
         @click="select(item.pubkey)"
+        @pin="togglePin(item.pubkey)"
       />
       <div
         v-if="uniqueConversations.length === 0"
@@ -36,6 +38,8 @@ import { useMessengerStore } from "src/stores/messenger";
 import { useNostrStore } from "src/stores/nostr";
 import ConversationListItem from "./ConversationListItem.vue";
 
+const props = defineProps<{ selectedPubkey: string }>();
+
 const emit = defineEmits(["select"]);
 const messenger = useMessengerStore();
 const nostr = useNostrStore();
@@ -48,8 +52,13 @@ const uniqueConversations = computed(() => {
       pubkey,
       lastMsg: msgs[msgs.length - 1],
       timestamp: msgs[msgs.length - 1]?.created_at,
+      pinned: messenger.pinned[pubkey] || false,
     }))
-    .sort((a, b) => b.timestamp - a.timestamp);
+    .sort((a, b) => {
+      if (a.pinned && !b.pinned) return -1;
+      if (b.pinned && !a.pinned) return 1;
+      return b.timestamp - a.timestamp;
+    });
 });
 
 const filtered = computed(() => {
@@ -77,4 +86,7 @@ onMounted(() => {});
 watch(uniqueConversations, loadProfiles);
 
 const select = (pubkey: string) => emit("select", pubkey);
+const togglePin = (pubkey: string) => {
+  messenger.togglePin(pubkey);
+};
 </script>

--- a/src/components/MessageInput.vue
+++ b/src/components/MessageInput.vue
@@ -2,6 +2,13 @@
   <div class="row no-wrap items-center q-pa-sm">
     <q-input v-model="text" class="col" dense outlined @keyup.enter="send">
       <template v-slot:append>
+        <q-btn
+          flat
+          round
+          color="primary"
+          @click="selectFile"
+          icon="attach_file"
+        />
         <q-btn flat round color="primary" @click="sendToken">
           <NutIcon />
         </q-btn>
@@ -11,11 +18,12 @@
           icon="send"
           color="primary"
           class="q-ml-sm"
-          :disable="!text.trim()"
+          :disable="!text.trim() && !attachment"
           @click="send"
         />
       </template>
     </q-input>
+    <input ref="fileInput" type="file" class="hidden" @change="handleFile" />
   </div>
 </template>
 
@@ -25,16 +33,36 @@ import { Nut as NutIcon } from "lucide-vue-next";
 
 const emit = defineEmits(["send", "sendToken"]);
 const text = ref("");
+const attachment = ref<string | null>(null);
+const fileInput = ref<HTMLInputElement>();
 
 const send = () => {
   const m = text.value.trim();
-  if (m) {
+  if (m || attachment.value) {
     emit("send", m);
+    if (attachment.value) {
+      emit("send", attachment.value);
+      attachment.value = null;
+    }
     text.value = "";
   }
 };
 
 const sendToken = () => {
   emit("sendToken");
+};
+
+const selectFile = () => {
+  fileInput.value?.click();
+};
+
+const handleFile = (e: Event) => {
+  const files = (e.target as HTMLInputElement).files;
+  if (!files || !files[0]) return;
+  const reader = new FileReader();
+  reader.onload = () => {
+    attachment.value = reader.result as string;
+  };
+  reader.readAsDataURL(files[0]);
 };
 </script>

--- a/src/components/MessageList.vue
+++ b/src/components/MessageList.vue
@@ -1,6 +1,14 @@
 <template>
   <q-scroll-area class="col column q-pa-md">
-    <ChatMessageBubble v-for="msg in messages" :key="msg.id" :message="msg" />
+    <template v-for="(msg, idx) in messages" :key="msg.id">
+      <div
+        v-if="showDateSeparator(idx)"
+        class="text-caption text-center q-my-md divider-text"
+      >
+        {{ formatDay(msg.created_at) }}
+      </div>
+      <ChatMessageBubble :message="msg" />
+    </template>
     <div ref="bottom"></div>
   </q-scroll-area>
 </template>
@@ -13,13 +21,30 @@ import ChatMessageBubble from "./ChatMessageBubble.vue";
 const props = defineProps<{ messages: MessengerMessage[] }>();
 const bottom = ref<HTMLElement>();
 
+function formatDay(ts: number) {
+  const d = new Date(ts * 1000);
+  return d.toLocaleDateString();
+}
+
+function showDateSeparator(idx: number) {
+  if (idx === 0) return true;
+  const prev = props.messages[idx - 1];
+  const prevDay = new Date(prev.created_at * 1000).toDateString();
+  const currDay = new Date(
+    props.messages[idx].created_at * 1000,
+  ).toDateString();
+  return prevDay !== currDay;
+}
+
 watch(
   () => props.messages,
   () => {
     nextTick(() => bottom.value?.scrollIntoView({ behavior: "smooth" }));
   },
-  { deep: true }
+  { deep: true },
 );
 
 const formatDate = (ts: number) => new Date(ts * 1000).toLocaleString();
+
+export { formatDay, showDateSeparator };
 </script>


### PR DESCRIPTION
## Summary
- pin conversations and store pinned state
- show pinned status, unread count and online state in list items
- group messages in MessageList by day
- allow file attachments in message input
- tweak drawer transition and status indicators
- use theme variables for bubbles

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864cd9edd888330a6cbd312fa85710f