### PR TITLE
Prefill Nutzap profile settings

### DIFF
--- a/src/pages/CreatorDashboardPage.vue
+++ b/src/pages/CreatorDashboardPage.vue
@@ -245,6 +245,11 @@ export default defineComponent({
       if (p) profile.value = { ...p };
       const npub = nostr.pubkey;
       const existing = await fetchNutzapProfile(npub);
+      if (existing) {
+        profilePub.value = existing.p2pkPubkey;
+        profileMints.value = existing.trustedMints.join(',');
+        profileRelays.value = (existing.relays || []).join(',');
+      }
       needsProfile.value = !existing;
     }
 


### PR DESCRIPTION
## Summary
- when a Nutzap profile already exists, prefill public key, mint URLs and relay list so editing doesn't require typing everything again

## Testing
- `pnpm test` *(fails: Error: Failed to resolve import "@scure/bip32")*
- `pnpm lint` *(fails: Invalid option '--ext')*

------
https://chatgpt.com/codex/tasks/task_e_68661dab37148330b21cbdb1846ffbb3