### PR TITLE
Add signer store import

### DIFF
--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -289,6 +289,7 @@ import { useNPCStore } from "src/stores/npubcash";
 import { useNostrStore, SignerType } from "src/stores/nostr";
 import { usePRStore } from "src/stores/payment-request";
 import { useDexieStore } from "src/stores/dexie";
+import { useSignerStore } from "src/stores/signer";
 
 import { useStorageStore } from "src/stores/storage";
 import ReceiveTokenDialog from "src/components/ReceiveTokenDialog.vue";


### PR DESCRIPTION
## Summary
- import `useSignerStore` in `WalletPage.vue`

## Testing
- `pnpm run test:ci` *(fails: Test Files 24 failed | 25 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6872114a78788330a0165bd62d01918f