### PR TITLE
Add carousel for subscription payments

### DIFF
--- a/src/components/ChatMessageBubble.vue
+++ b/src/components/ChatMessageBubble.vue
@@ -5,23 +5,59 @@
   >
     <div :class="message.outgoing ? 'sent' : 'received'" :style="bubbleStyle">
       <template v-if="message.subscriptionPayment">
-        <q-expansion-item dense switch-toggle-side>
-          <template #header>
-            Subscription payment ({{ message.subscriptionPayment.total_months }} months)
-          </template>
-          <TokenInformation
-            :encodedToken="message.subscriptionPayment.token"
-            :showAmount="true"
-            :showMintCheck="true"
-            :showP2PKCheck="true"
-          />
-          <q-btn
-            label="Redeem"
-            color="primary"
-            class="q-mt-sm"
-            @click.stop="redeemPayment"
-          />
-        </q-expansion-item>
+        <template v-if="message.subscriptionPayment.total_months > 1">
+          <q-carousel
+            v-model="activeSlide"
+            animated
+            control-color="primary"
+            swipeable
+            class="subscription-carousel"
+          >
+            <q-carousel-slide
+              v-for="idx in message.subscriptionPayment.total_months"
+              :key="idx"
+              :name="idx"
+            >
+              <q-expansion-item dense switch-toggle-side>
+                <template #header>Month {{ idx }}</template>
+                <TokenInformation
+                  :encodedToken="message.subscriptionPayment.token"
+                  :showAmount="true"
+                  :showMintCheck="true"
+                  :showP2PKCheck="true"
+                />
+                <q-btn
+                  label="Redeem"
+                  color="primary"
+                  class="q-mt-sm"
+                  @click.stop="redeemPayment"
+                />
+              </q-expansion-item>
+            </q-carousel-slide>
+          </q-carousel>
+        </template>
+        <template v-else>
+          <q-expansion-item dense switch-toggle-side>
+            <template #header>
+              Subscription payment ({{
+                message.subscriptionPayment.total_months
+              }}
+              months)
+            </template>
+            <TokenInformation
+              :encodedToken="message.subscriptionPayment.token"
+              :showAmount="true"
+              :showMintCheck="true"
+              :showP2PKCheck="true"
+            />
+            <q-btn
+              label="Redeem"
+              color="primary"
+              class="q-mt-sm"
+              @click.stop="redeemPayment"
+            />
+          </q-expansion-item>
+        </template>
       </template>
       <template v-else>
         {{ message.content }}
@@ -48,7 +84,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed } from "vue";
+import { computed, ref } from "vue";
 import { useQuasar } from "quasar";
 import { mdiCheck, mdiCheckAll } from "@quasar/extras/mdi-v6";
 import type { MessengerMessage } from "src/stores/messenger";
@@ -61,6 +97,8 @@ const props = defineProps<{
 }>();
 
 const $q = useQuasar();
+
+const activeSlide = ref(1);
 
 const receivedStyle = computed(() => ({
   backgroundColor: $q.dark.isActive


### PR DESCRIPTION
## Summary
- show multiple subscription months in a q-carousel
- keep single month payments outside of a carousel

## Testing
- `npm test` *(fails: 22 failed, 26 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6873eaf651cc83309674e11036eb253c