### PR TITLE
Handle NDK no-signer errors

### DIFF
--- a/src/components/NdkErrorDialog.vue
+++ b/src/components/NdkErrorDialog.vue
@@ -10,7 +10,8 @@
           or paste an <code>nsec</code> below.
         </p>
         <p v-else-if="reason === 'no-signer'">
-          No Nostr signer found. Paste an <code>nsec</code> to continue.
+          Please unlock your NIP‑07 signer extension or paste an <code>nsec</code>
+          to continue.
         </p>
         <p v-else>
           An unknown error occurred while starting Nostr.

--- a/src/components/SubscribeDialog.vue
+++ b/src/components/SubscribeDialog.vue
@@ -60,6 +60,8 @@ import { notifySuccess, notifyError } from "src/js/notify";
 import { storeToRefs } from "pinia";
 import { useNutzapStore } from "stores/nutzap";
 import { useI18n } from "vue-i18n";
+import { NdkBootError } from "boot/ndk";
+import { useBootErrorStore } from "stores/bootError";
 
 export default defineComponent({
   name: "SubscribeDialog",
@@ -198,9 +200,13 @@ export default defineComponent({
         }
       } catch (e: any) {
         console.error("Subscription failed", e);
-        notifyError(
-          e.message || t("FindCreators.notifications.subscription_failed")
-        );
+        if (e instanceof NdkBootError && e.reason === "no-signer") {
+          useBootErrorStore().set(e);
+        } else {
+          notifyError(
+            e.message || t("FindCreators.notifications.subscription_failed")
+          );
+        }
       }
     };
 


### PR DESCRIPTION
## Summary
- show guidance for missing NIP-07 signer in `NdkErrorDialog`
- display the error dialog from `SubscribeDialog` when `ndkSend` fails

## Testing
- `pnpm test` *(fails: vitest not found)*
- `pnpm lint` *(fails: invalid option '--ext')*

------
https://chatgpt.com/codex/tasks/task_e_686d501973f48330bce2672d9c31ec32