### PR TITLE
Add resend queue for Nutzap

### DIFF
--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1,4 +1,4 @@
-import { default as defaultLang } from 'quasar/lang/en-US'
+import { default as defaultLang } from "quasar/lang/en-US";
 
 export const messages = {
   copied_to_clipboard: "Copied to clipboard!",
@@ -1534,6 +1534,10 @@ export const messages = {
     row: {
       next_unlock_label: "Next unlock in { value }",
     },
+    pending_retry: "Queued { count } payments for resend",
+    actions: {
+      retry_now: { label: "Retry now" },
+    },
   },
   LockedTokensTable: {
     empty_text: "No locked tokens",
@@ -1619,6 +1623,6 @@ export const messages = {
 export default {
   ...(defaultLang as any),
   ...messages,
-  BucketManager: { helper: { intro: '' } },
-  MoveTokens:   { title: '', helper: '' }
+  BucketManager: { helper: { intro: "" } },
+  MoveTokens: { title: "", helper: "" },
 };

--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -6,174 +6,185 @@
           <ActivityOrb />
           <NoMintWarnBanner v-if="mints.length == 0" />
           <BalanceView v-else :set-tab="setTab" />
-      <div
-        class="wallet-actions row items-center justify-around q-gutter-x-xl q-pt-lg q-pb-md"
-      >
-        <q-btn
-          rounded
-          padding="lg xl"
-          class="wallet-action-btn q-mb-md text-subtitle2"
-          color="primary"
-          @click="showReceiveDialog = true"
-        >
-          <div class="button-content">
-            <q-icon name="south_west" size="1.2rem" class="q-mr-xs" />
-            <span>{{ $t("WalletPage.actions.receive.label") }}</span>
-          </div>
-        </q-btn>
-
-        <transition appear enter-active-class="animated pulse">
-          <div class="scan-button-container">
-            <q-btn size="lg" outline color="primary" flat @click="showCamera">
-              <ScanIcon size="2.5em" />
+          <div
+            class="wallet-actions row items-center justify-around q-gutter-x-xl q-pt-lg q-pb-md"
+          >
+            <q-btn
+              rounded
+              padding="lg xl"
+              class="wallet-action-btn q-mb-md text-subtitle2"
+              color="primary"
+              @click="showReceiveDialog = true"
+            >
+              <div class="button-content">
+                <q-icon name="south_west" size="1.2rem" class="q-mr-xs" />
+                <span>{{ $t("WalletPage.actions.receive.label") }}</span>
+              </div>
             </q-btn>
-            <InfoTooltip
-              class="q-mt-sm"
-              :text="$t('WalletPage.actions.scan.tooltip')"
-            />
-          </div>
-        </transition>
 
-        <!-- button to showSendDialog -->
-        <q-btn
-          rounded
-          padding="lg xl"
-          class="wallet-action-btn q-mb-md text-subtitle2"
-          color="primary"
-          @click="showSendDialog = true"
-        >
-          <div class="button-content">
-            <q-icon name="north_east" size="1.2rem" class="q-mr-xs" />
-            <span>{{ $t("WalletPage.actions.send.label") }}</span>
+            <transition appear enter-active-class="animated pulse">
+              <div class="scan-button-container">
+                <q-btn
+                  size="lg"
+                  outline
+                  color="primary"
+                  flat
+                  @click="showCamera"
+                >
+                  <ScanIcon size="2.5em" />
+                </q-btn>
+                <InfoTooltip
+                  class="q-mt-sm"
+                  :text="$t('WalletPage.actions.scan.tooltip')"
+                />
+              </div>
+            </transition>
+
+            <!-- button to showSendDialog -->
+            <q-btn
+              rounded
+              padding="lg xl"
+              class="wallet-action-btn q-mb-md text-subtitle2"
+              color="primary"
+              @click="showSendDialog = true"
+            >
+              <div class="button-content">
+                <q-icon name="north_east" size="1.2rem" class="q-mr-xs" />
+                <span>{{ $t("WalletPage.actions.send.label") }}</span>
+              </div>
+            </q-btn>
+            <ReceiveDialog v-model="showReceiveDialog" />
+            <SendDialog v-model="showSendDialog" />
           </div>
-        </q-btn>
-        <ReceiveDialog v-model="showReceiveDialog" />
-        <SendDialog v-model="showSendDialog" />
-      </div>
-      <!-- ///////////////////////////////////////////
+          <!-- ///////////////////////////////////////////
       ////////////////// TABLES /////////////////
       /////////////////////////////////////////// -->
-      <q-expansion-item expand-icon-class="hidden" v-model="expandHistory">
-        <template v-slot:header="{ expanded }">
-          <q-item-section class="item-center text-center">
-            <span
-              ><q-icon
-                color="primary"
-                :name="expanded ? 'keyboard_arrow_up' : 'keyboard_arrow_down'"
-            /></span>
-          </q-item-section>
-        </template>
-        <q-tabs
-          v-model="tab"
-          no-caps
-          :class="$q.dark.isActive ? 'bg-dark' : 'bg-white'"
-        >
-          <q-tab
-            name="history"
-            class="text-secondary"
-            :label="$t('WalletPage.tabs.history.label')"
-          ></q-tab>
-          <q-tab
-            name="invoices"
-            class="text-secondary"
-            :label="$t('WalletPage.tabs.invoices.label')"
-          ></q-tab>
-          <!-- <q-tab name="tokens" label="Tokens"></q-tab> -->
-          <q-tab
-            name="mints"
-            class="text-secondary"
-            :label="$t('WalletPage.tabs.mints.label')"
-          ></q-tab>
-          <q-tab
-            name="buckets"
-            class="text-secondary"
-            :label="$t('WalletPage.tabs.buckets.label')"
-          ></q-tab>
-        </q-tabs>
-
-        <q-tab-panels
-          :class="$q.dark.isActive ? 'bg-dark' : 'bg-white'"
-          v-model="tab"
-          animated
-        >
-          <!-- ////////////////// HISTORY LIST ///////////////// -->
-
-          <q-tab-panel name="history">
-            <HistoryTable />
-          </q-tab-panel>
-
-          <!-- ////////////////// INVOICE LIST ///////////////// -->
-
-          <q-tab-panel name="invoices">
-            <InvoicesTable />
-          </q-tab-panel>
-
-          <!-- ////////////////////// SETTINGS ////////////////// -->
-
-          <q-tab-panel name="mints" class="q-px-sm">
-            <MintSettings />
-          </q-tab-panel>
-          <q-tab-panel name="buckets" class="q-px-sm">
-            <BucketManager />
-          </q-tab-panel>
-        </q-tab-panels>
-      </q-expansion-item>
-
-      <div style="margin-bottom: 0rem">
-        <div class="row q-pt-sm">
-          <div class="col-12 q-pt-xs">
-            <q-btn
-              class="q-mx-xs q-px-sm q-my-sm"
-              outline
-              size="0.6rem"
-              v-if="
-                getPwaDisplayMode() == 'browser' &&
-                deferredPWAInstallPrompt != null
-              "
-              color="primary"
-              @click="triggerPwaInstall()"
-              ><b>{{ $t("WalletPage.install.text") }}</b
-              ><q-tooltip>{{
-                $t("WalletPage.install.tooltip")
-              }}</q-tooltip></q-btn
+          <q-expansion-item expand-icon-class="hidden" v-model="expandHistory">
+            <template v-slot:header="{ expanded }">
+              <q-item-section class="item-center text-center">
+                <span
+                  ><q-icon
+                    color="primary"
+                    :name="
+                      expanded ? 'keyboard_arrow_up' : 'keyboard_arrow_down'
+                    "
+                /></span>
+              </q-item-section>
+            </template>
+            <q-tabs
+              v-model="tab"
+              no-caps
+              :class="$q.dark.isActive ? 'bg-dark' : 'bg-white'"
             >
+              <q-tab
+                name="history"
+                class="text-secondary"
+                :label="$t('WalletPage.tabs.history.label')"
+              ></q-tab>
+              <q-tab
+                name="invoices"
+                class="text-secondary"
+                :label="$t('WalletPage.tabs.invoices.label')"
+              ></q-tab>
+              <!-- <q-tab name="tokens" label="Tokens"></q-tab> -->
+              <q-tab
+                name="mints"
+                class="text-secondary"
+                :label="$t('WalletPage.tabs.mints.label')"
+              ></q-tab>
+              <q-tab
+                name="buckets"
+                class="text-secondary"
+                :label="$t('WalletPage.tabs.buckets.label')"
+              ></q-tab>
+            </q-tabs>
+
+            <q-tab-panels
+              :class="$q.dark.isActive ? 'bg-dark' : 'bg-white'"
+              v-model="tab"
+              animated
+            >
+              <!-- ////////////////// HISTORY LIST ///////////////// -->
+
+              <q-tab-panel name="history">
+                <HistoryTable />
+              </q-tab-panel>
+
+              <!-- ////////////////// INVOICE LIST ///////////////// -->
+
+              <q-tab-panel name="invoices">
+                <InvoicesTable />
+              </q-tab-panel>
+
+              <!-- ////////////////////// SETTINGS ////////////////// -->
+
+              <q-tab-panel name="mints" class="q-px-sm">
+                <MintSettings />
+              </q-tab-panel>
+              <q-tab-panel name="buckets" class="q-px-sm">
+                <BucketManager />
+              </q-tab-panel>
+            </q-tab-panels>
+          </q-expansion-item>
+
+          <div style="margin-bottom: 0rem">
+            <div class="row q-pt-sm">
+              <div class="col-12 q-pt-xs">
+                <q-btn
+                  class="q-mx-xs q-px-sm q-my-sm"
+                  outline
+                  size="0.6rem"
+                  v-if="
+                    getPwaDisplayMode() == 'browser' &&
+                    deferredPWAInstallPrompt != null
+                  "
+                  color="primary"
+                  @click="triggerPwaInstall()"
+                  ><b>{{ $t("WalletPage.install.text") }}</b
+                  ><q-tooltip>{{
+                    $t("WalletPage.install.tooltip")
+                  }}</q-tooltip></q-btn
+                >
+              </div>
+            </div>
           </div>
+
+          <iOSPWAPrompt />
+          <AndroidPWAPrompt />
         </div>
-      </div>
 
-      <iOSPWAPrompt />
-      <AndroidPWAPrompt />
-    </div>
+        <!-- BOTTOM LIGHTNING BUTTONS -->
 
-    <!-- BOTTOM LIGHTNING BUTTONS -->
+        <!-- DIALOGS  -->
 
-    <!-- DIALOGS  -->
+        <!-- INPUT PARSER  -->
+        <PayInvoiceDialog v-model="payInvoiceData.show" />
 
-    <!-- INPUT PARSER  -->
-    <PayInvoiceDialog v-model="payInvoiceData.show" />
+        <!-- QR CODE SCANNER  -->
+        <q-dialog
+          v-model="camera.show"
+          backdrop-filter="blur(2px) brightness(60%)"
+        >
+          <QrcodeReader @decode="decodeQR" />
+        </q-dialog>
 
-    <!-- QR CODE SCANNER  -->
-    <q-dialog v-model="camera.show" backdrop-filter="blur(2px) brightness(60%)">
-      <QrcodeReader @decode="decodeQR" />
-    </q-dialog>
+        <!-- WELCOME DIALOG  -->
+        <WelcomeDialog
+          :welcome-dialog="welcomeDialog"
+          :trigger-pwa-install="triggerPwaInstall"
+          :set-tab="setTab"
+          :get-pwa-display-mode="getPwaDisplayMode"
+          :set-welcome-dialog-seen="setWelcomeDialogSeen"
+        />
 
-    <!-- WELCOME DIALOG  -->
-    <WelcomeDialog
-      :welcome-dialog="welcomeDialog"
-      :trigger-pwa-install="triggerPwaInstall"
-      :set-tab="setTab"
-      :get-pwa-display-mode="getPwaDisplayMode"
-      :set-welcome-dialog-seen="setWelcomeDialogSeen"
-    />
+        <!-- INVOICE DETAILS  -->
+        <InvoiceDetailDialog v-model="showInvoiceDetails" />
 
-    <!-- INVOICE DETAILS  -->
-    <InvoiceDetailDialog v-model="showInvoiceDetails" />
+        <!-- SEND TOKENS DIALOG  -->
+        <SendTokenDialog />
 
-    <!-- SEND TOKENS DIALOG  -->
-    <SendTokenDialog />
-
-    <!-- RECEIVE TOKENS DIALOG  -->
-    <ReceiveTokenDialog v-model="showReceiveTokens" />
+        <!-- RECEIVE TOKENS DIALOG  -->
+        <ReceiveTokenDialog v-model="showReceiveTokens" />
       </div>
     </template>
     <template #fallback>
@@ -277,6 +288,7 @@ import ReceiveTokenDialog from "src/components/ReceiveTokenDialog.vue";
 import { useWelcomeStore } from "../stores/welcome";
 import { useInvoicesWorkerStore } from "src/stores/invoicesWorker";
 import { useLockedTokensRedeemWorker } from "src/stores/lockedTokensRedeemWorker";
+import { useNutzapSendWorker } from "src/stores/nutzapSendWorker";
 import { notifyError, notify, notifyWarning } from "../js/notify";
 import { DEFAULT_BUCKET_ID } from "src/stores/buckets";
 
@@ -442,6 +454,7 @@ export default {
     ...mapActions(useLockedTokensRedeemWorker, [
       "startLockedTokensRedeemWorker",
     ]),
+    ...mapActions(useNutzapSendWorker, ["start"]),
     // TOKEN METHODS
     decodeToken: function (encoded_token) {
       try {
@@ -561,13 +574,13 @@ export default {
         this.deferredPWAInstallPrompt = e;
         debug(
           `'beforeinstallprompt' event was fired.`,
-          this.getPwaDisplayMode()
+          this.getPwaDisplayMode(),
         );
       });
     },
     getPwaDisplayMode: function () {
       const isStandalone = window.matchMedia(
-        "(display-mode: standalone)"
+        "(display-mode: standalone)",
       ).matches;
       if (document.referrer.startsWith("android-app://")) {
         return "twa";
@@ -596,7 +609,7 @@ export default {
         sessionStorage.setItem(
           "tabId",
           Math.random().toString(36).substring(2) +
-            new Date().getTime().toString(36)
+            new Date().getTime().toString(36),
         );
       }
       const tabId = sessionStorage.getItem("tabId");
@@ -630,12 +643,11 @@ export default {
                 postMessage({ type: "retry-locked-token", tokenId });
               }
             }
-          }
+          },
         );
       }
     },
     async initPage() {
-
       // Initialize and run migrations
       const migrationsStore = useMigrationsStore();
       migrationsStore.initMigrations();
@@ -694,12 +706,16 @@ export default {
           await this.initNip07Signer();
         } else {
           await this.initSigner();
-          this.notifyWarning(this.$t("settings.nostr.signing_extension.not_found"));
+          this.notifyWarning(
+            this.$t("settings.nostr.signing_extension.not_found"),
+          );
         }
       } else {
         await this.initSigner();
         if (this.signerType === SignerType.NIP07 && !hasExt) {
-          this.notifyWarning(this.$t("settings.nostr.signing_extension.not_found"));
+          this.notifyWarning(
+            this.$t("settings.nostr.signing_extension.not_found"),
+          );
         }
       }
 
@@ -716,6 +732,7 @@ export default {
       this.subscribeToNip04DirectMessages();
       this.startInvoiceCheckerWorker();
       this.startLockedTokensRedeemWorker();
+      this.start();
       this.checkPendingInvoices();
     },
   },

--- a/src/stores/nutzapSendWorker.ts
+++ b/src/stores/nutzapSendWorker.ts
@@ -1,0 +1,29 @@
+import { defineStore } from "pinia";
+import { useNutzapStore } from "./nutzap";
+import { useMessengerStore } from "./messenger";
+
+export const useNutzapSendWorker = defineStore("nutzapSendWorker", {
+  state: () => ({
+    interval: 5000,
+    worker: null as NodeJS.Timeout | null,
+  }),
+  actions: {
+    start() {
+      if (this.worker) return;
+      this.worker = setInterval(() => this.process(), this.interval);
+      this.process();
+    },
+    stop() {
+      if (this.worker) {
+        clearInterval(this.worker);
+        this.worker = null;
+      }
+    },
+    async process() {
+      const messenger = useMessengerStore();
+      const nutzap = useNutzapStore();
+      if (!messenger.isConnected() || !nutzap.sendQueue.length) return;
+      await nutzap.retryQueuedSends();
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- queue failed Nutzap subscription tokens and retry automatically
- show a banner when sends are queued with manual retry button
- start background worker for retrying queued sends
- test queued send failure scenario

## Testing
- `npm install --legacy-peer-deps`
- `npm run test:ci` *(fails: could not run all tests)*

------
https://chatgpt.com/codex/tasks/task_e_686d51d811788330b946e6bff5c60887