### PR TITLE
Improve bucket dialog UX

### DIFF
--- a/src/components/BucketDialog.vue
+++ b/src/components/BucketDialog.vue
@@ -1,52 +1,73 @@
 <template>
   <q-dialog v-model="showLocal" persistent>
-    <q-card class="q-pa-lg" style="max-width: 90vw">
+    <q-card class="q-pa-lg" style="max-width: 600px; width: 100%">
       <q-card-section>
         <h6 class="q-mt-none q-mb-md">
           {{ t('bucketManager.addDialog.title') }}
         </h6>
+        <div class="text-body2 q-mb-md">
+          {{ t('BucketManager.helper.intro') }}
+        </div>
       </q-card-section>
-      <q-form ref="formRef" @submit.prevent="save">
-        <q-input
-          v-model="form.name"
-          :label="t('bucket.name')"
-          :rules="nameRules"
-          outlined
-          class="q-mb-sm"
-        />
-        <q-color
-          v-model="form.color"
-          format="hex"
-          class="q-mb-sm"
-        />
+      <q-form ref="formRef" @submit.prevent="save" class="q-gutter-sm">
+        <div class="row q-col-gutter-md">
+          <div class="col-6">
+            <q-input v-model="form.name" outlined :rules="nameRules" class="q-mb-sm">
+              <template #label>
+                <div class="row items-center no-wrap">
+                  <span>{{ t('bucket.name') }}</span>
+                  <InfoTooltip class="q-ml-xs" :text="t('BucketManager.tooltips.name')" />
+                </div>
+              </template>
+            </q-input>
+          </div>
+          <div class="col-6">
+            <q-color v-model="form.color" format="hex" class="q-mb-sm">
+              <template #label>
+                <div class="row items-center no-wrap">
+                  <span>{{ t('bucket.color') }}</span>
+                  <InfoTooltip class="q-ml-xs" :text="t('BucketManager.tooltips.color')" />
+                </div>
+              </template>
+            </q-color>
+          </div>
+        </div>
         <q-input
           v-model.number="form.goal"
-          :label="t('bucket.goal')"
           type="number"
           :rules="goalRules"
           outlined
           class="q-mb-sm"
-        />
+        >
+          <template #label>
+            <div class="row items-center no-wrap">
+              <span>{{ t('bucket.goal') }}</span>
+              <InfoTooltip class="q-ml-xs" :text="t('BucketManager.tooltips.goal')" />
+            </div>
+          </template>
+        </q-input>
         <q-input
           v-model="form.desc"
-          :label="t('bucket.description')"
           type="textarea"
           autogrow
           outlined
           class="q-mb-sm"
-        />
-        <div class="row q-mt-md">
-          <q-btn
-            color="primary"
-            :disable="!canSave"
-            @click="save"
-          >
+        >
+          <template #label>
+            <div class="row items-center no-wrap">
+              <span>{{ t('bucket.description') }}</span>
+              <InfoTooltip class="q-ml-xs" :text="t('BucketManager.tooltips.description')" />
+            </div>
+          </template>
+        </q-input>
+        <q-card-actions align="right" class="q-mt-md">
+          <q-btn color="primary" :disable="!canSave" @click="save">
             {{ t('global.actions.save.label') }}
           </q-btn>
-          <q-btn flat color="grey" class="q-ml-auto" v-close-popup>
+          <q-btn flat color="grey" v-close-popup>
             {{ t('global.actions.cancel.label') }}
           </q-btn>
-        </div>
+        </q-card-actions>
       </q-form>
     </q-card>
   </q-dialog>

--- a/src/components/BucketManager.vue
+++ b/src/components/BucketManager.vue
@@ -52,21 +52,40 @@
   </div>
 
   <q-dialog v-model="showForm">
-    <q-card class="q-pa-lg" style="max-width: 90vw">
+    <q-card class="q-pa-lg" style="max-width: 600px; width: 100%">
       <h6 class="q-mt-none q-mb-md">{{ formTitle }}</h6>
-      <q-form ref="bucketForm">
-        <q-input
-          v-model="form.name"
-          outlined
-          :rules="nameRules"
-          :label="$t('bucket.name')"
-          class="q-mb-sm"
-        />
-        <q-color
-          v-model="form.color"
-          format="hex"
-          class="q-mb-sm"
-        />
+      <q-form ref="bucketForm" class="q-gutter-sm">
+        <div class="row q-col-gutter-md">
+          <div class="col-6">
+            <q-input
+              v-model="form.name"
+              outlined
+              :rules="nameRules"
+              class="q-mb-sm"
+            >
+              <template #label>
+                <div class="row items-center no-wrap">
+                  <span>{{ $t('bucket.name') }}</span>
+                  <InfoTooltip class="q-ml-xs" :text="$t('BucketManager.tooltips.name')" />
+                </div>
+              </template>
+            </q-input>
+          </div>
+          <div class="col-6">
+            <q-color
+              v-model="form.color"
+              format="hex"
+              class="q-mb-sm"
+            >
+              <template #label>
+                <div class="row items-center no-wrap">
+                  <span>{{ $t('bucket.color') }}</span>
+                  <InfoTooltip class="q-ml-xs" :text="$t('BucketManager.tooltips.color')" />
+                </div>
+              </template>
+            </q-color>
+          </div>
+        </div>
         <q-input
           v-model="form.description"
           outlined
@@ -104,7 +123,7 @@
         <q-input v-model="form.creatorPubkey" outlined class="q-mb-sm">
           <template #label>
             <div class="row items-center no-wrap">
-              <span>{{ $t("BucketManager.inputs.creator_pubkey") }}</span>
+              <span>{{ $t('BucketManager.inputs.creator_pubkey') }}</span>
               <InfoTooltip
                 class="q-ml-xs"
                 :text="$t('BucketManager.tooltips.creator_pubkey')"
@@ -112,14 +131,14 @@
             </div>
           </template>
         </q-input>
-        <div class="row q-mt-md">
+        <q-card-actions align="right" class="q-mt-md">
           <q-btn color="primary" rounded @click="saveBucket">{{
-            $t("global.actions.update.label")
+            $t('global.actions.update.label')
           }}</q-btn>
-          <q-btn flat rounded color="grey" class="q-ml-auto" v-close-popup>{{
-            $t("global.actions.cancel.label")
+          <q-btn flat rounded color="grey" v-close-popup>{{
+            $t('global.actions.cancel.label')
           }}</q-btn>
-        </div>
+        </q-card-actions>
       </q-form>
     </q-card>
   </q-dialog>

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1440,6 +1440,8 @@ export const messages = {
       creator_pubkey: "Creator pubkey",
     },
     tooltips: {
+      name: "Unique name for your bucket",
+      color: "Choose a color to help identify this bucket",
       description: "Buckets are for categorizing tokens",
       goal: "Set a target amount for this bucket",
       creator_pubkey: "Nostr pubkey to receive locked tokens",


### PR DESCRIPTION
## Summary
- enhance `BucketDialog` with a wider card, helper text, info tooltips and aligned actions
- apply the same layout improvements to the bucket edit form in `BucketManager`
- add tooltip strings for bucket name and color

## Testing
- `pnpm install --frozen-lockfile`
- `npm test` *(fails: Notify.create is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68737d24db5c8330a395a914ecb4d71b