### PR TITLE
Prepend imported and generated P2PK keys

### DIFF
--- a/src/stores/p2pk.ts
+++ b/src/stores/p2pk.ts
@@ -148,7 +148,7 @@ export const useP2PKStore = defineStore("p2pk", {
         used: false,
         usedCount: 0,
       };
-      this.p2pkKeys = this.p2pkKeys.concat(keyPair);
+      this.p2pkKeys.unshift(keyPair);
     },
     generateKeypair: function () {
       let sk = generateSecretKey(); // `sk` is a Uint8Array
@@ -161,7 +161,7 @@ export const useP2PKStore = defineStore("p2pk", {
         used: false,
         usedCount: 0,
       };
-      this.p2pkKeys = this.p2pkKeys.concat(keyPair);
+      this.p2pkKeys.unshift(keyPair);
     },
     async createAndSelectNewKey() {
       const { pub, priv } = generateP2pkKeyPair();

--- a/test/vitest/__tests__/p2pk.spec.ts
+++ b/test/vitest/__tests__/p2pk.spec.ts
@@ -203,6 +203,36 @@ describe("P2PK store", () => {
       "cashuA" + Buffer.from(JSON.stringify(tokenObj)).toString("base64");
     expect(p2pk.getPrivateKeyForP2PKEncodedToken(encoded)).toBe(skHex);
   });
+
+  it("prepends generated key", () => {
+    const p2pk = useP2PKStore();
+    p2pk.p2pkKeys = [
+      { publicKey: "aa", privateKey: "aa", used: false, usedCount: 0 },
+    ];
+    const first = p2pk.firstKey;
+    p2pk.generateKeypair();
+    expect(p2pk.p2pkKeys.length).toBe(2);
+    expect(p2pk.firstKey).not.toBe(first);
+    expect(p2pk.p2pkKeys[1]).toBe(first);
+  });
+
+  it("prepends imported nsec key", async () => {
+    const p2pk = useP2PKStore();
+    p2pk.p2pkKeys = [
+      { publicKey: "aa", privateKey: "aa", used: false, usedCount: 0 },
+    ];
+
+    const sk = generateSecretKey();
+    const skHex = bytesToHex(sk);
+    const nsec = nip19.nsecEncode(sk);
+    vi.stubGlobal("prompt", vi.fn(async () => nsec) as any);
+
+    await p2pk.importNsec();
+
+    expect(p2pk.p2pkKeys.length).toBe(2);
+    expect(p2pk.firstKey!.privateKey).toBe(skHex);
+    expect(p2pk.p2pkKeys[1].publicKey).toBe("aa");
+  });
 });
 
 describe("generateRefundSecret", () => {


### PR DESCRIPTION
## Summary
- ensure imported and generated P2PK keys go to the front of the list
- test that new keys become the first entry

## Testing
- `npm run test:ci` *(fails: ReferenceError and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_686e064189308330991bf51f8c3e732f