### PR TITLE
Fix profile loading on mount

### DIFF
--- a/src/components/ConversationList.vue
+++ b/src/components/ConversationList.vue
@@ -81,8 +81,7 @@ const loadProfiles = async () => {
   }
 };
 
-await loadProfiles();
-onMounted(() => {});
+onMounted(loadProfiles);
 watch(uniqueConversations, loadProfiles);
 
 const select = (pubkey: string) => emit("select", pubkey);


### PR DESCRIPTION
## Summary
- trigger `loadProfiles` when the conversation list component mounts

## Testing
- `pnpm run test:ci` *(fails: Failed to resolve import "@scure/bip32")*

------
https://chatgpt.com/codex/tasks/task_e_6868b130a6ac833093a390b921f3476d