### PR TITLE
Improve Buckets UI layout

### DIFF
--- a/src/components/BucketCard.vue
+++ b/src/components/BucketCard.vue
@@ -42,13 +42,10 @@
             round
             size="sm"
             @click.stop.prevent="emitEdit"
-            aria-label="Edit"
-            title="Edit"
-          />
-          <InfoTooltip
-            class="q-ml-xs"
-            :text="$t('BucketManager.tooltips.edit_button')"
-          />
+            :aria-label="$t('BucketManager.actions.edit')"
+          >
+            <q-tooltip>{{ $t('BucketManager.tooltips.edit_button') }}</q-tooltip>
+          </q-btn>
           <q-btn
             icon="delete"
             flat
@@ -56,12 +53,9 @@
             size="sm"
             @click.stop.prevent="emitDelete"
             :aria-label="$t('BucketManager.actions.delete')"
-            :title="$t('BucketManager.actions.delete')"
-          />
-          <InfoTooltip
-            class="q-ml-xs"
-            :text="$t('BucketManager.tooltips.delete_button')"
-          />
+          >
+            <q-tooltip>{{ $t('BucketManager.tooltips.delete_button') }}</q-tooltip>
+          </q-btn>
         </q-item-section>
       </q-item>
     </router-link>
@@ -71,14 +65,13 @@
 <script lang="ts">
 import { defineComponent, computed } from "vue";
 import { useI18n } from "vue-i18n";
-import InfoTooltip from "./InfoTooltip.vue";
 import { DEFAULT_BUCKET_ID } from "stores/buckets";
 import { useUiStore } from "stores/ui";
 import { DEFAULT_COLOR } from "src/js/constants";
 
 export default defineComponent({
   name: "BucketCard",
-  components: { InfoTooltip },
+  components: {},
   props: {
     bucket: { type: Object as () => any, required: true },
     balance: { type: Number, default: 0 },

--- a/src/components/BucketDialog.vue
+++ b/src/components/BucketDialog.vue
@@ -1,6 +1,6 @@
 <template>
   <q-dialog v-model="showLocal" persistent>
-    <q-card class="q-pa-lg" style="max-width: 500px">
+    <q-card class="q-pa-lg" style="max-width: 90vw">
       <q-form @submit.prevent="save">
         <q-input
           v-model="form.name"

--- a/src/components/BucketManager.vue
+++ b/src/components/BucketManager.vue
@@ -1,5 +1,5 @@
 <template>
-  <div style="max-width: 800px; margin: 0 auto">
+  <div>
     <div class="text-body2 q-mb-md">{{ $t("BucketManager.helper.intro") }}</div>
     <q-input
       v-model="searchTerm"
@@ -28,34 +28,31 @@
         />
       </div>
     </transition-group>
-    <div class="row q-col-gutter-md q-mt-md">
-      <div class="col-12 col-sm-6 col-md-4">
+    <q-page-sticky position="bottom" expand class="bg-grey-9">
+      <div class="q-pa-sm row justify-center q-gutter-sm">
         <q-btn
           color="primary"
           icon="add"
           outline
-          class="full-width"
           @click="openAdd"
-          :label="$t('bucketManager.actions.add')"
         >
-          <q-tooltip>{{ $t("BucketManager.tooltips.add_button") }}</q-tooltip>
+          {{ $t('bucketManager.actions.add') }}
+          <q-tooltip>{{ $t('BucketManager.tooltips.add_button') }}</q-tooltip>
         </q-btn>
-      </div>
-      <div class="col-12 col-sm-6 col-md-4">
         <router-link to="/move-tokens" style="text-decoration: none">
-          <q-btn color="primary" outline class="full-width">
-            {{ $t("BucketDetail.move") }}
+          <q-btn color="primary" outline>
+            {{ $t('BucketDetail.move') }}
             <q-tooltip>{{
-              $t("BucketManager.tooltips.move_button")
+              $t('BucketManager.tooltips.move_button')
             }}</q-tooltip>
           </q-btn>
         </router-link>
       </div>
-    </div>
+    </q-page-sticky>
   </div>
 
   <q-dialog v-model="showForm">
-    <q-card class="q-pa-lg" style="max-width: 500px">
+    <q-card class="q-pa-lg" style="max-width: 90vw">
       <h6 class="q-mt-none q-mb-md">{{ formTitle }}</h6>
       <q-form ref="bucketForm">
         <q-input
@@ -130,7 +127,7 @@
   </q-dialog>
 
   <q-dialog v-model="showDelete">
-    <q-card class="q-pa-md" style="max-width: 400px">
+    <q-card class="q-pa-md" style="max-width: 90vw">
       <q-card-section class="row items-center">
         <q-icon name="warning" color="red" size="2rem" />
         <span class="q-ml-sm">{{
@@ -301,7 +298,7 @@ export default defineComponent({
 <style scoped>
 .bucket-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
   gap: 16px;
 }
 

--- a/src/pages/Buckets.vue
+++ b/src/pages/Buckets.vue
@@ -1,12 +1,12 @@
 <template>
-  <div
+  <q-page
     :class="[
       $q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark',
-      'text-center q-pa-md flex flex-center',
+      'q-pa-md',
     ]"
   >
     <BucketManager />
-  </div>
+  </q-page>
 </template>
 
 <script>


### PR DESCRIPTION
## Summary
- make buckets page fill full width using `<q-page>`
- allow bucket dialogs to scale on small screens
- move bucket actions to sticky toolbar
- increase card grid width
- show tooltips for edit/delete icons

## Testing
- `pnpm run test:ci` *(fails: Notify.create is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6873541366b4833099bd1d0f9337cf29