### PR TITLE
Fix splitWithSecret usage for locks

### DIFF
--- a/test/vitest/__tests__/sendToLock-hash.spec.ts
+++ b/test/vitest/__tests__/sendToLock-hash.spec.ts
@@ -105,7 +105,8 @@ describe("sendToLock with hash lock", () => {
     expect(wallet.splitWithSecret).toHaveBeenCalledWith(
       amount,
       [{ secret: "s", amount: 1, id: "a", C: "c" }],
-      secretStr
+      secretStr,
+      { proofsWeHave: [{ secret: "s", amount: 1, id: "a", C: "c" }] }
     );
 
     randomStub.mockRestore();


### PR DESCRIPTION
## Summary
- pass stored proofs to `splitWithSecret` so wallet computes change properly
- handle errors when sending to lock
- update unit test expectations

## Testing
- `pnpm test` *(fails: Cannot find module and other vitest errors)*

------
https://chatgpt.com/codex/tasks/task_e_686d65fc40548330ba46b56ecca96eb4