### PR TITLE
Fix event serialization for storage

### DIFF
--- a/src/stores/creatorHub.ts
+++ b/src/stores/creatorHub.ts
@@ -190,6 +190,7 @@ export const useCreatorHubStore = defineStore("creatorHub", {
         tiers: tiersArray as any,
         eventId: ev.id!,
         updatedAt: ev.created_at!,
+        rawEvent: ev.rawEvent(),
       });
 
       notifySuccess("Tiers published");

--- a/src/stores/creators.ts
+++ b/src/stores/creators.ts
@@ -227,6 +227,7 @@ export const useCreatorsStore = defineStore("creators", {
             tiers: tiersArray,
             eventId: event.id!,
             updatedAt: event.created_at,
+            rawEvent: event,
           });
         } catch (e) {
           console.error("Indexer tier fetch error:", e);
@@ -249,6 +250,7 @@ export const useCreatorsStore = defineStore("creators", {
               tiers: tiersArray,
               eventId: event.id!,
               updatedAt: event.created_at,
+              rawEvent: event,
             });
           } catch (e) {
             console.error("Error parsing tier definitions JSON:", e);
@@ -279,6 +281,7 @@ export const useCreatorsStore = defineStore("creators", {
         tiers: tiersArray,
         eventId: event.id!,
         updatedAt: created_at,
+        rawEvent: event as NostrEvent,
       });
 
       this.tiersMap[creatorNpub] = tiersArray;

--- a/src/stores/dexie.ts
+++ b/src/stores/dexie.ts
@@ -6,6 +6,7 @@ import { WalletProof } from "./mints";
 import { useStorageStore } from "./storage";
 import { useProofsStore } from "./proofs";
 import { notifyError, notifySuccess } from "../js/notify";
+import type { NostrEvent } from "@nostr-dev-kit/ndk";
 
 export interface CachedProfileDexie {
   pubkey: string;
@@ -24,6 +25,7 @@ export interface CreatorTierDefinition {
   }[];
   eventId: string;
   updatedAt: number;
+  rawEvent?: NostrEvent;
 }
 
 export interface SubscriptionInterval {

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -967,7 +967,7 @@ export const useNostrStore = defineStore("nostr", {
               this.parseMessageForEcash(content, event.pubkey);
               try {
                 const chatStore = useDmChatsStore();
-                chatStore.addIncoming(event);
+                chatStore.addIncoming(event.rawEvent() as any);
               } catch {}
             }
           );
@@ -1163,7 +1163,7 @@ export const useNostrStore = defineStore("nostr", {
           this.parseMessageForEcash(content, dmEvent.pubkey);
           try {
             const chatStore = useDmChatsStore();
-            chatStore.addIncoming(dmEvent);
+            chatStore.addIncoming(dmEvent as any);
           } catch {}
         });
       });


### PR DESCRIPTION
## Summary
- include Nostr event type in Dexie creator tier definitions
- save raw Nostr events when publishing tiers
- keep raw tier events when caching creator data
- pass plain objects to DM chat store when receiving messages

## Testing
- `pnpm install`
- `npm run test:ci` *(fails: Failed to resolve import "@scure/bip32" ...)*

------
https://chatgpt.com/codex/tasks/task_e_6868b2105f2c8330ad08a78cf556096e