### PR TITLE
Add timeout when publishing Nostr events

### DIFF
--- a/src/components/ProfilePanel.vue
+++ b/src/components/ProfilePanel.vue
@@ -13,7 +13,11 @@ import { computed } from 'vue';
 import CreatorProfileForm from './CreatorProfileForm.vue';
 import { useCreatorHubStore } from 'stores/creatorHub';
 import { useCreatorProfileStore } from 'stores/creatorProfile';
-import { useNostrStore, publishDiscoveryProfile } from 'stores/nostr';
+import {
+  useNostrStore,
+  publishDiscoveryProfile,
+  PublishTimeoutError,
+} from 'stores/nostr';
 import { useMintsStore } from 'stores/mints';
 import { storeToRefs } from 'pinia';
 import { notifySuccess, notifyError } from 'src/js/notify';
@@ -49,7 +53,11 @@ async function publishProfile() {
     notifySuccess('Profile updated');
     profileStore.markClean();
   } catch (e: any) {
-    notifyError(e?.message || 'Failed to publish profile');
+    if (e instanceof PublishTimeoutError) {
+      notifyError('Publishing timed out');
+    } else {
+      notifyError(e?.message || 'Failed to publish profile');
+    }
   }
 }
 

--- a/src/pages/CreatorHubPage.vue
+++ b/src/pages/CreatorHubPage.vue
@@ -102,7 +102,13 @@ import { ref, reactive, computed, watch, onMounted } from 'vue';
 import { useQuasar } from 'quasar';
 import Draggable from 'vuedraggable';
 import { useCreatorHubStore, type Tier } from 'stores/creatorHub';
-import { useNostrStore, fetchNutzapProfile, publishDiscoveryProfile, RelayConnectionError } from 'stores/nostr';
+import {
+  useNostrStore,
+  fetchNutzapProfile,
+  publishDiscoveryProfile,
+  RelayConnectionError,
+  PublishTimeoutError,
+} from 'stores/nostr';
 import { useP2PKStore } from 'stores/p2pk';
 import { useMintsStore } from 'stores/mints';
 import { useCreatorProfileStore } from 'stores/creatorProfile';
@@ -241,7 +247,11 @@ async function publishFullProfile() {
     notifySuccess('Profile updated');
     profileStore.markClean();
   } catch (e: any) {
-    notifyError(e?.message || 'Failed to publish profile');
+    if (e instanceof PublishTimeoutError) {
+      notifyError('Publishing timed out');
+    } else {
+      notifyError(e?.message || 'Failed to publish profile');
+    }
   } finally {
     publishing.value = false;
   }


### PR DESCRIPTION
## Summary
- add `publishWithTimeout` helper and `PublishTimeoutError`
- use it in `publishDiscoveryProfile` and `publishNutzapProfile`
- catch timeout errors in CreatorHub and ProfilePanel

## Testing
- `pnpm install`
- `npm test` *(fails: vitest not running in container)*

------
https://chatgpt.com/codex/tasks/task_e_6874a421a28483308a2b210a6882e757