### PR TITLE
Center wallet buttons

### DIFF
--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -6,8 +6,7 @@
           <ActivityOrb />
           <NoMintWarnBanner v-if="mints.length == 0" />
           <BalanceView v-else :set-tab="setTab" />
-          <div class="wallet-actions">
-            <div class="row items-center justify-around q-mt-md">
+          <div class="wallet-actions justify-center q-gutter-x-md">
               <q-btn
                 fab
                 size="lg"
@@ -57,7 +56,6 @@
                   <span>{{ $t("WalletPage.actions.send.label") }}</span>
                 </div>
               </q-btn>
-            </div>
             <ReceiveDialog v-model="showReceiveDialog" />
             <SendDialog v-model="showSendDialog" />
           </div>


### PR DESCRIPTION
## Summary
- simplify wallet button markup
- remove extra row wrapper so buttons sit flush inside wallet actions container

## Testing
- `pnpm run test:ci` *(fails: vitest errors)*

------
https://chatgpt.com/codex/tasks/task_e_686ff1f196848330a43bf0dfbd622387