### PR TITLE
Fix refund P2PK crash

### DIFF
--- a/src/stores/donationPresets.ts
+++ b/src/stores/donationPresets.ts
@@ -80,7 +80,7 @@ export const useDonationPresetsStore = defineStore("donationPresets", {
           bucketId
         );
         tokens.push(locked);
-        return detailed ? tokens : locked.token;
+        return detailed ? tokens : locked.tokenString;
       }
       const base = startDate ?? Math.floor(Date.now() / 1000);
       for (let i = 0; i < months; i++) {
@@ -115,7 +115,7 @@ export const useDonationPresetsStore = defineStore("donationPresets", {
             unlockTs: t.locktime || 0,
             refundUnlockTs: 0,
             status: "pending",
-            tokenString: t.token,
+            tokenString: t.tokenString,
           })),
           status: "active",
           createdAt: 0,
@@ -124,7 +124,7 @@ export const useDonationPresetsStore = defineStore("donationPresets", {
           ...(subscription.benefits ? { benefits: subscription.benefits } : {}),
         } as any);
       }
-      return detailed ? tokens : tokens.map((t) => t.token).join("\n");
+      return detailed ? tokens : tokens.map((t) => t.tokenString).join("\n");
     },
   },
 });

--- a/src/stores/lockedTokens.ts
+++ b/src/stores/lockedTokens.ts
@@ -7,7 +7,9 @@ export type LockedToken = {
   id: string;
   amount: number;
   token: string;
+  tokenString: string;
   pubkey: string;
+  unlockTs?: number;
   label?: string;
   locktime?: number;
   refundPubkey?: string;

--- a/src/stores/nutzap.ts
+++ b/src/stores/nutzap.ts
@@ -159,11 +159,11 @@ export const useNutzapStore = defineStore("nutzap", {
             mintWallet,
             amount,
             creatorP2pk,
-          "nutzap",
-          unlockDate,
-          undefined,
-          hash
-        );
+            "nutzap",
+            unlockDate,
+            p2pk.firstKey?.publicKey,
+            hash
+          );
         const token = proofsStore.serializeProofs(sendProofs);
 
           await messenger.sendDm(
@@ -181,7 +181,7 @@ export const useNutzapStore = defineStore("nutzap", {
 
           const entry: DexieLockedToken = {
             id: locked.id,
-            tokenString: locked.token,
+            tokenString: locked.tokenString,
             amount,
             owner: "subscriber",
             creatorNpub: npub,
@@ -225,7 +225,7 @@ export const useNutzapStore = defineStore("nutzap", {
             unlockTs: t.unlockTs,
             refundUnlockTs: 0,
             status: "pending",
-            tokenString: t.token,
+            tokenString: t.tokenString,
           })),
           status: "active",
         } as any);

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -479,17 +479,17 @@ export const useWalletStore = defineStore("wallet", {
       let keepProofs: Proof[] = [];
       let sendProofs: Proof[] = [];
 
+      const tagList: [string, string][] = [["locktime", locktime.toString()]];
+      if (refundPubkey) tagList.push(["refund", refundPubkey]);
+      if (hashSecret) tagList.push(["hashlock", hashSecret]);
+
       if (hashSecret) {
         const customSecret = [
           "P2PK",
           {
             data: ensureCompressed(receiverPubkey),
             nonce: crypto.randomUUID().replace(/-/g, "").slice(0, 16),
-            tags: [
-              ["locktime", locktime.toString()],
-              ["refund", refundPubkey],
-              ["hashlock", hashSecret],
-            ],
+            tags: tagList,
           },
         ] as const;
 
@@ -518,10 +518,10 @@ export const useWalletStore = defineStore("wallet", {
       const locked = useLockedTokensStore().addLockedToken({
         id: uuidv4(),
         amount,
-        token: tokenStr,
-        bucketId: bucketsStore.ensureCreatorBucket(receiverPubkey),
+        tokenString: tokenStr,
         pubkey: receiverPubkey,
         locktime,
+        bucketId: bucketsStore.ensureCreatorBucket(receiverPubkey),
       });
       await proofsStore.addProofs(keepProofs, undefined, bucketId, "");
       useSignerStore().reset();

--- a/test/vitest/__tests__/donationPresets.spec.ts
+++ b/test/vitest/__tests__/donationPresets.spec.ts
@@ -14,7 +14,7 @@ beforeEach(() => {
 vi.mock("../../../src/stores/wallet", () => ({
   useWalletStore: () => ({
     wallet: {},
-    sendToLock: vi.fn(async (...args) => ({ locked: { id: "id", token: "tok" } })),
+    sendToLock: vi.fn(async (...args) => ({ locked: { id: "id", tokenString: "tok" } })),
   }),
 }));
 

--- a/test/vitest/__tests__/lockedTokens.spec.ts
+++ b/test/vitest/__tests__/lockedTokens.spec.ts
@@ -11,6 +11,7 @@ describe("LockedTokens store", () => {
     const t = store.addLockedToken({
       amount: 1,
       token: "tok",
+      tokenString: "tok",
       pubkey: "pk",
       bucketId: "b1",
     });
@@ -23,6 +24,7 @@ describe("LockedTokens store", () => {
     const t = store.addLockedToken({
       amount: 1,
       token: "tok",
+      tokenString: "tok",
       pubkey: "pk",
       bucketId: "b1",
     });
@@ -37,6 +39,7 @@ describe("LockedTokens store", () => {
     const t1 = store.addLockedToken({
       amount: 1,
       token: "a",
+      tokenString: "a",
       pubkey: "pk",
       bucketId: "b",
       locktime: past,
@@ -44,6 +47,7 @@ describe("LockedTokens store", () => {
     store.addLockedToken({
       amount: 1,
       token: "b",
+      tokenString: "b",
       pubkey: "pk",
       bucketId: "b",
       locktime: future,
@@ -51,6 +55,7 @@ describe("LockedTokens store", () => {
     store.addLockedToken({
       amount: 1,
       token: "c",
+      tokenString: "c",
       pubkey: "other",
       bucketId: "b",
     });
@@ -66,6 +71,7 @@ describe("LockedTokens store", () => {
         id: "a",
         amount: 1,
         token: "x",
+        tokenString: "x",
         pubkey: "pk1",
         bucketId: "b1",
         date: new Date().toISOString(),
@@ -74,6 +80,7 @@ describe("LockedTokens store", () => {
         id: "b",
         amount: 2,
         token: "y",
+        tokenString: "y",
         pubkey: "pk2",
         bucketId: "b2",
         date: new Date().toISOString(),


### PR DESCRIPTION
## Summary
- pass refund P2PK when locking Nutzap tokens
- fix token string field when persisting intervals
- support optional refund/hashlock tags in wallet
- store locked tokens using `tokenString`
- update store types and tests

## Testing
- `npx vitest run` *(fails: vitest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686b973b5a648330a2121b3585f6fdbe