### PR TITLE
Refactor tier components

### DIFF
--- a/src/components/TierCard.vue
+++ b/src/components/TierCard.vue
@@ -1,42 +1,84 @@
 <template>
-  <q-card flat bordered class="relative p-4 space-y-2">
+  <q-card flat bordered class="relative-position">
     <q-card-section class="row items-center justify-between">
-      <div class="text-subtitle2">{{ tierLocal.name || 'Tier' }}</div>
+      <div class="row items-center">
+        <div class="text-subtitle2">{{ tierLocal.name || 'Tier' }}</div>
+        <div class="text-caption text-grey q-ml-sm">{{ tierLocal.price }} sats</div>
+      </div>
       <q-btn flat dense round icon="mdi-drag" class="drag-handle" />
     </q-card-section>
-    <q-input v-model="tierLocal.name" label="Title" dense outlined />
-    <q-input v-model.number="tierLocal.price" label="Price (sats/month)" type="number" dense outlined />
-    <q-input v-model="tierLocal.description" label="Description" type="textarea" autogrow dense outlined />
-    <q-input v-model="tierLocal.welcomeMessage" label="Welcome Message" type="textarea" autogrow dense outlined />
+    <q-card-section>
+      <q-input v-model="tierLocal.name" label="Title" dense outlined class="q-mt-sm" />
+      <q-input
+        v-model.number="tierLocal.price"
+        label="Price (sats/month)"
+        type="number"
+        dense
+        outlined
+        class="q-mt-sm"
+      />
+      <q-input
+        v-model="tierLocal.description"
+        label="Description"
+        type="textarea"
+        autogrow
+        dense
+        outlined
+        class="q-mt-sm"
+      />
+      <q-input
+        v-model="tierLocal.welcomeMessage"
+        label="Welcome Message"
+        type="textarea"
+        autogrow
+        dense
+        outlined
+        class="q-mt-sm"
+      />
+    </q-card-section>
     <q-card-actions align="right">
-      <q-btn flat dense round icon="save" @click="save" />
-      <q-btn flat dense round icon="delete" color="negative" @click="remove" />
+      <q-btn flat dense round icon="save" @click="emitEdit" />
+      <q-btn flat dense round icon="delete" color="negative" @click="emitDelete" />
     </q-card-actions>
   </q-card>
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from 'vue';
-import { useCreatorHubStore, type Tier } from 'stores/creatorHub';
+import { reactive, watch, defineProps, defineEmits } from 'vue';
+import type { Tier } from 'stores/creatorHub';
 
 const props = defineProps<{ tier: Tier }>();
-const emit = defineEmits<{ (e: 'delete', id: string): void }>();
+const emit = defineEmits(['edit', 'delete', 'update:tier']);
 
-const store = useCreatorHubStore();
-const tierLocal = ref<Tier>({ ...props.tier });
+const tierLocal = reactive<Tier>({ ...props.tier });
 
 watch(
   () => props.tier,
-  val => { tierLocal.value = { ...val }; },
-  { deep: true }
+  (val) => {
+    Object.assign(tierLocal, val);
+  },
+  { immediate: true, deep: true },
 );
 
-async function save() {
-  store.updateTier(tierLocal.value.id, tierLocal.value);
-  await store.publishTierDefinitions();
+watch(
+  tierLocal,
+  () => {
+    emit('update:tier', { ...tierLocal });
+  },
+  { deep: true },
+);
+
+function emitEdit() {
+  emit('edit');
 }
 
-function remove() {
-  emit('delete', tierLocal.value.id);
+function emitDelete() {
+  emit('delete');
 }
 </script>
+
+<style scoped>
+.relative-position {
+  position: relative;
+}
+</style>

--- a/src/components/TierItem.vue
+++ b/src/components/TierItem.vue
@@ -1,92 +1,20 @@
 <template>
-  <q-card flat bordered :class="{ 'saved-bg': saved }" class="relative-position">
-    <transition name="fade">
-      <q-badge
-        v-if="saved"
-        color="positive"
-        rounded
-        icon="check"
-        class="saved-check"
-      />
-    </transition>
-    <q-card-section class="row items-center justify-between">
-      <div class="text-subtitle2">{{ localTier.name || 'Tier' }}</div>
-      <q-btn flat dense round icon="mdi-drag" class="drag-handle" />
-    </q-card-section>
-    <q-card-section>
-      <q-input v-model="localTier.name" label="Title" dense outlined class="q-mt-sm" />
-      <q-input
-        v-model.number="localTier.price"
-        label="Price (sats/month)"
-        type="number"
-        dense
-        outlined
-        class="q-mt-sm"
-      />
-      <q-input
-        v-model="localTier.description"
-        label="Description"
-        type="textarea"
-        autogrow
-        dense
-        outlined
-        class="q-mt-sm"
-      />
-      <q-input
-        v-model="localTier.welcomeMessage"
-        label="Welcome Message"
-        type="textarea"
-        autogrow
-        dense
-        outlined
-        class="q-mt-sm"
-      />
-    </q-card-section>
-    <q-card-actions align="right">
-      <q-btn flat dense round icon="save" @click="emit('save')" />
-      <q-btn flat dense round icon="delete" color="negative" @click="emit('delete')" />
-    </q-card-actions>
-  </q-card>
+  <TierCard
+    :tier="tierData"
+    @edit="emit('save')"
+    @delete="emit('delete')"
+    @reorder="emit('reorder', $event)"
+    @update:tier="emit('update:tierData', $event)"
+  />
 </template>
 
 <script setup lang="ts">
-import { defineProps, defineEmits, reactive, watch } from 'vue';
+import { defineProps, defineEmits } from 'vue';
+import TierCard from './TierCard.vue';
 import type { Tier } from 'stores/creatorHub';
 
 const props = defineProps<{ tierData: Tier; saved: boolean }>();
-const emit = defineEmits(['save', 'delete', 'update:tierData']);
-
-const localTier = reactive<Tier>({ ...props.tierData });
-
-watch(
-  () => props.tierData,
-  (val) => {
-    Object.assign(localTier, val);
-  },
-  { immediate: true, deep: true },
-);
-
-watch(
-  localTier,
-  () => {
-    emit('update:tierData', { ...localTier });
-  },
-  { deep: true },
-);
+const emit = defineEmits(['save', 'delete', 'reorder', 'update:tierData']);
 </script>
 
-<style scoped>
-.saved-bg {
-  background-color: rgba(76, 175, 80, 0.15);
-  transition: background-color 0.5s ease;
-}
-.saved-check {
-  position: absolute;
-  top: 4px;
-  right: 4px;
-  z-index: 1;
-}
-.relative-position {
-  position: relative;
-}
-</style>
+<style scoped></style>


### PR DESCRIPTION
## Summary
- simplify `TierItem` as a wrapper around `TierCard`
- rework `TierCard` to emit edit/delete events and expose the header row

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871593a894c833089fd38e9f38914aa