### PR TITLE
Add indexer fallback for tier definitions

### DIFF
--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -82,6 +82,10 @@ export const useSettingsStore = defineStore("settings", {
         "cashu.settings.searchBackendUrl",
         ""
       ),
+      tiersIndexerUrl: useLocalStorage<string>(
+        "cashu.settings.tiersIndexerUrl",
+        "https://api.nostr.band/v0/profile?pubkey={pubkey}"
+      ),
     };
   },
 });


### PR DESCRIPTION
## Summary
- retry tier definition fetch via HTTP indexer when relay subscriptions time out
- allow configuring the indexer URL in settings

## Testing
- `pnpm install`
- `npm run test:ci` *(fails: cannot resolve imports and multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6866d4ea86d88330afae895935b8eab5