### PR TITLE
Improve subscribe dialog error handling

### DIFF
--- a/src/components/SubscribeDialog.vue
+++ b/src/components/SubscribeDialog.vue
@@ -167,19 +167,25 @@ export default defineComponent({
       if (!startDate.value) {
         return;
       }
-      const profile = await fetchNutzapProfile(props.creatorPubkey);
-      if (!profile) {
-        notifyError("Creator has not published a Nutzap profile (kind-10019)");
-        return;
+      try {
+        const profile = await fetchNutzapProfile(props.creatorPubkey);
+        if (!profile) {
+          notifyError(
+            "Creator has not published a Nutzap profile (kind-10019)"
+          );
+          return;
+        }
+        await nutzap.send({
+          npub: props.creatorPubkey,
+          months: months.value,
+          amount: amount.value,
+          startDate: Math.floor(new Date(startDate.value).getTime() / 1000),
+        });
+        notifySuccess(t("FindCreators.notifications.subscription_success"));
+        emit("update:modelValue", false);
+      } catch (e: any) {
+        notifyError(e.message);
       }
-      await nutzap.send({
-        npub: props.creatorPubkey,
-        months: months.value,
-        amount: amount.value,
-        startDate: Math.floor(new Date(startDate.value).getTime() / 1000),
-      });
-      notifySuccess(t("FindCreators.notifications.subscription_success"));
-      emit("update:modelValue", false);
     };
 
     return {


### PR DESCRIPTION
## Summary
- handle errors when fetching Nutzap profile in `SubscribeDialog`

## Testing
- `npm run lint` *(fails: A config object is using the "extends" key, which is not supported)*
- `npm run checkformat` *(fails: code style issues found in many files)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68681ed046c08330a6eb293d318e0a20