### PR TITLE
Update event listener timing

### DIFF
--- a/src/pages/FindCreators.vue
+++ b/src/pages/FindCreators.vue
@@ -108,6 +108,7 @@ import { useSendTokensStore } from "stores/sendTokensStore";
 import { useDonationPresetsStore } from "stores/donationPresets";
 import { useCreatorsStore } from "stores/creators";
 import { useNostrStore, fetchNutzapProfile } from "stores/nostr";
+import { notifyWarning } from "src/js/notify";
 import { useI18n } from "vue-i18n";
 import {
   QDialog,
@@ -260,8 +261,12 @@ function handleDonate({
 }
 
 onMounted(async () => {
-  await nostr.initSignerIfNotSet();
   window.addEventListener("message", onMessage);
+  try {
+    await nostr.initSignerIfNotSet();
+  } catch (e: any) {
+    notifyWarning("Failed to initialize Nostr signer", e?.message);
+  }
 });
 
 onBeforeUnmount(() => {


### PR DESCRIPTION
## Summary
- ensure message listener is added before initializing signer in FindCreators page
- warn if signer initialization fails

## Testing
- `pnpm install --no-frozen-lockfile`
- `pnpm test` *(fails: Error: Failed to resolve import "@scure/bip32" and other failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_6868d652b8a4833081c7041abdb9f778