### PR TITLE
Fix mergeFilters usage

### DIFF
--- a/src/boot/ndk.ts
+++ b/src/boot/ndk.ts
@@ -1,6 +1,6 @@
 import { boot } from "quasar/wrappers";
 import { useBootErrorStore } from "stores/bootError";
-import NDK, { NDKSigner } from "@nostr-dev-kit/ndk";
+import NDK, { NDKSigner, mergeFilters } from "@nostr-dev-kit/ndk";
 import { useNostrStore } from "stores/nostr";
 import type { NDKEvent, NDKFilter } from "@nostr-dev-kit/ndk";
 import { useSettingsStore } from "src/stores/settings";
@@ -181,7 +181,7 @@ export async function ndkSend(
   const selfPub = useNostrStore().pubkey;
   const list = relays.length ? relays : ["wss://relay.damus.io"];
   const f: NDKFilter = { kinds: [4], authors: [selfPub], recipients: [toNpub] };
-  ndk.pool.mergeFilters([f]);
+  mergeFilters([f]);
   const ev = new NDKEvent(ndk);
   ev.kind = 4;
   ev.content = plaintext;


### PR DESCRIPTION
## Summary
- update ndk boot to use new `mergeFilters` helper

## Testing
- `pnpm run test:ci` *(fails: Cannot access 'ndkStub' before initialization)*

------
https://chatgpt.com/codex/tasks/task_e_686cd00ed1ac8330ba0f6751ab7b8bda