### PR TITLE
Fix local cashu-ts dependency path

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "vue": "^3.4.27",
     "vue-i18n": "^11.1.3",
     "vue-router": "^4.3.2",
-    "@cashu/cashu-ts": "file:./src/lib/cashu-ts"
+    "@cashu/cashu-ts": "file:src/lib/cashu-ts"
   },
   "devDependencies": {
     "@capacitor/assets": "^3.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^6.0.0
         version: 6.2.1(@capacitor/core@6.2.1)
       '@cashu/cashu-ts':
-        specifier: link:src/lib/cashu-ts
-        version: link:src/lib/cashu-ts
+        specifier: file:src/lib/cashu-ts
+        version: file:src/lib/cashu-ts
       '@cashu/crypto':
         specifier: ^0.3.4
         version: 0.3.4


### PR DESCRIPTION
## Summary
- fix local dependency path for `@cashu/cashu-ts` in `package.json`
- update lockfile to match new path

## Testing
- `pnpm install`

------
https://chatgpt.com/codex/tasks/task_e_686cd7aae3ac83308600970a64276501