### PR TITLE
Improve CreatorHub layout

### DIFF
--- a/src/pages/CreatorHubPage.vue
+++ b/src/pages/CreatorHubPage.vue
@@ -1,6 +1,6 @@
 <template>
   <q-page class="q-pa-md" :class="$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark'">
-    <div style="max-width:600px;margin:0 auto;width:100%">
+    <div style="max-width:1200px;margin:0 auto;width:100%">
       <div class="text-h5 text-center q-mb-lg">Creator Hub</div>
       <div v-if="!loggedIn" class="q-my-xl">
         <q-btn color="primary" class="full-width q-mb-md" @click="loginNip07">Login with Browser Signer</q-btn>
@@ -13,29 +13,51 @@
           Logged in as <span class="text-primary">{{ npub }}</span>
           <q-btn flat dense color="primary" class="q-ml-sm" @click="logout">Logout</q-btn>
         </div>
-        <div class="q-gutter-y-sm">
-          <q-input v-model="profile.display_name" label="Display Name" dense outlined />
-          <q-input v-model="profile.picture" label="Profile Picture URL" dense outlined />
-          <q-input v-model="profile.about" label="About" type="textarea" autogrow dense outlined />
-          <q-input v-model="profilePub" label="P2PK Public Key" dense outlined>
-            <template v-if="!hasP2PK" #append>
-              <q-btn flat dense icon="add" @click="generateP2PK" />
-            </template>
-          </q-input>
-          <q-input v-model="profileMints" label="Trusted Mints (comma separated)" dense outlined />
-          <q-input v-model="profileRelays" label="Relays (comma separated)" dense outlined />
-          <div class="text-center q-mt-sm">
-            <q-btn color="primary" :disable="!canPublish" @click="publishFullProfile">Publish Profile</q-btn>
+        <div class="row q-col-gutter-lg">
+          <div class="col-12 col-md-6">
+            <div class="q-gutter-y-sm">
+              <q-input v-model="profile.display_name" label="Display Name" dense outlined />
+              <q-input v-model="profile.picture" label="Profile Picture URL" dense outlined />
+              <q-input v-model="profile.about" label="About" type="textarea" autogrow dense outlined />
+              <div>
+                <q-select
+                  v-if="hasP2PK"
+                  v-model="profilePub"
+                  :options="p2pkOptions"
+                  emit-value
+                  map-options
+                  use-input
+                  fill-input
+                  input-debounce="0"
+                  label="P2PK Public Key"
+                  dense
+                  outlined
+                >
+                  <template #append>
+                    <q-btn flat dense icon="add" @click="generateP2PK" />
+                  </template>
+                </q-select>
+                <div v-else class="row items-center q-gutter-sm">
+                  <div class="text-caption">You don't have a P2PK Public key.</div>
+                  <q-btn flat dense color="primary" label="Generate" @click="generateP2PK" />
+                </div>
+              </div>
+              <q-input v-model="profileMints" label="Trusted Mints (comma separated)" dense outlined />
+              <q-input v-model="profileRelays" label="Relays (comma separated)" dense outlined />
+              <div class="text-center q-mt-sm">
+                <q-btn color="primary" class="q-mr-sm" :disable="!canPublish" @click="saveProfile">Save Changes</q-btn>
+                <q-btn color="primary" outline :disable="!canPublish" @click="publishFullProfile">Publish Profile</q-btn>
+              </div>
+            </div>
           </div>
-        </div>
-        <q-separator class="q-my-lg" />
-        <div class="text-h6 q-mb-md">Subscription Tiers</div>
-        <div v-for="tier in tierList" :key="tier.id" class="q-mb-md">
-          <q-card flat bordered :class="{ 'saved-bg': saved[tier.id] }" class="relative-position">
-            <transition name="fade">
-              <q-icon
-                v-if="saved[tier.id]"
-                name="check_circle"
+          <div class="col-12 col-md-6">
+            <div class="text-h6 q-mb-md">Subscription Tiers</div>
+            <div v-for="tier in tierList" :key="tier.id" class="q-mb-md">
+              <q-card flat bordered :class="{ 'saved-bg': saved[tier.id] }" class="relative-position">
+                <transition name="fade">
+                  <q-icon
+                    v-if="saved[tier.id]"
+                    name="check_circle"
                 color="positive"
                 size="sm"
                 class="saved-check"
@@ -51,10 +73,12 @@
               <q-btn flat color="primary" @click="saveTier(tier.id)">Save</q-btn>
               <q-btn flat color="negative" @click="removeTier(tier.id)">Delete</q-btn>
             </q-card-actions>
-          </q-card>
-        </div>
-        <div class="text-center q-mt-md">
-          <q-btn color="primary" flat @click="addTier">Add Tier</q-btn>
+            </q-card>
+          </div>
+          <div class="text-center q-mt-md">
+            <q-btn color="primary" flat @click="addTier">Add Tier</q-btn>
+          </div>
+          </div>
         </div>
       </div>
     </div>
@@ -70,6 +94,7 @@ import { useMintsStore } from 'stores/mints';
 import { v4 as uuidv4 } from 'uuid';
 import { nip19 } from 'nostr-tools';
 import { notifySuccess, notifyError } from 'src/js/notify';
+import { shortenString } from 'src/js/string-utils';
 
 const store = useCreatorHubStore();
 const nostr = useNostrStore();
@@ -84,6 +109,12 @@ const nsec = ref('');
 
 const loggedIn = computed(() => !!store.loggedInNpub);
 const hasP2PK = computed(() => p2pkStore.p2pkKeys.length > 0);
+const p2pkOptions = computed(() =>
+  p2pkStore.p2pkKeys.map((k) => ({
+    label: shortenString(k.publicKey, 16, 6),
+    value: k.publicKey,
+  }))
+);
 const tierList = computed<Tier[]>(() => store.getTierArray());
 const editedTiers = ref<Record<string, Tier>>({});
 const saved = ref<Record<string, boolean>>({});
@@ -161,6 +192,10 @@ async function publishFullProfile() {
   } catch (e: any) {
     notifyError(e.message);
   }
+}
+
+async function saveProfile() {
+  await publishFullProfile();
 }
 
 function generateP2PK() {


### PR DESCRIPTION
## Summary
- use responsive two-column grid for profile and tiers
- expose P2PK keys with dropdown and generation prompt
- add Save Changes button for profile

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870a96652a08330aa85ea6893ff9bd4