### PR TITLE
Wrap BucketManager container

### DIFF
--- a/src/pages/Buckets.vue
+++ b/src/pages/Buckets.vue
@@ -5,11 +5,16 @@
       :class="$q.screen.gt.md ? 'q-mx-xl' : 'q-mx-sm'"
     >
       <!-- Manager must stretch so the inner search / empty-state is visible -->
-      <BucketManager
-        class="q-pa-lg column fit"
-        :class="$q.screen.gt.xl ? 'self-center' : ''"
-        style="max-width: 1100px"
-      />
+      <div
+        class="column q-gutter-y-md"
+        style="min-height:200px;max-width:980px;margin:0 auto"
+      >
+        <BucketManager
+          class="q-pa-lg column fit"
+          :class="$q.screen.gt.xl ? 'self-center' : ''"
+          style="max-width: 1100px"
+        />
+      </div>
     </q-scroll-area>
   </q-page>
 </template>


### PR DESCRIPTION
## Summary
- wrap `<BucketManager>` with a container to control layout

## Testing
- `pnpm run test:ci` *(fails: InfoTooltip and many others)*

------
https://chatgpt.com/codex/tasks/task_e_68729b9a10b083308e9a21f56b725aff