### PR TITLE
Add BucketCard component

### DIFF
--- a/src/components/BucketCard.vue
+++ b/src/components/BucketCard.vue
@@ -1,0 +1,106 @@
+<template>
+  <q-card class="shadow-2 rounded-borders bg-grey-9 text-white">
+    <router-link
+      :to="`/buckets/${bucket.id}`"
+      style="text-decoration: none; display: block"
+      class="text-white"
+    >
+      <q-item clickable class="q-pa-md">
+        <q-item-section avatar>
+          <q-avatar square size="32px" class="bg-primary text-white">
+            {{ bucket.name.charAt(0).toUpperCase() }}
+          </q-avatar>
+        </q-item-section>
+        <q-item-section>
+          <q-item-label class="text-weight-bold row items-center no-wrap">
+            <span>{{ bucket.name }}</span>
+            <q-icon v-if="bucket.description" name="info" class="q-ml-sm" />
+          </q-item-label>
+          <q-item-label caption v-if="bucket.description">{{ bucket.description }}</q-item-label>
+          <q-item-label caption class="row items-center no-wrap">
+            <span>
+              {{ formatCurrency(balance || 0, activeUnit) }}
+              <span v-if="bucket.goal">
+                / {{ formatCurrency(bucket.goal, activeUnit) }}
+              </span>
+            </span>
+            <q-linear-progress
+              v-if="bucket.goal"
+              color="primary"
+              :value="Math.min((balance || 0) / bucket.goal, 1)"
+              style="width: 50px; height: 4px"
+              class="q-ml-sm"
+            />
+          </q-item-label>
+        </q-item-section>
+        <q-item-section side v-if="bucket.id !== DEFAULT_BUCKET_ID">
+          <q-btn
+            icon="edit"
+            flat
+            round
+            size="sm"
+            @click.stop.prevent="emitEdit"
+            aria-label="Edit"
+            title="Edit"
+          />
+          <InfoTooltip
+            class="q-ml-xs"
+            :text="$t('BucketManager.tooltips.edit_button')"
+          />
+          <q-btn
+            icon="delete"
+            flat
+            round
+            size="sm"
+            @click.stop.prevent="emitDelete"
+            :aria-label="$t('BucketManager.actions.delete')"
+            :title="$t('BucketManager.actions.delete')"
+          />
+          <InfoTooltip
+            class="q-ml-xs"
+            :text="$t('BucketManager.tooltips.delete_button')"
+          />
+        </q-item-section>
+      </q-item>
+    </router-link>
+  </q-card>
+</template>
+
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { useI18n } from 'vue-i18n';
+import InfoTooltip from './InfoTooltip.vue';
+import { DEFAULT_BUCKET_ID } from 'stores/buckets';
+import { useUiStore } from 'stores/ui';
+
+export default defineComponent({
+  name: 'BucketCard',
+  components: { InfoTooltip },
+  props: {
+    bucket: { type: Object as () => any, required: true },
+    balance: { type: Number, default: 0 },
+    activeUnit: { type: String, required: true }
+  },
+  emits: ['edit', 'delete'],
+  setup(props, { emit }) {
+    const uiStore = useUiStore();
+    const { t } = useI18n();
+
+    const formatCurrency = (amount: number, unit: string) => {
+      return uiStore.formatCurrency(amount, unit);
+    };
+
+    const emitEdit = () => emit('edit', props.bucket);
+    const emitDelete = () => emit('delete', props.bucket.id);
+
+    return {
+      formatCurrency,
+      emitEdit,
+      emitDelete,
+      DEFAULT_BUCKET_ID,
+      t,
+    };
+  }
+});
+</script>
+

--- a/src/components/BucketManager.vue
+++ b/src/components/BucketManager.vue
@@ -9,81 +9,13 @@
         @dragover.prevent
         @drop="handleDrop($event, bucket.id)"
       >
-        <router-link
-          :to="`/buckets/${bucket.id}`"
-          style="text-decoration: none; display: block"
-          class="text-dark"
-        >
-          <q-item clickable class="q-card q-pa-md">
-            <q-item-section avatar>
-              <q-avatar
-                size="32px"
-                :style="{
-                  backgroundColor: bucket.color || DEFAULT_COLOR,
-                  color: 'white',
-                }"
-              >
-                {{ bucket.name.charAt(0).toUpperCase() }}
-              </q-avatar>
-            </q-item-section>
-            <q-item-section>
-              <q-item-label class="text-weight-bold">{{
-                bucket.name
-              }}</q-item-label>
-              <q-item-label caption v-if="bucket.description">{{
-                bucket.description
-              }}</q-item-label>
-              <q-item-label caption class="row items-center no-wrap">
-                <span>
-                  {{
-                    formatCurrency(
-                      bucketBalances[bucket.id] || 0,
-                      activeUnit.value
-                    )
-                  }}
-                  <span v-if="bucket.goal">
-                    / {{ formatCurrency(bucket.goal, activeUnit.value) }}
-                  </span>
-                </span>
-                <q-linear-progress
-                  v-if="bucket.goal"
-                  color="primary"
-                  :value="Math.min(bucketBalances[bucket.id] / bucket.goal, 1)"
-                  style="width: 50px; height: 4px"
-                  class="q-ml-sm"
-                />
-              </q-item-label>
-            </q-item-section>
-            <q-item-section side v-if="bucket.id !== DEFAULT_BUCKET_ID">
-              <q-btn
-                icon="edit"
-                flat
-                round
-                size="sm"
-                @click.stop.prevent="openEdit(bucket)"
-                aria-label="Edit"
-                title="Edit"
-              />
-              <InfoTooltip
-                class="q-ml-xs"
-                :text="$t('BucketManager.tooltips.edit_button')"
-              />
-              <q-btn
-                icon="delete"
-                flat
-                round
-                size="sm"
-                @click.stop.prevent="openDelete(bucket.id)"
-                :aria-label="$t('BucketManager.actions.delete')"
-                :title="$t('BucketManager.actions.delete')"
-              />
-              <InfoTooltip
-                class="q-ml-xs"
-                :text="$t('BucketManager.tooltips.delete_button')"
-              />
-            </q-item-section>
-          </q-item>
-        </router-link>
+        <BucketCard
+          :bucket="bucket"
+          :balance="bucketBalances[bucket.id] || 0"
+          :activeUnit="activeUnit.value"
+          @edit="openEdit"
+          @delete="openDelete"
+        />
       </div>
       <q-item>
         <q-item-section>
@@ -213,9 +145,11 @@ import { storeToRefs } from "pinia";
 import { useUiStore } from "stores/ui";
 import { notifyError } from "src/js/notify";
 import { DEFAULT_COLOR } from "src/js/constants";
+import BucketCard from "./BucketCard.vue";
 
 export default defineComponent({
   name: "BucketManager",
+  components: { BucketCard },
   setup() {
     const bucketsStore = useBucketsStore();
     const uiStore = useUiStore();


### PR DESCRIPTION
## Summary
- create `BucketCard.vue` for bucket display logic
- refactor `BucketManager.vue` to use new BucketCard component

## Testing
- `npm run lint` *(fails: A config object is using the "extends" key, which is not supported in flat config system)*
- `npm run test:ci` *(fails to run tests: numerous module and function errors)*

------
https://chatgpt.com/codex/tasks/task_e_686f9d6159fc8330acdf3d84aef7c326