### PR TITLE
Add optional backend search

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,13 @@ git grep -n "new NDK("
 git grep -n ".ndk"
 ```
 
+### Optional Backend Search Service
+You can configure a URL that returns NIP-50 search results for the
+`find-creators.html` page. Set the value in local storage using the key
+`cashu.settings.searchBackendUrl`. When defined, search queries hit this
+backend first and fall back to client-side relay queries if no results are
+returned.
+
 ## Contributing
 
 Contributions are welcome! Open an issue or pull request to discuss your ideas. Bug reports and feature requests are encouraged. Help with translation and documentation is always appreciated.

--- a/public/find-creators.html
+++ b/public/find-creators.html
@@ -289,6 +289,8 @@
         "wss://purplepag.es",
         "wss://relay.nostr.band",
       ];
+      const BACKEND_SEARCH_URL =
+        window.localStorage.getItem("cashu.settings.searchBackendUrl") || "";
       let storedRelays = [];
       try {
         const stored = window.localStorage.getItem(
@@ -445,6 +447,35 @@
             loaderElement.style.display = "none";
           }
           return;
+        }
+
+        if (BACKEND_SEARCH_URL) {
+          statusMessageElement.textContent = `Searching backend for "${cleanQuery}"...`;
+          try {
+            const resp = await fetch(
+              `${BACKEND_SEARCH_URL}?q=${encodeURIComponent(cleanQuery)}`
+            );
+            if (resp.ok) {
+              const events = await resp.json();
+              if (Array.isArray(events) && events.length > 0) {
+                const pubkeys = Array.from(
+                  new Set(events.map((e) => e.pubkey))
+                );
+                await fetchAndDisplayProfiles(
+                  pubkeys,
+                  resultsListElement,
+                  foundSearchProfiles,
+                  loaderElement,
+                  statusMessageElement,
+                  false,
+                  true
+                );
+                return;
+              }
+            }
+          } catch (e) {
+            console.warn("Backend search failed:", e);
+          }
         }
 
         statusMessageElement.textContent = `Searching relays for "${cleanQuery}"... (NIP-50)`;

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -78,6 +78,10 @@ export const useSettingsStore = defineStore("settings", {
         "cashu.settings.auditorApiUrl",
         "https://api.audit.8333.space"
       ),
+      searchBackendUrl: useLocalStorage<string>(
+        "cashu.settings.searchBackendUrl",
+        ""
+      ),
     };
   },
 });


### PR DESCRIPTION
## Summary
- allow configuring a NIP‑50 backend search service via localStorage
- query this backend before falling back to relay searches
- expose `searchBackendUrl` in settings
- document backend search option in README

## Testing
- `npm run test:ci` *(fails: `vitest` not found)*
- `npm install` *(fails: Invalid Version: file:./src/lib/cashu-ts)*

------
https://chatgpt.com/codex/tasks/task_e_6864e549d2dc8330acb31a6acf7f88a6