### PR TITLE
Improve find-creators messaging flow

### DIFF
--- a/public/find-creators.html
+++ b/public/find-creators.html
@@ -633,26 +633,39 @@
             lud16Element.innerHTML = `<strong>LN:</strong> ${profile.lud16}`;
             infoDiv.appendChild(lud16Element);
           }
-          profileHeaderDiv.appendChild(avatarImg);
-          profileHeaderDiv.appendChild(infoDiv);
-          cardElement.appendChild(profileHeaderDiv);
+          cardElement.className = "flex items-center justify-between bg-gray-800 rounded-lg shadow p-4 mb-3 text-white";
+          const avatarSpan = document.createElement("span");
+          avatarSpan.className = "inline-flex h-10 w-10 items-center justify-center rounded-full bg-purple-600 text-lg font-bold mr-4";
+          avatarSpan.textContent = (profile.name || "N")[0].toUpperCase();
+          const middleDiv = document.createElement("div");
+          middleDiv.className = "flex-1";
+          const nameEl = document.createElement("div");
+          nameEl.className = "text-base font-semibold";
+          nameEl.textContent = profile.name || (profile.nip05 ? profile.nip05.split('@')[0] : "Unnamed User");
+          middleDiv.appendChild(nameEl);
+          if (profile.about) {
+            const aboutEl = document.createElement("div");
+            aboutEl.className = "text-xs text-gray-400 truncate";
+            aboutEl.textContent = profile.about;
+            middleDiv.appendChild(aboutEl);
+          }
           const actionsContainer = document.createElement("div");
-          actionsContainer.className = "creator-actions";
+          actionsContainer.className = "flex";
           const viewButton = document.createElement("button");
-          viewButton.className = "action-button view-button";
-          viewButton.textContent = "View";
-          viewButton.onclick = (e) => { e.stopPropagation(); window.parent.postMessage({ type: "viewProfile", pubkey: profile.pubkey }, "*"); };
+          viewButton.className = "btn-view q-px-sm bg-transparent border border-purple-500 text-purple-400 hover:bg-purple-500 hover:text-white rounded-md text-xs font-medium mr-2";
+          viewButton.textContent = "View Subscription Tiers";
+          viewButton.addEventListener('click', (e) => { e.stopPropagation(); window.parent.postMessage({ type: "viewProfile", pubkey: profile.pubkey }, "*"); });
           const messageButton = document.createElement("button");
-          messageButton.className = "action-button message-button";
+          messageButton.className = "btn-message bg-purple-600 hover:bg-purple-700 text-white rounded-md text-xs font-medium px-3 py-1";
           messageButton.textContent = "Message";
-          messageButton.onclick = (e) => { e.stopPropagation(); window.parent.location.href = `/nostr-messenger`; };
-          const donateButton = document.createElement("button");
-          donateButton.className = "action-button donate-button";
-          donateButton.textContent = "Donate";
-          donateButton.onclick = (e) => { e.stopPropagation(); window.parent.postMessage({ type: "donate", pubkey: profile.pubkey }, "*"); };
+          const creatorNpub = nip19.npubEncode(profile.pubkey);
+          messageButton.addEventListener('click', () => {
+            window.parent.location.href = `/nostr-messenger?peer=${encodeURIComponent(creatorNpub)}`;
+          });
           actionsContainer.appendChild(viewButton);
-actionsContainer.appendChild(messageButton);
-          actionsContainer.appendChild(donateButton);
+          actionsContainer.appendChild(messageButton);
+          cardElement.appendChild(avatarSpan);
+          cardElement.appendChild(middleDiv);
           cardElement.appendChild(actionsContainer);
           targetElement.appendChild(cardElement);
         });

--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -72,7 +72,7 @@
 
 <script lang="ts">
 import { defineComponent, computed, ref, onMounted, watch } from "vue";
-import { useRouter } from "vue-router";
+import { useRouter, useRoute } from "vue-router";
 import { useLocalStorage } from "@vueuse/core";
 import { useMessengerStore } from "src/stores/messenger";
 import { useNdk } from "src/composables/useNdk";
@@ -124,6 +124,7 @@ export default defineComponent({
     onMounted(init);
 
     const router = useRouter();
+    const route = useRoute();
 
     const goBack = () => {
       if (window.history.length > 1) {
@@ -147,6 +148,18 @@ export default defineComponent({
     const showRelays = useLocalStorage<boolean>(
       "cashu.messenger.showRelays",
       true,
+    );
+
+    onMounted(() => {
+      const peer = route.query.peer as string | undefined;
+      if (peer) messenger.openConversation(peer);
+    });
+
+    watch(
+      () => route.query.peer,
+      (newPeer) => {
+        if (typeof newPeer === "string") messenger.openConversation(newPeer);
+      },
     );
 
     watch(

--- a/src/stores/messenger.ts
+++ b/src/stores/messenger.ts
@@ -420,5 +420,11 @@ export const useMessengerStore = defineStore("messenger", {
     setDrawer(open: boolean) {
       this.drawerOpen = open;
     },
+
+    openConversation(pubkey: string) {
+      this.createConversation(pubkey);
+      this.markRead(pubkey);
+      this.setCurrentConversation(pubkey);
+    },
   },
 });

--- a/test/vitest/__tests__/find-creators.spec.ts
+++ b/test/vitest/__tests__/find-creators.spec.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { JSDOM } from "jsdom";
+import { nip19 } from "nostr-tools";
+import fs from "fs";
+import vm from "vm";
+
+const htmlFile = fs.readFileSync("public/find-creators.html", "utf8");
+const scriptMatch = htmlFile.match(/<script type="module">([\s\S]*?)<\/script>/);
+const script = (scriptMatch ? scriptMatch[1] : "")
+  .replace(/import\s+\{[^}]+\}\s+from\s+['"]\/src\/config\/relays['"];?/, "const DEFAULT_RELAYS = [];")
+  .replace(/document.addEventListener\([^]*?\);/, "");
+
+const dom = new JSDOM(htmlFile.replace(/<script type="module">([\s\S]*?)<\/script>/, ""), { runScripts: "dangerously" });
+
+dom.window.NostrTools = require("nostr-tools");
+
+vm.runInContext(script, dom.getInternalVMContext());
+
+describe("find-creators message button", () => {
+  it("navigates to messenger with peer query", () => {
+    const profile = { name: "Alice", pubkey: "a".repeat(64), about: "bio" };
+    const list = dom.window.document.getElementById("resultsList")!;
+    dom.window.renderProfiles([profile], list, false);
+    dom.window.parent = { location: { href: "" } } as any;
+    const btn = dom.window.document.querySelector(".btn-message") as HTMLElement;
+    btn.dispatchEvent(new dom.window.Event("click", { bubbles: true }));
+    const expected = `/nostr-messenger?peer=${encodeURIComponent(nip19.npubEncode(profile.pubkey))}`;
+    expect(dom.window.parent.location.href).toBe(expected);
+  });
+});

--- a/test/vitest/__tests__/messenger-route.spec.ts
+++ b/test/vitest/__tests__/messenger-route.spec.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import NostrMessenger from "../../../src/pages/NostrMessenger.vue";
+
+const openConversation = vi.fn();
+
+vi.mock("../../../src/stores/messenger", () => ({
+  useMessengerStore: () => ({
+    drawerOpen: false,
+    conversations: {},
+    openConversation,
+    loadIdentity: vi.fn(),
+    start: vi.fn(),
+    setDrawer: vi.fn(),
+    markRead: vi.fn(),
+    createConversation: vi.fn(),
+    setCurrentConversation: vi.fn(),
+  }),
+}));
+
+vi.mock("../../../src/stores/nostr", () => ({ useNostrStore: () => ({ initSignerIfNotSet: vi.fn() }) }));
+vi.mock("../../../src/composables/useNdk", () => ({ useNdk: vi.fn() }));
+
+vi.mock("vue-router", () => ({
+  useRouter: () => ({ back: vi.fn(), push: vi.fn() }),
+  useRoute: () => ({ query: { peer: "npub1abcd" } }),
+}));
+
+describe("NostrMessenger route", () => {
+  it("opens conversation from query param", async () => {
+    mount(NostrMessenger, {
+      global: {
+        stubs: {
+          NostrIdentityManager: true,
+          RelayManager: true,
+          NewChat: true,
+          ConversationList: true,
+          ActiveChatHeader: true,
+          MessageList: true,
+          MessageInput: true,
+          ChatSendTokenDialog: true,
+        },
+      },
+    });
+    expect(openConversation).toHaveBeenCalledWith("npub1abcd");
+  });
+});


### PR DESCRIPTION
## Summary
- restyle search result cards in `find-creators.html`
- link message buttons directly to `/nostr-messenger?peer=`
- auto-open peer conversation in `NostrMessenger.vue`
- expose `openConversation` helper in messenger store
- add basic tests for the new behaviour

## Testing
- `vitest` *(fails: Command "vitest" not found)*

------
https://chatgpt.com/codex/tasks/task_e_687011493a6083309314e9e078d2f576