### PR TITLE
Update default relay list

### DIFF
--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -2,9 +2,14 @@ import { defineStore } from "pinia";
 import { useLocalStorage } from "@vueuse/core";
 
 const defaultNostrRelays = [
-  "wss://relay.f7z.io/",
+  "wss://relay.damus.io/",
   "wss://relay.primal.net/",
+  "wss://nos.lol/",
+  "wss://nostr.wine/",
+  "wss://purplepag.es/",
   "wss://relay.nostr.band/",
+  "wss://eden.nostr.land/",
+  "wss://njump.me/",
 ];
 
 export const useSettingsStore = defineStore("settings", {


### PR DESCRIPTION
## Summary
- broaden the default Nostr relay list in the settings store

## Testing
- `npm run test:ci` *(fails: `vitest` not found)*
- `npm install` *(fails: Invalid Version: file:./src/lib/cashu-ts)*

------
https://chatgpt.com/codex/tasks/task_e_6867637a3b008330bec9b45c1dd14b0f