### PR TITLE
Fix missing div end tag in CreatorHubPage

### DIFF
--- a/src/pages/CreatorHubPage.vue
+++ b/src/pages/CreatorHubPage.vue
@@ -268,6 +268,7 @@
     </q-card-actions>
   </q-card>
 </q-dialog>
+</div>
 </q-card>
     <q-footer v-if="loggedIn" class="bg-grey-9 q-pa-sm">
       <div class="text-center">


### PR DESCRIPTION
## Summary
- close unclosed `<div>` in `CreatorHubPage.vue`

## Testing
- `npm test` *(fails: `vitest` not found)*
- `npm run lint` *(fails: config issues)*

------
https://chatgpt.com/codex/tasks/task_e_6870c4392da48330a28311b43170fe07