### PR TITLE
Implement relay auto heal and npub util

### DIFF
--- a/src/composables/useNdk.ts
+++ b/src/composables/useNdk.ts
@@ -1,5 +1,10 @@
 import NDK, { NDKSigner } from "@nostr-dev-kit/ndk";
-import { DEFAULT_RELAYS, createNdk, createSignedNdk } from "boot/ndk";
+import {
+  DEFAULT_RELAYS,
+  createNdk,
+  createSignedNdk,
+  mergeDefaultRelays,
+} from "boot/ndk";
 import { useNostrStore } from "stores/nostr";
 import { useSettingsStore } from "stores/settings";
 
@@ -9,6 +14,7 @@ let cached: NDK | undefined;
 export async function rebuildNdk(relays: string[], signer?: NDKSigner) {
   const { default: NDK } = await import("@nostr-dev-kit/ndk");
   cached = new NDK({ explicitRelayUrls: relays });
+  mergeDefaultRelays(cached);
   if (signer) cached.signer = signer;
   await cached.connect({ timeoutMs: 10_000 });
   return cached;


### PR DESCRIPTION
## Summary
- ensure default relays are merged for every new NDK instance
- retry connect with defaults if no relay connected
- preserve default relays on rebuild
- add robust `npubToHex` helper and use it when fetching Nutzap profiles
- search creators using shared NDK and connectivity guard

## Testing
- `npm run lint` *(fails: config issues)*
- `npm run test:ci` *(fails: vitest not found)*
- `npx tsc -p tsconfig.json` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68658118a790833094e26fff67d2c1e1