### PR TITLE
Hook profile buttons and tier save

### DIFF
--- a/src/pages/CreatorHubPage.vue
+++ b/src/pages/CreatorHubPage.vue
@@ -146,8 +146,22 @@
 </q-dialog>
 </div>
   <div v-if="loggedIn" class="bg-grey-9 q-pa-sm text-center">
-    <q-btn color="primary" class="q-mr-sm" :disable="!isDirty" @click="saveProfile">Save Changes</q-btn>
-    <q-btn color="primary" outline :disable="!isDirty" @click="publishFullProfile">Publish Profile</q-btn>
+    <q-btn
+      color="primary"
+      class="q-mr-sm"
+      :disable="!isDirty"
+      @click="saveProfile()"
+    >
+      Save Changes
+    </q-btn>
+    <q-btn
+      color="primary"
+      outline
+      :disable="!isDirty"
+      @click="publishFullProfile()"
+    >
+      Publish Profile
+    </q-btn>
   </div>
 </q-card>
   </q-page>
@@ -325,7 +339,7 @@ async function saveTier(id: string) {
   if (data) {
     try {
       store.updateTier(id, data);
-      await store.publishTierDefinitions();
+      await store.saveTier(data);
       notifySuccess('Tier saved');
       saved.value[id] = true;
       setTimeout(() => {


### PR DESCRIPTION
## Summary
- connect profile actions to the page functions
- call store `saveTier` when saving a tier

## Testing
- `npm run lint` *(fails: A config object is using the "extends" key, which is not supported in flat config system)*
- `npm run test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870f770c3e08330b4289f0d740b60b2