### PR TITLE
Handle multiline direct messages

### DIFF
--- a/src/stores/messenger.ts
+++ b/src/stores/messenger.ts
@@ -282,8 +282,15 @@ export const useMessengerStore = defineStore("messenger", {
         event.content,
       );
       let subscriptionInfo: SubscriptionPayment | undefined;
-      try {
-        const payload = JSON.parse(decrypted);
+      const lines = decrypted.split("\n").filter((l) => l.trim().length > 0);
+      for (const line of lines) {
+        let payload: any;
+        try {
+          payload = JSON.parse(line);
+        } catch (e) {
+          console.warn("[messenger.addIncomingMessage] invalid JSON", e);
+          continue;
+        }
         if (
           payload &&
           payload.type === "cashu_subscription_payment" &&
@@ -375,7 +382,7 @@ export const useMessengerStore = defineStore("messenger", {
             }
           }
         }
-      } catch {}
+      }
       if (this.eventLog.some((m) => m.id === event.id)) return;
       const msg: MessengerMessage = {
         id: event.id,

--- a/test/vitest/__tests__/messenger.spec.ts
+++ b/test/vitest/__tests__/messenger.spec.ts
@@ -92,4 +92,17 @@ describe("messenger store", () => {
     await messenger.start();
     expect(notifyErrorSpy).toHaveBeenCalled();
   });
+
+  it("handles multi-line JSON messages", async () => {
+    const messenger = useMessengerStore();
+    (decryptDm as any).mockResolvedValue('{"a":1}\n{"b":2}');
+    await messenger.addIncomingMessage({
+      id: "1",
+      pubkey: "s",
+      content: "c",
+      created_at: 1,
+    } as any);
+    expect(messenger.eventLog.length).toBe(1);
+    expect(messenger.eventLog[0].content).toBe('{"a":1}\n{"b":2}');
+  });
 });


### PR DESCRIPTION
## Summary
- support newline-delimited JSON payloads when receiving messages
- test that multiline messages are stored correctly

## Testing
- `pnpm run test:ci` *(fails: many tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_6874b792ff888330877466f1b93e24af