### PR TITLE
Fix token property in subscription intervals

### DIFF
--- a/src/stores/nutzap.ts
+++ b/src/stores/nutzap.ts
@@ -225,7 +225,7 @@ export const useNutzapStore = defineStore("nutzap", {
             unlockTs: t.unlockTs,
             refundUnlockTs: 0,
             status: "pending",
-            tokenString: t.tokenString,
+            tokenString: t.token,
           })),
           status: "active",
         } as any);


### PR DESCRIPTION
## Summary
- use `token` property when creating subscription intervals in Nutzap

## Testing
- `pnpm test` *(fails: Failed to resolve import `@scure/bip32`)*

------
https://chatgpt.com/codex/tasks/task_e_686b8f69261083308b879e1ed1357c71