### PR TITLE
Fix subscription DM

### DIFF
--- a/src/js/token.ts
+++ b/src/js/token.ts
@@ -1,7 +1,17 @@
 import { type Token, getDecodedToken } from "@cashu/cashu-ts";
 import { useMintsStore, WalletProof } from "src/stores/mints";
 import { useProofsStore } from "src/stores/proofs";
-export default { decode, getProofs, getMint, getUnit, getMemo };
+import { sha256 } from "@noble/hashes/sha256";
+import { bytesToHex } from "@noble/hashes/utils";
+export default {
+  decode,
+  getProofs,
+  getMint,
+  getUnit,
+  getMemo,
+  createP2PKHTLC,
+};
+export { createP2PKHTLC, hash };
 
 /**
  * Decodes an encoded cashu token
@@ -61,4 +71,19 @@ function getMemo(decoded_token: Token) {
   } else {
     return "";
   }
+}
+
+function hash(secret: string, receiver: string): string {
+  return bytesToHex(sha256(new TextEncoder().encode(secret + receiver)));
+}
+
+function createP2PKHTLC(
+  amount: number,
+  receiverP2PK: string,
+  months: number,
+  startDate: number,
+) {
+  const lockSecret = crypto.randomUUID();
+  const token = JSON.stringify({ amount, receiverP2PK, months, startDate, lockSecret });
+  return { token, hash: hash(lockSecret, receiverP2PK) };
 }

--- a/test/vitest/__tests__/sendToLock-hash.spec.ts
+++ b/test/vitest/__tests__/sendToLock-hash.spec.ts
@@ -4,6 +4,7 @@ import { useProofsStore } from "../../../src/stores/proofs";
 import { useBucketsStore } from "../../../src/stores/buckets";
 import { useLockedTokensStore } from "../../../src/stores/lockedTokens";
 import { useSignerStore } from "../../../src/stores/signer";
+import { hash } from "../../../src/js/token";
 
 vi.mock("../../../src/utils/ecash", () => ({
   ensureCompressed: (pk: string) => pk,
@@ -74,7 +75,8 @@ describe("sendToLock with hash lock", () => {
     const amount = 1;
     const locktime = 99;
     const receiver = "pk";
-    const hashSecret = "hs";
+    const lockSecret = "hs";
+    const hashSecret = hash(lockSecret, receiver);
     const secretStr = JSON.stringify([
       "P2PK",
       {
@@ -86,6 +88,7 @@ describe("sendToLock with hash lock", () => {
         ],
       },
     ] as const);
+    expect(hash(lockSecret, receiver)).toBe(hashSecret);
 
     await walletStore.sendToLock(
       [{ secret: "s", amount: 1, id: "a", C: "c" } as any],


### PR DESCRIPTION
## Summary
- update SubscribeDialog to compute tier price directly
- allow Nutzap store to send P2PK HTLC subscriptions
- add ndkSend helper for sending DMs
- export `createP2PKHTLC` and hashing helper in token utils
- update hash-lock unit test

## Testing
- `pnpm exec vitest run` *(fails: Command "vitest" not found)*
- `pnpm tsc -p tsconfig.json --noEmit` *(fails to find dependencies)*
- `pnpm quasar dev` *(fails: quasar not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cb9915b9c8330bcfd80465394a8b6