### PR TITLE
Fix messenger locktime parsing

### DIFF
--- a/src/stores/messenger.ts
+++ b/src/stores/messenger.ts
@@ -368,7 +368,7 @@ export const useMessengerStore = defineStore("messenger", {
                   token: payload.token,
                   pubkey: event.pubkey,
                   locktime:
-                    payload.unlock_time ?? payload.unlockTime || undefined,
+                    payload.unlock_time ?? payload.unlockTime,
                   bucketId: bucket.id,
                 });
               }


### PR DESCRIPTION
## Summary
- fix syntax mixing nullish coalescing with `||` for locktime field

## Testing
- `npm run lint` *(fails: A config object is using the "extends" key, which is not supported in flat config system)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6874e369ab2883308670c2e0bd21b04c