### PR TITLE
Add relay override option for DM sending

### DIFF
--- a/src/stores/messenger.ts
+++ b/src/stores/messenger.ts
@@ -76,7 +76,7 @@ export const useMessengerStore = defineStore("messenger", {
         console.warn("[messenger] signer unavailable, continuing read-only", e);
       }
     },
-    async sendDm(recipient: string, message: string) {
+    async sendDm(recipient: string, message: string, relays?: string[]) {
       await this.loadIdentity();
       const nostr = useNostrStore();
       let privKey: string | undefined = undefined;
@@ -89,6 +89,7 @@ export const useMessengerStore = defineStore("messenger", {
         message,
         privKey,
         nostr.pubkey,
+        relays,
       );
       if (success && event) {
         this.addOutgoingMessage(recipient, message, event.created_at, event.id);

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -892,7 +892,8 @@ export const useNostrStore = defineStore("nostr", {
       recipient: string,
       message: string,
       privKey?: string,
-      pubKey?: string
+      pubKey?: string,
+      relays?: string[]
     ): Promise<{ success: boolean; event: NDKEvent | null }> {
       recipient = this.resolvePubkey(recipient);
       if (pubKey) {
@@ -923,7 +924,7 @@ export const useNostrStore = defineStore("nostr", {
       const pool = new SimplePool();
       const nostrEvent = await event.toNostrEvent();
       try {
-        await pool.publish(this.relays, nostrEvent);
+        await pool.publish(relays ?? this.relays, nostrEvent);
         notifySuccess("NIP-04 event published");
         return { success: true, event };
       } catch (e) {

--- a/src/stores/nutzap.ts
+++ b/src/stores/nutzap.ts
@@ -158,7 +158,8 @@ export const useNutzapStore = defineStore("nutzap", {
             month_index: i + 1,
             total_months: months,
             token,
-          })
+          }),
+          profile.relays
         );
 
           lockedTokens.push(locked);

--- a/test/vitest/__tests__/messenger-send-token.spec.ts
+++ b/test/vitest/__tests__/messenger-send-token.spec.ts
@@ -83,7 +83,8 @@ describe("messenger.sendToken", () => {
       "receiver",
       expect.stringContaining('\"token\":\"TOKEN\"'),
       "priv",
-      "pub"
+      "pub",
+      undefined
     );
     expect(addPending).toHaveBeenCalledWith({
       amount: -1,

--- a/test/vitest/__tests__/messenger.spec.ts
+++ b/test/vitest/__tests__/messenger.spec.ts
@@ -61,7 +61,7 @@ describe("messenger store", () => {
   it("uses global key when sending DMs", async () => {
     const messenger = useMessengerStore();
     await messenger.sendDm("r", "m");
-    expect(sendDm).toHaveBeenCalledWith("r", "m", "priv", "pub");
+    expect(sendDm).toHaveBeenCalledWith("r", "m", "priv", "pub", undefined);
   });
 
   it("decrypts incoming messages with global key", async () => {


### PR DESCRIPTION
## Summary
- allow messenger.sendDm and Nostr.sendNip04DirectMessage to take optional `relays`
- use provided relays when publishing a NIP-04 event
- pass creator relay hints when sending Nutzap subscriptions
- update unit tests for new parameter

## Testing
- `pnpm test` *(fails: Failed to resolve import "@scure/bip32" and other suite failures)*

------
https://chatgpt.com/codex/tasks/task_e_68682d47dc5483308b35d3dd3d6c1e5a