### PR TITLE
Fix BucketManager export

### DIFF
--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1644,6 +1644,9 @@ export const messages = {
 export default {
   ...(defaultLang as any),
   ...messages,
-  BucketManager: { helper: { intro: "" } },
+  BucketManager: {
+    ...messages.BucketManager,
+    helper: { intro: "" },
+  },
   MoveTokens: { title: "", helper: "" },
 };


### PR DESCRIPTION
## Summary
- combine BucketManager message keys when exporting en-US locale file

## Testing
- `npx vitest run` *(fails: Cannot find module 'vitest/config')*

------
https://chatgpt.com/codex/tasks/task_e_68735cac979883309805fa0201f856a6