### PR TITLE
Add URL validation in profile form

### DIFF
--- a/src/components/CreatorProfileForm.vue
+++ b/src/components/CreatorProfileForm.vue
@@ -13,6 +13,7 @@
       label="Profile Picture URL"
       dense
       outlined
+      :rules="[urlRule]"
     />
     <q-img
       :src="pictureLocal"
@@ -177,6 +178,7 @@ const profileRelaysLocal = computed({
 });
 
 const validUrl = computed(() => /^https?:\/\/.+/.test(pictureLocal.value));
+const urlRule = (val: string) => /^https?:\/\/.+/.test(val) || 'Invalid URL';
 const urlListRule = (val: string[]) =>
   val.every((u) => /^wss?:\/\//.test(u)) || "Invalid URL";
 </script>


### PR DESCRIPTION
## Summary
- validate profile picture input with a url rule

## Testing
- `pnpm test:ci --silent` *(fails: cannot access vitest or missing mocks)*

------
https://chatgpt.com/codex/tasks/task_e_687166bc752c8330bca2e67681ed3764