### PR TITLE
Implement P2PK timed outputs helper

### DIFF
--- a/test/buildTimedOutputs.spec.ts
+++ b/test/buildTimedOutputs.spec.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { CashuWallet } from "@cashu/cashu-ts";
+import { buildTimedOutputs } from "stores/p2pk";
+
+describe("buildTimedOutputs", () => {
+  let wallet: CashuWallet;
+
+  beforeEach(async () => {
+    wallet = new CashuWallet("https://example-mint.test", "sat");
+    // mock internal methods so test is pure
+    wallet.split = async (amts, { buildSecret }) => {
+      return {
+        proofs: amts.map((a, idx) => ({
+          id: "1",
+          amount: a,
+          secret: buildSecret(idx),
+        })),
+        tokenStrings: amts.map((a, idx) => `cashu_mock_${idx}_${a}`),
+      } as any;
+    };
+  });
+
+  it("creates N proofs, each with a locktime tag except index\u00a00", async () => {
+    const { proofs } = await buildTimedOutputs(
+      wallet,
+      120,
+      3,
+      "0202…abcd", // sample SEC hex
+      1_700_000_000,
+      100,
+    );
+    expect(proofs).toHaveLength(3);
+    proofs.forEach((p, idx) => {
+      const secret = JSON.parse(p.secret);
+      const tags = secret[1].tags || [];
+      const lock = tags.find((t: any[]) => t[0] === "locktime");
+      if (idx === 0) {
+        expect(lock).toBeUndefined();
+      } else {
+        expect(lock).toBeDefined();
+      }
+      // no hash tag
+      const hash = tags.find((t: any[]) => t[0] === "hash");
+      expect(hash).toBeUndefined();
+    });
+  });
+});

--- a/test/vitest/__tests__/p2pk.spec.ts
+++ b/test/vitest/__tests__/p2pk.spec.ts
@@ -78,44 +78,45 @@ describe("P2PK store", () => {
     );
   });
 
-  it("uses splitWithSecret when hashSecret is provided", async () => {
-    const walletStore = useWalletStore();
-    const proofsStore = useProofsStore();
-    vi.spyOn(proofsStore, "removeProofs").mockResolvedValue();
-    vi.spyOn(proofsStore, "addProofs").mockResolvedValue();
-
-    walletStore.spendableProofs = vi.fn(() => [
-      { secret: "s", amount: 1, id: "a", C: "c" } as any,
-    ]);
-    walletStore.coinSelect = vi.fn(() => [
-      { secret: "s", amount: 1, id: "a", C: "c" } as any,
-    ]);
-    walletStore.getKeyset = vi.fn(() => "kid");
-    const wallet = {
-      mint: { mintUrl: "m" },
-      unit: "sat",
-      splitWithSecret: vi.fn(async (_a: number, _p: any, opts: any) => ({
-        keep: [],
-        send: [],
-      })),
-    } as any;
-
-    await walletStore.sendToLock(
-      [{ secret: "s", amount: 1, id: "a", C: "c" } as any],
-      wallet,
-      1,
-      "pk",
-      "b",
-      123,
-      "r",
-      "hs"
-    );
-    expect(wallet.splitWithSecret).toHaveBeenCalledWith(
-      1,
-      [{ secret: "s", amount: 1, id: "a", C: "c" }],
-      { pubkey: "pk", locktime: 123, refund: "r", hashSecret: "hs" }
-    );
-  });
+  // Legacy hashlock functionality has been removed.
+  // it("uses splitWithSecret when hashSecret is provided", async () => {
+  //   const walletStore = useWalletStore();
+  //   const proofsStore = useProofsStore();
+  //   vi.spyOn(proofsStore, "removeProofs").mockResolvedValue();
+  //   vi.spyOn(proofsStore, "addProofs").mockResolvedValue();
+  //
+  //   walletStore.spendableProofs = vi.fn(() => [
+  //     { secret: "s", amount: 1, id: "a", C: "c" } as any,
+  //   ]);
+  //   walletStore.coinSelect = vi.fn(() => [
+  //     { secret: "s", amount: 1, id: "a", C: "c" } as any,
+  //   ]);
+  //   walletStore.getKeyset = vi.fn(() => "kid");
+  //   const wallet = {
+  //     mint: { mintUrl: "m" },
+  //     unit: "sat",
+  //     splitWithSecret: vi.fn(async (_a: number, _p: any, opts: any) => ({
+  //       keep: [],
+  //       send: [],
+  //     })),
+  //   } as any;
+  //
+  //   await walletStore.sendToLock(
+  //     [{ secret: "s", amount: 1, id: "a", C: "c" } as any],
+  //     wallet,
+  //     1,
+  //     "pk",
+  //     "b",
+  //     123,
+  //     "r",
+  //     "hs"
+  //   );
+  //   expect(wallet.splitWithSecret).toHaveBeenCalledWith(
+  //     1,
+  //     [{ secret: "s", amount: 1, id: "a", C: "c" }],
+  //     { pubkey: "pk", locktime: 123, refund: "r", hashSecret: "hs" }
+  //   );
+  // });
 
   it("extracts pubkeys from encoded token", () => {
     const p2pk = useP2PKStore();

--- a/test/vitest/setup-file.js
+++ b/test/vitest/setup-file.js
@@ -1,3 +1,5 @@
+import 'fake-indexeddb/auto';
+
 vi.mock('quasar', async (importOriginal) => {
   const actual = await importOriginal();
   return {


### PR DESCRIPTION
## Summary
- add new `buildTimedOutputs` helper for creating time locked proofs
- drop legacy refund secret and hashlock test
- provide indexedDB shim for vitest
- add tests for `buildTimedOutputs`

## Testing
- `pnpm test` *(fails: Multiple exports with the same name "buildTimedOutputs"; other suite errors)*

------
https://chatgpt.com/codex/tasks/task_e_68677d4336f083308afed21f8114508e