### PR TITLE
Adjust wallet action buttons

### DIFF
--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -8,11 +8,12 @@
           <BalanceView v-else :set-tab="setTab" />
           <div class="wallet-actions justify-center q-gutter-sm">
             <q-btn
-              fab
-              size="lg"
+              size="md"
               color="primary"
               glossy
               unelevated
+              round
+              push
               class="wallet-action-btn"
               @click="showReceiveDialog = true"
               :aria-label="$t('global.actions.receive.label')"
@@ -26,11 +27,12 @@
             <transition appear enter-active-class="animated pulse">
               <div class="scan-button-container">
                 <q-btn
-                  fab
-                  size="lg"
+                  size="md"
                     color="primary"
                     glossy
                     unelevated
+                    round
+                    push
                     class="wallet-action-btn"
                     @click="showCamera"
                     :aria-label="$t('global.actions.scan.label')"
@@ -46,11 +48,12 @@
 
             <!-- button to showSendDialog -->
             <q-btn
-              fab
-              size="lg"
+              size="md"
               color="primary"
               glossy
                 unelevated
+                round
+                push
                 class="wallet-action-btn"
                 @click="showSendDialog = true"
                 :aria-label="$t('global.actions.send.label')"
@@ -226,9 +229,10 @@
 
 .wallet-action-btn {
   flex: 0 0 auto;
-  min-width: 8rem;
+  min-width: 6rem;
   white-space: nowrap;
-  font-size: 0.9rem;
+  font-size: 0.8rem;
+  padding: 0.4rem 0.6rem;
 }
 .wallet-action-btn:hover {
   box-shadow: 0 0 6px rgba(0, 0, 0, 0.15);


### PR DESCRIPTION
## Summary
- standardize wallet action button sizes
- tweak styling for `.wallet-action-btn`

## Testing
- `pnpm test` *(fails: Vitest tests)*

------
https://chatgpt.com/codex/tasks/task_e_686ffd0d64608330861fcac05cb8ad7b