### PR TITLE
Fix tokenString property in addSubscription

### DIFF
--- a/src/stores/nutzap.ts
+++ b/src/stores/nutzap.ts
@@ -208,7 +208,7 @@ export const useNutzapStore = defineStore("nutzap", {
             unlockTs: t.locktime || 0,
             refundUnlockTs: 0,
             status: "pending",
-            tokenString: t.token,
+            tokenString: t.tokenString,
           })),
           status: "active",
         } as any);


### PR DESCRIPTION
## Summary
- correct property name in Nutzap store when adding subscription intervals

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686acbbcd9f08330b346c4b8a7534c35