### PR TITLE
Add creator hub endpoints header

### DIFF
--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -1380,6 +1380,7 @@ export default {
     publish: "Publish Profile",
     saveDraft: "Save Draft",
     profileHeader: "Profile details",
+    endpointsHeader: "Endpoints",
   },
   swap: {
     in_progress_warning_text: "التبديل قيد التقدم",

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -1386,6 +1386,7 @@ export default {
     publish: "Publish Profile",
     saveDraft: "Save Draft",
     profileHeader: "Profile details",
+    endpointsHeader: "Endpoints",
   },
   swap: {
     in_progress_warning_text: "Swap läuft",

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -1390,6 +1390,7 @@ export default {
     publish: "Publish Profile",
     saveDraft: "Save Draft",
     profileHeader: "Profile details",
+    endpointsHeader: "Endpoints",
   },
   swap: {
     in_progress_warning_text: "Η ανταλλαγή βρίσκεται σε εξέλιξη",

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1610,6 +1610,7 @@ export const messages = {
     publish: "Publish Profile",
     saveDraft: "Save Draft",
     profileHeader: "Profile details",
+    endpointsHeader: "Endpoints",
   },
   swap: {
     in_progress_warning_text: "Swap in progress",

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -1387,6 +1387,7 @@ export default {
     publish: "Publish Profile",
     saveDraft: "Save Draft",
     profileHeader: "Profile details",
+    endpointsHeader: "Endpoints",
   },
   swap: {
     in_progress_warning_text: "Intercambio en progreso",

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -1377,6 +1377,7 @@ export default {
     publish: "Publish Profile",
     saveDraft: "Save Draft",
     profileHeader: "Profile details",
+    endpointsHeader: "Endpoints",
   },
   swap: {
     in_progress_warning_text: "Échange en cours",

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -1369,6 +1369,7 @@ export default {
     publish: "Publish Profile",
     saveDraft: "Save Draft",
     profileHeader: "Profile details",
+    endpointsHeader: "Endpoints",
   },
   swap: {
     in_progress_warning_text: "Scambio in corso",

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -1370,6 +1370,7 @@ export default {
     publish: "Publish Profile",
     saveDraft: "Save Draft",
     profileHeader: "Profile details",
+    endpointsHeader: "Endpoints",
   },
   swap: {
     in_progress_warning_text: "スワップ進行中",

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -1369,6 +1369,7 @@ export default {
     publish: "Publish Profile",
     saveDraft: "Save Draft",
     profileHeader: "Profile details",
+    endpointsHeader: "Endpoints",
   },
   swap: {
     in_progress_warning_text: "Byte pågår",

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -1367,6 +1367,7 @@ export default {
     publish: "Publish Profile",
     saveDraft: "Save Draft",
     profileHeader: "Profile details",
+    endpointsHeader: "Endpoints",
   },
   swap: {
     in_progress_warning_text: "กำลังดำเนินการแลกเปลี่ยน",

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -1372,6 +1372,7 @@ export default {
     publish: "Publish Profile",
     saveDraft: "Save Draft",
     profileHeader: "Profile details",
+    endpointsHeader: "Endpoints",
   },
   swap: {
     in_progress_warning_text: "Takas devam ediyor",

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -1359,6 +1359,7 @@ export default {
     publish: "Publish Profile",
     saveDraft: "Save Draft",
     profileHeader: "Profile details",
+    endpointsHeader: "Endpoints",
   },
   swap: {
     in_progress_warning_text: "兑换进行中",


### PR DESCRIPTION
## Summary
- update english translation with endpoints header
- mirror same section in all locales

## Testing
- `pnpm run test:ci` *(fails: 22 failed, 26 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68716cf5cfac83309384efd27a2efe38