### PR TITLE
Fix P2PK secret parsing and relay list

### DIFF
--- a/public/find-creators.html
+++ b/public/find-creators.html
@@ -232,6 +232,14 @@
 
     <script type="module">
       import { DEFAULT_RELAYS } from '/src/config/relays';
+
+      const FALLBACK_RELAYS = [
+        'wss://relay.damus.io',
+        'wss://relay.primal.net',
+        'wss://relay.snort.social',
+        'wss://nostr.wine',
+        'wss://nos.lol'
+      ];
       // --- Nostr Tools ---
       if (!window.NostrTools) {
         document.getElementById("statusMessage").textContent = "Error: nostr-tools library not loaded.";
@@ -247,7 +255,7 @@
       } catch {
         storedRelays = [];
       }
-      const RELAYS = Array.from(new Set([...storedRelays, ...DEFAULT_RELAYS]));
+      const RELAYS = Array.from(new Set([...storedRelays, ...FALLBACK_RELAYS]));
       document.getElementById("relayList").textContent = RELAYS.join(", ");
 
       const pool = new SimplePool({ eoseSubTimeout: 8000 });

--- a/src/stores/p2pk.ts
+++ b/src/stores/p2pk.ts
@@ -222,7 +222,14 @@ export const useP2PKStore = defineStore("p2pk", {
       return { pubkey: "", locktime: undefined, refundKeys: [] }; // Token is not locked / secret is not P2PK
     },
     getSecretP2PKPubkey: function (secret: string): string {
+      console.log('Attempting to parse P2PK secret:', secret);
       try {
+        // If the secret doesn't appear to be JSON, assume it's already the public key
+        if (typeof secret === 'string' && !secret.startsWith('{')) {
+          console.warn('P2PK secret is not a JSON object, treating as raw pubkey.');
+          return secret;
+        }
+
         const secretObject = JSON.parse(secret);
         if (secretObject[0] !== "P2PK" || !secretObject[1]?.data) {
           return ""; // Not a valid P2PK secret
@@ -254,8 +261,8 @@ export const useP2PKStore = defineStore("p2pk", {
         // Lock has expired and there are no refund keys
         return ensureCompressed(data);
       } catch (e) {
-        console.error("Error parsing P2PK secret:", e);
-        return "";
+        console.error('Failed to parse P2PK secret:', e);
+        return '';
       }
     },
     isLocked: function (proofs: WalletProof[]) {


### PR DESCRIPTION
## Summary
- handle malformed P2PK secrets gracefully
- update fallback relay list used by find-creators page

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a391097288330b0b7f8dc2ce594d7