### PR TITLE
Fix MessageList exports

### DIFF
--- a/src/components/MessageList.vue
+++ b/src/components/MessageList.vue
@@ -46,5 +46,5 @@ watch(
 
 const formatDate = (ts: number) => new Date(ts * 1000).toLocaleString();
 
-export { formatDay, showDateSeparator };
+defineExpose({ formatDay, showDateSeparator });
 </script>


### PR DESCRIPTION
## Summary
- fix `<script setup>` by replacing ESM export with `defineExpose`

## Testing
- `npm run lint` *(fails: A config object is using the "extends" key, which is not supported in flat config system)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864d511e0fc833096b44d11b2cc103b