### PR TITLE
Handle npub input for tier fetch

### DIFF
--- a/test/vitest/__tests__/creators-tiers.spec.ts
+++ b/test/vitest/__tests__/creators-tiers.spec.ts
@@ -86,4 +86,30 @@ describe("fetchTierDefinitions fallback", () => {
     expect(store.tiersMap["pub"].length).toBe(1);
     fetchSpy.mockRestore();
   });
+
+  it("decodes npub and stores using hex", async () => {
+    filterMock.mockResolvedValue([]);
+    const fetchSpy = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          event: {
+            id: "1",
+            created_at: 1,
+            content:
+              '[{"id":"t","name":"T","price_sats":1,"description":"d","benefits":[]}]',
+            tags: [["d", "tiers"]],
+          },
+        }),
+      } as any);
+    const { nip19 } = await import("nostr-tools");
+    const hex = "f".repeat(64);
+    const npub = nip19.npubEncode(hex);
+    const store = useCreatorsStore();
+    await store.fetchTierDefinitions(npub);
+    expect(fetchSpy).toHaveBeenCalled();
+    expect(store.tiersMap[hex].length).toBe(1);
+    fetchSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
## Summary
- decode npub in `fetchTierDefinitions`
- use hex key for tier caches and subscriptions
- test fetching tiers with an npub

## Testing
- `npm test --silent` *(fails: Tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_6874bf25cd1083309abfa40b7e57fab9