### PR TITLE
Fix BucketManager layout and translations

### DIFF
--- a/src/components/BucketManager.vue
+++ b/src/components/BucketManager.vue
@@ -1,6 +1,6 @@
 <template>
   <!-- guaranteed flex box with height -->
-  <div class="column fit q-gutter-y-md" style="max-width: 980px; margin:0 auto">
+  <div  class="column q-gutter-y-md"  style="min-height:200px;max-width:980px;margin:0 auto">
     <div class="text-body2 q-mb-md">{{ $t("BucketManager.helper.intro") }}</div>
     <q-input
       v-model="search"
@@ -9,7 +9,7 @@
       debounce="200"
       :placeholder="$t('bucket.search')"
       clearable
-      class="q-mb-md bg-grey-8"
+      class="q-mb-md"
     >
       <template #prepend><q-icon name="search" /></template>
     </q-input>
@@ -17,7 +17,7 @@
       v-model="sortBy"
       :options="['name', 'balance']"
       dense
-      class="q-mb-md bg-grey-8"
+      class="q-mb-md"
     />
     <q-list padding>
       <template v-if="filteredBuckets.length">

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1645,6 +1645,6 @@ export const messages = {
 export default {
   ...(defaultLang as any),
   ...messages,
-  BucketManager: { helper: { intro: "" } },
-  MoveTokens: { title: "", helper: "" },
+  BucketManager: { ...messages.BucketManager, helper: { intro: "" } },
+  MoveTokens: { ...messages.MoveTokens, title: "", helper: "" },
 };


### PR DESCRIPTION
## Summary
- adjust BucketManager layout so it always displays
- merge default English translations with overrides to avoid missing keys

## Testing
- `pnpm test` *(fails: Tests failed. Watching for file changes...)*

------
https://chatgpt.com/codex/tasks/task_e_6872272a7a208330b4edddb15c8bda69