### PR TITLE
Fix P2PK subscriptions

### DIFF
--- a/src/stores/dexie.ts
+++ b/src/stores/dexie.ts
@@ -66,6 +66,7 @@ export interface LockedToken {
   owner: "subscriber" | "creator";
   subscriberNpub?: string;
   creatorNpub?: string;
+  creatorP2PK?: string;
   tierId: string;
   intervalKey: string;
   unlockTs: number;

--- a/src/stores/nutzap.ts
+++ b/src/stores/nutzap.ts
@@ -10,7 +10,11 @@ import { useMintsStore } from "./mints";
 import { useProofsStore } from "./proofs";
 import { useMessengerStore } from "./messenger";
 import { useSubscriptionsStore } from "./subscriptions";
-import type { CreatorIdentity, SubscribeTierOptions } from "src/types/creator";
+import type {
+  CreatorIdentity,
+  SubscribeTierOptions,
+} from "src/types/creator";
+import { isValidCashuP2pk } from "src/types/creator";
 import {
   fetchNutzapProfile,
   subscribeToNutzaps,
@@ -178,7 +182,7 @@ export const useNutzapStore = defineStore("nutzap", {
       }
 
       const p2pkStore = useP2PKStore();
-      if (!p2pkStore.isValidPubkey(creator.cashuP2pk)) {
+      if (!isValidCashuP2pk(creator.cashuP2pk)) {
         throw new Error("Creator profile missing Cashu P2PK key");
       }
 
@@ -263,6 +267,7 @@ export const useNutzapStore = defineStore("nutzap", {
           amount: price,
           owner: "subscriber",
           creatorNpub: creator.nostrPubkey,
+          creatorP2PK: creator.cashuP2pk,
           tierId,
           intervalKey: String(i + 1),
           unlockTs: unlockDate,
@@ -414,6 +419,7 @@ export const useNutzapStore = defineStore("nutzap", {
             amount,
             owner: "subscriber",
             creatorNpub: npub,
+            creatorP2PK: creatorP2pk,
             tierId: "nutzap",
             intervalKey: String(i + 1),
             unlockTs: unlockDate,

--- a/src/types/creator.ts
+++ b/src/types/creator.ts
@@ -3,6 +3,10 @@ export interface CreatorIdentity {
   cashuP2pk: string; // SEC-compressed Cashu P2PK key
 }
 
+export function isValidCashuP2pk(key: string): boolean {
+  return /^(02|03)[0-9a-f]{64}$/i.test(key);
+}
+
 export interface SubscribeTierOptions {
   creator: CreatorIdentity;
   tierId: string;


### PR DESCRIPTION
## Summary
- check Cashu P2PK using new helper `isValidCashuP2pk`
- store creator P2PK with locked tokens
- expose helper in types

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e252b7d9c8330ba9dbc5c3b653288