### PR TITLE
Refactor redeem API

### DIFF
--- a/src/components/ChatMessageBubble.vue
+++ b/src/components/ChatMessageBubble.vue
@@ -127,7 +127,7 @@ async function redeemPayment() {
   const payment = props.message.subscriptionPayment;
   const wallet = useWalletStore();
   try {
-    await wallet.redeem(payment.token, payment.preimage ?? undefined);
+    await wallet.redeem(payment.token);
     if (payment.subscription_id) {
       const sub = await cashuDb.subscriptions.get(payment.subscription_id);
       const idx = sub?.intervals.findIndex(

--- a/src/components/CreatorLockedTokensTable.vue
+++ b/src/components/CreatorLockedTokensTable.vue
@@ -117,7 +117,7 @@ export default defineComponent({
       receiveStore.receiveData.bucketId = token.tierId;
       receiveStore.receiveData.p2pkPrivateKey =
         p2pkStore.getPrivateKeyForP2PKEncodedToken(token.tokenString);
-      await wallet.redeem(token.tierId, token.preimage ?? undefined);
+      await wallet.redeem(token.tokenString);
       await cashuDb.lockedTokens
         .where("tokenString")
         .equals(token.tokenString)

--- a/src/stores/lockedTokensRedeemWorker.ts
+++ b/src/stores/lockedTokensRedeemWorker.ts
@@ -148,8 +148,7 @@ export const useLockedTokensRedeemWorker = defineStore(
 
             debug("locked token redeem: sending proofs", proofs);
             try {
-              const witness = entry.preimage ?? undefined;
-              await wallet.redeem(entry.tokenString, witness);
+              await wallet.redeem(entry.tokenString);
               await cashuDb.lockedTokens
                 .where("tokenString")
                 .equals(entry.tokenString)

--- a/src/stores/npubcash.ts
+++ b/src/stores/npubcash.ts
@@ -176,7 +176,7 @@ export const useNPCStore = defineStore("npc", {
             try {
               // redeem token automatically
               const walletStore = useWalletStore();
-              await walletStore.redeem();
+              await walletStore.redeem(token);
             } catch {
               // if it doesn't work, show the receive window
               receiveStore.showReceiveTokens = true;

--- a/src/stores/receiveTokensStore.ts
+++ b/src/stores/receiveTokensStore.ts
@@ -96,7 +96,7 @@ export const useReceiveTokensStore = defineStore("receiveTokensStore", {
       }
       // redeem the token
       try {
-        await walletStore.redeem(bucketId);
+        await walletStore.redeem(receiveStore.receiveData.tokensBase64);
       } finally {
         await cashuDb.lockedTokens
           .where("tokenString")

--- a/test/vitest/__tests__/redeem-with-preimage.spec.ts
+++ b/test/vitest/__tests__/redeem-with-preimage.spec.ts
@@ -26,7 +26,7 @@ const TokenCarouselStub = {
 };
 
 describe("redeem payment", () => {
-  it("calls wallet.redeem with preimage", async () => {
+  it("calls wallet.redeem", async () => {
     const payment = { token: "tok", preimage: "secret123", month_index: 1, total_months: 1, subscription_id: "s", tier_id: "t", amount: 1 };
     const wrapper = mount(ChatMessageBubble, {
       props: { message: { id: "1", pubkey: "p", content: "", created_at: 0, outgoing: false, subscriptionPayment: payment } },
@@ -35,6 +35,6 @@ describe("redeem payment", () => {
 
     await wrapper.findComponent(TokenCarouselStub).vm.$emit("redeem", payment);
 
-    expect(redeemMock).toHaveBeenCalledWith("tok", "secret123");
+    expect(redeemMock).toHaveBeenCalledWith("tok");
   });
 });


### PR DESCRIPTION
## Summary
- simplify `redeem` and `attemptRedeem` to only accept token strings
- remove witness preimage injection
- update components and worker calls
- adjust automatic redeem flow and related tests

## Testing
- `pnpm run test:ci` *(fails: Vitest reported numerous failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_687561aff66083309ed8227909b3cb42