### PR TITLE
Improve relay connection error handling

### DIFF
--- a/scripts/verifyNutzapProfile.ts
+++ b/scripts/verifyNutzapProfile.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import 'fake-indexeddb/auto';
 import { createPinia, setActivePinia } from 'pinia';
-import { fetchNutzapProfile, useNostrStore } from '../src/stores/nostr';
+import { fetchNutzapProfile, useNostrStore, RelayConnectionError } from '../src/stores/nostr';
 import { useSettingsStore } from '../src/stores/settings';
 
 async function main() {
@@ -16,8 +16,16 @@ async function main() {
   const nostr = useNostrStore();
   await nostr.initNdkReadOnly();
 
-  const profile = await fetchNutzapProfile(npub);
-  console.log(JSON.stringify(profile, null, 2));
+  try {
+    const profile = await fetchNutzapProfile(npub);
+    console.log(JSON.stringify(profile, null, 2));
+  } catch (e: any) {
+    if (e instanceof RelayConnectionError) {
+      console.error("Unable to connect to Nostr relays");
+      return;
+    }
+    throw e;
+  }
 }
 
 main().catch((e) => {

--- a/src/components/SettingsView.vue
+++ b/src/components/SettingsView.vue
@@ -1791,6 +1791,7 @@ import {
   useNostrStore,
   publishNutzapProfile as publishNutzapProfileFn,
   fetchNutzapProfile,
+  RelayConnectionError,
 } from "src/stores/nostr";
 import { useNPCStore } from "src/stores/npubcash";
 import { useP2PKStore } from "src/stores/p2pk";
@@ -2073,7 +2074,16 @@ export default defineComponent({
           relays: this.defaultNostrRelays,
         });
         this.notifySuccess("Profile published");
-        const profile = await fetchNutzapProfile(this.pubkey);
+        let profile = null;
+        try {
+          profile = await fetchNutzapProfile(this.pubkey);
+        } catch (e: any) {
+          if (e instanceof RelayConnectionError) {
+            this.notifyError("Unable to connect to Nostr relays");
+            return;
+          }
+          throw e;
+        }
         Dialog.create({
           message: `Profile fetched: ${JSON.stringify(profile, null, 2)}`,
         });

--- a/src/components/SubscribeDialog.vue
+++ b/src/components/SubscribeDialog.vue
@@ -63,7 +63,7 @@ import { useDonationPresetsStore } from "stores/donationPresets";
 import { useBucketsStore, DEFAULT_BUCKET_ID } from "stores/buckets";
 import { useMintsStore } from "stores/mints";
 import { useUiStore } from "stores/ui";
-import { fetchNutzapProfile, npubToHex } from "stores/nostr";
+import { fetchNutzapProfile, npubToHex, RelayConnectionError } from "stores/nostr";
 import { notifySuccess, notifyError } from "src/js/notify";
 import { storeToRefs } from "pinia";
 import { useNutzapStore } from "stores/nutzap";
@@ -172,7 +172,16 @@ export default defineComponent({
           notifyError(t("FindCreators.notifications.invalid_creator_pubkey"));
           return;
         }
-        const profile = await fetchNutzapProfile(props.creatorPubkey);
+        let profile = null;
+        try {
+          profile = await fetchNutzapProfile(props.creatorPubkey);
+        } catch (e: any) {
+          if (e instanceof RelayConnectionError) {
+            notifyError("Unable to connect to Nostr relays");
+            return;
+          }
+          throw e;
+        }
         if (!profile) {
           notifyError("Creator has not published a Nutzap profile (kind-10019)");
           return;

--- a/src/pages/SubscriptionsOverview.vue
+++ b/src/pages/SubscriptionsOverview.vue
@@ -492,7 +492,7 @@ import { useNostrStore } from "stores/nostr";
 import { useMessengerStore } from "stores/messenger";
 import { useSubscriptionsStore } from "stores/subscriptions";
 import { useNutzapStore } from "stores/nutzap";
-import { fetchNutzapProfile } from "stores/nostr";
+import { fetchNutzapProfile, RelayConnectionError } from "stores/nostr";
 import { useRouter } from "vue-router";
 import { useQuasar } from "quasar";
 import { useClipboard } from "src/composables/useClipboard";
@@ -730,7 +730,16 @@ function extendSubscription(pubkey: string) {
       : Math.floor(Date.now() / 1000);
     const startDate = lastLock + 30 * 24 * 60 * 60;
     try {
-      const profile = await fetchNutzapProfile(pubkey);
+      let profile = null;
+      try {
+        profile = await fetchNutzapProfile(pubkey);
+      } catch (e: any) {
+        if (e instanceof RelayConnectionError) {
+          notifyError("Unable to connect to Nostr relays");
+          return;
+        }
+        throw e;
+      }
       if (!profile) {
         notifyError("Creator has not published a Nutzap profile (kind-10019)");
         return;

--- a/src/stores/creatorHub.ts
+++ b/src/stores/creatorHub.ts
@@ -7,6 +7,7 @@ import {
   fetchNutzapProfile,
   publishNutzapProfile,
   ensureRelayConnectivity,
+  RelayConnectionError,
 } from "./nostr";
 import { useP2PKStore } from "./p2pk";
 import { useMintsStore } from "./mints";
@@ -39,7 +40,16 @@ export async function maybeRepublishNutzapProfile() {
       "You need to connect a Nostr signer before publishing tiers",
     );
   }
-  const current = await fetchNutzapProfile(nostrStore.pubkey);
+  let current = null;
+  try {
+    current = await fetchNutzapProfile(nostrStore.pubkey);
+  } catch (e: any) {
+    if (e instanceof RelayConnectionError) {
+      notifyError("Unable to connect to Nostr relays");
+      return;
+    }
+    throw e;
+  }
   const desiredMints = useMintsStore()
     .mints.map((m) => m.url)
     .sort()


### PR DESCRIPTION
## Summary
- add `RelayConnectionError` and use it in `fetchNutzapProfile`
- surface relay connection failures across the UI
- adjust CLI script to report relay issues

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint config error)*

------
https://chatgpt.com/codex/tasks/task_e_686a2cbd99e88330ae60d208ae324cf0