### PR TITLE
Adjust margins of CreatorHub card

### DIFF
--- a/src/pages/CreatorHubPage.vue
+++ b/src/pages/CreatorHubPage.vue
@@ -1,8 +1,8 @@
 <template>
   <q-page class="bg-grey-10 flex justify-center">
     <q-card
-      class="q-pa-lg q-mt-lg q-mb-lg bg-grey-9 shadow-4"
-      style="max-width:1024px"
+      class="q-pa-lg q-mt-md q-mb-md bg-grey-9 shadow-4"
+      style="max-width: 1200px; width: 100%"
     >
       <div class="text-h5 text-center q-mb-lg">Creator Hub</div>
       <div v-if="!loggedIn" class="q-mt-lg q-mb-lg">


### PR DESCRIPTION
## Summary
- remove excessive margins on CreatorHubPage outer card
- widen card to better use page space

## Testing
- `pnpm run test:ci` *(fails: Notify.create is not a function and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6870d2d2e3dc83309f511c7b3ecb4d22