### PR TITLE
Fix signer store import

### DIFF
--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -282,6 +282,7 @@ import { useNPCStore } from "src/stores/npubcash";
 import { useNostrStore, SignerType } from "src/stores/nostr";
 import { usePRStore } from "src/stores/payment-request";
 import { useDexieStore } from "src/stores/dexie";
+import { useSignerStore } from "src/stores/signer";
 
 import { useStorageStore } from "src/stores/storage";
 import ReceiveTokenDialog from "src/components/ReceiveTokenDialog.vue";


### PR DESCRIPTION
## Summary
- import `useSignerStore` in `WalletPage.vue`

## Testing
- `npm run lint` *(fails: A config object is using the "extends" key, which is not supported in flat config system)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dfcb579ec83309a82f61502fadca1