### PR TITLE
Add HTLC metadata fields to subscription DM

### DIFF
--- a/src/js/receipt-utils.ts
+++ b/src/js/receipt-utils.ts
@@ -7,6 +7,9 @@ export type Receipt = {
   refundPubkey?: string;
   bucketId: string;
   date: string;
+  receiver_p2pk?: string;
+  unlock_time?: number;
+  hashlock?: string;
 };
 
 export function formatTimestamp(ts: number): string {
@@ -36,6 +39,9 @@ export function receiptToDmText(
         month_index: subscription.month_index,
         total_months: subscription.total_months,
         token: receipt.token,
+        receiver_p2pk: receipt.receiver_p2pk ?? receipt.pubkey,
+        unlock_time: receipt.unlock_time ?? receipt.locktime ?? null,
+        hashlock: receipt.hashlock ?? null,
       }
     : {
         token: receipt.token,
@@ -43,6 +49,9 @@ export function receiptToDmText(
         unlockTime: receipt.locktime ?? null,
         bucketId: receipt.bucketId,
         referenceId: receipt.id,
+        receiver_p2pk: receipt.receiver_p2pk ?? receipt.pubkey,
+        unlock_time: receipt.unlock_time ?? receipt.locktime ?? null,
+        hashlock: receipt.hashlock ?? null,
       };
   return JSON.stringify(payload);
 }
@@ -54,14 +63,17 @@ export function receiptsToDmText(
 ): string {
   return receipts
     .map((r, idx) =>
-      receiptToDmText(r, supporterName, subscription
-        ? {
-            subscription_id: subscription.subscription_id,
-            tier_id: subscription.tier_id,
-            month_index: idx + 1,
-            total_months: receipts.length,
-          }
-        : undefined,
+      receiptToDmText(
+        r,
+        supporterName,
+        subscription
+          ? {
+              subscription_id: subscription.subscription_id,
+              tier_id: subscription.tier_id,
+              month_index: idx + 1,
+              total_months: receipts.length,
+            }
+          : undefined
       )
     )
     .join("\n");

--- a/src/stores/nutzap.ts
+++ b/src/stores/nutzap.ts
@@ -230,6 +230,9 @@ export const useNutzapStore = defineStore("nutzap", {
               month_index: i + 1,
               total_months: months,
               token: tokenStr,
+              receiver_p2pk: creator.cashuP2pk,
+              unlock_time: unlockDate,
+              hashlock: hash,
             }),
             relayList
           );


### PR DESCRIPTION
## Summary
- extend receipt-utils with `receiver_p2pk`, `unlock_time` and `hashlock`
- include the same fields when building direct messages for `subscribeToTier`

## Testing
- `pnpm run test:ci` *(fails: 23 failed, 26 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6874d9a478cc8330a61a370949dd4e00