### PR TITLE
Fix future Nostr timestamps

### DIFF
--- a/test/vitest/__tests__/nostr.spec.ts
+++ b/test/vitest/__tests__/nostr.spec.ts
@@ -104,3 +104,16 @@ describe("sendNip04DirectMessage", () => {
     publishSuccess = true;
   });
 });
+
+describe("lastEventTimestamp", () => {
+  it("clamps future timestamps on init", () => {
+    const future = Math.floor(Date.now() / 1000) + 1000;
+    localStorage.setItem(
+      "cashu.ndk.lastEventTimestamp",
+      JSON.stringify(future)
+    );
+    const store = useNostrStore();
+    const now = Math.floor(Date.now() / 1000);
+    expect(store.lastEventTimestamp).toBeLessThanOrEqual(now);
+  });
+});


### PR DESCRIPTION
## Summary
- clamp `lastEventTimestamp` during store init and when subscribing
- ensure DM subscription never requests future events
- test clamping of future timestamps

## Testing
- `npx vitest run test/vitest/__tests__/nostr.spec.ts` *(fails: Cannot access 'encryptMock' before initialization)*

------
https://chatgpt.com/codex/tasks/task_e_686cff4c955c8330b1ea09a47c10ee6c