### PR TITLE
Improve subscribe error handling

### DIFF
--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1397,6 +1397,8 @@ export const messages = {
       donation_sent: "Donation sent",
       message_sent: "Message sent",
       subscription_success: "Subscription successful",
+      invalid_creator_pubkey: "Invalid creator pubkey",
+      subscription_failed: "Subscription failed",
     },
   },
   ChooseExistingTokenDialog: {


### PR DESCRIPTION
## Summary
- catch errors in `SubscribeDialog` and validate creator pubkey
- add translations for new error notifications

## Testing
- `npm run lint` *(fails: config error)*
- `npx --yes vitest run` *(fails: Cannot find module 'vitest/config')*

------
https://chatgpt.com/codex/tasks/task_e_6868e1071b2883309908712d98bbb506