### PR TITLE
Fix discovery profile publishing

### DIFF
--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -262,8 +262,7 @@ export async function publishDiscoveryProfile(opts: {
     notifyWarning("Relay connection failed", e?.message ?? String(e));
   }
   try {
-    // NDK's publish method can take a single event or an array of events
-    await ndk.publish(eventsToPublish, relaySet);
+    await Promise.all(eventsToPublish.map((ev) => ev.publish(relaySet)));
     notifySuccess("Profile published successfully to your relays!");
   } catch (e: any) {
     notifyError(e?.message ?? String(e));


### PR DESCRIPTION
## Summary
- publish discovery profile events individually rather than as an array

## Testing
- `pnpm install`
- `npm run test:ci` *(fails: Failed to resolve import "@scure/bip32")*

------
https://chatgpt.com/codex/tasks/task_e_6868bd39a9fc8330af3053f17ce7c064