### PR TITLE
Enable bucket filtering

### DIFF
--- a/src/components/BucketManager.vue
+++ b/src/components/BucketManager.vue
@@ -1,9 +1,16 @@
 <template>
   <div style="max-width: 800px; margin: 0 auto">
     <div class="text-body2 q-mb-md">{{ $t("BucketManager.helper.intro") }}</div>
+    <q-input
+      v-model="searchTerm"
+      outlined
+      dense
+      class="q-mb-md"
+      :placeholder="$t('bucketManager.inputs.search.placeholder')"
+    />
     <q-list padding>
       <div
-        v-for="bucket in bucketList"
+        v-for="bucket in filteredBuckets"
         :key="bucket.id"
         class="q-mb-md"
         @dragover.prevent
@@ -177,6 +184,13 @@ export default defineComponent({
     });
 
     const bucketList = computed(() => bucketsStore.bucketList);
+    const searchTerm = ref("");
+    const filteredBuckets = computed(() => {
+      const term = searchTerm.value.toLowerCase();
+      return bucketList.value.filter((b) =>
+        b.name.toLowerCase().includes(term)
+      );
+    });
     const bucketBalances = computed(() => bucketsStore.bucketBalances);
 
     const formatCurrency = (amount, unit) => {
@@ -253,6 +267,8 @@ export default defineComponent({
     return {
       DEFAULT_BUCKET_ID,
       bucketList,
+      searchTerm,
+      filteredBuckets,
       bucketBalances,
       activeUnit,
       showForm,

--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -1397,6 +1397,11 @@ export default {
   bucketManager: {
     actions: { add: "Add bucket" },
     addDialog: { title: "Create new bucket" },
+    inputs: {
+      search: {
+        placeholder: "Search buckets",
+      },
+    },
   },
   bucket: {
     name: "Name",

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -1403,6 +1403,11 @@ export default {
   bucketManager: {
     actions: { add: "Add bucket" },
     addDialog: { title: "Create new bucket" },
+    inputs: {
+      search: {
+        placeholder: "Search buckets",
+      },
+    },
   },
   bucket: {
     name: "Name",

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -1407,6 +1407,11 @@ export default {
   bucketManager: {
     actions: { add: "Add bucket" },
     addDialog: { title: "Create new bucket" },
+    inputs: {
+      search: {
+        placeholder: "Search buckets",
+      },
+    },
   },
   bucket: {
     name: "Name",

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1627,6 +1627,11 @@ export const messages = {
   bucketManager: {
     actions: { add: "Add bucket" },
     addDialog: { title: "Create new bucket" },
+    inputs: {
+      search: {
+        placeholder: "Search buckets",
+      },
+    },
   },
   bucket: {
     name: "Name",

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -1404,6 +1404,11 @@ export default {
   bucketManager: {
     actions: { add: "Add bucket" },
     addDialog: { title: "Create new bucket" },
+    inputs: {
+      search: {
+        placeholder: "Search buckets",
+      },
+    },
   },
   bucket: {
     name: "Name",

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -1394,6 +1394,11 @@ export default {
   bucketManager: {
     actions: { add: "Add bucket" },
     addDialog: { title: "Create new bucket" },
+    inputs: {
+      search: {
+        placeholder: "Search buckets",
+      },
+    },
   },
   bucket: {
     name: "Name",

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -1386,6 +1386,11 @@ export default {
   bucketManager: {
     actions: { add: "Add bucket" },
     addDialog: { title: "Create new bucket" },
+    inputs: {
+      search: {
+        placeholder: "Search buckets",
+      },
+    },
   },
   bucket: {
     name: "Name",

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -1387,6 +1387,11 @@ export default {
   bucketManager: {
     actions: { add: "Add bucket" },
     addDialog: { title: "Create new bucket" },
+    inputs: {
+      search: {
+        placeholder: "Search buckets",
+      },
+    },
   },
   bucket: {
     name: "Name",

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -1386,6 +1386,11 @@ export default {
   bucketManager: {
     actions: { add: "Add bucket" },
     addDialog: { title: "Create new bucket" },
+    inputs: {
+      search: {
+        placeholder: "Search buckets",
+      },
+    },
   },
   bucket: {
     name: "Name",

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -1384,6 +1384,11 @@ export default {
   bucketManager: {
     actions: { add: "Add bucket" },
     addDialog: { title: "Create new bucket" },
+    inputs: {
+      search: {
+        placeholder: "Search buckets",
+      },
+    },
   },
   bucket: {
     name: "Name",

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -1389,6 +1389,11 @@ export default {
   bucketManager: {
     actions: { add: "Add bucket" },
     addDialog: { title: "Create new bucket" },
+    inputs: {
+      search: {
+        placeholder: "Search buckets",
+      },
+    },
   },
   bucket: {
     name: "Name",

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -1376,6 +1376,11 @@ export default {
   bucketManager: {
     actions: { add: "Add bucket" },
     addDialog: { title: "Create new bucket" },
+    inputs: {
+      search: {
+        placeholder: "Search buckets",
+      },
+    },
   },
   bucket: {
     name: "Name",

--- a/test/vitest/__tests__/bucketManagerForm.spec.ts
+++ b/test/vitest/__tests__/bucketManagerForm.spec.ts
@@ -2,13 +2,18 @@ import { describe, it, expect, vi } from "vitest";
 import { shallowMount } from "@vue/test-utils";
 import BucketManager from "../../../src/components/BucketManager.vue";
 
+const mockBuckets = [
+  { id: "b1", name: "Alpha" },
+  { id: "b2", name: "Beta" },
+];
+
 vi.mock("../../../src/stores/proofs", () => ({
   useProofsStore: () => ({ moveProofs: vi.fn() }),
 }));
 
 vi.mock("../../../src/stores/buckets", () => ({
   useBucketsStore: () => ({
-    bucketList: [],
+    bucketList: mockBuckets,
     bucketBalances: {},
     addBucket: vi.fn(),
     editBucket: vi.fn(),
@@ -36,5 +41,13 @@ describe("BucketManager form", () => {
     vm.openAdd();
     await wrapper.vm.$nextTick();
     expect(wrapper.find("info-tooltip-stub").exists()).toBe(true);
+  });
+
+  it("filters buckets by search term", async () => {
+    const wrapper = shallowMount(BucketManager);
+    expect(wrapper.findAll("bucket-card-stub").length).toBe(2);
+    (wrapper.vm as any).searchTerm = "Beta";
+    await wrapper.vm.$nextTick();
+    expect(wrapper.findAll("bucket-card-stub").length).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- allow searching buckets in BucketManager
- add placeholder translations for the new search field
- test bucket filtering logic

## Testing
- `pnpm test` *(fails: multiple tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_687341f8cf2c8330bc8a8c3f6442d53f