### PR TITLE
Fix creator hub tier save errors

### DIFF
--- a/src/pages/CreatorHubPage.vue
+++ b/src/pages/CreatorHubPage.vue
@@ -168,19 +168,27 @@ function addTier() {
 async function saveTier(id: string) {
   const data = editedTiers.value[id];
   if (data) {
-    store.updateTier(id, data);
-    await store.publishTierDefinitions();
-    notifySuccess('Tier saved');
-    saved.value[id] = true;
-    setTimeout(() => {
-      saved.value[id] = false;
-    }, 2000);
+    try {
+      store.updateTier(id, data);
+      await store.publishTierDefinitions();
+      notifySuccess('Tier saved');
+      saved.value[id] = true;
+      setTimeout(() => {
+        saved.value[id] = false;
+      }, 2000);
+    } catch (e: any) {
+      notifyError(e?.message || 'Failed to save tier');
+    }
   }
 }
 
-function removeTier(id: string) {
-  store.removeTier(id);
-  store.publishTierDefinitions();
+async function removeTier(id: string) {
+  try {
+    store.removeTier(id);
+    await store.publishTierDefinitions();
+  } catch (e: any) {
+    notifyError(e?.message || 'Failed to delete tier');
+  }
 }
 
 onMounted(async () => {

--- a/src/stores/creatorHub.ts
+++ b/src/stores/creatorHub.ts
@@ -1,4 +1,5 @@
 import { defineStore } from "pinia";
+import { toRaw } from "vue";
 import { useLocalStorage } from "@vueuse/core";
 import { NDKEvent, NDKKind, NDKFilter } from "@nostr-dev-kit/ndk";
 import {
@@ -159,7 +160,7 @@ export const useCreatorHubStore = defineStore("creatorHub", {
     },
 
     async publishTierDefinitions() {
-      const tiersArray = this.getTierArray();
+      const tiersArray = this.getTierArray().map((t) => ({ ...toRaw(t) }));
       const nostr = useNostrStore();
 
       if (!nostr.signer) {


### PR DESCRIPTION
## Summary
- avoid storing reactive proxies in IndexedDB by cloning tiers with `toRaw`
- handle errors when saving or deleting tiers

## Testing
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868cd46ac4c8330b6ba0fd9b472704b