### PR TITLE
Cache Nutzap profiles in Dexie

### DIFF
--- a/src/stores/dexie.ts
+++ b/src/stores/dexie.ts
@@ -13,6 +13,12 @@ export interface CachedProfileDexie {
   fetchedAt: number;
 }
 
+export interface NutzapProfileDexie {
+  hexPub: string;
+  profile: any;
+  fetchedAt: number;
+}
+
 export interface CreatorTierDefinition {
   creatorNpub: string;
   tiers: {
@@ -80,6 +86,7 @@ export interface LockedToken {
 export class CashuDexie extends Dexie {
   proofs!: Table<WalletProof>;
   profiles!: Table<CachedProfileDexie>;
+  nutzapProfiles!: Table<NutzapProfileDexie>;
   creatorsTierDefinitions!: Table<CreatorTierDefinition, string>;
   subscriptions!: Table<Subscription, string>;
   lockedTokens!: Table<LockedToken, string>;
@@ -148,6 +155,15 @@ export class CashuDexie extends Dexie {
             }
           });
       });
+    this.version(7).stores({
+      proofs: "secret, id, C, amount, reserved, quote, bucketId, label",
+      profiles: "pubkey",
+      nutzapProfiles: "hexPub",
+      creatorsTierDefinitions: "&creatorNpub, eventId, updatedAt",
+      subscriptions: "&id, creatorNpub, tierId, status, createdAt, updatedAt",
+      lockedTokens:
+        "&id, tokenString, owner, tierId, intervalKey, unlockTs, refundUnlockTs, status, subscriptionEventId",
+    });
   }
 }
 


### PR DESCRIPTION
## Summary
- add Dexie table `nutzapProfiles` for storing kind 10019 profile data
- cache Nutzap profiles in the nostr store
- return cached data when up to date and only query relays when cache is stale

## Testing
- `pnpm test` *(fails: Missing packages and environment issues)*

------
https://chatgpt.com/codex/tasks/task_e_6866280746288330baf1780c6a31229d