### PR TITLE
Bind trusted mint and relay fields to store

### DIFF
--- a/src/components/CreatorProfileForm.vue
+++ b/src/components/CreatorProfileForm.vue
@@ -77,53 +77,65 @@
 
 <script setup lang="ts">
 import { computed } from 'vue';
+import { storeToRefs } from 'pinia';
 import InfoTooltip from './InfoTooltip.vue';
+import { useCreatorProfileStore } from 'stores/creatorProfile';
+import { useP2PKStore } from 'stores/p2pk';
+import { shortenString } from 'src/js/string-utils';
 
-const props = defineProps<{
-  display_name: string;
-  picture: string;
-  about: string;
-  profilePub: string | null;
-  profileMints: string[];
-  profileRelays: string[];
-  hasP2PK: boolean;
-  p2pkOptions: any[];
-  selectedKeyShort: string;
-  generateP2PK: () => void;
-}>();
+const profileStore = useCreatorProfileStore();
+const p2pkStore = useP2PKStore();
 
-const emit = defineEmits<{
-  (e: 'update:display_name', val: string): void;
-  (e: 'update:picture', val: string): void;
-  (e: 'update:about', val: string): void;
-  (e: 'update:profilePub', val: string | null): void;
-  (e: 'update:profileMints', val: string[]): void;
-  (e: 'update:profileRelays', val: string[]): void;
-}>();
+const {
+  display_name,
+  picture,
+  about,
+  pubkey: profilePub,
+  mints: profileMints,
+  relays: profileRelays,
+} = storeToRefs(profileStore);
+
+const hasP2PK = computed(() => p2pkStore.p2pkKeys.length > 0);
+const p2pkOptions = computed(() =>
+  p2pkStore.p2pkKeys.map((k) => ({
+    label: shortenString(k.publicKey, 16, 6),
+    value: k.publicKey,
+  }))
+);
+const selectedKeyShort = computed(() =>
+  profilePub.value ? shortenString(profilePub.value, 16, 6) : ''
+);
+
+function generateP2PK() {
+  p2pkStore.createAndSelectNewKey().then(() => {
+    if (!profilePub.value && p2pkStore.firstKey)
+      profilePub.value = p2pkStore.firstKey.publicKey;
+  });
+}
 
 const display_nameLocal = computed({
-  get: () => props.display_name,
-  set: (val: string) => emit('update:display_name', val),
+  get: () => display_name.value,
+  set: (val: string) => (display_name.value = val),
 });
 const pictureLocal = computed({
-  get: () => props.picture,
-  set: (val: string) => emit('update:picture', val),
+  get: () => picture.value,
+  set: (val: string) => (picture.value = val),
 });
 const aboutLocal = computed({
-  get: () => props.about,
-  set: (val: string) => emit('update:about', val),
+  get: () => about.value,
+  set: (val: string) => (about.value = val),
 });
 const profilePubLocal = computed({
-  get: () => props.profilePub,
-  set: (val: string | null) => emit('update:profilePub', val),
+  get: () => profilePub.value,
+  set: (val: string | null) => (profilePub.value = val || ''),
 });
 const profileMintsLocal = computed({
-  get: () => props.profileMints,
-  set: (val: string[]) => emit('update:profileMints', val),
+  get: () => profileMints.value,
+  set: (val: string[]) => (profileMints.value = val),
 });
 const profileRelaysLocal = computed({
-  get: () => props.profileRelays,
-  set: (val: string[]) => emit('update:profileRelays', val),
+  get: () => profileRelays.value,
+  set: (val: string[]) => (profileRelays.value = val),
 });
 </script>
 

--- a/src/components/ProfilePanel.vue
+++ b/src/components/ProfilePanel.vue
@@ -1,17 +1,6 @@
 <template>
   <div class="space-y-4">
-    <CreatorProfileForm
-      v-model:display_name="display_name"
-      v-model:picture="picture"
-      v-model:about="about"
-      v-model:profilePub="profilePub"
-      v-model:profileMints="profileMints"
-      v-model:profileRelays="profileRelays"
-      :hasP2PK="hasP2PK"
-      :p2pkOptions="p2pkOptions"
-      :selectedKeyShort="selectedKeyShort"
-      :generateP2PK="generateP2PK"
-    />
+    <CreatorProfileForm />
     <div class="flex space-x-2">
       <q-btn color="primary" :disable="!isDirty" @click="saveProfile">Save Changes</q-btn>
       <q-btn color="primary" outline :disable="!isDirty" @click="publishProfile">Publish Profile</q-btn>
@@ -24,16 +13,13 @@ import { computed } from 'vue';
 import CreatorProfileForm from './CreatorProfileForm.vue';
 import { useCreatorHubStore } from 'stores/creatorHub';
 import { useCreatorProfileStore } from 'stores/creatorProfile';
-import { useP2PKStore } from 'stores/p2pk';
 import { useNostrStore, publishDiscoveryProfile } from 'stores/nostr';
 import { useMintsStore } from 'stores/mints';
 import { storeToRefs } from 'pinia';
 import { notifySuccess, notifyError } from 'src/js/notify';
-import { shortenString } from 'src/js/string-utils';
 
 const hub = useCreatorHubStore();
 const profileStore = useCreatorProfileStore();
-const p2pkStore = useP2PKStore();
 const nostr = useNostrStore();
 const mintsStore = useMintsStore();
 
@@ -47,19 +33,6 @@ const {
   isDirty,
 } = storeToRefs(profileStore);
 
-const hasP2PK = computed(() => p2pkStore.p2pkKeys.length > 0);
-const p2pkOptions = computed(() =>
-  p2pkStore.p2pkKeys.map(k => ({ label: shortenString(k.publicKey, 16, 6), value: k.publicKey }))
-);
-const selectedKeyShort = computed(() =>
-  profilePub.value ? shortenString(profilePub.value, 16, 6) : ''
-);
-
-function generateP2PK() {
-  p2pkStore.createAndSelectNewKey().then(() => {
-    if (!profilePub.value && p2pkStore.firstKey) profilePub.value = p2pkStore.firstKey.publicKey;
-  });
-}
 
 async function publishProfile() {
   try {

--- a/src/pages/CreatorHubPage.vue
+++ b/src/pages/CreatorHubPage.vue
@@ -18,18 +18,7 @@
         </div>
 <q-splitter v-if="!isMobile" v-model="splitterModel">
   <template #before>
-    <CreatorProfileForm
-      v-model:display_name="display_name"
-      v-model:picture="picture"
-      v-model:about="about"
-      v-model:profilePub="profilePub"
-      v-model:profileMints="profileMints"
-      v-model:profileRelays="profileRelays"
-      :hasP2PK="hasP2PK"
-      :p2pkOptions="p2pkOptions"
-      :selectedKeyShort="selectedKeyShort"
-      :generateP2PK="generateP2PK"
-    />
+    <CreatorProfileForm />
   </template>
   <template #after>
     <div>
@@ -78,18 +67,7 @@
   </q-tabs>
   <q-tab-panels v-model="tab" animated>
     <q-tab-panel name="profile">
-      <CreatorProfileForm
-        v-model:display_name="display_name"
-        v-model:picture="picture"
-        v-model:about="about"
-        v-model:profilePub="profilePub"
-        v-model:profileMints="profileMints"
-        v-model:profileRelays="profileRelays"
-        :hasP2PK="hasP2PK"
-        :p2pkOptions="p2pkOptions"
-        :selectedKeyShort="selectedKeyShort"
-        :generateP2PK="generateP2PK"
-      />
+      <CreatorProfileForm />
     </q-tab-panel>
     <q-tab-panel name="tiers">
       <div>
@@ -180,7 +158,6 @@ import { storeToRefs } from 'pinia';
 import { v4 as uuidv4 } from 'uuid';
 import { nip19 } from 'nostr-tools';
 import { notifySuccess, notifyError } from 'src/js/notify';
-import { shortenString } from 'src/js/string-utils';
 import CreatorProfileForm from 'components/CreatorProfileForm.vue';
 
 const store = useCreatorHubStore();
@@ -210,16 +187,6 @@ const splitterModel = ref(50);
 const tab = ref<'profile' | 'tiers'>('profile');
 
 const loggedIn = computed(() => !!store.loggedInNpub);
-const hasP2PK = computed(() => p2pkStore.p2pkKeys.length > 0);
-const p2pkOptions = computed(() =>
-  p2pkStore.p2pkKeys.map((k) => ({
-    label: shortenString(k.publicKey, 16, 6),
-    value: k.publicKey,
-  }))
-);
-const selectedKeyShort = computed(() =>
-  profilePub.value ? shortenString(profilePub.value, 16, 6) : ''
-);
 const tierList = computed<Tier[]>(() => store.getTierArray());
 const editedTiers = ref<Record<string, Tier>>({});
 const saved = ref<Record<string, boolean>>({});
@@ -312,12 +279,6 @@ async function publishFullProfile() {
 
 async function saveProfile() {
   await publishFullProfile();
-}
-
-function generateP2PK() {
-  p2pkStore.createAndSelectNewKey().then(() => {
-    if (!profilePub.value && p2pkStore.firstKey) profilePub.value = p2pkStore.firstKey.publicKey;
-  });
 }
 
 function addTier() {

--- a/src/pages/MyProfilePage.vue
+++ b/src/pages/MyProfilePage.vue
@@ -23,18 +23,7 @@
       icon="edit"
       :label="$t('CreatorHub.profile.edit')"
     >
-      <CreatorProfileForm
-        v-model:display_name="display_name"
-        v-model:picture="picture"
-        v-model:about="about"
-        v-model:profilePub="profilePub"
-        v-model:profileMints="profileMints"
-        v-model:profileRelays="profileRelays"
-        :hasP2PK="hasP2PK"
-        :p2pkOptions="p2pkOptions"
-        :selectedKeyShort="selectedKeyShort"
-        :generateP2PK="generateP2PK"
-      />
+      <CreatorProfileForm />
       <div class="text-center q-mt-md">
         <q-btn color="primary" :disable="!isDirty" @click="saveProfile"
           >Save Changes</q-btn
@@ -218,16 +207,6 @@ export default defineComponent({
       picture: picture.value,
       about: about.value,
     }));
-    const hasP2PK = computed(() => p2pkStore.p2pkKeys.length > 0);
-    const p2pkOptions = computed(() =>
-      p2pkStore.p2pkKeys.map((k) => ({
-        label: shortenString(k.publicKey, 16, 6),
-        value: k.publicKey,
-      }))
-    );
-    const selectedKeyShort = computed(() =>
-      profilePub.value ? shortenString(profilePub.value, 16, 6) : ""
-    );
     const walletBalance = computed(() => mints.activeBalance);
     const activeUnit = computed(() => mints.activeUnit);
     const bucketCount = computed(() => buckets.bucketList.length);
@@ -278,12 +257,6 @@ export default defineComponent({
       }
     }
 
-    function generateP2PK() {
-      p2pkStore.createAndSelectNewKey().then(() => {
-        if (!profilePub.value && p2pkStore.firstKey)
-          profilePub.value = p2pkStore.firstKey.publicKey;
-      });
-    }
 
     function openP2PKDialog() {
       if (!p2pkStore.p2pkKeys.length) {
@@ -310,9 +283,6 @@ export default defineComponent({
       profileMints,
       profileRelays,
       isDirty,
-      hasP2PK,
-      p2pkOptions,
-      selectedKeyShort,
       bitcoinPrice,
       walletBalance,
       activeUnit,
@@ -321,7 +291,6 @@ export default defineComponent({
       shortenString,
       renderMarkdown,
       formatFiat,
-      generateP2PK,
       openP2PKDialog,
       showP2PKKeyEntry,
       saveProfile,


### PR DESCRIPTION
## Summary
- bind creator profile form directly to creatorProfile store
- drop prop-based bindings from all profile pages
- use p2pk store inside CreatorProfileForm to manage keys

## Testing
- `npm run lint` *(fails: A config object is using the "extends" key, which is not supported in flat config system)*
- `npm run test` *(fails: sh: 1: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870f87beb2c83308da5ebda9a1ef98c