### PR TITLE
Add aria labels for Receive, Scan, and Send

### DIFF
--- a/src/components/ReceiveEcashDrawer.vue
+++ b/src/components/ReceiveEcashDrawer.vue
@@ -15,16 +15,17 @@
         <div class="col text-center">
           <span class="text-h6">{{ $t("ReceiveEcashDrawer.title") }}</span>
         </div>
-        <q-btn
-          flat
-          round
-          dense
-          @click="showCamera"
-          class="q-mr-sm"
-          color="primary"
-        >
-          <ScanIcon />
-        </q-btn>
+          <q-btn
+            flat
+            round
+            dense
+            @click="showCamera"
+            class="q-mr-sm"
+            color="primary"
+            :aria-label="$t('global.actions.scan.label')"
+          >
+            <ScanIcon />
+          </q-btn>
       </q-card-section>
 
       <q-card-section class="q-pa-md">
@@ -45,7 +46,11 @@
             </div>
           </q-btn>
 
-          <q-btn class="full-width custom-btn" @click="showCamera">
+          <q-btn
+            class="full-width custom-btn"
+            @click="showCamera"
+            :aria-label="$t('global.actions.scan.label')"
+          >
             <div class="row items-center full-width">
               <div
                 class="icon-background q-mr-md"

--- a/src/components/ReceiveTokenDialog.vue
+++ b/src/components/ReceiveTokenDialog.vue
@@ -97,6 +97,7 @@
             class="q-mx-sm"
             v-if="hasCamera"
             @click="showCamera"
+            :aria-label="$t('global.actions.scan.label')"
           >
             <ScanIcon size="1.5em" />
             <span class="q-pl-sm">{{
@@ -186,6 +187,7 @@
               class="q-ml-xs q-mr-sm"
               :disabled="addMintBlocking"
               :loading="swapBlocking"
+              :aria-label="$t('global.actions.receive.label')"
               :label="
                 knowThisMint
                   ? addMintBlocking

--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -16,6 +16,7 @@
                 unelevated
                 class="wallet-action-btn"
                 @click="showReceiveDialog = true"
+                :aria-label="$t('global.actions.receive.label')"
               >
                 <div class="button-content">
                   <q-icon name="south_west" size="1.2rem" class="q-mr-xs" />
@@ -35,6 +36,7 @@
                     unelevated
                     class="wallet-action-btn"
                     @click="showCamera"
+                    :aria-label="$t('global.actions.scan.label')"
                   >
                     <ScanIcon size="2.5em" />
                   </q-btn>
@@ -56,6 +58,7 @@
                 unelevated
                 class="wallet-action-btn"
                 @click="showSendDialog = true"
+                :aria-label="$t('global.actions.send.label')"
               >
                 <div class="button-content">
                   <q-icon name="north_east" size="1.2rem" class="q-mr-xs" />


### PR DESCRIPTION
## Summary
- improve accessibility for wallet buttons by adding aria labels
- include labels on receive token dialog and receive ecash drawer scan buttons

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: ESLint config error)*

------
https://chatgpt.com/codex/tasks/task_e_686ff5e772248330813422d8f90189ef