### PR TITLE
Remove Nutzap republish calls

### DIFF
--- a/src/stores/mints.ts
+++ b/src/stores/mints.ts
@@ -544,7 +544,6 @@ export const useMintsStore = defineStore("mints", {
         await this.activateMint(this.mints[0], false);
       }
       notifySuccess(this.t("wallet.mint.notifications.removed"));
-      await maybeRepublishNutzapProfile();
     },
     assertMintError: function (response: { error?: any }, verbose = true) {
       if (response.error != null) {

--- a/src/stores/p2pk.ts
+++ b/src/stores/p2pk.ts
@@ -115,7 +115,6 @@ export const useP2PKStore = defineStore("p2pk", {
         usedCount: 0,
       };
       this.p2pkKeys = this.p2pkKeys.concat(keyPair);
-      maybeRepublishNutzapProfile();
     },
     generateKeypair: function () {
       let sk = generateSecretKey(); // `sk` is a Uint8Array
@@ -129,7 +128,6 @@ export const useP2PKStore = defineStore("p2pk", {
         usedCount: 0,
       };
       this.p2pkKeys = this.p2pkKeys.concat(keyPair);
-      maybeRepublishNutzapProfile();
     },
     async createAndSelectNewKey() {
       const { pub, priv } = generateP2pkKeyPair();
@@ -139,9 +137,6 @@ export const useP2PKStore = defineStore("p2pk", {
         used: false,
         usedCount: 0,
       });
-      if (typeof maybeRepublishNutzapProfile === "function") {
-        await maybeRepublishNutzapProfile();
-      }
     },
     getSecretP2PKInfo: function (secret: string): {
       pubkey: string;


### PR DESCRIPTION
## Summary
- remove all maybeRepublishNutzapProfile() calls in p2pk store
- remove maybeRepublishNutzapProfile() call from removeMint action

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686644dc06e88330972797544d99efa5