### PR TITLE
Fix P2PK redemption key lookup

### DIFF
--- a/src/stores/p2pk.ts
+++ b/src/stores/p2pk.ts
@@ -230,7 +230,10 @@ export const useP2PKStore = defineStore("p2pk", {
       locktime?: number;
     } {
       const { pubkey, locktime } = this.getSecretP2PKInfo(secret);
-      return { pubkey, locktime };
+      return {
+        pubkey: pubkey ? ensureCompressed(pubkey) : "",
+        locktime,
+      };
     },
     isLocked: function (proofs: WalletProof[]) {
       const secrets = proofs.map((p) => p.secret);

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -700,14 +700,18 @@ export const useWalletStore = defineStore("wallet", {
         const keysetId = this.getKeyset(historyToken.mint, historyToken.unit);
         const counter = this.keysetCounter(keysetId);
         const nostrStore = useNostrStore();
-        let privkey =
-          receiveStore.receiveData.p2pkPrivateKey ||
-          nostrStore.activePrivkeyHex;
+        const localPriv = receiveStore.receiveData.p2pkPrivateKey;
 
         /* ---------- P2PK remote-sign fall-back ------------ */
         const needsSig = proofs.some(
           (p) => typeof p.secret === "string" && p.secret.startsWith('["P2PK"')
         );
+
+        if (needsSig && !localPriv) {
+          throw new Error("You do not have the private key to unlock this token.");
+        }
+
+        let privkey = localPriv || nostrStore.activePrivkeyHex;
 
         let remoteSigned = false;
         if (!privkey && needsSig) {


### PR DESCRIPTION
## Summary
- always return compressed key in getSecretP2PKPubkey
- abort redeem when P2PK key is missing instead of showing signer dialog

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint config error)*

------
https://chatgpt.com/codex/tasks/task_e_68696e8c511883309a8e5c9296bfe390