### PR TITLE
Update BucketManager conditional rendering

### DIFF
--- a/src/components/BucketManager.vue
+++ b/src/components/BucketManager.vue
@@ -20,20 +20,26 @@
       class="q-mb-md"
     />
     <q-list padding>
-      <template v-if="filteredBuckets.length">
-        <div
-          v-for="bucket in filteredBuckets"
-          :key="bucket.id"
-          class="q-mb-md"
-        >
-          <BucketCard
-            :bucket="bucket"
-            :balance="bucketBalances[bucket.id] || 0"
-            :activeUnit="activeUnit.value"
-            @edit="openEdit"
-            @delete="openDelete"
-            @drop="handleDrop($event, bucket.id)"
-          />
+      <template v-if="hasUserBuckets">
+        <template v-if="filteredBuckets.length">
+          <div
+            v-for="bucket in filteredBuckets"
+            :key="bucket.id"
+            class="q-mb-md"
+            v-show="!(onlyDefaultBucket && bucket.id === DEFAULT_BUCKET_ID && (bucketBalances[bucket.id] || 0) === 0)"
+          >
+            <BucketCard
+              :bucket="bucket"
+              :balance="bucketBalances[bucket.id] || 0"
+              :activeUnit="activeUnit.value"
+              @edit="openEdit"
+              @delete="openDelete"
+              @drop="handleDrop($event, bucket.id)"
+            />
+          </div>
+        </template>
+        <div v-else class="text-grey-5 text-center q-pa-md">
+          {{ $t('bucket.no_results') }}
         </div>
       </template>
       <BucketsEmptyState v-else @add="openAdd" />
@@ -206,6 +212,23 @@ export default defineComponent({
       return arr;
     });
 
+    const hasUserBuckets = computed(() =>
+      bucketList.value.some((b) => b.id !== DEFAULT_BUCKET_ID)
+    );
+
+    const onlyDefaultBucket = computed(
+      () =>
+        bucketList.value.length === 1 &&
+        bucketList.value[0].id === DEFAULT_BUCKET_ID
+    );
+
+    const noResults = computed(
+      () =>
+        hasUserBuckets.value &&
+        filteredBuckets.value.length === 0 &&
+        search.value.trim().length > 0
+    );
+
     const formatCurrency = (amount, unit) => {
       return uiStore.formatCurrency(amount, unit);
     };
@@ -288,6 +311,9 @@ export default defineComponent({
       search,
       sortBy,
       filteredBuckets,
+      hasUserBuckets,
+      onlyDefaultBucket,
+      noResults,
       activeUnit,
       showForm,
       dialogOpen,

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1638,6 +1638,7 @@ export const messages = {
     description: "Description",
     search: "Search buckets",
     empty: "No buckets yet. Tap + to add your first one.",
+    no_results: "No buckets match your search.",
     moved: "Tokens moved to bucket",
   },
 };


### PR DESCRIPTION
## Summary
- add search result helpers and computed logic in BucketManager
- hide default bucket when it has no balance
- show message if no buckets match search
- add English translation for empty search results

## Testing
- `pnpm lint` *(fails: Invalid option '--ext')*
- `pnpm test` *(fails: 24 test files failed)*

------
https://chatgpt.com/codex/tasks/task_e_68729c86a5508330b6cb384796f2c87d