### PR TITLE
Add saved badge for tier updates

### DIFF
--- a/src/components/TierItem.vue
+++ b/src/components/TierItem.vue
@@ -1,11 +1,11 @@
 <template>
   <q-card flat bordered :class="{ 'saved-bg': saved }" class="relative-position">
     <transition name="fade">
-      <q-icon
+      <q-badge
         v-if="saved"
-        name="check_circle"
         color="positive"
-        size="sm"
+        rounded
+        icon="check"
         class="saved-check"
       />
     </transition>


### PR DESCRIPTION
## Summary
- show a green badge when a tier is saved
- keep a reactive `saved` record keyed by tier ID

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687142ad5ce48330a2372278fdd633e6