### PR TITLE
Add bucket dialog

### DIFF
--- a/src/components/BucketDialog.vue
+++ b/src/components/BucketDialog.vue
@@ -1,0 +1,94 @@
+<template>
+  <q-dialog v-model="showLocal" persistent>
+    <q-card class="q-pa-lg" style="max-width: 500px">
+      <q-form @submit.prevent="save">
+        <q-input
+          v-model="form.name"
+          :label="t('BucketManager.inputs.name')"
+          outlined
+          class="q-mb-sm"
+        />
+        <q-input
+          v-model="form.color"
+          :label="t('BucketManager.inputs.color')"
+          type="color"
+          outlined
+          class="q-mb-sm"
+        />
+        <q-input
+          v-model.number="form.goal"
+          :label="t('BucketManager.inputs.goal')"
+          type="number"
+          outlined
+          class="q-mb-sm"
+        />
+        <q-input
+          v-model="form.desc"
+          :label="t('BucketManager.inputs.description')"
+          type="textarea"
+          autogrow
+          outlined
+          class="q-mb-sm"
+        />
+        <div class="row q-mt-md">
+          <q-btn
+            color="primary"
+            :disable="!canSave"
+            @click="save"
+          >
+            {{ t('global.actions.save.label') }}
+          </q-btn>
+          <q-btn flat color="grey" class="q-ml-auto" v-close-popup>
+            {{ t('global.actions.cancel.label') }}
+          </q-btn>
+        </div>
+      </q-form>
+    </q-card>
+  </q-dialog>
+</template>
+
+<script setup lang="ts">
+import { computed, reactive } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useBucketsStore } from 'stores/buckets'
+import { DEFAULT_COLOR } from 'src/js/constants'
+
+const props = defineProps<{ modelValue: boolean }>()
+const emit = defineEmits(['update:modelValue'])
+
+const showLocal = computed({
+  get: () => props.modelValue,
+  set: (val: boolean) => emit('update:modelValue', val)
+})
+
+const form = reactive({
+  name: '',
+  color: DEFAULT_COLOR,
+  goal: null as number | null,
+  desc: ''
+})
+
+const { t } = useI18n()
+const buckets = useBucketsStore()
+
+const canSave = computed(() => form.name.trim().length > 0)
+
+function reset () {
+  form.name = ''
+  form.color = DEFAULT_COLOR
+  form.goal = null
+  form.desc = ''
+}
+
+function save () {
+  if (!canSave.value) return
+  buckets.addBucket({
+    name: form.name,
+    color: form.color,
+    goal: form.goal ?? undefined,
+    description: form.desc
+  })
+  emit('update:modelValue', false)
+  reset()
+}
+</script>

--- a/src/components/BucketManager.vue
+++ b/src/components/BucketManager.vue
@@ -133,6 +133,8 @@
       </q-card-actions>
     </q-card>
   </q-dialog>
+
+  <BucketDialog v-model="showAddDialog" />
 </template>
 
 <script>
@@ -146,15 +148,17 @@ import { useUiStore } from "stores/ui";
 import { notifyError } from "src/js/notify";
 import { DEFAULT_COLOR } from "src/js/constants";
 import BucketCard from "./BucketCard.vue";
+import BucketDialog from "./BucketDialog.vue";
 
 export default defineComponent({
   name: "BucketManager",
-  components: { BucketCard },
+  components: { BucketCard, BucketDialog },
   setup() {
     const bucketsStore = useBucketsStore();
     const uiStore = useUiStore();
     const { t } = useI18n();
     const showForm = ref(false);
+    const showAddDialog = ref(false);
     const bucketForm = ref(null);
     const showDelete = ref(false);
     const editId = ref(null);
@@ -178,15 +182,7 @@ export default defineComponent({
     const { activeUnit } = storeToRefs(mintsStore);
 
     const openAdd = () => {
-      editId.value = null;
-      form.value = {
-        name: "",
-        color: DEFAULT_COLOR,
-        description: "",
-        goal: null,
-        creatorPubkey: "",
-      };
-      showForm.value = true;
+      showAddDialog.value = true;
     };
 
     const openEdit = (bucket) => {
@@ -257,6 +253,7 @@ export default defineComponent({
       bucketBalances,
       activeUnit,
       showForm,
+      showAddDialog,
       showDelete,
       form,
       bucketForm,


### PR DESCRIPTION
## Summary
- add new `BucketDialog` component
- integrate `BucketDialog` with `BucketManager`

## Testing
- `npm run lint` *(fails: "A config object is using the \"extends\" key, which is not supported in flat config system")*
- `npm run test` *(fails: `vitest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686fa0f168cc8330808f616e3245bcd7