### PR TITLE
Add refund secret generator

### DIFF
--- a/src/stores/p2pk.ts
+++ b/src/stores/p2pk.ts
@@ -3,7 +3,8 @@ import { defineStore } from "pinia";
 import { useLocalStorage } from "@vueuse/core";
 import { generateSecretKey, getPublicKey, nip19 } from "nostr-tools";
 import { ensureCompressed } from "src/utils/ecash";
-import { bytesToHex } from "@noble/hashes/utils";
+import { bytesToHex, randomBytes } from "@noble/hashes/utils";
+import { sha256 } from "@noble/hashes/sha256";
 import { WalletProof } from "stores/mints";
 import token from "src/js/token";
 import { useWalletStore } from "./wallet";
@@ -99,6 +100,11 @@ export const useP2PKStore = defineStore("p2pk", {
       } catch (e) {
         return false;
       }
+    },
+    generateRefundSecret: function () {
+      const pre = randomBytes(32);
+      const hash = sha256(pre);
+      return { preimage: bytesToHex(pre), hash: bytesToHex(hash) };
     },
     setPrivateKeyUsed: function (key: string) {
       const thisKeys = this.p2pkKeys.filter((k) => k.privateKey == key);

--- a/test/vitest/__tests__/p2pk.spec.ts
+++ b/test/vitest/__tests__/p2pk.spec.ts
@@ -204,3 +204,13 @@ describe("P2PK store", () => {
     expect(p2pk.getPrivateKeyForP2PKEncodedToken(encoded)).toBe(skHex);
   });
 });
+
+describe("generateRefundSecret", () => {
+  it("returns 64-char hex strings", () => {
+    const p2pk = useP2PKStore();
+    const { preimage, hash } = p2pk.generateRefundSecret();
+    expect(preimage).toMatch(/^[0-9a-f]{64}$/);
+    expect(hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(preimage).not.toBe(hash);
+  });
+});


### PR DESCRIPTION
## Summary
- generate random refund secrets in p2pk store
- test refund secret generation

## Testing
- `pnpm vitest run --dom` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b70ef48f483309ac995909c46a6e9