### PR TITLE
Update BucketCard defaults

### DIFF
--- a/src/components/BucketCard.vue
+++ b/src/components/BucketCard.vue
@@ -1,6 +1,6 @@
 <template>
   <q-card
-    class="shadow-2 rounded-borders bg-grey-9 text-white"
+    class="shadow-2 rounded-borders bg-grey-8 text-white"
     :class="{ 'drag-hover': isDrag }"
     :style="{ borderLeft: '4px solid ' + (bucket.color || 'var(--q-primary)') }"
     @dragenter="onDragEnter"
@@ -92,7 +92,10 @@ export default defineComponent({
   props: {
     bucket: { type: Object as () => any, required: true },
     balance: { type: Number, default: 0 },
-    activeUnit: { type: String, required: true }
+    activeUnit: {
+      type: String,
+      default: 'sat'
+    }
   },
   emits: ['edit', 'delete', 'drop'],
   setup(props, { emit }) {


### PR DESCRIPTION
## Summary
- tweak BucketCard background colour
- make `activeUnit` prop optional with `'sat'` default
- confirm single `isDrag` flag implementation

## Testing
- `pnpm install`
- `pnpm test` *(fails: 24 failed, 25 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68720a8579608330901dbc5417ed68b1