### PR TITLE
Update wallet.send options for lock transactions

### DIFF
--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -501,9 +501,11 @@ export const useWalletStore = defineStore("wallet", {
           proofsToSend,
           {
             keysetId,
-            pubkey: ensureCompressed(receiverPubkey),
-            locktime,
-            refund: refundPubkey,
+            p2pk: {
+              pubkey: ensureCompressed(receiverPubkey),
+              locktime,
+              refundKeys: refundPubkey ? [refundPubkey] : undefined,
+            },
           }
         ));
       }


### PR DESCRIPTION
## Summary
- refactor `sendToLock` to pass P2PK options to `wallet.send`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686907443620833089e44a18e1f94652