### PR TITLE
Fix translation for subscription tiers

### DIFF
--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1602,7 +1602,7 @@ export const messages = {
     },
     profile: {
       back: "Back",
-      tiers: "Donation Tiers",
+      tiers: "Subscription Tiers",
       edit: "Edit",
     },
   },


### PR DESCRIPTION
## Summary
- rename "Donation Tiers" to "Subscription Tiers" in the English translation

## Testing
- `pnpm install`
- `pnpm run test:ci` *(fails: 21 failed, 26 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6870e1f7cee48330ac7941ab6185a239