### PR TITLE
Add Creator Hub section card styling

### DIFF
--- a/src/css/creator-hub.scss
+++ b/src/css/creator-hub.scss
@@ -1,0 +1,6 @@
+.section-card {
+  background-color: var(--panel-bg-color);
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  padding: 16px;
+}

--- a/src/pages/CreatorHubPage.vue
+++ b/src/pages/CreatorHubPage.vue
@@ -21,40 +21,12 @@
         </div>
 <q-splitter v-if="!isMobile" v-model="splitterModel">
   <template #before>
-    <CreatorProfileForm />
+    <q-card class="section-card">
+      <CreatorProfileForm />
+    </q-card>
   </template>
   <template #after>
-    <div>
-      <div class="text-h6 q-mb-md">Subscription Tiers</div>
-      <Draggable v-model="draggableTiers" item-key="id" handle=".drag-handle" @end="updateOrder">
-        <template #item="{ element }">
-          <div class="q-mb-md">
-            <TierItem
-              :tier-data="editedTiers[element.id]"
-              :saved="saved[element.id]"
-              @update:tierData="val => (editedTiers[element.id] = val)"
-              @save="saveTier(element.id)"
-              @delete="confirmDelete(element.id)"
-            />
-          </div>
-        </template>
-      </Draggable>
-      <div class="text-center q-mt-md">
-        <q-btn color="primary" flat @click="addTier">Add Tier</q-btn>
-      </div>
-    </div>
-  </template>
-</q-splitter>
-<div v-else>
-  <q-tabs v-model="tab" no-caps align="justify" class="q-mb-md">
-    <q-tab name="profile" label="Profile" />
-    <q-tab name="tiers" label="Subscription Tiers" />
-  </q-tabs>
-  <q-tab-panels v-model="tab" animated>
-    <q-tab-panel name="profile">
-      <CreatorProfileForm />
-    </q-tab-panel>
-    <q-tab-panel name="tiers">
+    <q-card class="section-card">
       <div>
         <div class="text-h6 q-mb-md">Subscription Tiers</div>
         <Draggable v-model="draggableTiers" item-key="id" handle=".drag-handle" @end="updateOrder">
@@ -74,6 +46,42 @@
           <q-btn color="primary" flat @click="addTier">Add Tier</q-btn>
         </div>
       </div>
+    </q-card>
+  </template>
+</q-splitter>
+<div v-else>
+  <q-tabs v-model="tab" no-caps align="justify" class="q-mb-md">
+    <q-tab name="profile" label="Profile" />
+    <q-tab name="tiers" label="Subscription Tiers" />
+  </q-tabs>
+  <q-tab-panels v-model="tab" animated>
+    <q-tab-panel name="profile">
+      <q-card class="section-card">
+        <CreatorProfileForm />
+      </q-card>
+    </q-tab-panel>
+    <q-tab-panel name="tiers">
+      <q-card class="section-card">
+        <div>
+          <div class="text-h6 q-mb-md">Subscription Tiers</div>
+          <Draggable v-model="draggableTiers" item-key="id" handle=".drag-handle" @end="updateOrder">
+            <template #item="{ element }">
+              <div class="q-mb-md">
+                <TierItem
+                  :tier-data="editedTiers[element.id]"
+                  :saved="saved[element.id]"
+                  @update:tierData="val => (editedTiers[element.id] = val)"
+                  @save="saveTier(element.id)"
+                  @delete="confirmDelete(element.id)"
+                />
+              </div>
+            </template>
+          </Draggable>
+          <div class="text-center q-mt-md">
+            <q-btn color="primary" flat @click="addTier">Add Tier</q-btn>
+          </div>
+        </div>
+      </q-card>
     </q-tab-panel>
   </q-tab-panels>
 </div>
@@ -290,5 +298,7 @@ onMounted(async () => {
   if (store.loggedInNpub) await initPage();
 });
 </script>
+
+<style lang="scss" src="../css/creator-hub.scss" scoped></style>
 
 


### PR DESCRIPTION
## Summary
- style Creator Hub sections with new `section-card` helper
- use `section-card` to wrap profile form and tier list
- load new SCSS in `CreatorHubPage.vue`

## Testing
- `pnpm lint` *(fails: A config object is using the "extends" key, which is not supported in flat config system)*
- `pnpm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68715555e02c8330aee565b110966b05