### PR TITLE
Fix lint error due to prop mutation

### DIFF
--- a/src/components/ChatMessageBubble.vue
+++ b/src/components/ChatMessageBubble.vue
@@ -13,7 +13,7 @@
         />
         <q-toggle
           v-if="!message.outgoing"
-          v-model="message.autoRedeem"
+          v-model="autoRedeem"
           label="Auto-redeem"
           class="q-mt-sm"
           @update:model-value="updateAutoRedeem"
@@ -88,13 +88,14 @@ const deliveryIcon = computed(() =>
 
 const receiveStore = useReceiveTokensStore();
 const redeemed = ref(false);
+const autoRedeem = ref(false);
 if (props.message.subscriptionPayment) {
   cashuDb.lockedTokens
     .where("tokenString")
     .equals(props.message.subscriptionPayment.token)
     .first()
     .then((row) => {
-      props.message.autoRedeem = row?.autoRedeem ?? false;
+      autoRedeem.value = row?.autoRedeem ?? false;
     });
 }
 
@@ -153,6 +154,7 @@ async function updateAutoRedeem(val: boolean) {
     .equals(props.message.subscriptionPayment.token)
     .first();
   if (row) await cashuDb.lockedTokens.update(row.id, { autoRedeem: val });
+  autoRedeem.value = val;
 }
 </script>
 

--- a/src/components/TierCard.vue
+++ b/src/components/TierCard.vue
@@ -31,7 +31,7 @@
 </template>
 
 <script setup lang="ts">
-import { reactive, watch, defineProps, defineEmits } from "vue";
+import { reactive, watch } from "vue";
 import type { Tier } from "stores/creatorHub";
 
 const props = defineProps<{ tier: Tier }>();

--- a/src/components/TierItem.vue
+++ b/src/components/TierItem.vue
@@ -8,7 +8,6 @@
 </template>
 
 <script setup lang="ts">
-import { defineProps, defineEmits } from "vue";
 import TierCard from "./TierCard.vue";
 import type { Tier } from "stores/creatorHub";
 


### PR DESCRIPTION
## Summary
- fix eslint `vue/no-mutating-props` rule by using a local `autoRedeem` state in `ChatMessageBubble.vue`
- remove unnecessary imports of `defineProps`/`defineEmits`

## Testing
- `npm run lint` *(fails: A config object is using the "extends" key, which is not supported)*
- `npm run test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_687540277ef48330b9a05058e2a996ed