### PR TITLE
Add creatorP2PK support for locked tokens

### DIFF
--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -1285,6 +1285,7 @@ export default defineComponent({
           amount: sendAmount,
           token: this.sendData.tokensBase64,
           pubkey: this.sendData.p2pkPubkey,
+          creatorP2PK: this.sendData.p2pkPubkey,
           locktime: this.sendData.locktime || undefined,
           refundPubkey: this.sendData.refundPubkey || undefined,
           bucketId,

--- a/src/stores/dexie.ts
+++ b/src/stores/dexie.ts
@@ -195,6 +195,26 @@ export class CashuDexie extends Dexie {
             });
           });
       });
+
+    this.version(8)
+      .stores({
+        proofs: "secret, id, C, amount, reserved, quote, bucketId, label",
+        profiles: "pubkey",
+        creatorsTierDefinitions: "&creatorNpub, eventId, updatedAt",
+        subscriptions: "&id, creatorNpub, tierId, status, createdAt, updatedAt",
+        lockedTokens:
+          "&id, tokenString, owner, tierId, intervalKey, unlockTs, refundUnlockTs, status, subscriptionEventId, subscriptionId, monthIndex, totalMonths",
+      })
+      .upgrade(async (tx) => {
+        await tx
+          .table("lockedTokens")
+          .toCollection()
+          .modify((entry: any) => {
+            if (entry.creatorP2PK === undefined) {
+              entry.creatorP2PK = null;
+            }
+          });
+      });
   }
 }
 

--- a/src/stores/lockedTokens.ts
+++ b/src/stores/lockedTokens.ts
@@ -9,6 +9,7 @@ export type LockedToken = {
   token: string;
   tokenString: string;
   pubkey: string;
+  creatorP2PK?: string;
   unlockTs?: number;
   label?: string;
   locktime?: number;

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -531,6 +531,7 @@ export const useWalletStore = defineStore("wallet", {
           amount,
           tokenString: tokenStr,
           pubkey: receiverPubkey,
+          creatorP2PK: receiverPubkey,
           locktime,
           bucketId: bucketsStore.ensureCreatorBucket(receiverPubkey),
         });


### PR DESCRIPTION
## Summary
- extend LockedToken state with `creatorP2PK`
- store creator P2PK when sending or manually locking tokens
- include upgrade path for Dexie database

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint configuration error)*

------
https://chatgpt.com/codex/tasks/task_e_686e4b3b1cc48330b0a967b909a04792