### PR TITLE
Refactor creator hub tiers

### DIFF
--- a/src/components/DeleteModal.vue
+++ b/src/components/DeleteModal.vue
@@ -1,0 +1,26 @@
+<template>
+  <q-dialog v-model="showLocal">
+    <q-card class="q-pa-md" style="max-width: 400px">
+      <q-card-section class="row items-center">
+        <q-icon name="warning" color="red" size="2rem" />
+        <span class="q-ml-sm">Are you sure you want to delete this tier?</span>
+      </q-card-section>
+      <q-card-actions align="right">
+        <q-btn flat color="grey" v-close-popup>Cancel</q-btn>
+        <q-btn color="negative" @click="emit('confirm')">Delete</q-btn>
+      </q-card-actions>
+    </q-card>
+  </q-dialog>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+const props = defineProps<{ modelValue: boolean }>();
+const emit = defineEmits(['update:modelValue', 'confirm']);
+
+const showLocal = computed({
+  get: () => props.modelValue,
+  set: (val: boolean) => emit('update:modelValue', val),
+});
+</script>

--- a/src/components/TierItem.vue
+++ b/src/components/TierItem.vue
@@ -1,0 +1,74 @@
+<template>
+  <q-card flat bordered :class="{ 'saved-bg': saved }" class="relative-position">
+    <transition name="fade">
+      <q-icon
+        v-if="saved"
+        name="check_circle"
+        color="positive"
+        size="sm"
+        class="saved-check"
+      />
+    </transition>
+    <q-card-section class="row items-center justify-between">
+      <div class="text-subtitle2">{{ tierData.name || 'Tier' }}</div>
+      <q-btn flat dense round icon="mdi-drag" class="drag-handle" />
+    </q-card-section>
+    <q-card-section>
+      <q-input v-model="tierData.name" label="Title" dense outlined class="q-mt-sm" />
+      <q-input
+        v-model.number="tierData.price"
+        label="Price (sats/month)"
+        type="number"
+        dense
+        outlined
+        class="q-mt-sm"
+      />
+      <q-input
+        v-model="tierData.description"
+        label="Description"
+        type="textarea"
+        autogrow
+        dense
+        outlined
+        class="q-mt-sm"
+      />
+      <q-input
+        v-model="tierData.welcomeMessage"
+        label="Welcome Message"
+        type="textarea"
+        autogrow
+        dense
+        outlined
+        class="q-mt-sm"
+      />
+    </q-card-section>
+    <q-card-actions align="right">
+      <q-btn flat dense round icon="save" @click="emit('save')" />
+      <q-btn flat dense round icon="delete" color="negative" @click="emit('delete')" />
+    </q-card-actions>
+  </q-card>
+</template>
+
+<script setup lang="ts">
+import { defineProps, defineEmits } from 'vue';
+import type { Tier } from 'stores/creatorHub';
+
+const props = defineProps<{ tierData: Tier; saved: boolean }>();
+const emit = defineEmits(['save', 'delete']);
+</script>
+
+<style scoped>
+.saved-bg {
+  background-color: rgba(76, 175, 80, 0.15);
+  transition: background-color 0.5s ease;
+}
+.saved-check {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  z-index: 1;
+}
+.relative-position {
+  position: relative;
+}
+</style>


### PR DESCRIPTION
## Summary
- extract tier editing card to `TierItem.vue`
- add reusable `DeleteModal` component
- refactor `CreatorHubPage` to use new components
- add sticky action bar for profile saves

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68712d5d97cc8330abf3b21bdc58bab0