### PR TITLE
Handle Nutzap subscription failures

### DIFF
--- a/src/components/SubscribeDialog.vue
+++ b/src/components/SubscribeDialog.vue
@@ -164,9 +164,11 @@ export default defineComponent({
           profile = await fetchNutzapProfile(creatorHex);
         } catch (e: any) {
           if (e instanceof RelayConnectionError) {
+            console.error("Relay connection error", e);
             notifyError("Unable to connect to Nostr relays");
             return;
           }
+          console.error("Failed to fetch Nutzap profile", e);
           throw e;
         }
         if (!profile) {
@@ -182,16 +184,20 @@ export default defineComponent({
           startDate: Math.floor(new Date(startDate.value).getTime() / 1000),
           relayList: profile.relays ?? [],
         });
-        if (!success) return;
-        notifySuccess(t("FindCreators.notifications.subscription_success"));
-        emit("confirm", {
-          bucketId: bucketId.value,
-          months: months.value,
-          startDate: Math.floor(new Date(startDate.value).getTime() / 1000),
-          total: total.value,
-        });
-        emit("update:modelValue", false);
+        if (success) {
+          notifySuccess(t("FindCreators.notifications.subscription_success"));
+          emit("confirm", {
+            bucketId: bucketId.value,
+            months: months.value,
+            startDate: Math.floor(new Date(startDate.value).getTime() / 1000),
+            total: total.value,
+          });
+          emit("update:modelValue", false);
+        } else {
+          notifyError(t("FindCreators.notifications.subscription_failed"));
+        }
       } catch (e: any) {
+        console.error("Subscription failed", e);
         notifyError(
           e.message || t("FindCreators.notifications.subscription_failed")
         );

--- a/src/stores/nutzap.ts
+++ b/src/stores/nutzap.ts
@@ -143,8 +143,9 @@ export const useNutzapStore = defineStore("nutzap", {
       try {
         await ndkSend(creator.npub, token, relayList);
       } catch (e: any) {
+        console.error("Failed to send subscription token", e);
         notifyError(e?.message || "Failed to send subscription token");
-        return false;
+        throw e;
       }
 
       const p2pk = useP2PKStore();


### PR DESCRIPTION
## Summary
- propagate errors from `subscribeToTier` so callers know when a DM fails
- show success or failure notifications in `SubscribeDialog`
- log relay and signer issues to the console for easier debugging

## Testing
- `pnpm test` *(fails: vitest not found / numerous failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_686d45bac70483308d41b559fbf619c9