### PR TITLE
Fix subscription payment bubble

### DIFF
--- a/src/components/ChatMessageBubble.vue
+++ b/src/components/ChatMessageBubble.vue
@@ -5,59 +5,24 @@
   >
     <div :class="message.outgoing ? 'sent' : 'received'" :style="bubbleStyle">
       <template v-if="message.subscriptionPayment">
-        <template v-if="message.subscriptionPayment.total_months > 1">
-          <q-carousel
-            v-model="activeSlide"
-            animated
-            control-color="primary"
-            swipeable
-            class="subscription-carousel"
-          >
-            <q-carousel-slide
-              v-for="idx in message.subscriptionPayment.total_months"
-              :key="idx"
-              :name="idx"
-            >
-              <q-expansion-item dense switch-toggle-side>
-                <template #header>Month {{ idx }}</template>
-                <TokenInformation
-                  :encodedToken="message.subscriptionPayment.token"
-                  :showAmount="true"
-                  :showMintCheck="true"
-                  :showP2PKCheck="true"
-                />
-                <q-btn
-                  label="Redeem"
-                  color="primary"
-                  class="q-mt-sm"
-                  @click.stop="redeemPayment"
-                />
-              </q-expansion-item>
-            </q-carousel-slide>
-          </q-carousel>
-        </template>
-        <template v-else>
-          <q-expansion-item dense switch-toggle-side>
-            <template #header>
-              Subscription payment ({{
-                message.subscriptionPayment.total_months
-              }}
-              months)
-            </template>
-            <TokenInformation
-              :encodedToken="message.subscriptionPayment.token"
-              :showAmount="true"
-              :showMintCheck="true"
-              :showP2PKCheck="true"
-            />
-            <q-btn
-              label="Redeem"
-              color="primary"
-              class="q-mt-sm"
-              @click.stop="redeemPayment"
-            />
-          </q-expansion-item>
-        </template>
+        <q-expansion-item dense switch-toggle-side>
+          <template #header>
+            Month {{ message.subscriptionPayment.month_index }} of
+            {{ message.subscriptionPayment.total_months }}
+          </template>
+          <TokenInformation
+            :encodedToken="message.subscriptionPayment.token"
+            :showAmount="true"
+            :showMintCheck="true"
+            :showP2PKCheck="true"
+          />
+          <q-btn
+            label="Redeem"
+            color="primary"
+            class="q-mt-sm"
+            @click.stop="redeemPayment"
+          />
+        </q-expansion-item>
       </template>
       <template v-else>
         {{ message.content }}
@@ -84,7 +49,7 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, ref } from "vue";
+import { computed } from "vue";
 import { useQuasar } from "quasar";
 import { mdiCheck, mdiCheckAll } from "@quasar/extras/mdi-v6";
 import type { MessengerMessage } from "src/stores/messenger";
@@ -98,7 +63,6 @@ const props = defineProps<{
 
 const $q = useQuasar();
 
-const activeSlide = ref(1);
 
 const receivedStyle = computed(() => ({
   backgroundColor: $q.dark.isActive


### PR DESCRIPTION
## Summary
- simplify ChatMessageBubble subscription rendering
  - display current token only
  - show month info in header
- remove unused carousel state

## Testing
- `pnpm run test:ci` *(fails: p2pkStore.getPrivateKeyForP2PKEncodedToken is not a function, module mock errors)*

------
https://chatgpt.com/codex/tasks/task_e_6874b0cc08988330bfb1ba9b38989b0a