### PR TITLE
Add combined attachment message support

### DIFF
--- a/src/components/ChatMessageBubble.vue
+++ b/src/components/ChatMessageBubble.vue
@@ -10,11 +10,12 @@
           :outgoing="message.outgoing"
         />
       </template>
+      <template v-else-if="messageType === 'attachment'">
+        <div v-if="payload?.text" class="q-mb-sm">{{ payload.text }}</div>
+        <AttachmentBubble :src="payload?.data" :outgoing="message.outgoing" />
+      </template>
       <template v-else-if="message.content.startsWith('data:')">
-        <AttachmentBubble
-          :src="message.content"
-          :outgoing="message.outgoing"
-        />
+        <AttachmentBubble :src="message.content" :outgoing="message.outgoing" />
       </template>
       <template v-else>
         {{ message.content }}

--- a/src/components/MessageInput.vue
+++ b/src/components/MessageInput.vue
@@ -39,8 +39,13 @@ const fileInput = ref<HTMLInputElement>();
 const send = () => {
   const m = text.value.trim();
   if (m || attachment.value) {
-    emit("send", m);
-    if (attachment.value) {
+    if (m && attachment.value) {
+      const payload = { type: "attachment", text: m, data: attachment.value };
+      emit("send", JSON.stringify(payload));
+      attachment.value = null;
+    } else if (m) {
+      emit("send", m);
+    } else if (attachment.value) {
       emit("send", attachment.value);
       attachment.value = null;
     }

--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -185,9 +185,10 @@ export default defineComponent({
       selected.value = pubkey;
     };
 
-    const sendMessage = (text: string) => {
+    const sendMessage = (payload: string | Record<string, any>) => {
       if (!selected.value) return;
-      messenger.sendDm(selected.value, text);
+      const msg = typeof payload === "string" ? payload : JSON.stringify(payload);
+      messenger.sendDm(selected.value, msg);
     };
 
     function openSendTokenDialog() {


### PR DESCRIPTION
## Summary
- improve MessageInput `send` logic to send one JSON string when message has text and attachment
- parse new attachment message format in ChatMessageBubble
- allow sendMessage in NostrMessenger to accept objects

## Testing
- `pnpm test` *(fails: `Vitest caught 4 unhandled errors`, `Test Files 4 failed`)*

------
https://chatgpt.com/codex/tasks/task_e_68739a4bf91c833087d5a25afba568f1