### PR TITLE
Implement locked token storage on subscription

### DIFF
--- a/test/vitest/__tests__/nutzap.spec.ts
+++ b/test/vitest/__tests__/nutzap.spec.ts
@@ -97,5 +97,26 @@ describe("Nutzap store", () => {
     expect(count).toBe(1);
     expect(store.incoming.length).toBe(1);
   });
+
+  it("subscribeToTier stores locked tokens", async () => {
+    const store = useNutzapStore();
+    const start = 1000;
+    const ok = await store.subscribeToTier({
+      creator: { npub: "creator", p2pk: "pk" },
+      tierId: "tier",
+      months: 2,
+      price: 1,
+      startDate: start,
+      relayList: [],
+    });
+
+    expect(ok).toBe(true);
+    expect(sendToLock).toHaveBeenCalledTimes(2);
+    const tokens = await cashuDb.lockedTokens.toArray();
+    expect(tokens.length).toBe(2);
+    const sub = await cashuDb.subscriptions.toArray();
+    expect(sub.length).toBe(1);
+    expect(sub[0].intervals[0].lockedTokenId).toBe(tokens[0].id);
+  });
 });
 


### PR DESCRIPTION
## Summary
- lock real proofs when subscribing to a tier
- reference locked tokens in the subscription entry
- test locked tokens persisted on subscribe

## Testing
- `npm run lint` *(fails: extends key unsupported)*
- `pnpm test` *(fails: 20 test files failed)*

------
https://chatgpt.com/codex/tasks/task_e_686cfcc6ff308330b761496a5d4ccec1