### PR TITLE
Add tier update handler in CreatorHubPage

### DIFF
--- a/src/pages/CreatorHubPage.vue
+++ b/src/pages/CreatorHubPage.vue
@@ -32,6 +32,7 @@
             <TierItem
               :tier-data="editedTiers[element.id]"
               :saved="saved[element.id]"
+              @update:tierData="val => (editedTiers[element.id] = val)"
               @save="saveTier(element.id)"
               @delete="confirmDelete(element.id)"
             />
@@ -62,6 +63,7 @@
               <TierItem
                 :tier-data="editedTiers[element.id]"
                 :saved="saved[element.id]"
+                @update:tierData="val => (editedTiers[element.id] = val)"
                 @save="saveTier(element.id)"
                 @delete="confirmDelete(element.id)"
               />


### PR DESCRIPTION
## Summary
- emit updated tier data to `CreatorHubPage` in both mobile and desktop views

## Testing
- `pnpm run test:ci` *(fails: 21 failed, 26 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68714b08a4e0833098c40a0a9c047dd7