### PR TITLE
Add comment about permanent unassigned bucket

### DIFF
--- a/src/stores/buckets.ts
+++ b/src/stores/buckets.ts
@@ -27,6 +27,8 @@ export type BucketRule = {
 export const DEFAULT_BUCKET_ID = "unassigned";
 export const DEFAULT_BUCKET_NAME = "Default";
 
+// The "unassigned" bucket is permanent. Users cannot delete or rename it
+// because it holds tokens not explicitly allocated.
 function ensureDefaultBucket(buckets: { value: Bucket[] }) {
   if (!buckets.value.find((b) => b.id === DEFAULT_BUCKET_ID)) {
     buckets.value.unshift({ id: DEFAULT_BUCKET_ID, name: DEFAULT_BUCKET_NAME });


### PR DESCRIPTION
## Summary
- document that the `unassigned` bucket cannot be renamed or deleted

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: Invalid Version: file:./src/lib/cashu-ts)*

------
https://chatgpt.com/codex/tasks/task_e_6872a21e85e08330a4e780dff4b59277