### PR TITLE
Remove redundant relay toast and share ndk in creators store

### DIFF
--- a/src/stores/creators.ts
+++ b/src/stores/creators.ts
@@ -8,7 +8,6 @@ import {
   subscribeToNostr,
 } from "./nostr";
 import { useNdk } from "src/composables/useNdk";
-import { ensureRelayConnectivity } from "./nostr";
 import { nip19 } from "nostr-tools";
 import { Event as NostrEvent } from "nostr-tools";
 
@@ -61,13 +60,6 @@ export const useCreatorsStore = defineStore("creators", {
       this.searching = true;
       await nostrStore.initNdkReadOnly();
       const ndk = await useNdk({ requireSigner: false });
-      try {
-        await ensureRelayConnectivity(ndk);
-      } catch (e: any) {
-        this.error = e?.message ?? String(e);
-        this.searching = false;
-        return;
-      }
       let pubkey = query.trim();
       if (pubkey.startsWith("npub")) {
         try {
@@ -111,6 +103,7 @@ export const useCreatorsStore = defineStore("creators", {
       this.error = "";
       this.searching = true;
       await nostrStore.initNdkReadOnly();
+      const ndk = await useNdk({ requireSigner: false });
 
       const pubkeys: string[] = [];
       for (const entry of FEATURED_CREATORS) {
@@ -138,7 +131,7 @@ export const useCreatorsStore = defineStore("creators", {
         const results = await Promise.all(
           pubkeys.map(async (pubkey) => {
             try {
-              const user = nostrStore.ndk.getUser({ pubkey });
+              const user = ndk.getUser({ pubkey });
               const [_, followers, following, joined] = await Promise.all([
                 user.fetchProfile(),
                 nostrStore.fetchFollowerCount(pubkey),


### PR DESCRIPTION
## Summary
- stop checking relay connectivity in `searchCreators`
- fetch featured creators using the same `ndk` instance

## Testing
- `ESLINT_USE_FLAT_CONFIG=false npm run lint -- src/stores/creators.ts` *(fails: Cannot find module '@typescript-eslint/parser')*
- `npm run test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865866850a48330b35ce9b7a41bf09e