### PR TITLE
Fix bucket manager view

### DIFF
--- a/src/components/BucketManager.vue
+++ b/src/components/BucketManager.vue
@@ -20,39 +20,38 @@
       class="q-mb-md"
     />
     <q-list padding>
-      <template v-if="hasUserBuckets">
-        <template v-if="filteredBuckets.length">
-          <div
-            v-for="bucket in filteredBuckets"
-            :key="bucket.id"
-            class="q-mb-md"
-            v-show="!(onlyDefaultBucket && bucket.id === DEFAULT_BUCKET_ID && (bucketBalances[bucket.id] || 0) === 0)"
-          >
-            <BucketCard
-              :bucket="bucket"
-              :balance="bucketBalances[bucket.id] || 0"
-              :activeUnit="activeUnit.value"
-              @edit="openEdit"
-              @delete="openDelete"
-              @drop="handleDrop($event, bucket.id)"
-            />
-          </div>
-        </template>
-        <div v-else class="text-grey-5 text-center q-pa-md">
-          {{ $t('bucket.no_results') }}
+      <template v-if="!hasUserBuckets">
+        <BucketsEmptyState @add="openAdd" />
+      </template>
+
+      <template v-else-if="noResults">
+        <div class="column items-center text-grey-5 q-pa-md">
+          <q-icon name="search_off" size="32px" class="q-mb-xs"/>
+          <div class="text-caption">{{ $t('bucket.no_results') }}</div>
         </div>
       </template>
-      <BucketsEmptyState v-else @add="openAdd" />
+
+      <template v-else>
+        <div v-for="bucket in filteredBuckets"
+             :key="bucket.id"
+             class="q-mb-md">
+          <BucketCard
+            :bucket="bucket"
+            :balance="bucketBalances[bucket.id] || 0"
+            :activeUnit="activeUnit.value"
+            @edit="openEdit"
+            @delete="openDelete"
+            @drop="handleDrop($event, bucket.id)"
+          />
+        </div>
+      </template>
     </q-list>
-    <q-btn
-      fab
-      icon="add"
-      color="primary"
-      glossy
-      unelevated
-      class="fab-add-bucket"
-      @click="openAdd"
-    />
+
+    <q-page-sticky position="bottom-right" :offset="[32,32]">
+      <q-btn fab icon="add" color="primary" glossy unelevated
+             :aria-label="$t('BucketManager.actions.add')"
+             @click="openAdd"/>
+    </q-page-sticky>
     <q-dialog v-model="showForm">
     <q-card class="q-pa-lg" style="max-width: 500px">
       <h6 class="q-mt-none q-mb-md">{{ formTitle }}</h6>
@@ -358,17 +357,3 @@ export default defineComponent({
 });
 </script>
 
-<style scoped>
-.fab-add-bucket {
-  position: fixed;
-  right: 32px;
-  bottom: 80px;
-  z-index: 1101;
-}
-@media (max-width: 599px) {
-  .fab-add-bucket {
-    right: 16px;
-    bottom: 70px;
-  }
-}
-</style>

--- a/src/components/BucketsEmptyState.vue
+++ b/src/components/BucketsEmptyState.vue
@@ -3,7 +3,8 @@
      <q-icon name="inventory_2" size="72px" />
      <div class="text-subtitle2 q-mt-md">{{ $t('bucket.empty') }}</div>
      <q-btn color="primary" icon="add" class="q-mt-md"
-            @click="$emit('add')" label="Add bucket"/>
+            :label="$t('BucketManager.actions.add')"
+            @click="$emit('add')" />
   </div>
 </template>
 

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1646,6 +1646,6 @@ export const messages = {
 export default {
   ...(defaultLang as any),
   ...messages,
-  BucketManager: { ...messages.BucketManager, helper: { intro: "" } },
+  BucketManager: messages.BucketManager,
   MoveTokens: { ...messages.MoveTokens, title: "", helper: "" },
 };


### PR DESCRIPTION
## Summary
- update BucketManager template to correctly handle empty or filtered states
- add q-page-sticky FAB
- remove CSS overrides and show default helper text
- hook up EmptyState add button to translation

## Testing
- `pnpm run test:ci` *(fails: 25 failed, 24 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6872b67bcae88330bd6eb4a027559352