### PR TITLE
Add validation for Nutzap profile publishing

### DIFF
--- a/src/pages/CreatorDashboardPage.vue
+++ b/src/pages/CreatorDashboardPage.vue
@@ -42,7 +42,7 @@
     <q-card class="q-mt-md q-mb-md" flat bordered>
       <q-card-section>
         <div class="text-h6">Nutzap receiving profile</div>
-        <q-input v-model="profilePub" label="P2PK pubkey (hex, start with 02…)" dense />
+        <q-input v-model="profilePub" label="P2PK pubkey (hex or npub)" dense />
         <q-input v-model="profileMints" label="Trusted mints (comma-separated URLs)" dense />
         <q-input v-model="profileRelays" label="Relay hints (comma-separated wss://…)" dense />
       </q-card-section>
@@ -214,7 +214,10 @@ export default defineComponent({
     const profileRelays = ref("");
 
     const canSaveNutzap = computed(
-      () => profilePub.value.startsWith("02") && profileMints.value.length > 0
+      () =>
+        (/^(02|03)/.test(profilePub.value.trim()) ||
+          profilePub.value.trim().startsWith("npub")) &&
+        profileMints.value.length > 0
     );
 
     const p2pkStore = useP2PKStore();

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -209,9 +209,38 @@ export async function publishNutzapProfile(opts: {
   if (!nostr.signer) {
     throw new Error("Signer required to publish Nutzap profile");
   }
+  let p2pkHex = opts.p2pkPub.trim();
+  if (p2pkHex.startsWith("npub")) {
+    const decoded = npubToHex(p2pkHex);
+    if (!decoded) throw new Error("Invalid npub for p2pkPub");
+    p2pkHex = ensureCompressed(decoded);
+  } else {
+    try {
+      p2pkHex = ensureCompressed(p2pkHex);
+    } catch {
+      throw new Error("p2pkPub must be a 66-character hex string or npub");
+    }
+    if (!/^(02|03)[0-9a-f]{64}$/.test(p2pkHex)) {
+      throw new Error("p2pkPub must be a 66-character hex string");
+    }
+  }
+
+  const mintUrls: string[] = [];
+  for (const m of opts.mints) {
+    try {
+      const u = new URL(m);
+      if (!/^https?:$/.test(u.protocol)) throw new Error();
+      mintUrls.push(u.toString());
+    } catch {
+      throw new Error(`Invalid mint URL: ${m}`);
+    }
+  }
+  if (mintUrls.length === 0) {
+    throw new Error("At least one mint URL required");
+  }
   await nostr.ensureNdkConnected(opts.relays);
-  const tags: NDKTag[] = [["pubkey", opts.p2pkPub]];
-  for (const url of opts.mints) tags.push(["mint", url]);
+  const tags: NDKTag[] = [["pubkey", p2pkHex]];
+  for (const url of mintUrls) tags.push(["mint", url]);
   if (opts.relays)
     for (const r of opts.relays) tags.push(["relay", r]);
 


### PR DESCRIPTION
## Summary
- validate `p2pkPub` and mint URLs when publishing Nutzap profiles
- support npub keys for profiles
- enable npub input on creator dashboard

## Testing
- `pnpm run test:ci` *(fails: Notify.create is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6866299df0a083308d95851d0731a07c