### PR TITLE
Add bucket i18n keys

### DIFF
--- a/src/components/BucketDialog.vue
+++ b/src/components/BucketDialog.vue
@@ -4,27 +4,27 @@
       <q-form @submit.prevent="save">
         <q-input
           v-model="form.name"
-          :label="t('BucketManager.inputs.name')"
+          :label="t('bucket.name')"
           outlined
           class="q-mb-sm"
         />
         <q-input
           v-model="form.color"
-          :label="t('BucketManager.inputs.color')"
+          :label="t('bucket.color')"
           type="color"
           outlined
           class="q-mb-sm"
         />
         <q-input
           v-model.number="form.goal"
-          :label="t('BucketManager.inputs.goal')"
+          :label="t('bucket.goal')"
           type="number"
           outlined
           class="q-mb-sm"
         />
         <q-input
           v-model="form.desc"
-          :label="t('BucketManager.inputs.description')"
+          :label="t('bucket.description')"
           type="textarea"
           autogrow
           outlined

--- a/src/components/BucketManager.vue
+++ b/src/components/BucketManager.vue
@@ -53,13 +53,13 @@
           v-model="form.name"
           outlined
           :rules="nameRules"
-          :label="$t('BucketManager.inputs.name')"
+          :label="$t('bucket.name')"
           class="q-mb-sm"
         />
         <q-input
           v-model="form.color"
           outlined
-          :label="$t('BucketManager.inputs.color')"
+          :label="$t('bucket.color')"
           class="q-mb-sm"
           type="color"
         />
@@ -72,7 +72,7 @@
         >
           <template #label>
             <div class="row items-center no-wrap">
-              <span>{{ $t("BucketManager.inputs.description") }}</span>
+              <span>{{ $t('bucket.description') }}</span>
               <InfoTooltip
                 class="q-ml-xs"
                 :text="$t('BucketManager.tooltips.description')"
@@ -89,7 +89,7 @@
         >
           <template #label>
             <div class="row items-center no-wrap">
-              <span>{{ $t("BucketManager.inputs.goal") }}</span>
+              <span>{{ $t('bucket.goal') }}</span>
               <InfoTooltip
                 class="q-ml-xs"
                 :text="$t('BucketManager.tooltips.goal')"

--- a/src/components/DonateDialog.vue
+++ b/src/components/DonateDialog.vue
@@ -12,7 +12,7 @@
           map-options
           outlined
           dense
-          :label="$t('BucketManager.inputs.name')"
+          :label="$t('bucket.name')"
         />
         <q-input
           v-model.number="amount"

--- a/src/components/HistoryTable.vue
+++ b/src/components/HistoryTable.vue
@@ -152,7 +152,7 @@
           outlined
           type="color"
           class="q-mt-md"
-          :label="$t('BucketManager.inputs.color')"
+          :label="$t('bucket.color')"
         />
         <div class="row q-mt-md">
           <q-btn color="primary" rounded @click="saveLabel">{{

--- a/src/components/PayInvoiceDialog.vue
+++ b/src/components/PayInvoiceDialog.vue
@@ -79,7 +79,7 @@
             map-options
             outlined
             dense
-            :label="$t('BucketManager.inputs.name')"
+            :label="$t('bucket.name')"
           />
         </div>
         <div

--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -107,7 +107,7 @@
                 map-options
                 outlined
                 dense
-                :label="$t('BucketManager.inputs.name')"
+                :label="$t('bucket.name')"
               />
             </div>
           </div>

--- a/src/components/SubscribeDialog.vue
+++ b/src/components/SubscribeDialog.vue
@@ -13,7 +13,7 @@
           map-options
           outlined
           dense
-          :label="$t('BucketManager.inputs.name')"
+          :label="$t('bucket.name')"
         />
         <q-select
           v-model="months"

--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -1358,6 +1358,16 @@ export default {
       },
     },
   },
+  bucketManager: {
+    actions: { add: "Add bucket" },
+    addDialog: { title: "Create new bucket" },
+  },
+  bucket: {
+    name: "Name",
+    color: "Color",
+    goal: "Monthly goal",
+    description: "Description",
+  },
   SubscriptionsOverview: {
     export_csv: "Export CSV",
     filter: {

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -1364,6 +1364,16 @@ export default {
       },
     },
   },
+  bucketManager: {
+    actions: { add: "Add bucket" },
+    addDialog: { title: "Create new bucket" },
+  },
+  bucket: {
+    name: "Name",
+    color: "Color",
+    goal: "Monthly goal",
+    description: "Description",
+  },
   SubscriptionsOverview: {
     export_csv: "Export CSV",
     filter: {

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -1368,6 +1368,16 @@ export default {
       },
     },
   },
+  bucketManager: {
+    actions: { add: "Add bucket" },
+    addDialog: { title: "Create new bucket" },
+  },
+  bucket: {
+    name: "Name",
+    color: "Color",
+    goal: "Monthly goal",
+    description: "Description",
+  },
   SubscriptionsOverview: {
     export_csv: "Export CSV",
     filter: {

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1618,6 +1618,16 @@ export const messages = {
       },
     },
   },
+  bucketManager: {
+    actions: { add: "Add bucket" },
+    addDialog: { title: "Create new bucket" },
+  },
+  bucket: {
+    name: "Name",
+    color: "Color",
+    goal: "Monthly goal",
+    description: "Description",
+  },
 };
 
 export default {

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -1365,6 +1365,16 @@ export default {
       },
     },
   },
+  bucketManager: {
+    actions: { add: "Add bucket" },
+    addDialog: { title: "Create new bucket" },
+  },
+  bucket: {
+    name: "Name",
+    color: "Color",
+    goal: "Monthly goal",
+    description: "Description",
+  },
   SubscriptionsOverview: {
     export_csv: "Export CSV",
     filter: {

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -1355,6 +1355,16 @@ export default {
       },
     },
   },
+  bucketManager: {
+    actions: { add: "Add bucket" },
+    addDialog: { title: "Create new bucket" },
+  },
+  bucket: {
+    name: "Name",
+    color: "Color",
+    goal: "Monthly goal",
+    description: "Description",
+  },
   SubscriptionsOverview: {
     export_csv: "Export CSV",
     filter: {

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -1347,6 +1347,16 @@ export default {
       },
     },
   },
+  bucketManager: {
+    actions: { add: "Add bucket" },
+    addDialog: { title: "Create new bucket" },
+  },
+  bucket: {
+    name: "Name",
+    color: "Color",
+    goal: "Monthly goal",
+    description: "Description",
+  },
   SubscriptionsOverview: {
     export_csv: "Export CSV",
     filter: {

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -1348,6 +1348,16 @@ export default {
       },
     },
   },
+  bucketManager: {
+    actions: { add: "Add bucket" },
+    addDialog: { title: "Create new bucket" },
+  },
+  bucket: {
+    name: "Name",
+    color: "Color",
+    goal: "Monthly goal",
+    description: "Description",
+  },
   SubscriptionsOverview: {
     export_csv: "Export CSV",
     filter: {

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -1347,6 +1347,16 @@ export default {
       },
     },
   },
+  bucketManager: {
+    actions: { add: "Add bucket" },
+    addDialog: { title: "Create new bucket" },
+  },
+  bucket: {
+    name: "Name",
+    color: "Color",
+    goal: "Monthly goal",
+    description: "Description",
+  },
   SubscriptionsOverview: {
     export_csv: "Export CSV",
     filter: {

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -1345,6 +1345,16 @@ export default {
       },
     },
   },
+  bucketManager: {
+    actions: { add: "Add bucket" },
+    addDialog: { title: "Create new bucket" },
+  },
+  bucket: {
+    name: "Name",
+    color: "Color",
+    goal: "Monthly goal",
+    description: "Description",
+  },
   SubscriptionsOverview: {
     export_csv: "Export CSV",
     filter: {

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -1350,6 +1350,16 @@ export default {
       },
     },
   },
+  bucketManager: {
+    actions: { add: "Add bucket" },
+    addDialog: { title: "Create new bucket" },
+  },
+  bucket: {
+    name: "Name",
+    color: "Color",
+    goal: "Monthly goal",
+    description: "Description",
+  },
   SubscriptionsOverview: {
     export_csv: "Export CSV",
     filter: {

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -1337,6 +1337,16 @@ export default {
       },
     },
   },
+  bucketManager: {
+    actions: { add: "Add bucket" },
+    addDialog: { title: "Create new bucket" },
+  },
+  bucket: {
+    name: "Name",
+    color: "Color",
+    goal: "Monthly goal",
+    description: "Description",
+  },
   SubscriptionsOverview: {
     export_csv: "Export CSV",
     filter: {


### PR DESCRIPTION
## Summary
- add `bucketManager` and `bucket` strings to all languages
- use new keys in bucket-related components

## Testing
- `pnpm test` *(fails: vitest tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_686fa59ec248833087c2151382915733