### PR TITLE
Fix bucket card drag style and i18n keys

### DIFF
--- a/src/components/BucketCard.vue
+++ b/src/components/BucketCard.vue
@@ -1,7 +1,7 @@
 <template>
   <q-card
     class="shadow-2 rounded-borders bg-grey-9 text-white"
-    :class="{ 'drag-hover': dragHover }"
+    :class="{ 'drag-hover': isDrag }"
     :style="{ borderLeft: '4px solid ' + (bucket.color || 'var(--q-primary)') }"
     @dragenter="onDragEnter"
     @dragleave="onDragLeave"
@@ -98,7 +98,7 @@ export default defineComponent({
   setup(props, { emit }) {
     const uiStore = useUiStore();
     const { t } = useI18n();
-    const dragHover = ref(false);
+    const isDrag = ref(false);
 
     const formatCurrency = (amount: number, unit: string) => {
       return uiStore.formatCurrency(amount, unit);
@@ -108,13 +108,13 @@ export default defineComponent({
     const emitDelete = () => emit('delete', props.bucket.id);
 
     const onDragEnter = () => {
-      dragHover.value = true;
+      isDrag.value = true;
     };
     const onDragLeave = () => {
-      dragHover.value = false;
+      isDrag.value = false;
     };
     const onDrop = (e: DragEvent) => {
-      dragHover.value = false;
+      isDrag.value = false;
       emit('drop', e);
     };
 
@@ -124,7 +124,7 @@ export default defineComponent({
       emitDelete,
       DEFAULT_BUCKET_ID,
       t,
-      dragHover,
+      isDrag,
       onDragEnter,
       onDragLeave,
       onDrop,

--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -943,9 +943,6 @@ export default {
       label: {
         label: "Label",
       },
-    search: "Search buckets",
-    empty: "No buckets yet. Tap + to add your first one.",
-    moved: "Tokens moved to bucket",
     },
     errors: {
       invalid_token: {
@@ -1405,6 +1402,9 @@ export default {
     color: "Color",
     goal: "Monthly goal",
     description: "Description",
+    search: "Search buckets",
+    empty: "No buckets yet. Tap + to add your first one.",
+    moved: "Tokens moved to bucket",
   },
   SubscriptionsOverview: {
     export_csv: "Export CSV",

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -952,9 +952,6 @@ export default {
       label: {
         label: "Label",
       },
-    search: "Search buckets",
-    empty: "No buckets yet. Tap + to add your first one.",
-    moved: "Tokens moved to bucket",
     },
     errors: {
       invalid_token: {
@@ -1415,6 +1412,9 @@ export default {
     color: "Color",
     goal: "Monthly goal",
     description: "Description",
+    search: "Search buckets",
+    empty: "No buckets yet. Tap + to add your first one.",
+    moved: "Tokens moved to bucket",
   },
   SubscriptionsOverview: {
     export_csv: "Export CSV",

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -950,9 +950,6 @@ export default {
       label: {
         label: "Label",
       },
-    search: "Search buckets",
-    empty: "No buckets yet. Tap + to add your first one.",
-    moved: "Tokens moved to bucket",
     },
     errors: {
       invalid_token: {
@@ -1412,6 +1409,9 @@ export default {
     color: "Color",
     goal: "Monthly goal",
     description: "Description",
+    search: "Search buckets",
+    empty: "No buckets yet. Tap + to add your first one.",
+    moved: "Tokens moved to bucket",
   },
   SubscriptionsOverview: {
     export_csv: "Export CSV",

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -948,9 +948,6 @@ export default {
       label: {
         label: "Label",
       },
-    search: "Search buckets",
-    empty: "No buckets yet. Tap + to add your first one.",
-    moved: "Tokens moved to bucket",
     },
     errors: {
       invalid_token: {
@@ -1402,6 +1399,9 @@ export default {
     color: "Color",
     goal: "Monthly goal",
     description: "Description",
+    search: "Search buckets",
+    empty: "No buckets yet. Tap + to add your first one.",
+    moved: "Tokens moved to bucket",
   },
   SubscriptionsOverview: {
     export_csv: "Export CSV",

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -942,9 +942,6 @@ export default {
       label: {
         label: "Label",
       },
-    search: "Search buckets",
-    empty: "No buckets yet. Tap + to add your first one.",
-    moved: "Tokens moved to bucket",
     },
     errors: {
       invalid_token: {
@@ -1394,6 +1391,9 @@ export default {
     color: "Color",
     goal: "Monthly goal",
     description: "Description",
+    search: "Search buckets",
+    empty: "No buckets yet. Tap + to add your first one.",
+    moved: "Tokens moved to bucket",
   },
   SubscriptionsOverview: {
     export_csv: "Export CSV",

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -941,9 +941,6 @@ export default {
       label: {
         label: "Label",
       },
-    search: "Search buckets",
-    empty: "No buckets yet. Tap + to add your first one.",
-    moved: "Tokens moved to bucket",
     },
     errors: {
       invalid_token: {
@@ -1395,6 +1392,9 @@ export default {
     color: "Color",
     goal: "Monthly goal",
     description: "Description",
+    search: "Search buckets",
+    empty: "No buckets yet. Tap + to add your first one.",
+    moved: "Tokens moved to bucket",
   },
   SubscriptionsOverview: {
     export_csv: "Export CSV",

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -942,9 +942,6 @@ export default {
       label: {
         label: "Label",
       },
-    search: "Search buckets",
-    empty: "No buckets yet. Tap + to add your first one.",
-    moved: "Tokens moved to bucket",
     },
     errors: {
       invalid_token: {
@@ -1394,6 +1391,9 @@ export default {
     color: "Color",
     goal: "Monthly goal",
     description: "Description",
+    search: "Search buckets",
+    empty: "No buckets yet. Tap + to add your first one.",
+    moved: "Tokens moved to bucket",
   },
   SubscriptionsOverview: {
     export_csv: "Export CSV",

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -939,9 +939,6 @@ export default {
       label: {
         label: "Label",
       },
-    search: "Search buckets",
-    empty: "No buckets yet. Tap + to add your first one.",
-    moved: "Tokens moved to bucket",
     },
     errors: {
       invalid_token: {
@@ -1392,6 +1389,9 @@ export default {
     color: "Color",
     goal: "Monthly goal",
     description: "Description",
+    search: "Search buckets",
+    empty: "No buckets yet. Tap + to add your first one.",
+    moved: "Tokens moved to bucket",
   },
   SubscriptionsOverview: {
     export_csv: "Export CSV",

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -944,9 +944,6 @@ export default {
       label: {
         label: "Label",
       },
-    search: "Search buckets",
-    empty: "No buckets yet. Tap + to add your first one.",
-    moved: "Tokens moved to bucket",
     },
     errors: {
       invalid_token: {
@@ -1397,6 +1394,9 @@ export default {
     color: "Color",
     goal: "Monthly goal",
     description: "Description",
+    search: "Search buckets",
+    empty: "No buckets yet. Tap + to add your first one.",
+    moved: "Tokens moved to bucket",
   },
   SubscriptionsOverview: {
     export_csv: "Export CSV",

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -932,9 +932,6 @@ export default {
       label: {
         label: "Label",
       },
-    search: "Search buckets",
-    empty: "No buckets yet. Tap + to add your first one.",
-    moved: "Tokens moved to bucket",
     },
     errors: {
       invalid_token: {
@@ -1384,6 +1381,9 @@ export default {
     color: "Color",
     goal: "Monthly goal",
     description: "Description",
+    search: "Search buckets",
+    empty: "No buckets yet. Tap + to add your first one.",
+    moved: "Tokens moved to bucket",
   },
   SubscriptionsOverview: {
     export_csv: "Export CSV",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
     include: [
       "src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}",
       "test/vitest/__tests__/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}",
+      "test/vitest/**/*.spec.{js,ts}",
     ],
   },
   resolve: {


### PR DESCRIPTION
## Summary
- clean up drag state in `BucketCard`
- move bucket search translations to top-level bucket object
- extend Vitest include globs

## Testing
- `pnpm test` *(fails: 24 failed, 25 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6871f8578b788330a5af06cde9c360fd