### PR TITLE
Handle locked tokens in receive flow

### DIFF
--- a/src/stores/dexie.ts
+++ b/src/stores/dexie.ts
@@ -73,13 +73,14 @@ export interface LockedToken {
   intervalKey: string;
   unlockTs: number;
   refundUnlockTs: number;
-  status: "pending" | "unlockable" | "claimed" | "expired";
+  status: "pending" | "unlockable" | "claimed" | "expired" | "locked";
   subscriptionEventId: string | null;
   subscriptionId?: string;
   monthIndex?: number;
   totalMonths?: number;
   label?: string;
   autoRedeem?: boolean;
+  refundPubkey?: string;
 }
 
 // export interface Proof {


### PR DESCRIPTION
## Summary
- record a token as `locked` when its secret contains a future locktime
- keep refund public key
- add new status to dexie LockedToken interface

## Testing
- `pnpm test` *(fails: Notify.create is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6876000c429883309d57cd1637ed5ad9