### PR TITLE
Fix P2PK key normalization

### DIFF
--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -662,6 +662,7 @@ import { Buffer } from "buffer";
 import { useCameraStore } from "src/stores/camera";
 import { useP2PKStore } from "src/stores/p2pk";
 import { nip19, ProfilePointer } from "nostr-tools";
+import { ensureCompressed } from "src/utils/ecash";
 import TokenInformation from "components/TokenInformation.vue";
 import {
   getDecodedToken,
@@ -943,7 +944,7 @@ export default defineComponent({
       "setTokenPaid",
       "deleteToken",
     ]),
-    ...mapActions(useP2PKStore, ["isValidPubkey", "maybeConvertNpub"]),
+    ...mapActions(useP2PKStore, ["isValidPubkey"]),
     ...mapActions(useCameraStore, ["closeCamera", "showCamera"]),
     ...mapActions(useMintsStore, ["toggleUnit"]),
     onDialogShown() {
@@ -1204,10 +1205,10 @@ export default defineComponent({
             console.error(e);
           }
         }
-        this.sendData.p2pkPubkey = this.maybeConvertNpub(
+        this.sendData.p2pkPubkey = ensureCompressed(
           this.sendData.p2pkPubkey
         );
-        this.sendData.refundPubkey = this.maybeConvertNpub(
+        this.sendData.refundPubkey = ensureCompressed(
           this.sendData.refundPubkey
         );
         let { _, sendProofs } = await this.sendToLock(

--- a/src/stores/donationPresets.ts
+++ b/src/stores/donationPresets.ts
@@ -7,6 +7,7 @@ import { LockedToken } from "./lockedTokens";
 import { useSubscriptionsStore } from "./subscriptions";
 import { useP2PKStore } from "./p2pk";
 import { DEFAULT_BUCKET_ID } from "./buckets";
+import { ensureCompressed } from "src/utils/ecash";
 
 export type DonationPreset = {
   months: number;
@@ -55,7 +56,7 @@ export const useDonationPresetsStore = defineStore("donationPresets", {
       const subscriptionsStore = useSubscriptionsStore();
       const p2pkStore = useP2PKStore();
 
-      const convertedPubkey = p2pkStore.maybeConvertNpub(pubkey);
+      const convertedPubkey = ensureCompressed(pubkey);
 
       const wallet = walletStore.wallet;
       let proofs = mintsStore.activeProofs.filter(

--- a/test/vitest/__tests__/timelock.spec.ts
+++ b/test/vitest/__tests__/timelock.spec.ts
@@ -59,7 +59,7 @@ describe("Timelock", () => {
       "P2PK",
       { data: "02aa", tags: [["locktime", String(locktime)]] },
     ]);
-    const info = p2pk.getSecretP2PKPubkey(secret);
+    const info = p2pk.getSecretP2PKInfo(secret);
     expect(info.locktime).toBe(locktime);
   });
 });


### PR DESCRIPTION
## Summary
- implement new `ensureCompressed` helper
- refactor `p2pk` store to use `ensureCompressed`
- remove `maybeConvertNpub` usage
- update dialog and donation preset helpers for new util
- adjust unit tests for changed API

## Testing
- `npx vitest run` *(fails: Cannot find module 'vitest/config')*

------
https://chatgpt.com/codex/tasks/task_e_6869767801108330a12383584ca6ab51