### PR TITLE
Handle npub keys in Nutzap profile

### DIFF
--- a/src/js/__tests__/nutzapProfile.test.ts
+++ b/src/js/__tests__/nutzapProfile.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from "vitest";
+import { nip19 } from "nostr-tools";
+import { ensureCompressed } from "src/utils/ecash";
+
+const hex = "11".repeat(32);
+const npub = nip19.npubEncode(hex);
+
+const event = {
+  tags: [
+    ["pubkey", npub],
+    ["mint", "https://mint"],
+  ],
+} as any;
+
+const subMock = {
+  on: vi.fn((_evt: string, cb: any) => cb(event)),
+  stop: vi.fn(),
+};
+
+vi.mock("src/composables/useNdk", () => ({
+  useNdk: vi.fn(async () => ({ subscribe: vi.fn(() => subMock) })),
+}));
+
+const storeMock = { initNdkReadOnly: vi.fn() };
+vi.mock("stores/nostr", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    useNostrStore: () => storeMock,
+    ensureRelayConnectivity: vi.fn(),
+  };
+});
+
+import { fetchNutzapProfile } from "stores/nostr";
+
+describe("fetchNutzapProfile", () => {
+  it("returns compressed hex from npub tag", async () => {
+    const prof = await fetchNutzapProfile("npub123");
+    expect(prof?.p2pkPubkey).toBe(ensureCompressed(hex));
+    expect(prof?.p2pkPubkey?.length).toBe(66);
+  });
+});

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -170,9 +170,19 @@ export async function fetchNutzapProfile(
 
   return new Promise((resolve) => {
     sub.on("event", (ev: NostrEvent) => {
-      const p2pkPubkey = ev.tags.find((t) => t[0] === "pubkey")?.[1];
+      let p2pkPubkey = ev.tags.find((t) => t[0] === "pubkey")?.[1];
       const mints = ev.tags.filter((t) => t[0] === "mint").map((t) => t[1]);
       if (p2pkPubkey) {
+        if (p2pkPubkey.startsWith("npub")) {
+          const hx = npubToHex(p2pkPubkey);
+          if (hx) p2pkPubkey = hx;
+        }
+        try {
+          p2pkPubkey = ensureCompressed(p2pkPubkey);
+        } catch (e) {
+          console.error("Invalid P2PK pubkey", e);
+          p2pkPubkey = "";
+        }
         resolve({
           hexPub: hex,
           p2pkPubkey,


### PR DESCRIPTION
## Summary
- make `fetchNutzapProfile` convert npub tag to SEC-compressed hex
- test that npub pubkey is correctly normalized

## Testing
- `npm test` *(fails: "Mint returned deprecated 'contact' field" and module mock errors)*

------
https://chatgpt.com/codex/tasks/task_e_686d6e2ab75c83308faa10f35206f82c