### PR TITLE
Fix SettingsView TypeScript parsing

### DIFF
--- a/src/components/SettingsView.vue
+++ b/src/components/SettingsView.vue
@@ -1774,7 +1774,7 @@
   <!-- NWC DIALOG -->
   <NWCDialog v-model="showNWCDialog" />
 </template>
-<script>
+<script lang="ts">
 import { debug } from "src/js/logger";
 import { defineComponent } from "vue";
 import { useClipboard } from "src/composables/useClipboard";


### PR DESCRIPTION
## Summary
- make SettingsView `<script>` block use TypeScript

## Testing
- `pnpm install`
- `npm run test:ci` *(fails: 29 failed, 13 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6864db41c76c83309c78a1c9b4d86bad