### PR TITLE
Fix NDK import statement

### DIFF
--- a/src/boot/ndk.ts
+++ b/src/boot/ndk.ts
@@ -2,7 +2,7 @@ import { boot } from "quasar/wrappers";
 import { useBootErrorStore } from "stores/bootError";
 import NDK, { NDKSigner } from "@nostr-dev-kit/ndk";
 import { useNostrStore } from "stores/nostr";
-import type { NDKEvent, NDKFilter } from "@nostr-dev-kit/ndk";
+import { NDKEvent, type NDKFilter } from "@nostr-dev-kit/ndk";
 import { useSettingsStore } from "src/stores/settings";
 import { DEFAULT_RELAYS } from "src/config/relays";
 


### PR DESCRIPTION
## Summary
- fix the NDK import so `NDKEvent` is imported as a value instead of a type

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: quasar not found)*
- `npm install` *(fails: Invalid Version: file:./src/lib/cashu-ts)*

------
https://chatgpt.com/codex/tasks/task_e_686ce08005b08330982cfbf398e56067