### PR TITLE
Handle P2PK prefix in getSecretP2PKPubkey

### DIFF
--- a/src/stores/p2pk.ts
+++ b/src/stores/p2pk.ts
@@ -240,6 +240,9 @@ export const useP2PKStore = defineStore("p2pk", {
       // by returning them directly. This prevents the JSON.parse crash.
       if (!trimmedSecret.startsWith('{')) {
         console.warn('P2PK secret is not a JSON object, treating as raw pubkey.');
+        if (trimmedSecret.startsWith("P2PK:")) {
+          return trimmedSecret.slice("P2PK:".length);
+        }
         return trimmedSecret;
       }
 


### PR DESCRIPTION
## Summary
- adjust non-JSON secret handling in `getSecretP2PKPubkey`
- strip `P2PK:` prefix before returning raw secret

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dfd93941c83309e83b828e92c7f1b