### PR TITLE
Centralize default relay URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,14 +185,14 @@ You can also override the relays used by the creator search. Set
 URLs. If not defined, the search falls back to the following list:
 
 ```
-wss://relay.damus.io
-wss://relay.primal.net
-wss://nos.lol
-wss://nostr.wine
-wss://purplepag.es
-wss://relay.nostr.band
-wss://eden.nostr.land
-wss://njump.me
+wss://relay.damus.io/
+wss://relay.primal.net/
+wss://eden.nostr.land/
+wss://nos.lol/
+wss://nostr-pub.wellorder.net/
+wss://nostr.bitcoiner.social/
+wss://relay.nostr.band/
+wss://relay.snort.social/
 ```
 
 ### Verify Nutzap Profile

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -1,16 +1,6 @@
 import { defineStore } from "pinia";
 import { useLocalStorage } from "@vueuse/core";
-
-const defaultNostrRelays = [
-  "wss://relay.damus.io/",
-  "wss://relay.primal.net/",
-  "wss://nos.lol/",
-  "wss://nostr.wine/",
-  "wss://purplepag.es/",
-  "wss://relay.nostr.band/",
-  "wss://eden.nostr.land/",
-  "wss://njump.me/",
-];
+import { DEFAULT_RELAYS } from "boot/ndk";
 
 export const useSettingsStore = defineStore("settings", {
   state: () => {
@@ -41,7 +31,7 @@ export const useSettingsStore = defineStore("settings", {
       ),
       defaultNostrRelays: useLocalStorage<string[]>(
         "cashu.settings.defaultNostrRelays",
-        defaultNostrRelays
+        DEFAULT_RELAYS,
       ),
       includeFeesInSendAmount: useLocalStorage<boolean>(
         "cashu.settings.includeFeesInSendAmount",


### PR DESCRIPTION
## Summary
- use a single DEFAULT_RELAYS constant from `src/boot/ndk.ts`
- update settings store to rely on this constant
- refresh README relay list

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint config error)*

------
https://chatgpt.com/codex/tasks/task_e_686a2a47db1c83308f587547495df436