### PR TITLE
Apply hotfix for buckets page layout

### DIFF
--- a/src/components/BucketManager.vue
+++ b/src/components/BucketManager.vue
@@ -1,6 +1,6 @@
 <template>
   <!-- guaranteed flex box with height -->
-  <div class="column fit q-gutter-y-md" style="max-width: 980px; margin:0 auto">
+  <div  class="column q-gutter-y-md"  style="min-height:200px;max-width:980px;margin:0 auto">
     <div class="text-body2 q-mb-md">{{ $t("BucketManager.helper.intro") }}</div>
     <q-input
       v-model="search"


### PR DESCRIPTION
## Summary
- prevent the Buckets page wrapper from collapsing on initial render

## Testing
- `pnpm run test:ci` *(fails: Test Files 24 failed | 25 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6872272a7a208330b4edddb15c8bda69