### PR TITLE
Add AttachmentBubble for media messages

### DIFF
--- a/src/components/AttachmentBubble.vue
+++ b/src/components/AttachmentBubble.vue
@@ -1,0 +1,24 @@
+<template>
+  <div>
+    <q-img
+      v-if="isImage"
+      :src="src"
+      style="max-width: 300px; max-height: 300px"
+    />
+    <video
+      v-else-if="isVideo"
+      :src="src"
+      controls
+      style="max-width: 300px; max-height: 300px"
+    />
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { computed } from 'vue';
+
+const props = defineProps<{ src: string; outgoing?: boolean }>();
+
+const isImage = computed(() => props.src.startsWith('data:image/'));
+const isVideo = computed(() => props.src.startsWith('data:video/'));
+</script>

--- a/src/components/ChatMessageBubble.vue
+++ b/src/components/ChatMessageBubble.vue
@@ -11,7 +11,10 @@
         />
       </template>
       <template v-else-if="message.content.startsWith('data:')">
-        <AttachmentBubble :payload="payload" />
+        <AttachmentBubble
+          :src="message.content"
+          :outgoing="message.outgoing"
+        />
       </template>
       <template v-else>
         {{ message.content }}


### PR DESCRIPTION
## Summary
- add `AttachmentBubble.vue` component to show image/video data URLs
- render new AttachmentBubble when ChatMessageBubble message starts with `data:`

## Testing
- `pnpm run test:ci` *(fails: Test Files 23 failed | 25 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6873971bc87083309043bbd598a26b40