### PR TITLE
Normalize pubkeys before chat actions

### DIFF
--- a/src/components/ConversationList.vue
+++ b/src/components/ConversationList.vue
@@ -84,8 +84,8 @@ const loadProfiles = async () => {
 onMounted(loadProfiles);
 watch(uniqueConversations, loadProfiles);
 
-const select = (pubkey: string) => emit("select", pubkey);
+const select = (pubkey: string) => emit("select", nostr.resolvePubkey(pubkey));
 const togglePin = (pubkey: string) => {
-  messenger.togglePin(pubkey);
+  messenger.togglePin(nostr.resolvePubkey(pubkey));
 };
 </script>

--- a/src/components/ConversationListItem.vue
+++ b/src/components/ConversationListItem.vue
@@ -131,8 +131,8 @@ export default defineComponent({
 
     const snippet = computed(() => props.lastMsg?.content?.slice(0, 30) || "");
 
-    const handleClick = () => emit("click", props.pubkey);
-    const togglePin = () => emit("pin", props.pubkey);
+    const handleClick = () => emit("click", nostr.resolvePubkey(props.pubkey));
+    const togglePin = () => emit("pin", nostr.resolvePubkey(props.pubkey));
 
     return {
       profile,

--- a/src/components/NewChat.vue
+++ b/src/components/NewChat.vue
@@ -22,9 +22,11 @@
 import { ref } from "vue";
 import { nip19 } from "nostr-tools";
 import { notifyError } from "src/js/notify";
+import { useNostrStore } from "src/stores/nostr";
 
 const emit = defineEmits(["start"]);
 const pubkey = ref("");
+const nostr = useNostrStore();
 
 const start = () => {
   const pk = pubkey.value.trim();
@@ -40,7 +42,8 @@ const start = () => {
     notifyError("Invalid Nostr pubkey");
     return;
   }
-  emit("start", pk);
+  const resolved = nostr.resolvePubkey(pk);
+  emit("start", resolved);
   pubkey.value = "";
 };
 </script>

--- a/src/pages/FindCreators.vue
+++ b/src/pages/FindCreators.vue
@@ -200,7 +200,7 @@ async function onMessage(ev: MessageEvent) {
     await nextTick();
     showTierDialog.value = true;
   } else if (ev.data && ev.data.type === "startChat" && ev.data.pubkey) {
-    const pubkey = ev.data.pubkey;
+    const pubkey = nostr.resolvePubkey(ev.data.pubkey);
     router.push({ path: "/nostr-messenger", query: { pubkey } });
     const stop = watch(
       () => messenger.started,


### PR DESCRIPTION
## Summary
- resolve pubkeys in `NewChat` before emitting
- normalize pubkeys from conversation list
- normalize startChat request from FindCreators page

## Testing
- `npx -y vitest` *(fails: Cannot find module 'vitest/config')*

------
https://chatgpt.com/codex/tasks/task_e_6873fa0491a48330bfb4f542c49bcfac