### PR TITLE
Handle wallet boot without mint

### DIFF
--- a/src/boot/cashu.js
+++ b/src/boot/cashu.js
@@ -8,14 +8,16 @@ export default boot(async () => {
   const walletStore = useWalletStore();
   const wallet = walletStore.wallet;
   const mints = useMintsStore();
-  const ok = await verifyMint(mints.activeMintUrl);
-  if (!ok) {
-    Notify.create({
-      type: "negative",
-      message:
-        "Selected mint lacks conditional‑secret support (NUT‑10/11/14)",
-    });
-    throw new Error("Unsupported mint");
+  if (mints.activeMintUrl) {
+    const ok = await verifyMint(mints.activeMintUrl);
+    if (!ok) {
+      Notify.create({
+        type: "negative",
+        message:
+          "Selected mint lacks conditional‑secret support (NUT‑10/11/14)",
+      });
+      throw new Error("Unsupported mint");
+    }
   }
   if (typeof wallet.initKeys === "function") {
     await wallet.initKeys();

--- a/test/vitest/__tests__/cashu-boot.spec.ts
+++ b/test/vitest/__tests__/cashu-boot.spec.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from "vitest";
+import cashuBoot from "../../../src/boot/cashu";
+
+var verifyMintMock: any;
+var initKeysMock: any;
+
+vi.mock("../../../src/boot/mint-info", () => {
+  verifyMintMock = vi.fn();
+  return { verifyMint: verifyMintMock };
+});
+vi.mock("../../../src/stores/wallet", () => {
+  initKeysMock = vi.fn();
+  return { useWalletStore: () => ({ wallet: { initKeys: initKeysMock } }) };
+});
+vi.mock("../../../src/stores/mints", () => ({ useMintsStore: () => ({ activeMintUrl: "" }) }));
+vi.mock("quasar", () => ({ Notify: { create: vi.fn() } }));
+
+describe("cashu boot", () => {
+  it("succeeds without active mint", async () => {
+    await expect(cashuBoot()).resolves.toBeUndefined();
+    expect(verifyMintMock).not.toHaveBeenCalled();
+    expect(initKeysMock).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- skip `verifyMint` when no mint is selected so fresh installs start cleanly
- cover boot behavior with a new unit test

## Testing
- `npx vitest run test/vitest/__tests__/cashu-boot.spec.ts`
- `pnpm test` *(fails: Failed Suites 25 | Tests 6 failed)*

------
https://chatgpt.com/codex/tasks/task_e_6865175f1f8c8330bcf8dc2756b4c9d0