### PR TITLE
Improve bucket page layout

### DIFF
--- a/src/components/BucketCard.vue
+++ b/src/components/BucketCard.vue
@@ -42,26 +42,26 @@
             round
             size="sm"
             @click.stop.prevent="emitEdit"
+            label="Edit"
             aria-label="Edit"
-            title="Edit"
-          />
-          <InfoTooltip
-            class="q-ml-xs"
-            :text="$t('BucketManager.tooltips.edit_button')"
-          />
+          >
+            <q-tooltip>{{
+              $t("BucketManager.tooltips.edit_button")
+            }}</q-tooltip>
+          </q-btn>
           <q-btn
             icon="delete"
             flat
             round
             size="sm"
             @click.stop.prevent="emitDelete"
+            label="Delete"
             :aria-label="$t('BucketManager.actions.delete')"
-            :title="$t('BucketManager.actions.delete')"
-          />
-          <InfoTooltip
-            class="q-ml-xs"
-            :text="$t('BucketManager.tooltips.delete_button')"
-          />
+          >
+            <q-tooltip>{{
+              $t("BucketManager.tooltips.delete_button")
+            }}</q-tooltip>
+          </q-btn>
         </q-item-section>
       </q-item>
     </router-link>
@@ -71,14 +71,12 @@
 <script lang="ts">
 import { defineComponent, computed } from "vue";
 import { useI18n } from "vue-i18n";
-import InfoTooltip from "./InfoTooltip.vue";
 import { DEFAULT_BUCKET_ID } from "stores/buckets";
 import { useUiStore } from "stores/ui";
 import { DEFAULT_COLOR } from "src/js/constants";
 
 export default defineComponent({
   name: "BucketCard",
-  components: { InfoTooltip },
   props: {
     bucket: { type: Object as () => any, required: true },
     balance: { type: Number, default: 0 },

--- a/src/components/BucketDialog.vue
+++ b/src/components/BucketDialog.vue
@@ -1,6 +1,6 @@
 <template>
   <q-dialog v-model="showLocal" persistent>
-    <q-card class="q-pa-lg" style="max-width: 500px">
+    <q-card class="q-pa-lg" style="max-width: 90vw">
       <q-form @submit.prevent="save">
         <q-input
           v-model="form.name"
@@ -31,15 +31,11 @@
           class="q-mb-sm"
         />
         <div class="row q-mt-md">
-          <q-btn
-            color="primary"
-            :disable="!canSave"
-            @click="save"
-          >
-            {{ t('global.actions.save.label') }}
+          <q-btn color="primary" :disable="!canSave" @click="save">
+            {{ t("global.actions.save.label") }}
           </q-btn>
           <q-btn flat color="grey" class="q-ml-auto" v-close-popup>
-            {{ t('global.actions.cancel.label') }}
+            {{ t("global.actions.cancel.label") }}
           </q-btn>
         </div>
       </q-form>
@@ -48,47 +44,47 @@
 </template>
 
 <script setup lang="ts">
-import { computed, reactive } from 'vue'
-import { useI18n } from 'vue-i18n'
-import { useBucketsStore } from 'stores/buckets'
-import { DEFAULT_COLOR } from 'src/js/constants'
+import { computed, reactive } from "vue";
+import { useI18n } from "vue-i18n";
+import { useBucketsStore } from "stores/buckets";
+import { DEFAULT_COLOR } from "src/js/constants";
 
-const props = defineProps<{ modelValue: boolean }>()
-const emit = defineEmits(['update:modelValue'])
+const props = defineProps<{ modelValue: boolean }>();
+const emit = defineEmits(["update:modelValue"]);
 
 const showLocal = computed({
   get: () => props.modelValue,
-  set: (val: boolean) => emit('update:modelValue', val)
-})
+  set: (val: boolean) => emit("update:modelValue", val),
+});
 
 const form = reactive({
-  name: '',
+  name: "",
   color: DEFAULT_COLOR,
   goal: null as number | null,
-  desc: ''
-})
+  desc: "",
+});
 
-const { t } = useI18n()
-const buckets = useBucketsStore()
+const { t } = useI18n();
+const buckets = useBucketsStore();
 
-const canSave = computed(() => form.name.trim().length > 0)
+const canSave = computed(() => form.name.trim().length > 0);
 
-function reset () {
-  form.name = ''
-  form.color = DEFAULT_COLOR
-  form.goal = null
-  form.desc = ''
+function reset() {
+  form.name = "";
+  form.color = DEFAULT_COLOR;
+  form.goal = null;
+  form.desc = "";
 }
 
-function save () {
-  if (!canSave.value) return
+function save() {
+  if (!canSave.value) return;
   buckets.addBucket({
     name: form.name,
     color: form.color,
     goal: form.goal ?? undefined,
-    description: form.desc
-  })
-  emit('update:modelValue', false)
-  reset()
+    description: form.desc,
+  });
+  emit("update:modelValue", false);
+  reset();
 }
 </script>

--- a/src/components/BucketManager.vue
+++ b/src/components/BucketManager.vue
@@ -1,5 +1,5 @@
 <template>
-  <div style="max-width: 800px; margin: 0 auto">
+  <div class="q-px-md">
     <div class="text-body2 q-mb-md">{{ $t("BucketManager.helper.intro") }}</div>
     <q-input
       v-model="searchTerm"
@@ -28,22 +28,19 @@
         />
       </div>
     </transition-group>
-    <div class="row q-col-gutter-md q-mt-md">
-      <div class="col-12 col-sm-6 col-md-4">
+    <q-page-sticky position="bottom" expand class="bg-grey-1">
+      <div class="row justify-center q-gutter-sm q-pa-sm">
         <q-btn
           color="primary"
           icon="add"
           outline
-          class="full-width"
           @click="openAdd"
           :label="$t('bucketManager.actions.add')"
         >
           <q-tooltip>{{ $t("BucketManager.tooltips.add_button") }}</q-tooltip>
         </q-btn>
-      </div>
-      <div class="col-12 col-sm-6 col-md-4">
         <router-link to="/move-tokens" style="text-decoration: none">
-          <q-btn color="primary" outline class="full-width">
+          <q-btn color="primary" outline>
             {{ $t("BucketDetail.move") }}
             <q-tooltip>{{
               $t("BucketManager.tooltips.move_button")
@@ -51,11 +48,11 @@
           </q-btn>
         </router-link>
       </div>
-    </div>
+    </q-page-sticky>
   </div>
 
   <q-dialog v-model="showForm">
-    <q-card class="q-pa-lg" style="max-width: 500px">
+    <q-card class="q-pa-lg" style="max-width: 90vw">
       <h6 class="q-mt-none q-mb-md">{{ formTitle }}</h6>
       <q-form ref="bucketForm">
         <q-input
@@ -81,7 +78,7 @@
         >
           <template #label>
             <div class="row items-center no-wrap">
-              <span>{{ $t('bucket.description') }}</span>
+              <span>{{ $t("bucket.description") }}</span>
               <InfoTooltip
                 class="q-ml-xs"
                 :text="$t('BucketManager.tooltips.description')"
@@ -98,7 +95,7 @@
         >
           <template #label>
             <div class="row items-center no-wrap">
-              <span>{{ $t('bucket.goal') }}</span>
+              <span>{{ $t("bucket.goal") }}</span>
               <InfoTooltip
                 class="q-ml-xs"
                 :text="$t('BucketManager.tooltips.goal')"
@@ -190,7 +187,7 @@ export default defineComponent({
     const filteredBuckets = computed(() => {
       const term = searchTerm.value.toLowerCase();
       return bucketList.value.filter((b) =>
-        b.name.toLowerCase().includes(term)
+        b.name.toLowerCase().includes(term),
       );
     });
     const bucketBalances = computed(() => bucketsStore.bucketBalances);
@@ -283,7 +280,7 @@ export default defineComponent({
       bucketForm,
       nameRules,
       goalRules,
-      formTitle: computed(() => t('BucketManager.actions.edit')),
+      formTitle: computed(() => t("BucketManager.actions.edit")),
       openAdd,
       openEdit,
       saveBucket,
@@ -301,7 +298,7 @@ export default defineComponent({
 <style scoped>
 .bucket-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
   gap: 16px;
 }
 

--- a/src/pages/Buckets.vue
+++ b/src/pages/Buckets.vue
@@ -1,12 +1,10 @@
 <template>
-  <div
-    :class="[
-      $q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark',
-      'text-center q-pa-md flex flex-center',
-    ]"
+  <q-page
+    class="q-pa-md"
+    :class="$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark'"
   >
     <BucketManager />
-  </div>
+  </q-page>
 </template>
 
 <script>


### PR DESCRIPTION
## Summary
- use `<q-page>` wrapper for buckets page
- expand BucketManager grid and add sticky action bar
- label edit/delete buttons for accessibility
- make bucket dialogs responsive

## Testing
- `npx prettier -w src/pages/Buckets.vue src/components/BucketManager.vue src/components/BucketCard.vue src/components/BucketDialog.vue`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873541366b4833099bd1d0f9337cf29