### PR TITLE
Fix refund tag initialization

### DIFF
--- a/src/stores/nutzap.ts
+++ b/src/stores/nutzap.ts
@@ -136,6 +136,8 @@ export const useNutzapStore = defineStore("nutzap", {
         const trustedRelays = profile.relays;
         const wallet = useWalletStore();
         const p2pk = useP2PKStore();
+        if (!p2pk.firstKey) await p2pk.generateKeypair();
+        const refundKey = p2pk.firstKey!.publicKey;
         const mints = useMintsStore();
         const proofsStore = useProofsStore();
         const messenger = useMessengerStore();
@@ -161,7 +163,7 @@ export const useNutzapStore = defineStore("nutzap", {
             creatorP2pk,
             "nutzap",
             unlockDate,
-            p2pk.firstKey?.publicKey,
+            refundKey,
             hash
           );
         const token = proofsStore.serializeProofs(sendProofs);
@@ -213,7 +215,7 @@ export const useNutzapStore = defineStore("nutzap", {
           creatorNpub: npub,
           tierId: "nutzap",
           creatorP2PK: creatorP2pk,
-          subscriberRefundP2PK: p2pk.firstKey?.publicKey || "",
+          subscriberRefundP2PK: refundKey,
           mintUrl: mints.activeMintUrl,
           amountPerInterval: amount,
           frequency: "monthly",

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -499,6 +499,11 @@ export const useWalletStore = defineStore("wallet", {
 
         console.log("customSecret", customSecret);
         console.log("tagList", tagList);
+        console.log("DEBUG tagList JSON", JSON.stringify(tagList));
+        console.log(
+          "DEBUG secret.tags JSON",
+          JSON.stringify(customSecret[1].tags)
+        );
 
         ({ keep: keepProofs, send: sendProofs } =
           await (wallet as any).splitWithSecret(amount, customSecret));


### PR DESCRIPTION
## Summary
- ensure a refund key exists when sending Nutzap payments
- hook up refund key to subscription data and lock transactions
- add debug logs for tag content during lock creation

## Testing
- `npm run test:ci` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686babaadda08330aaac19a443350638