### PR TITLE
Add publishDiscoveryProfile and update dashboard

### DIFF
--- a/src/pages/CreatorDashboardPage.vue
+++ b/src/pages/CreatorDashboardPage.vue
@@ -1,176 +1,81 @@
 <template>
-  <div
-    :class="[
-      $q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark',
-      'q-pa-md',
-    ]"
-  >
+  <div :class="[$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark', 'q-pa-md']">
     <div class="row items-center justify-between">
       <div class="text-h5">{{ $t("CreatorHub.dashboard.title") }}</div>
-      <q-btn flat color="primary" @click="logout">{{
-        $t("CreatorHub.dashboard.logout")
-      }}</q-btn>
-      <q-btn
-        v-if="signerChecked && !nostr.signer"
-        flat
-        color="primary"
-        class="q-ml-sm"
-        @click="connectSigner"
-      >
-        Connect Nostr Signer
-      </q-btn>
+      <div>
+        <q-btn v-if="signerChecked && !nostr.signer" flat color="primary" class="q-ml-sm" @click="connectSigner">
+          Connect Nostr Signer
+        </q-btn>
+        <q-btn flat color="primary" @click="logout">{{ $t("CreatorHub.dashboard.logout") }}</q-btn>
+      </div>
     </div>
 
     <q-banner v-if="needsProfile" dense class="bg-orange text-white q-mt-md">
       <div class="row items-center">
         <div class="col">
-          ⚠ You haven’t published a Nutzap profile yet. Supporters cannot
-          subscribe to your tiers.
+          ⚠ Your public profile is incomplete. Fill out and publish the details below so supporters can find you.
         </div>
-        <q-btn
-          v-if="!hasP2PK"
-          color="white"
-          text-color="orange"
-          label="Generate P2PK key"
-          @click="generateP2PK"
-          class="q-ml-md"
-        />
       </div>
     </q-banner>
 
-    <!-- NEW: profile composer ------------------------------------- -->
+    <!-- UNIFIED PROFILE EDITOR -->
     <q-card class="q-mt-md q-mb-md" flat bordered>
       <q-card-section>
-        <div class="text-h6">Nutzap receiving profile</div>
-        <q-input v-model="profilePub" label="P2PK pubkey (hex, start with 02…)" dense />
-        <q-input v-model="profileMints" label="Trusted mints (comma-separated URLs)" dense />
-        <q-input v-model="profileRelays" label="Relay hints (comma-separated wss://…)" dense />
+        <div class="text-h6">Your Public Creator Profile</div>
+        <p class="text-caption text-grey-7">This information will be published to Nostr so others can find and subscribe to you.</p>
+
+        <div class="q-gutter-y-md q-mt-md">
+          <q-input v-model="profile.display_name" label="Display Name" dense outlined />
+          <q-input v-model="profile.picture" label="Profile Picture URL" dense outlined />
+          <q-input v-model="profile.about" type="textarea" label="Bio" dense outlined autogrow />
+          <q-input v-model="profileRelays" label="Your Public Relays (comma-separated wss://…)" dense outlined hint="These are the relays others will use to find you."/>
+          <q-input v-model="profileMints" label="Your Trusted Cashu Mints (comma-separated URLs)" dense outlined hint="Fans will use these mints to pay you."/>
+          <q-input v-model="profilePub" label="Your Cashu P2PK Public Key (hex)" dense outlined>
+             <template v-if="!hasP2PK" #append>
+                <q-btn flat dense color="primary" label="Generate" @click="generateP2PK" />
+            </template>
+          </q-input>
+        </div>
       </q-card-section>
       <q-card-actions align="right">
-        <q-btn color="primary" :disable="!canSaveNutzap" @click="publishProfile">Publish now</q-btn>
+        <q-btn color="primary" :disable="!canPublish" @click="publishFullProfile">
+          Publish Profile to Nostr
+        </q-btn>
       </q-card-actions>
     </q-card>
 
     <NutzapNotification class="q-mt-md" />
 
-    <div class="q-mt-md">
-      <div class="text-h6">{{ $t("CreatorHub.dashboard.edit_profile") }}</div>
-      <q-input
-        v-model="profile.display_name"
-        label="Display Name"
-        class="q-mt-sm"
-      />
-      <q-input
-        v-model="profile.picture"
-        label="Profile Picture URL"
-        class="q-mt-sm"
-      />
-      <q-input
-        v-model="profile.about"
-        type="textarea"
-        label="Bio"
-        class="q-mt-sm"
-      />
-      <q-btn color="primary" flat class="q-mt-sm" @click="saveProfile">{{
-        $t("global.actions.update.label")
-      }}</q-btn>
-    </div>
-
+    <!-- TIER MANAGEMENT (Unchanged) -->
     <div class="q-mt-lg">
       <div class="text-h6">{{ $t("CreatorHub.dashboard.manage_tiers") }}</div>
-      <AddTierDialog
-        v-model="showAddTierDialog"
-        :tier="newTier"
-        @save="saveNewTier"
-      />
+      <AddTierDialog v-model="showAddTierDialog" :tier="newTier" @save="saveNewTier" />
       <div v-for="tier in tiers" :key="tier.id" class="q-mt-md">
         <q-card>
           <q-card-section>
-            <q-input
-              :id="`tier-name-${tier.id}`"
-              v-model="editedTiers[tier.id].name"
-              label="Title"
-              dense
-              outlined
-              class="q-mt-sm"
-            />
-            <q-input
-              v-model.number="editedTiers[tier.id].price"
-              label="Cost / month (sats)"
-              type="number"
-              dense
-              outlined
-              class="q-mt-sm"
-            >
+            <q-input :id="`tier-name-${tier.id}`" v-model="editedTiers[tier.id].name" label="Title" dense outlined class="q-mt-sm" />
+            <q-input v-model.number="editedTiers[tier.id].price" label="Cost / month (sats)" type="number" dense outlined class="q-mt-sm">
               <template #hint>
                 <div v-if="bitcoinPrice">
-                  ~{{
-                    formatCurrency(
-                      (bitcoinPrice / 100000000) * editedTiers[tier.id].price,
-                      "USD"
-                    )
-                  }}
-                  /
-                  {{
-                    formatCurrency(
-                      (bitcoinPrice / 100000000) * editedTiers[tier.id].price,
-                      "EUR"
-                    )
-                  }}
+                  ~{{ formatCurrency((bitcoinPrice / 100000000) * editedTiers[tier.id].price, "USD") }} /
+                  {{ formatCurrency((bitcoinPrice / 100000000) * editedTiers[tier.id].price, "EUR") }}
                 </div>
               </template>
             </q-input>
-            <q-input
-              v-model="editedTiers[tier.id].description"
-              label="Description (Markdown)"
-              type="textarea"
-              autogrow
-              dense
-              outlined
-              class="q-mt-sm"
-            />
-            <q-input
-              v-model="editedTiers[tier.id].welcomeMessage"
-              label="Welcome Message"
-              type="textarea"
-              autogrow
-              dense
-              outlined
-              class="q-mt-sm"
-            />
-            <q-input
-              v-model="editedTiers[tier.id].id"
-              label="ID (optional)"
-              dense
-              outlined
-              class="q-mt-sm"
-            />
+            <q-input v-model="editedTiers[tier.id].description" label="Description (Markdown)" type="textarea" autogrow dense outlined class="q-mt-sm" />
+            <q-input v-model="editedTiers[tier.id].welcomeMessage" label="Welcome Message" type="textarea" autogrow dense outlined class="q-mt-sm" />
+            <q-input v-model="editedTiers[tier.id].id" label="ID (optional)" dense outlined class="q-mt-sm" />
           </q-card-section>
           <q-card-actions align="right">
-            <q-btn color="primary" flat @click="saveTier(tier)">{{
-              $t("CreatorHub.dashboard.save_tier")
-            }}</q-btn>
-            <q-btn
-              outline
-              color="primary"
-              class="q-mr-sm"
-              :style="{ borderRadius: '8px' }"
-              @click="cancelEdit(tier.id)"
-              >{{ $t("global.actions.cancel.label") }}</q-btn
-            >
-            <q-btn color="negative" flat @click="removeTier(tier.id)">{{
-              $t("CreatorHub.dashboard.delete_tier")
-            }}</q-btn>
+            <q-btn color="primary" flat @click="saveTier(tier)">{{ $t("CreatorHub.dashboard.save_tier") }}</q-btn>
+            <q-btn outline color="primary" class="q-mr-sm" :style="{ borderRadius: '8px' }" @click="cancelEdit(tier.id)">{{ $t("global.actions.cancel.label") }}</q-btn>
+            <q-btn color="negative" flat @click="removeTier(tier.id)">{{ $t("CreatorHub.dashboard.delete_tier") }}</q-btn>
           </q-card-actions>
         </q-card>
       </div>
       <div class="row q-gutter-sm q-mt-md">
-        <q-btn color="primary" flat @click="openAddTier">{{
-          $t("CreatorHub.dashboard.add_tier")
-        }}</q-btn>
-        <q-btn color="primary" flat @click="saveAllTiers">{{
-          $t("CreatorHub.dashboard.save_tier")
-        }}</q-btn>
+        <q-btn color="primary" flat @click="openAddTier">{{ $t("CreatorHub.dashboard.add_tier") }}</q-btn>
+        <q-btn color="primary" flat @click="saveAllTiers">{{ $t("CreatorHub.dashboard.save_tier") }}</q-btn>
       </div>
     </div>
   </div>
@@ -184,7 +89,8 @@ import NutzapNotification from "components/NutzapNotification.vue";
 import {
   useNostrStore,
   fetchNutzapProfile,
-  publishNutzapProfile,
+  // NEW: Import our powerful new function
+  publishDiscoveryProfile,
 } from "stores/nostr";
 import { useP2PKStore } from "stores/p2pk";
 import { useMintsStore } from "stores/mints";
@@ -205,23 +111,23 @@ export default defineComponent({
     const router = useRouter();
     const priceStore = usePriceStore();
     const uiStore = useUiStore();
-    const profile = ref<any>({ display_name: "", picture: "", about: "" });
-    const needsProfile = ref(false);
     const signerChecked = ref(false);
 
+    // --- State for all profile fields ---
+    const profile = ref({ display_name: "", picture: "", about: "" });
     const profilePub = ref("");
     const profileMints = ref("");
     const profileRelays = ref("");
+    const needsProfile = ref(false);
 
-    const canSaveNutzap = computed(
-      () => profilePub.value.startsWith("02") && profileMints.value.length > 0
+    const canPublish = computed(
+      () => profilePub.value.startsWith("02") && profileMints.value.length > 0 && profile.value.display_name
     );
 
     const p2pkStore = useP2PKStore();
     const mintsStore = useMintsStore();
     const hasP2PK = computed(() => p2pkStore.p2pkKeys.length > 0);
     const tiers = computed<Tier[]>(() => store.getTierArray());
-
     const editedTiers = ref<Record<string, Tier>>({});
 
     watch(
@@ -241,16 +147,28 @@ export default defineComponent({
         router.push("/creator/login");
         return;
       }
+      // Fetch Kind 0
       const p = await nostr.getProfile(store.loggedInNpub);
       if (p) profile.value = { ...p };
+
+      // Fetch Kind 10019
       const npub = nostr.pubkey;
-      const existing = await fetchNutzapProfile(npub);
-      if (existing) {
-        profilePub.value = existing.p2pkPubkey;
-        profileMints.value = existing.trustedMints.join(',');
-        profileRelays.value = (existing.relays || []).join(',');
+      const existingNutzap = await fetchNutzapProfile(npub);
+      if (existingNutzap) {
+        profilePub.value = existingNutzap.p2pkPubkey;
+        profileMints.value = existingNutzap.trustedMints.join(',');
+        profileRelays.value = (existingNutzap.relays || nostr.relays).join(',');
+      } else {
+        // Pre-fill with defaults if no profile exists
+        profileRelays.value = nostr.relays.join(',');
+        if (p2pkStore.firstKey) {
+            profilePub.value = p2pkStore.firstKey.publicKey;
+        }
+        if (mintsStore.mints.length > 0) {
+            profileMints.value = mintsStore.mints.map(m => m.url).join(',');
+        }
       }
-      needsProfile.value = !existing;
+      needsProfile.value = !existingNutzap || !p;
     }
 
     onMounted(async () => {
@@ -269,22 +187,31 @@ export default defineComponent({
       router.push("/creator/login");
     };
 
-    const saveProfile = async () => {
-      await store.updateProfile(profile.value);
-      notifySuccess("Profile saved");
-    };
+    // --- NEW: Unified Publish Function ---
+    // This function gathers all data from the form and calls our new store action
+    async function publishFullProfile() {
+      if (!canPublish.value) {
+        notifyError("Please fill out your Display Name, P2PK key, and at least one Mint URL.");
+        return;
+      }
+      try {
+        await publishDiscoveryProfile({
+          profile: profile.value,
+          p2pkPub: profilePub.value,
+          mints: profileMints.value.split(",").map((s) => s.trim()).filter(Boolean),
+          relays: profileRelays.value.split(",").map((s) => s.trim()).filter(Boolean),
+        });
+        needsProfile.value = false;
+      } catch (e: any) {
+        notifyError(e.message || "Failed to publish profile.");
+      }
+    }
 
     const showAddTierDialog = ref(false);
     const newTier = ref<Partial<Tier>>({});
 
     const openAddTier = () => {
-      newTier.value = {
-        id: uuidv4(),
-        name: "",
-        price: 0,
-        description: "",
-        welcomeMessage: "",
-      };
+      newTier.value = { id: uuidv4(), name: "", price: 0, description: "", welcomeMessage: "" };
       showAddTierDialog.value = true;
     };
 
@@ -307,43 +234,12 @@ export default defineComponent({
       notifySuccess("Tier removed");
     };
 
-    async function doPublish() {
-      const first = p2pkStore.firstKey;
-      if (!first) {
-        notifyError('No P2PK key');
-      }
-      try {
-        await publishNutzapProfile({
-          p2pkPub: first.publicKey,
-          mints: mintsStore.mints.map((m) => m.url),
-          relays: nostr.relays,
-        });
-        notifySuccess("Profile published");
-        needsProfile.value = false;
-      } catch (e: any) {
-        notifyError("Failed to publish");
-      }
-    }
-
-    async function publishProfile() {
-      try {
-        await publishNutzapProfile({
-          p2pkPub: profilePub.value,
-          mints: profileMints.value.split(",").map((s) => s.trim()),
-          relays: profileRelays.value
-            .split(",")
-            .map((s) => s.trim())
-            .filter(Boolean),
-        });
-        notifySuccess("Nutzap profile published ✔");
-        needsProfile.value = false;
-      } catch (e: any) {
-        notifyError(e);
-      }
-    }
-
     async function generateP2PK() {
       await p2pkStore.createAndSelectNewKey();
+      // auto-populate the field if it's empty
+      if (!profilePub.value && p2pkStore.firstKey) {
+          profilePub.value = p2pkStore.firstKey.publicKey
+      }
     }
 
     async function connectSigner() {
@@ -366,20 +262,12 @@ export default defineComponent({
 
     const cancelEdit = (id: string) => {
       const tier = store.tiers[id];
-      if (tier) {
-        editedTiers.value[id] = { ...tier };
-      } else {
-        delete editedTiers.value[id];
-        if (newTier.value.id === id) {
-          showAddTierDialog.value = false;
-        }
-      }
+      if (tier) editedTiers.value[id] = { ...tier };
+      else delete editedTiers.value[id];
     };
 
     const bitcoinPrice = computed(() => priceStore.bitcoinPrice);
-
-    const formatCurrency = (amount: number, unit: string) =>
-      uiStore.formatCurrency(amount, unit);
+    const formatCurrency = (amount: number, unit: string) => uiStore.formatCurrency(amount, unit);
 
     return {
       profile,
@@ -389,7 +277,6 @@ export default defineComponent({
       bitcoinPrice,
       formatCurrency,
       logout,
-      saveProfile,
       openAddTier,
       showAddTierDialog,
       newTier,
@@ -397,7 +284,6 @@ export default defineComponent({
       saveAllTiers,
       removeTier,
       saveTier,
-      doPublish,
       generateP2PK,
       connectSigner,
       editedTiers,
@@ -405,8 +291,8 @@ export default defineComponent({
       profilePub,
       profileMints,
       profileRelays,
-      canSaveNutzap,
-      publishProfile,
+      canPublish,
+      publishFullProfile, // Expose the new function to the template
       signerChecked,
       nostr,
     };


### PR DESCRIPTION
## Summary
- publish complete discovery profile with profile metadata, relay list, and payment info
- refactor CreatorDashboardPage to use new publish function and simplified UI

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68663684d2148330b718937447e9e83e