### PR TITLE
Add hover and active styles

### DIFF
--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -236,6 +236,18 @@
   white-space: nowrap;
   font-size: 0.9rem;
 }
+.wallet-action-btn:hover {
+  box-shadow: 0 0 6px rgba(0, 0, 0, 0.15);
+}
+body.body--dark .wallet-action-btn:hover {
+  box-shadow: 0 0 6px rgba(255, 255, 255, 0.15);
+}
+.wallet-action-btn:active {
+  box-shadow: 0 0 6px rgba(0, 0, 0, 0.3) inset;
+}
+body.body--dark .wallet-action-btn:active {
+  box-shadow: 0 0 6px rgba(255, 255, 255, 0.3) inset;
+}
 
 .button-content {
   display: flex;


### PR DESCRIPTION
## Summary
- tweak wallet button styling to respond to hover and active states

## Testing
- `pnpm run test:ci` *(fails: InfoTooltip > shows tooltip on hover, plus other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_686ff7345030833080f5b58baac1ff90