### PR TITLE
Fix conversation selection when pubkey missing

### DIFF
--- a/src/stores/messenger.ts
+++ b/src/stores/messenger.ts
@@ -504,6 +504,10 @@ export const useMessengerStore = defineStore("messenger", {
     },
 
     setCurrentConversation(pubkey: string) {
+      if (!pubkey) {
+        this.currentConversation = "";
+        return;
+      }
       this.currentConversation = this.normalizeKey(pubkey);
     },
 


### PR DESCRIPTION
## Summary
- avoid resolving empty pubkeys when changing conversations

## Testing
- `pnpm install`
- `npm test` *(fails: 22 test files failed)*

------
https://chatgpt.com/codex/tasks/task_e_68740178f5a88330bc1b1d07606e8521