### PR TITLE
Fix creator hub scss build error

### DIFF
--- a/src/css/creator-hub.scss
+++ b/src/css/creator-hub.scss
@@ -1,6 +1,6 @@
 .section-card {
   padding: 24px;
-  @extend .bg-grey-9;
-  @extend .shadow-2;
-  @extend .rounded-borders;
+  background-color: var(--q-color-grey-9);
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  border-radius: 8px;
 }


### PR DESCRIPTION
## Summary
- avoid extending Quasar utility classes in `creator-hub.scss`

## Testing
- `npm install` *(fails: Invalid Version: file:./src/lib/cashu-ts)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68716fc6bbfc833096309f0c85444a2c