### PR TITLE
Add Nutzap profile verification helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,17 @@ wss://eden.nostr.land
 wss://njump.me
 ```
 
+### Verify Nutzap Profile
+After publishing your `kind:10019` Nutzap profile, you can confirm that relays
+have received it. Run the helper script with your npub:
+
+```bash
+npx ts-node scripts/verifyNutzapProfile.ts <your-npub>
+```
+
+The script connects read-only to your configured relays and prints the fetched
+profile data so you can double-check the values.
+
 ## Contributing
 
 Contributions are welcome! Open an issue or pull request to discuss your ideas. Bug reports and feature requests are encouraged. Help with translation and documentation is always appreciated.

--- a/scripts/verifyNutzapProfile.ts
+++ b/scripts/verifyNutzapProfile.ts
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+import 'fake-indexeddb/auto';
+import { createPinia, setActivePinia } from 'pinia';
+import { fetchNutzapProfile, useNostrStore } from '../src/stores/nostr';
+import { useSettingsStore } from '../src/stores/settings';
+
+async function main() {
+  const npub = process.argv[2];
+  if (!npub) {
+    console.error('Usage: verifyNutzapProfile <npub>');
+    process.exit(1);
+  }
+
+  setActivePinia(createPinia());
+  useSettingsStore();
+  const nostr = useNostrStore();
+  await nostr.initNdkReadOnly();
+
+  const profile = await fetchNutzapProfile(npub);
+  console.log(JSON.stringify(profile, null, 2));
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/components/SettingsView.vue
+++ b/src/components/SettingsView.vue
@@ -1790,6 +1790,7 @@ import { useSettingsStore } from "src/stores/settings";
 import {
   useNostrStore,
   publishNutzapProfile as publishNutzapProfileFn,
+  fetchNutzapProfile,
 } from "src/stores/nostr";
 import { useNPCStore } from "src/stores/npubcash";
 import { useP2PKStore } from "src/stores/p2pk";
@@ -1804,6 +1805,7 @@ import { useReceiveTokensStore } from "../stores/receiveTokensStore";
 import { useWelcomeStore } from "src/stores/welcome";
 import { useStorageStore } from "src/stores/storage";
 import { useI18n } from "vue-i18n";
+import { Dialog } from "quasar";
 
 export default defineComponent({
   name: "SettingsView",
@@ -2071,6 +2073,10 @@ export default defineComponent({
           relays: this.defaultNostrRelays,
         });
         this.notifySuccess("Profile published");
+        const profile = await fetchNutzapProfile(this.pubkey);
+        Dialog.create({
+          message: `Profile fetched: ${JSON.stringify(profile, null, 2)}`,
+        });
       } catch (e) {
         this.notifyError("Failed to publish");
       }


### PR DESCRIPTION
## Summary
- allow verifying a published Nutzap profile from the settings view
- script to fetch a Nutzap profile by npub
- document profile verification in the README

## Testing
- `npm run test:ci` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868cab8eff48330a8041721da59b164