### PR TITLE
Fix relay initialization for updated NDK

### DIFF
--- a/src/boot/ndk.ts
+++ b/src/boot/ndk.ts
@@ -38,7 +38,7 @@ export const DEFAULT_RELAYS = [
 export function mergeDefaultRelays(ndk: NDK) {
   for (const url of DEFAULT_RELAYS) {
     if (!ndk.pool.relays.has(url)) {
-      ndk.pool.addRelay(url, { read: true, write: true });
+      ndk.addExplicitRelay(url);
     }
   }
 }

--- a/src/components/RelayManager.vue
+++ b/src/components/RelayManager.vue
@@ -70,12 +70,12 @@ const connect = async () => {
     .map((r) => r.trim())
     .filter(Boolean);
   try {
-    const ndk = await useNdk({ requireSigner: false });
-    for (const url of urls) {
-      ndk.pool.addRelay(url, { read: true, write: true });
-    }
-    await messenger.connect(urls);
-    notifySuccess("Connected to relays");
+      const ndk = await useNdk({ requireSigner: false });
+      for (const url of urls) {
+        ndk.addExplicitRelay(url);
+      }
+      await messenger.connect(urls);
+      notifySuccess("Connected to relays");
   } catch (err: any) {
     notifyError(err?.message || "Failed to connect");
   }


### PR DESCRIPTION
## Summary
- adjust `mergeDefaultRelays` to use `addExplicitRelay`
- fix relay manager connection logic

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686589f010d88330b1bf2ccd9af63152