### PR TITLE
Store raw Nostr events as JSON strings

### DIFF
--- a/src/stores/creatorHub.ts
+++ b/src/stores/creatorHub.ts
@@ -190,7 +190,7 @@ export const useCreatorHubStore = defineStore("creatorHub", {
         tiers: tiersArray as any,
         eventId: ev.id!,
         updatedAt: ev.created_at!,
-        rawEvent: ev.rawEvent(),
+        rawEventJson: JSON.stringify(ev.rawEvent()),
       });
 
       notifySuccess("Tiers published");

--- a/src/stores/creators.ts
+++ b/src/stores/creators.ts
@@ -169,10 +169,14 @@ export const useCreatorsStore = defineStore("creators", {
     async fetchTierDefinitions(creatorNpub: string) {
       const cached = await db.creatorsTierDefinitions.get(creatorNpub);
       if (cached) {
+        const rawEvent = cached.rawEventJson
+          ? JSON.parse(cached.rawEventJson)
+          : undefined;
         this.tiersMap[creatorNpub] = cached.tiers.map((t: any) => ({
           ...t,
           price_sats: t.price_sats ?? t.price ?? 0,
         }));
+        void rawEvent; // parsed for potential use
       }
       const filter = {
         authors: [creatorNpub],
@@ -227,7 +231,7 @@ export const useCreatorsStore = defineStore("creators", {
             tiers: tiersArray,
             eventId: event.id!,
             updatedAt: event.created_at,
-            rawEvent: event,
+            rawEventJson: JSON.stringify(event),
           });
         } catch (e) {
           console.error("Indexer tier fetch error:", e);
@@ -250,7 +254,7 @@ export const useCreatorsStore = defineStore("creators", {
               tiers: tiersArray,
               eventId: event.id!,
               updatedAt: event.created_at,
-              rawEvent: event,
+              rawEventJson: JSON.stringify(event),
             });
           } catch (e) {
             console.error("Error parsing tier definitions JSON:", e);
@@ -281,7 +285,7 @@ export const useCreatorsStore = defineStore("creators", {
         tiers: tiersArray,
         eventId: event.id!,
         updatedAt: created_at,
-        rawEvent: event as NostrEvent,
+        rawEventJson: JSON.stringify(event),
       });
 
       this.tiersMap[creatorNpub] = tiersArray;

--- a/src/stores/dexie.ts
+++ b/src/stores/dexie.ts
@@ -25,7 +25,8 @@ export interface CreatorTierDefinition {
   }[];
   eventId: string;
   updatedAt: number;
-  rawEvent?: NostrEvent;
+  /** Raw Nostr event JSON string */
+  rawEventJson?: string;
 }
 
 export interface SubscriptionInterval {


### PR DESCRIPTION
## Summary
- save creator tier definition events in Dexie as JSON strings
- update creator hub and creators stores to use the new field

## Testing
- `pnpm test` *(fails: Failed to resolve import `@scure/bip32`)*

------
https://chatgpt.com/codex/tasks/task_e_6868c033f5748330970eac1883819c2f