### PR TITLE
Add bucket dialog title

### DIFF
--- a/src/components/BucketDialog.vue
+++ b/src/components/BucketDialog.vue
@@ -1,6 +1,11 @@
 <template>
   <q-dialog v-model="showLocal" persistent>
     <q-card class="q-pa-lg" style="max-width: 90vw">
+      <q-card-section>
+        <h6 class="q-mt-none q-mb-md">
+          {{ t('bucketManager.addDialog.title') }}
+        </h6>
+      </q-card-section>
       <q-form ref="formRef" @submit.prevent="save">
         <q-input
           v-model="form.name"

--- a/test/vitest/__tests__/bucketDialog.spec.ts
+++ b/test/vitest/__tests__/bucketDialog.spec.ts
@@ -49,6 +49,19 @@ describe("BucketDialog", () => {
     expect(addBucketMock).toHaveBeenCalled();
     expect(wrapper.emitted()["update:modelValue"][0]).toEqual([false]);
   });
+
+  it("displays title when creating new bucket", () => {
+    const i18n = createI18n({
+      legacy: false,
+      locale: "en",
+      messages: { en: { bucketManager: { addDialog: { title: "Create new bucket" } } } },
+    });
+    const wrapper = mount(BucketDialog, {
+      props: { modelValue: true },
+      global: { plugins: [i18n] },
+    });
+    expect(wrapper.text()).toContain("Create new bucket");
+  });
 });
 
 describe("BucketManager", () => {


### PR DESCRIPTION
## Summary
- show bucket creation title in BucketDialog
- test for title translation

## Testing
- `pnpm run test:ci` *(fails: 23 failed, 25 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68736107f4d08330a30e8d8f7e7ba7c9