### PR TITLE
Update docs on P2PK keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,22 @@ mint URLs to use.
 6. Creators claim the tokens as they arrive, unlocking them when the timelock
    expires.
 
+### P2PK Keys & Locked Tokens
+
+Fundstr lets you lock Cashu tokens to any SEC-compressed public key. A creator
+can either generate a key locally or import the secret from an existing Nostr
+account.
+
+- **Generate a key** – use `useP2PKStore.generateKeypair()` to create a new
+  P2PK keypair saved in local storage. No Nostr account is required.
+- **Import a Nostr key** – call `useP2PKStore.importNsec()` and paste your
+  `nsec` to load the matching 66‑character pubkey.
+
+Tokens can then be **locked** to the pubkey via Cashu's P2PK mechanism. To
+spend the locked tokens, the owner proves knowledge of the corresponding private
+key when calling `claimLockedToken`. If the key only exists locally, you can use
+these features without registering a Nostr account.
+
 ## Roadmap & Future Ideas
 
 - Advanced creator discovery with search, filters and Nostr recommendations


### PR DESCRIPTION
## Summary
- document how to generate and import P2PK keys
- explain that tokens locked to a P2PK pubkey can be redeemed by proving ownership
- clarify that a Nostr account isn't required when keys are stored locally

## Testing
- `npm run test:ci` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686909da99b483309806c009494c2422