### PR TITLE
Remove duplicate buildTimedOutputs export

### DIFF
--- a/src/stores/p2pk.ts
+++ b/src/stores/p2pk.ts
@@ -389,4 +389,5 @@ export const useP2PKStore = defineStore("p2pk", {
   },
 });
 
-export { buildTimedOutputs };
+// Disabled because buildTimedOutputs is already exported above.
+// export { buildTimedOutputs };


### PR DESCRIPTION
## Summary
- comment out the duplicate export of `buildTimedOutputs` in `src/stores/p2pk.ts`
- ran `pnpm build` to verify bundler

## Testing
- `pnpm install`
- `pnpm build` *(fails: Element is missing end tag)*

------
https://chatgpt.com/codex/tasks/task_e_68680d3b17ac83308c4508c87dcbffa8