### PR TITLE
Fix duplicate attribute in FindCreators.vue

### DIFF
--- a/src/pages/FindCreators.vue
+++ b/src/pages/FindCreators.vue
@@ -27,7 +27,7 @@
         </QCardSection>
         <QCardSection v-else-if="nutzapProfile">
           <div class="text-subtitle2 q-mb-xs">P2PK public key</div>
-          <div class="text-caption" style="word-break: break-all" class="q-mb-sm">
+          <div class="text-caption q-mb-sm" style="word-break: break-all">
             {{ nutzapProfile.p2pkPubkey }}
           </div>
           <div class="text-subtitle2 q-mb-xs">Trusted mints</div>


### PR DESCRIPTION
## Summary
- fix duplicate class attribute in FindCreators.vue template

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868d2a560588330bf58a415198fdbf6