### PR TITLE
Fix splitWithSecret call

### DIFF
--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -505,8 +505,14 @@ export const useWalletStore = defineStore("wallet", {
           JSON.stringify(customSecret[1].tags)
         );
 
+        const secretStr = JSON.stringify(customSecret);
+        const proofsSigned = this.signP2PKIfNeeded(proofsToSend);
         ({ keep: keepProofs, send: sendProofs } =
-          await (wallet as any).splitWithSecret(amount, customSecret));
+          await (wallet as any).splitWithSecret(
+            amount,
+            proofsSigned,
+            secretStr
+          ));
       } else {
         ({ keep: keepProofs, send: sendProofs } = await wallet.send(
           amount,


### PR DESCRIPTION
## Summary
- invoke `splitWithSecret` with amount, signed proofs and secret JSON

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: eslint config issue)*

------
https://chatgpt.com/codex/tasks/task_e_686c09093dc08330923fd9ea8a62cfe6