### PR TITLE
Use P2PK store for key generation

### DIFF
--- a/src/components/CreatorProfileForm.vue
+++ b/src/components/CreatorProfileForm.vue
@@ -106,11 +106,11 @@ const selectedKeyShort = computed(() =>
   profilePub.value ? shortenString(profilePub.value, 16, 6) : ''
 );
 
-function generateP2PK() {
-  p2pkStore.createAndSelectNewKey().then(() => {
-    if (!profilePub.value && p2pkStore.firstKey)
-      profilePub.value = p2pkStore.firstKey.publicKey;
-  });
+async function generateP2PK() {
+  await p2pkStore.createAndSelectNewKey();
+  if (p2pkStore.firstKey) {
+    profilePub.value = p2pkStore.firstKey.publicKey;
+  }
 }
 
 const display_nameLocal = computed({


### PR DESCRIPTION
## Summary
- generate new P2PK keys through `useP2PKStore` in CreatorProfileForm

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68713024c2d48330af92e64e5541325d