### PR TITLE
Enhance bucket UI

### DIFF
--- a/src/components/BucketCard.vue
+++ b/src/components/BucketCard.vue
@@ -1,5 +1,8 @@
 <template>
-  <q-card class="shadow-2 rounded-borders bg-grey-9 text-white">
+  <q-card
+    class="shadow-2 rounded-borders text-white"
+    :style="{ backgroundColor: bucket.color || DEFAULT_COLOR }"
+  >
     <router-link
       :to="`/buckets/${bucket.id}`"
       style="text-decoration: none; display: block"
@@ -24,11 +27,12 @@
                 / {{ formatCurrency(bucket.goal, activeUnit) }}
               </span>
             </span>
-            <q-linear-progress
+            <q-circular-progress
               v-if="bucket.goal"
-              color="primary"
-              :value="Math.min((balance || 0) / bucket.goal, 1)"
-              style="width: 50px; height: 4px"
+              :value="Math.min((balance || 0) / bucket.goal, 1) * 100"
+              size="28px"
+              track-color="grey-5"
+              :color="bucket.color || 'primary'"
               class="q-ml-sm"
             />
           </q-item-label>
@@ -72,6 +76,7 @@ import { useI18n } from 'vue-i18n';
 import InfoTooltip from './InfoTooltip.vue';
 import { DEFAULT_BUCKET_ID } from 'stores/buckets';
 import { useUiStore } from 'stores/ui';
+import { DEFAULT_COLOR } from 'src/js/constants';
 
 export default defineComponent({
   name: 'BucketCard',
@@ -98,6 +103,7 @@ export default defineComponent({
       emitEdit,
       emitDelete,
       DEFAULT_BUCKET_ID,
+      DEFAULT_COLOR,
       t,
     };
   }

--- a/src/components/BucketManager.vue
+++ b/src/components/BucketManager.vue
@@ -1,13 +1,24 @@
 <template>
   <div style="max-width: 800px; margin: 0 auto">
     <div class="text-body2 q-mb-md">{{ $t("BucketManager.helper.intro") }}</div>
+    <q-input
+      v-model="search"
+      dense
+      debounce="300"
+      outlined
+      class="q-mb-md"
+      :placeholder="$t('global.actions.search.label')"
+    />
     <q-list padding>
       <div
-        v-for="bucket in bucketList"
+        v-for="bucket in filteredBuckets"
         :key="bucket.id"
         class="q-mb-md"
         @dragover.prevent
+        @dragenter="draggedOverId = bucket.id"
+        @dragleave="draggedOverId = null"
         @drop="handleDrop($event, bucket.id)"
+        :class="{ 'drag-over': draggedOverId === bucket.id }"
       >
         <BucketCard
           :bucket="bucket"
@@ -178,6 +189,21 @@ export default defineComponent({
 
     const bucketList = computed(() => bucketsStore.bucketList);
     const bucketBalances = computed(() => bucketsStore.bucketBalances);
+    const search = ref("");
+    const draggedOverId = ref<string | null>(null);
+    const filteredBuckets = computed(() => {
+      const term = search.value.toLowerCase();
+      const list = bucketList.value.filter((b) =>
+        b.name.toLowerCase().includes(term)
+      );
+      list.sort((a, b) => a.name.localeCompare(b.name));
+      const idx = list.findIndex((b) => b.id === DEFAULT_BUCKET_ID);
+      if (idx > -1) {
+        const def = list.splice(idx, 1)[0];
+        list.unshift(def);
+      }
+      return list;
+    });
 
     const formatCurrency = (amount, unit) => {
       return uiStore.formatCurrency(amount, unit);
@@ -270,8 +296,18 @@ export default defineComponent({
       deleteBucket,
       formatCurrency,
       handleDrop,
+      search,
+      filteredBuckets,
+      draggedOverId,
       DEFAULT_COLOR,
     };
   },
 });
 </script>
+
+<style scoped>
+.drag-over {
+  border: 2px dashed #aaa;
+  border-radius: 8px;
+}
+</style>


### PR DESCRIPTION
## Summary
- make bucket cards adopt the chosen color and show a circular progress bar
- highlight buckets on drag-over
- support searching and alphabetic sort in BucketManager

## Testing
- `npx --yes vitest run` *(fails: Cannot find module 'vitest/config')*

------
https://chatgpt.com/codex/tasks/task_e_68733703bbc88330ad50a43dd53661ec