### PR TITLE
Emit confirm data from SubscribeDialog

### DIFF
--- a/src/components/SubscribeDialog.vue
+++ b/src/components/SubscribeDialog.vue
@@ -179,6 +179,13 @@ export default defineComponent({
         startDate: Math.floor(new Date(startDate.value).getTime() / 1000),
       });
       notifySuccess(t("FindCreators.notifications.subscription_success"));
+      emit("confirm", {
+        bucketId: bucketId.value,
+        months: months.value,
+        amount: amount.value,
+        startDate: Math.floor(new Date(startDate.value).getTime() / 1000),
+        total: total.value,
+      });
       emit("update:modelValue", false);
     };
 

--- a/src/pages/FindCreators.vue
+++ b/src/pages/FindCreators.vue
@@ -14,7 +14,6 @@
       :creator-pubkey="dialogPubkey.value"
       @confirm="confirmSubscribe"
     />
-    <SubscriptionReceipt v-model="showReceiptDialog" :receipts="receiptList" />
     <SendTokenDialog />
     <QDialog v-model="showTierDialog">
       <QCard class="tier-dialog">
@@ -80,14 +79,11 @@ import {
 } from "vue";
 import DonateDialog from "components/DonateDialog.vue";
 import SubscribeDialog from "components/SubscribeDialog.vue";
-import SubscriptionReceipt from "components/SubscriptionReceipt.vue";
 import SendTokenDialog from "components/SendTokenDialog.vue";
 import { useSendTokensStore } from "stores/sendTokensStore";
 import { useDonationPresetsStore } from "stores/donationPresets";
 import { useCreatorsStore } from "stores/creators";
-import { useNostrStore, fetchNutzapProfile } from "stores/nostr";
-import { notifyError, notifySuccess, notifyWarning } from "src/js/notify";
-import { useNutzapStore } from "stores/nutzap";
+import { useNostrStore } from "stores/nostr";
 import { useI18n } from "vue-i18n";
 import {
   QDialog,
@@ -96,7 +92,6 @@ import {
   QCardActions,
   QBtn,
   QSeparator,
-  Loading,
 } from "quasar";
 import { nip19 } from "nostr-tools";
 
@@ -111,12 +106,9 @@ const sendTokensStore = useSendTokensStore();
 const donationStore = useDonationPresetsStore();
 const creators = useCreatorsStore();
 const nostr = useNostrStore();
-const nutzap = useNutzapStore();
 const { t } = useI18n();
 const tiers = computed(() => creators.tiersMap[dialogPubkey.value] || []);
 const showSubscribeDialog = ref(false);
-const showReceiptDialog = ref(false);
-const receiptList = ref<any[]>([]);
 const selectedTier = ref<any>(null);
 let tierTimeout: ReturnType<typeof setTimeout> | null = null;
 
@@ -181,39 +173,17 @@ function retryFetchTiers() {
   creators.fetchTierDefinitions(dialogPubkey.value);
 }
 
-async function confirmSubscribe({
+function confirmSubscribe({
   bucketId,
   months,
   amount,
   startDate,
   total,
 }: any) {
-  if (!dialogPubkey.value) return;
-  Loading.show({ message: "Loading..." });
-  try {
-    const profile = await fetchNutzapProfile(dialogPubkey.value);
-    if (!profile) {
-      notifyError("Creator has not published a Nutzap profile (kind-10019)");
-      return;
-    }
-
-    const receipts = (await nutzap.send({
-      npub: dialogPubkey.value,
-      months,
-      amount,
-      startDate,
-    })) as any[];
-
-    receiptList.value = receipts;
-    showReceiptDialog.value = true;
-    showSubscribeDialog.value = false;
-    showTierDialog.value = false;
-    notifySuccess(t("FindCreators.notifications.subscription_success"));
-  } catch (e: any) {
-    notifyError(e.message);
-  } finally {
-    Loading.hide();
-  }
+  // Nutzap transaction is handled within SubscribeDialog.
+  // Close surrounding dialogs and process any additional UI updates here.
+  showSubscribeDialog.value = false;
+  showTierDialog.value = false;
 }
 
 function handleDonate({

--- a/src/pages/PublicCreatorProfilePage.vue
+++ b/src/pages/PublicCreatorProfilePage.vue
@@ -96,10 +96,7 @@ import { usePriceStore } from "stores/price";
 import { useUiStore } from "stores/ui";
 import SubscribeDialog from "components/SubscribeDialog.vue";
 import SubscriptionReceipt from "components/SubscriptionReceipt.vue";
-import { notifyError, notifySuccess } from "src/js/notify";
-import { useNutzapStore } from "stores/nutzap";
 import { useI18n } from "vue-i18n";
-import { Loading } from "quasar";
 import { renderMarkdown as renderMarkdownFn } from "src/js/simple-markdown";
 import PaywalledContent from "components/PaywalledContent.vue";
 
@@ -113,7 +110,6 @@ export default defineComponent({
     const nostr = useNostrStore();
     const priceStore = usePriceStore();
     const uiStore = useUiStore();
-    const nutzap = useNutzapStore();
     const { t } = useI18n();
     const bitcoinPrice = computed(() => priceStore.bitcoinPrice);
     const profile = ref<any>({});
@@ -149,31 +145,15 @@ export default defineComponent({
       ).slice(-2)}`;
     };
 
-    const confirmSubscribe = async ({
+    const confirmSubscribe = ({
       bucketId,
       months,
       amount,
       startDate,
       total,
     }: any) => {
-      Loading.show({ message: "Loading..." });
-      try {
-        const receipts = await nutzap.send({
-          npub: creatorNpub,
-          months,
-          amount,
-          startDate,
-        });
-
-        receiptList.value = receipts as any[];
-        showReceiptDialog.value = true;
-        showSubscribeDialog.value = false;
-        notifySuccess(t("FindCreators.notifications.subscription_success"));
-      } catch (e: any) {
-        notifyError(e.message);
-      } finally {
-        Loading.hide();
-      }
+      // Transaction already processed in SubscribeDialog.
+      showSubscribeDialog.value = false;
     };
     function renderMarkdown(text: string): string {
       return renderMarkdownFn(text || "");


### PR DESCRIPTION
## Summary
- send Nutzap payment in `SubscribeDialog` then emit a `confirm` payload
- drop duplicate `nutzap.send` usage in `FindCreators` and `PublicCreatorProfilePage`
- clean up unused imports

## Testing
- `npm run lint` *(fails: config migration issue)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686825ad211c83308bcf69199f86300e