### PR TITLE
Fix creators relay subscription fallback

### DIFF
--- a/src/stores/creators.ts
+++ b/src/stores/creators.ts
@@ -7,6 +7,8 @@ import {
   publishEvent,
   subscribeToNostr,
 } from "./nostr";
+import { useSettingsStore } from "./settings";
+import { DEFAULT_RELAYS } from "boot/ndk";
 import { useNdk } from "src/composables/useNdk";
 import { nip19 } from "nostr-tools";
 import { Event as NostrEvent } from "nostr-tools";
@@ -177,6 +179,12 @@ export const useCreatorsStore = defineStore("creators", {
         kinds: [30000],
         "#d": ["tiers"],
       };
+      const settings = useSettingsStore();
+      const relayUrls =
+        Array.isArray(settings.defaultNostrRelays.value) &&
+        settings.defaultNostrRelays.value.length > 0
+          ? settings.defaultNostrRelays.value
+          : DEFAULT_RELAYS;
       subscribeToNostr(filter, async (event) => {
         try {
           const tiersArray: Tier[] = JSON.parse(event.content).map(
@@ -195,7 +203,7 @@ export const useCreatorsStore = defineStore("creators", {
         } catch (e) {
           console.error("Error parsing tier definitions JSON:", e);
         }
-      });
+      }, relayUrls);
     },
 
     async publishTierDefinitions(tiersArray: Tier[]) {

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -1346,15 +1346,22 @@ export async function publishEvent(event: NostrEvent): Promise<void> {
   }
 }
 
-export function subscribeToNostr(filter: any, cb: (ev: NostrEvent) => void) {
-  const relays = useSettingsStore().defaultNostrRelays.value;
-  if (!relays || relays.length === 0) {
+export function subscribeToNostr(
+  filter: any,
+  cb: (ev: NostrEvent) => void,
+  relays?: string[],
+) {
+  const relayUrls =
+    relays && relays.length > 0
+      ? relays
+      : useSettingsStore().defaultNostrRelays.value;
+  if (!relayUrls || relayUrls.length === 0) {
     console.warn('[nostr] subscribeMany called with empty relay list');
     return;
   }
   const pool = new SimplePool();
   try {
-    pool.subscribeMany(relays, [filter], { onevent: cb });
+    pool.subscribeMany(relayUrls, [filter], { onevent: cb });
   } catch (e) {
     console.error("Failed to subscribe", e);
   }


### PR DESCRIPTION
## Summary
- allow specifying relay list in `subscribeToNostr`
- use settings relays with fallback to `DEFAULT_RELAYS` when fetching tier definitions

## Testing
- `npm install` *(fails: Invalid Version: file:./src/lib/cashu-ts)*
- `npm run test:ci` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866d29d4ab0833090bbfda94faaa9a3