### PR TITLE
Fix CORS proxy for tier indexer

### DIFF
--- a/src/stores/creators.ts
+++ b/src/stores/creators.ts
@@ -191,9 +191,12 @@ export const useCreatorsStore = defineStore("creators", {
         if (received) return;
         const indexerUrl = settings.tiersIndexerUrl.value;
         if (!indexerUrl) return;
-        const url = indexerUrl.includes("{pubkey}")
+        let url = indexerUrl.includes("{pubkey}")
           ? indexerUrl.replace("{pubkey}", creatorNpub)
           : `${indexerUrl}${indexerUrl.includes("?") ? "&" : "?"}pubkey=${creatorNpub}`;
+        if (!url.startsWith("https://corsproxy.io/?")) {
+          url = `https://corsproxy.io/?${url}`;
+        }
         try {
           const controller = new AbortController();
           const id = setTimeout(() => controller.abort(), 8000);

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -84,7 +84,7 @@ export const useSettingsStore = defineStore("settings", {
       ),
       tiersIndexerUrl: useLocalStorage<string>(
         "cashu.settings.tiersIndexerUrl",
-        "https://api.nostr.band/v0/profile?pubkey={pubkey}"
+        "https://corsproxy.io/?https://api.nostr.band/v0/profile?pubkey={pubkey}"
       ),
     };
   },


### PR DESCRIPTION
## Summary
- update default tier indexer URL to use corsproxy
- prepend corsproxy prefix for fallback tier fetches

## Testing
- `pnpm install`
- `npm run test:ci` *(fails: 29 test files failed)*
- `firefox --headless --screenshot https://corsproxy.io/?https://api.nostr.band/v0/profile?pubkey=000...` *(fails: requires snapd)*

------
https://chatgpt.com/codex/tasks/task_e_6866d869e2688330a6a3158b470cfe39