### PR TITLE
Add redemption queue

### DIFF
--- a/src/components/ChatMessageBubble.vue
+++ b/src/components/ChatMessageBubble.vue
@@ -153,11 +153,12 @@ async function redeemPayment() {
   if (!props.message.subscriptionPayment) return;
   const payment = props.message.subscriptionPayment;
   const wallet = useWalletStore();
+  const receiveStore = useReceiveTokensStore();
   try {
     if (unlockTime.value && remaining.value > 0) {
       return;
     }
-    await wallet.redeem(payment.token);
+    await receiveStore.enqueue(() => wallet.redeem(payment.token));
     if (payment.subscription_id) {
       const sub = await cashuDb.subscriptions.get(payment.subscription_id);
       const idx = sub?.intervals.findIndex(

--- a/src/components/CreatorLockedTokensTable.vue
+++ b/src/components/CreatorLockedTokensTable.vue
@@ -112,12 +112,13 @@ export default defineComponent({
     async redeem(token) {
       const receiveStore = useReceiveTokensStore();
       const wallet = useWalletStore();
+      const receiveStore = useReceiveTokensStore();
       const p2pkStore = useP2PKStore();
       receiveStore.receiveData.tokensBase64 = token.tokenString;
       receiveStore.receiveData.bucketId = token.tierId;
       receiveStore.receiveData.p2pkPrivateKey =
         p2pkStore.getPrivateKeyForP2PKEncodedToken(token.tokenString);
-      await wallet.redeem(token.tokenString);
+      await receiveStore.enqueue(() => wallet.redeem(token.tokenString));
       await cashuDb.lockedTokens
         .where("tokenString")
         .equals(token.tokenString)

--- a/src/stores/lockedTokensRedeemWorker.ts
+++ b/src/stores/lockedTokensRedeemWorker.ts
@@ -153,7 +153,9 @@ export const useLockedTokensRedeemWorker = defineStore(
 
             debug("locked token redeem: sending proofs", proofs);
             try {
-              await wallet.redeem(entry.tokenString);
+              await receiveStore.enqueue(() =>
+                wallet.redeem(entry.tokenString),
+              );
               await cashuDb.lockedTokens
                 .where("tokenString")
                 .equals(entry.tokenString)

--- a/src/stores/messenger.ts
+++ b/src/stores/messenger.ts
@@ -383,7 +383,9 @@ export const useMessengerStore = defineStore("messenger", {
 
           const receiveStore = useReceiveTokensStore();
           receiveStore.receiveData.tokensBase64 = payload.token;
-          await receiveStore.receiveToken(payload.token, DEFAULT_BUCKET_ID);
+          await receiveStore.enqueue(() =>
+            receiveStore.receiveToken(payload.token, DEFAULT_BUCKET_ID),
+          );
         } else if (payload && payload.type === "cashu_subscription_claimed") {
           const sub = await cashuDb.subscriptions.get(payload.subscription_id);
           const idx = sub?.intervals.findIndex(
@@ -429,9 +431,11 @@ export const useMessengerStore = defineStore("messenger", {
               receiveStore.receiveData.tokensBase64 = payload.token;
               receiveStore.receiveData.bucketId =
                 payload.bucketId ?? receiveStore.receiveData.bucketId;
-              await receiveStore.receiveToken(
-                payload.token,
-                receiveStore.receiveData.bucketId,
+              await receiveStore.enqueue(() =>
+                receiveStore.receiveToken(
+                  payload.token,
+                  receiveStore.receiveData.bucketId,
+                ),
               );
             }
           }

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -1359,7 +1359,9 @@ export const useNostrStore = defineStore("nostr", {
           await cashuDb.lockedTokens.put(entry);
           const receiveStore = useReceiveTokensStore();
           receiveStore.receiveData.tokensBase64 = payload.token;
-          await receiveStore.receiveToken(payload.token, DEFAULT_BUCKET_ID);
+          await receiveStore.enqueue(() =>
+            receiveStore.receiveToken(payload.token, DEFAULT_BUCKET_ID),
+          );
           return;
         }
         if (payload && payload.type === "cashu_subscription_claimed") {

--- a/src/stores/npubcash.ts
+++ b/src/stores/npubcash.ts
@@ -176,7 +176,7 @@ export const useNPCStore = defineStore("npc", {
             try {
               // redeem token automatically
               const walletStore = useWalletStore();
-              await walletStore.redeem(token);
+              await receiveStore.enqueue(() => walletStore.redeem(token));
             } catch {
               // if it doesn't work, show the receive window
               receiveStore.showReceiveTokens = true;

--- a/test/vitest/__tests__/redeem-with-preimage.spec.ts
+++ b/test/vitest/__tests__/redeem-with-preimage.spec.ts
@@ -9,7 +9,10 @@ vi.mock("../../../src/stores/wallet", () => ({
 }));
 
 vi.mock("../../../src/stores/receiveTokensStore", () => ({
-  useReceiveTokensStore: () => ({ receiveData: {} }),
+  useReceiveTokensStore: () => ({
+    receiveData: {},
+    enqueue: (fn: any) => fn(),
+  }),
 }));
 
 vi.mock("../../../src/stores/dexie", () => ({

--- a/test/vitest/__tests__/subscriptions.spec.ts
+++ b/test/vitest/__tests__/subscriptions.spec.ts
@@ -82,7 +82,10 @@ vi.mock("../../../src/stores/settings", () => ({
 }));
 
 vi.mock("../../../src/stores/receiveTokensStore", () => ({
-  useReceiveTokensStore: () => ({ receiveData: { tokensBase64: "", bucketId: "" } }),
+  useReceiveTokensStore: () => ({
+    receiveData: { tokensBase64: "", bucketId: "" },
+    enqueue: (fn: any) => fn(),
+  }),
 }));
 
 vi.mock("../../../src/js/token", () => ({


### PR DESCRIPTION
## Summary
- implement a promise queue in receiveTokensStore
- enqueue redemptions from various modules to avoid concurrent wallet.redeem calls
- adapt tests to new queue API

## Testing
- `pnpm test` *(fails: many tests report missing functions and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_6875e9a629bc83308b096b088dce6118