### PR TITLE
Fix P2PK subscription locking

### DIFF
--- a/src/components/SubscribeDialog.vue
+++ b/src/components/SubscribeDialog.vue
@@ -72,6 +72,7 @@ import { useNutzapStore } from "stores/nutzap";
 import { useI18n } from "vue-i18n";
 import { NdkBootError } from "boot/ndk";
 import { useBootErrorStore } from "stores/bootError";
+import type { CreatorIdentity } from "src/types/creator";
 
 export default defineComponent({
   name: "SubscribeDialog",
@@ -201,7 +202,10 @@ export default defineComponent({
           notifyError("Creator has not published a Nutzap profile (kind-10019)");
           return;
         }
-        const creator = { npub: creatorHex, p2pk: profile.p2pkPubkey };
+        const creator: CreatorIdentity = {
+          nostrPubkey: creatorHex,
+          cashuP2pk: profile.p2pkPubkey,
+        };
         const success = await nutzap.subscribeToTier({
           creator,
           tierId: props.tier?.id ?? props.tier?.name ?? 'tier',

--- a/src/stores/p2pk.ts
+++ b/src/stores/p2pk.ts
@@ -92,11 +92,10 @@ export const useP2PKStore = defineStore("p2pk", {
       try {
         if (key.startsWith("npub1")) {
           const { type, data } = nip19.decode(key);
-          if (type === "npub") {
-            key = data as string;
-          }
+          if (type === "npub") key = data as string;
         }
-        return ensureCompressed(key).length === 66;
+        const COMPRESSED_RE = /^(02|03)[0-9a-f]{64}$/i;
+        return COMPRESSED_RE.test(ensureCompressed(key));
       } catch (e) {
         return false;
       }

--- a/src/types/creator.ts
+++ b/src/types/creator.ts
@@ -1,0 +1,13 @@
+export interface CreatorIdentity {
+  nostrPubkey: string; // hex encoded Nostr pubkey
+  cashuP2pk: string; // SEC-compressed Cashu P2PK key
+}
+
+export interface SubscribeTierOptions {
+  creator: CreatorIdentity;
+  tierId: string;
+  months: number;
+  price: number;
+  startDate: number;
+  relayList: string[];
+}

--- a/test/vitest/__tests__/nutzap.spec.ts
+++ b/test/vitest/__tests__/nutzap.spec.ts
@@ -130,7 +130,7 @@ describe("Nutzap store", () => {
     const store = useNutzapStore();
     const start = 1000;
     const ok = await store.subscribeToTier({
-      creator: { npub: "creator", p2pk: "pk" },
+      creator: { nostrPubkey: "creator", cashuP2pk: "pk" },
       tierId: "tier",
       months: 2,
       price: 1,
@@ -157,7 +157,7 @@ describe("Nutzap store", () => {
     isValidPubkey = vi.fn(() => false);
     await expect(
       store.subscribeToTier({
-        creator: { npub: "creator", p2pk: "bad" },
+        creator: { nostrPubkey: "creator", cashuP2pk: "bad" },
         tierId: "tier",
         months: 1,
         price: 1,

--- a/test/vitest/__tests__/subscribeP2pkToken.spec.ts
+++ b/test/vitest/__tests__/subscribeP2pkToken.spec.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useNutzapStore } from "../../../src/stores/nutzap";
+import { cashuDb } from "../../../src/stores/dexie";
+
+let createHtlc: any;
+let sendToLock: any;
+let sendDm: any;
+
+vi.mock("../../../src/stores/p2pk", () => ({
+  useP2PKStore: () => ({
+    isValidPubkey: () => true,
+    generateRefundSecret: () => ({ hash: "h" }),
+    generateKeypair: vi.fn(),
+    firstKey: { publicKey: "refund" },
+  }),
+}));
+
+vi.mock("../../../src/stores/wallet", () => ({
+  useWalletStore: () => ({
+    findSpendableMint: () => ({ url: "mint" }),
+    sendToLock: (...args: any[]) => sendToLock(...args),
+    mintWallet: () => ({}),
+  }),
+}));
+
+vi.mock("../../../src/stores/mints", () => ({
+  useMintsStore: () => ({
+    activeUnit: "sat",
+    mintUnitProofs: () => [{ id: "kid", amount: 1, secret: "s" }],
+  }),
+}));
+
+vi.mock("../../../src/stores/messenger", () => ({
+  useMessengerStore: () => ({ sendDm: (...args: any[]) => sendDm(...args) }),
+}));
+
+vi.mock("../../../src/js/token", () => ({
+  createP2PKHTLC: (...args: any[]) => createHtlc(...args),
+  default: { decode: vi.fn(), getProofs: vi.fn() },
+}));
+
+beforeEach(async () => {
+  localStorage.clear();
+  await cashuDb.close();
+  await cashuDb.delete();
+  await cashuDb.open();
+  sendDm = vi.fn(async () => ({ success: true }));
+  sendToLock = vi.fn(async () => ({
+    sendProofs: ["p"],
+    locked: { id: "1", tokenString: "t" },
+  }));
+  createHtlc = vi.fn((amt: number, receiver: string) => ({
+    token: JSON.stringify({ receiver }),
+    hash: "h",
+  }));
+});
+
+describe("subscribeToTier", () => {
+  it("uses creator cashuP2pk when building HTLC token", async () => {
+    const store = useNutzapStore();
+    const pk = "021f77d9dc444b" + "0".repeat(52);
+    await store.subscribeToTier({
+      creator: { nostrPubkey: "1975".repeat(16), cashuP2pk: pk },
+      tierId: "tier",
+      months: 1,
+      price: 1,
+      startDate: 0,
+      relayList: [],
+    });
+    const built = JSON.parse(createHtlc.mock.results[0].value.token);
+    expect(built.receiver).toBe(pk);
+  });
+});

--- a/test/vitest/__tests__/subscriptions.spec.ts
+++ b/test/vitest/__tests__/subscriptions.spec.ts
@@ -245,7 +245,7 @@ describe("Nutzap subscriptions", () => {
     sendDm = vi.fn(async () => ({ success: true }));
     cashuDb.lockedTokens.bulkAdd = vi.fn();
     await subStore.subscribeToTier({
-      creator: { npub: "npub", p2pk: "pk" },
+      creator: { nostrPubkey: "npub", cashuP2pk: "pk" },
       tierId: "tier", months: 1, price: 1, startDate: 0, relayList: []
     });
     expect(setBootError).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- add creator identity types
- validate compressed pubkeys with regex
- use cashuP2pk for subscription locking
- update Subscribe dialog
- add regression tests

## Testing
- `pnpm lint` *(fails: Invalid option '--ext' - perhaps you meant '-c'?)*
- `pnpm test` *(fails to run all tests)*

------
https://chatgpt.com/codex/tasks/task_e_686e0feae6808330a42d4bf5c1a091c6