### PR TITLE
Add bucket no_results translations

### DIFF
--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -1415,6 +1415,7 @@ export default {
     description: "Description",
     search: "Search buckets",
     empty: "No buckets yet. Tap + to add your first one.",
+    no_results: "No buckets match your search.",
     moved: "Tokens moved to bucket",
   },
   SubscriptionsOverview: {

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -1421,6 +1421,7 @@ export default {
     description: "Description",
     search: "Search buckets",
     empty: "No buckets yet. Tap + to add your first one.",
+    no_results: "No buckets match your search.",
     moved: "Tokens moved to bucket",
   },
   SubscriptionsOverview: {

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -1425,6 +1425,7 @@ export default {
     description: "Description",
     search: "Search buckets",
     empty: "No buckets yet. Tap + to add your first one.",
+    no_results: "No buckets match your search.",
     moved: "Tokens moved to bucket",
   },
   SubscriptionsOverview: {

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -1422,6 +1422,7 @@ export default {
     description: "Description",
     search: "Search buckets",
     empty: "No buckets yet. Tap + to add your first one.",
+    no_results: "No buckets match your search.",
     moved: "Tokens moved to bucket",
   },
   SubscriptionsOverview: {

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -1412,6 +1412,7 @@ export default {
     description: "Description",
     search: "Search buckets",
     empty: "No buckets yet. Tap + to add your first one.",
+    no_results: "No buckets match your search.",
     moved: "Tokens moved to bucket",
   },
   SubscriptionsOverview: {

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -1404,6 +1404,7 @@ export default {
     description: "Description",
     search: "Search buckets",
     empty: "No buckets yet. Tap + to add your first one.",
+    no_results: "No buckets match your search.",
     moved: "Tokens moved to bucket",
   },
   SubscriptionsOverview: {

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -1405,6 +1405,7 @@ export default {
     description: "Description",
     search: "Search buckets",
     empty: "No buckets yet. Tap + to add your first one.",
+    no_results: "No buckets match your search.",
     moved: "Tokens moved to bucket",
   },
   SubscriptionsOverview: {

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -1404,6 +1404,7 @@ export default {
     description: "Description",
     search: "Search buckets",
     empty: "No buckets yet. Tap + to add your first one.",
+    no_results: "No buckets match your search.",
     moved: "Tokens moved to bucket",
   },
   SubscriptionsOverview: {

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -1402,6 +1402,7 @@ export default {
     description: "Description",
     search: "Search buckets",
     empty: "No buckets yet. Tap + to add your first one.",
+    no_results: "No buckets match your search.",
     moved: "Tokens moved to bucket",
   },
   SubscriptionsOverview: {

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -1407,6 +1407,7 @@ export default {
     description: "Description",
     search: "Search buckets",
     empty: "No buckets yet. Tap + to add your first one.",
+    no_results: "No buckets match your search.",
     moved: "Tokens moved to bucket",
   },
   SubscriptionsOverview: {

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -1394,6 +1394,7 @@ export default {
     description: "Description",
     search: "Search buckets",
     empty: "No buckets yet. Tap + to add your first one.",
+    no_results: "No buckets match your search.",
     moved: "Tokens moved to bucket",
   },
   SubscriptionsOverview: {


### PR DESCRIPTION
## Summary
- add missing "no_results" bucket message to all languages

## Testing
- `pnpm test` *(fails: "Tests failed. Watching for file changes...")*

------
https://chatgpt.com/codex/tasks/task_e_6872a2dd0c608330b418c58879fae924