### PR TITLE
Initialize Nostr signer early

### DIFF
--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -27,8 +27,10 @@ export default defineComponent({
     NdkErrorDialog,
     MissingSignerModal,
   },
-  mounted() {
-    const myHex = useNostrStore().pubkey;
+  async mounted() {
+    const nostr = useNostrStore();
+    await nostr.initSignerIfNotSet();
+    const myHex = nostr.pubkey;
     useNutzapStore().initListener(myHex);
   },
 });

--- a/src/pages/CreatorDashboardPage.vue
+++ b/src/pages/CreatorDashboardPage.vue
@@ -249,6 +249,7 @@ export default defineComponent({
 
     onMounted(async () => {
       try {
+        await nostr.initSignerIfNotSet();
         await initPage();
       } catch (e) {
         notifyError('Creator dashboard disabled – signer missing');

--- a/src/pages/FindCreators.vue
+++ b/src/pages/FindCreators.vue
@@ -242,7 +242,8 @@ function handleDonate({
   }
 }
 
-onMounted(() => {
+onMounted(async () => {
+  await nostr.initSignerIfNotSet();
   window.addEventListener("message", onMessage);
 });
 

--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -76,6 +76,7 @@ import { useRouter } from "vue-router";
 import { useLocalStorage } from "@vueuse/core";
 import { useMessengerStore } from "src/stores/messenger";
 import { useNdk } from "src/composables/useNdk";
+import { useNostrStore } from "src/stores/nostr";
 
 import NostrIdentityManager from "components/NostrIdentityManager.vue";
 import RelayManager from "components/RelayManager.vue";
@@ -101,6 +102,7 @@ export default defineComponent({
   setup() {
     const loading = ref(true);
     const messenger = useMessengerStore();
+    const nostr = useNostrStore();
 
     function timeout(ms: number) {
       return new Promise<void>((resolve) => setTimeout(resolve, ms));
@@ -108,6 +110,7 @@ export default defineComponent({
 
     async function init() {
       try {
+        await nostr.initSignerIfNotSet();
         await messenger.loadIdentity();
         await useNdk();
         await Promise.race([messenger.start(), timeout(10000)]);


### PR DESCRIPTION
## Summary
- ensure the Nostr signer is initialized on app start
- load signer on mount in CreatorDashboard, Messenger, and FindCreators

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68661877ffb483308a1ae098492441a0