### PR TITLE
Sync profile store with relays/mints

### DIFF
--- a/src/components/SettingsView.vue
+++ b/src/components/SettingsView.vue
@@ -1796,6 +1796,7 @@ import {
 } from "src/stores/nostr";
 import { useNPCStore } from "src/stores/npubcash";
 import { useP2PKStore } from "src/stores/p2pk";
+import { useCreatorProfileStore } from "src/stores/creatorProfile";
 import { useNWCStore } from "src/stores/nwc";
 import { useUiStore } from "../stores/ui";
 import { useWorkersStore } from "src/stores/workers";
@@ -2073,10 +2074,11 @@ export default defineComponent({
           this.notifyError("No P2PK key");
           return;
         }
+        const profileStore = useCreatorProfileStore();
         await publishNutzapProfileFn({
           p2pkPub: this.firstKey.publicKey,
-          mints: this.mints.map((m) => m.url),
-          relays: this.defaultNostrRelays,
+          mints: profileStore.mints,
+          relays: profileStore.relays,
         });
         this.notifySuccess("Profile published");
         let profile = null;
@@ -2141,12 +2143,18 @@ export default defineComponent({
           this.notifyWarning("Relay already added");
         } else {
           this.relays.push(this.newRelay);
+          const profileStore = useCreatorProfileStore();
+          if (!profileStore.relays.includes(this.newRelay)) {
+            profileStore.relays.push(this.newRelay);
+          }
           this.newRelay = "";
         }
       }
     },
     removeRelay: function (relay) {
       this.relays = this.relays.filter((r) => r !== relay);
+      const profileStore = useCreatorProfileStore();
+      profileStore.relays = profileStore.relays.filter((r) => r !== relay);
     },
     addNostrRelay: function () {
       if (this.newNostrRelay) {
@@ -2155,6 +2163,10 @@ export default defineComponent({
           this.notifyWarning("Relay already added");
         } else {
           this.defaultNostrRelays.push(this.newNostrRelay);
+          const profileStore = useCreatorProfileStore();
+          if (!profileStore.relays.includes(this.newNostrRelay)) {
+            profileStore.relays.push(this.newNostrRelay);
+          }
           this.newNostrRelay = "";
         }
       }
@@ -2163,9 +2175,14 @@ export default defineComponent({
       this.defaultNostrRelays = this.defaultNostrRelays.filter(
         (r) => r !== relay
       );
+      const profileStore = useCreatorProfileStore();
+      profileStore.relays = profileStore.relays.filter((r) => r !== relay);
     },
     updateNostrRelay: function (index: number, value: string) {
-      this.defaultNostrRelays.splice(index, 1, value.trim());
+      const val = value.trim();
+      this.defaultNostrRelays.splice(index, 1, val);
+      const profileStore = useCreatorProfileStore();
+      profileStore.relays.splice(index, 1, val);
     },
     changeLanguage(locale) {
       if (locale === "en") {

--- a/src/pages/CreatorHubPage.vue
+++ b/src/pages/CreatorHubPage.vue
@@ -186,6 +186,12 @@ async function initPage() {
   await nostr.initSignerIfNotSet();
   const p = await nostr.getProfile(store.loggedInNpub);
   if (p) profileStore.setProfile(p);
+  if (profileStore.mints.length) {
+    profileMints.value = [...profileStore.mints];
+  }
+  if (profileStore.relays.length) {
+    profileRelays.value = [...profileStore.relays];
+  }
   let existing = null;
   try {
     existing = await fetchNutzapProfile(store.loggedInNpub);
@@ -201,9 +207,12 @@ async function initPage() {
     profileMints.value = [...existing.trustedMints];
     profileRelays.value = existing.relays ? [...existing.relays] : [...nostr.relays];
   } else {
-    profileRelays.value = [...nostr.relays];
+    if (!profileStore.relays.length) {
+      profileRelays.value = [...nostr.relays];
+    }
     if (p2pkStore.firstKey) profilePub.value = p2pkStore.firstKey.publicKey;
-    if (mintsStore.mints.length > 0) profileMints.value = mintsStore.mints.map((m) => m.url);
+    if (!profileStore.mints.length && mintsStore.mints.length > 0)
+      profileMints.value = mintsStore.mints.map((m) => m.url);
   }
   await store.loadTiersFromNostr(store.loggedInNpub);
   profileStore.markClean();

--- a/src/pages/MyProfilePage.vue
+++ b/src/pages/MyProfilePage.vue
@@ -222,6 +222,12 @@ export default defineComponent({
         profileStore.setProfile(p);
         profileStore.markClean();
       }
+      if (profileStore.mints.length) {
+        profileMints.value = [...profileStore.mints];
+      }
+      if (profileStore.relays.length) {
+        profileRelays.value = [...profileStore.relays];
+      }
     }
 
     onMounted(() => {

--- a/src/stores/creatorHub.ts
+++ b/src/stores/creatorHub.ts
@@ -10,7 +10,7 @@ import {
   RelayConnectionError,
 } from "./nostr";
 import { useP2PKStore } from "./p2pk";
-import { useMintsStore } from "./mints";
+import { useCreatorProfileStore } from "./creatorProfile";
 import { db } from "./dexie";
 import { v4 as uuidv4 } from "uuid";
 import { notifySuccess, notifyError } from "src/js/notify";
@@ -50,10 +50,8 @@ export async function maybeRepublishNutzapProfile() {
     }
     throw e;
   }
-  const desiredMints = useMintsStore()
-    .mints.map((m) => m.url)
-    .sort()
-    .join(",");
+  const profileStore = useCreatorProfileStore();
+  const desiredMints = profileStore.mints.sort().join(",");
   const desiredP2PK = useP2PKStore().firstKey?.publicKey;
 
   if (!desiredP2PK) return;
@@ -66,8 +64,8 @@ export async function maybeRepublishNutzapProfile() {
   if (hasDiff) {
     await publishNutzapProfile({
       p2pkPub: desiredP2PK,
-      mints: useMintsStore().mints.map((m) => m.url),
-      relays: nostrStore.relays,
+      mints: [...profileStore.mints],
+      relays: [...profileStore.relays],
     });
   }
 }

--- a/src/stores/mints.ts
+++ b/src/stores/mints.ts
@@ -25,6 +25,7 @@ import { ref, computed, watch } from "vue";
 import { useProofsStore } from "./proofs";
 import { useI18n } from "vue-i18n";
 import { maybeRepublishNutzapProfile } from "./creatorHub";
+import { useCreatorProfileStore } from "./creatorProfile";
 import { i18n } from "src/boot/i18n";
 
 export type Mint = {
@@ -342,6 +343,10 @@ export const useMintsStore = defineStore("mints", {
         if (verbose) {
           await notifySuccess(this.t("wallet.mint.notifications.added"));
         }
+        const profileStore = useCreatorProfileStore();
+        if (!profileStore.mints.includes(url)) {
+          profileStore.mints.push(url);
+        }
         await maybeRepublishNutzapProfile();
         return mintToAdd;
       } catch (error) {
@@ -543,6 +548,8 @@ export const useMintsStore = defineStore("mints", {
       if (this.mints.length > 0) {
         await this.activateMint(this.mints[0], false);
       }
+      const profileStore = useCreatorProfileStore();
+      profileStore.mints = profileStore.mints.filter((m) => m !== url);
       notifySuccess(this.t("wallet.mint.notifications.removed"));
     },
     assertMintError: function (response: { error?: any }, verbose = true) {


### PR DESCRIPTION
## Summary
- ensure trusted mints/relays chip lists initialise from the creator profile store
- keep creator profile arrays in sync when adding or removing items
- publish Nutzap profile using arrays from the creator profile store

## Testing
- `npx vitest run` *(fails: vitest not installed)*
- `npm run lint` *(fails: eslint config error)*

------
https://chatgpt.com/codex/tasks/task_e_687131a173148330ae9a4e4c67fca577