### PR TITLE
Fix my-profile page crash by exporting shortenString

### DIFF
--- a/src/pages/MyProfilePage.vue
+++ b/src/pages/MyProfilePage.vue
@@ -318,6 +318,7 @@ export default defineComponent({
       activeUnit,
       bucketCount,
       walletBalanceFormatted,
+      shortenString,
       renderMarkdown,
       formatFiat,
       generateP2PK,


### PR DESCRIPTION
## Summary
- expose `shortenString` from MyProfilePage setup so the page renders

## Testing
- `pnpm install`
- `pnpm run test:ci` *(fails: Notify.create is not a function, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6870f1398fb8833085c7865d460a8d4f