### PR TITLE
Fix NIP07 fallback for subscriptions

### DIFF
--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -569,11 +569,7 @@ export const useNostrStore = defineStore("nostr", {
           this.nip07Checked &&
           !this.nip07SignerAvailable
         ) {
-          if (!this.initialized) {
-            await this.initNdkReadOnly();
-            this.initialized = true;
-          }
-          return;
+          this.signerType = SignerType.SEED;
         }
         this.initialized = false; // force re-initialisation
       }


### PR DESCRIPTION
## Summary
- adjust `initSignerIfNotSet` so the app automatically falls back to the seed signer if NIP-07 is unavailable

## Testing
- `npm run test:ci` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cdc5e89ec8330a3f5352a3ee8c8ed