### PR TITLE
Add profile dirty state test

### DIFF
--- a/src/pages/CreatorHubPage.vue
+++ b/src/pages/CreatorHubPage.vue
@@ -292,7 +292,7 @@ async function publishFullProfile() {
     notifySuccess('Profile updated');
     profileStore.markClean();
   } catch (e: any) {
-    notifyError(e.message);
+    notifyError(e?.message || 'Failed to publish profile');
   }
 }
 

--- a/test/vitest/__tests__/creatorProfileStore.spec.ts
+++ b/test/vitest/__tests__/creatorProfileStore.spec.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useCreatorProfileStore } from '../../../src/stores/creatorProfile'
+
+beforeEach(() => {
+  localStorage.clear()
+})
+
+describe('CreatorProfileStore isDirty', () => {
+  it('becomes true when any field changes', () => {
+    const store = useCreatorProfileStore()
+    store.setProfile({
+      display_name: 'name',
+      picture: 'pic',
+      about: 'about',
+      pubkey: 'pub',
+      mints: ['m1'],
+      relays: ['r1'],
+    })
+    store.markClean()
+    expect(store.isDirty).toBe(false)
+
+    store.display_name = 'changed'
+    expect(store.isDirty).toBe(true)
+    store.markClean()
+
+    store.picture = 'newpic'
+    expect(store.isDirty).toBe(true)
+    store.markClean()
+
+    store.about = 'new about'
+    expect(store.isDirty).toBe(true)
+    store.markClean()
+
+    store.pubkey = 'newpub'
+    expect(store.isDirty).toBe(true)
+    store.markClean()
+
+    store.mints = ['m1', 'm2']
+    expect(store.isDirty).toBe(true)
+    store.markClean()
+
+    store.relays = ['r1', 'r2']
+    expect(store.isDirty).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- verify CreatorProfileForm changes mark store dirty
- show error on publishing profile
- add basic test for creator profile dirty state

## Testing
- `pnpm test` *(fails: vitest not configured or failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_6870d3a5778c833099eacbffcc3fef21