### PR TITLE
Fix P2PK expired lock pubkey

### DIFF
--- a/src/stores/p2pk.ts
+++ b/src/stores/p2pk.ts
@@ -238,6 +238,10 @@ export const useP2PKStore = defineStore("p2pk", {
           }
           return { pubkey: refundKeys[0], locktime, refundKeys };
         }
+        if (locktime !== undefined && locktime <= now) {
+          debug("p2pk token - lock has expired");
+          return { pubkey: mainKey, locktime, refundKeys: [] };
+        }
         debug("p2pk token - lock has expired");
       } catch {}
       return { pubkey: "", locktime: undefined, refundKeys: [] }; // Token is not locked / secret is not P2PK

--- a/test/vitest/__tests__/p2pk.spec.ts
+++ b/test/vitest/__tests__/p2pk.spec.ts
@@ -40,6 +40,18 @@ describe("P2PK store", () => {
     expect(info.locktime).toBe(locktime);
   });
 
+  it("returns pubkey for expired locktime secret without refund", () => {
+    const p2pk = useP2PKStore();
+    const locktime = Math.floor(Date.now() / 1000) - 1000;
+    const secret = JSON.stringify([
+      "P2PK",
+      { data: "02aa", tags: [["locktime", String(locktime)]] },
+    ]);
+    const info = p2pk.getSecretP2PKPubkey(secret);
+    expect(info.pubkey).toBe("02aa");
+    expect(info.locktime).toBe(locktime);
+  });
+
   it("forwards options in sendToLock", async () => {
     const walletStore = useWalletStore();
     const proofsStore = useProofsStore();


### PR DESCRIPTION
## Summary
- return the original pubkey for expired timelocks without refund keys
- test the behaviour

## Testing
- `pnpm test` *(fails: Failed to resolve import `@scure/bip32`)*

------
https://chatgpt.com/codex/tasks/task_e_6868fec6424483308605db3e8daaf30d