### PR TITLE
Apply theme-friendly styles

### DIFF
--- a/src/components/SettingsView.vue
+++ b/src/components/SettingsView.vue
@@ -1301,7 +1301,7 @@
                     flat
                     @click="changeColor('freedom')"
                     icon="format_color_fill"
-                    color="pink-13"
+                    color="primary"
                     size="md"
                     :aria-label="
                       $t('Settings.appearance.theme.tooltips.freedom')
@@ -1317,7 +1317,7 @@
                     flat
                     @click="changeColor('nostr')"
                     icon="format_color_fill"
-                    color="deep-purple"
+                    color="primary"
                     size="md"
                     :aria-label="$t('Settings.appearance.theme.tooltips.nostr')"
                     :title="$t('Settings.appearance.theme.tooltips.nostr')"
@@ -1388,7 +1388,7 @@
                     flat
                     @click="changeColor('flamingo')"
                     icon="format_color_fill"
-                    color="pink-3"
+                    color="primary"
                     size="md"
                     :aria-label="
                       $t('Settings.appearance.theme.tooltips.flamingo')

--- a/src/pages/CreatorHubPage.vue
+++ b/src/pages/CreatorHubPage.vue
@@ -1,9 +1,8 @@
 <template>
-  <q-page class="flex justify-center">
+  <q-page class="bg-grey-10 flex justify-center">
     <q-card
-      class="q-pa-lg q-my-xl"
+      class="q-pa-lg q-my-xl bg-grey-9 shadow-4"
       style="max-width:1024px"
-      :class="$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark'"
     >
       <div class="text-h5 text-center q-mb-lg">Creator Hub</div>
       <div v-if="!loggedIn" class="q-my-xl">

--- a/src/pages/NostrLogin.vue
+++ b/src/pages/NostrLogin.vue
@@ -1,11 +1,6 @@
 <template>
-  <div
-    :class="[
-      $q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark',
-      'q-pa-md flex flex-center',
-    ]"
-  >
-    <q-card class="q-pa-md" style="max-width: 400px; width: 100%">
+  <q-page class="bg-grey-10 q-pa-md flex flex-center">
+    <q-card class="q-pa-md bg-grey-9 shadow-4" style="max-width: 400px; width: 100%">
       <q-card-section class="text-h6">Nostr Identity</q-card-section>
       <q-card-section v-if="hasExistingKey">
         <q-banner dense class="bg-grey-3 q-mb-md">
@@ -23,7 +18,7 @@
         >
       </q-card-actions>
     </q-card>
-  </div>
+  </q-page>
 </template>
 
 <script lang="ts">


### PR DESCRIPTION
## Summary
- use consistent `grey` theme colors for login and creator pages
- clean up inline shades for dynamic themes
- standardize button colors in settings

## Testing
- `pnpm test` *(fails: Tests failed. Watching for file changes...)*

------
https://chatgpt.com/codex/tasks/task_e_6870b6ac2fb48330803d9d52aeca5dcd