### PR TITLE
Add generateRefundSecret helper

### DIFF
--- a/test/vitest/__tests__/p2pk.spec.ts
+++ b/test/vitest/__tests__/p2pk.spec.ts
@@ -203,4 +203,12 @@ describe("P2PK store", () => {
       "cashuA" + Buffer.from(JSON.stringify(tokenObj)).toString("base64");
     expect(p2pk.getPrivateKeyForP2PKEncodedToken(encoded)).toBe(skHex);
   });
+
+  it("generateRefundSecret returns 64-char hex strings", () => {
+    const p2pk = useP2PKStore();
+    const { preimage, hash } = p2pk.generateRefundSecret();
+    expect(preimage).toMatch(/^[0-9a-f]{64}$/);
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(preimage).not.toBe(hash);
+  });
 });


### PR DESCRIPTION
## Summary
- expose `generateRefundSecret` in the P2PK store
- test the refund secret helper

## Testing
- `pnpm vitest run --dom` *(fails: Failed to resolve import `@scure/bip32`)*
- `pnpm run dev`

------
https://chatgpt.com/codex/tasks/task_e_686b70ef48f483309ac995909c46a6e9