### PR TITLE
Enhance Nostr signer init

### DIFF
--- a/src/pages/FindCreators.vue
+++ b/src/pages/FindCreators.vue
@@ -263,9 +263,9 @@ function handleDonate({
 onMounted(async () => {
   window.addEventListener("message", onMessage);
   try {
-    await nostr.initSignerIfNotSet();
+    await nostr.initNdkReadOnly();
   } catch (e: any) {
-    notifyWarning("Failed to initialize Nostr signer", e?.message);
+    notifyWarning("Failed to connect to Nostr relays", e?.message);
   }
 });
 

--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -268,7 +268,7 @@ import { useCameraStore } from "src/stores/camera";
 import { useP2PKStore } from "src/stores/p2pk";
 import { useNWCStore } from "src/stores/nwc";
 import { useNPCStore } from "src/stores/npubcash";
-import { useNostrStore } from "src/stores/nostr";
+import { useNostrStore, SignerType } from "src/stores/nostr";
 import { usePRStore } from "src/stores/payment-request";
 import { useDexieStore } from "src/stores/dexie";
 
@@ -689,11 +689,18 @@ export default {
       this.initializeMnemonic();
 
       const hasExt = await this.checkNip07Signer();
-      if (hasExt) {
-        await this.initNip07Signer();
+      if (this.signerType === SignerType.NIP07) {
+        if (hasExt) {
+          await this.initNip07Signer();
+        } else {
+          await this.initSigner();
+          this.notifyWarning(this.$t("settings.nostr.signing_extension.not_found"));
+        }
       } else {
         await this.initSigner();
-        this.notifyWarning(this.$t("settings.nostr.signing_extension.not_found"));
+        if (this.signerType === SignerType.NIP07 && !hasExt) {
+          this.notifyWarning(this.$t("settings.nostr.signing_extension.not_found"));
+        }
       }
 
       this.showWelcomePage();


### PR DESCRIPTION
## Summary
- cache NIP-07 detection result in the Nostr store
- notify once when extension is locked or unavailable
- avoid repeated initialisation attempts
- use read‑only NDK mode on Find Creators page
- respect persisted signer type in wallet page

## Testing
- `pnpm test` *(fails: Failed to resolve import "@scure/bip32")*

------
https://chatgpt.com/codex/tasks/task_e_6868d9236d848330b946e8a056168d0e