### PR TITLE
Remove unused hashlock/preimage fields

### DIFF
--- a/src/js/receipt-utils.ts
+++ b/src/js/receipt-utils.ts
@@ -9,7 +9,6 @@ export type Receipt = {
   date: string;
   receiver_p2pk?: string;
   unlock_time?: number;
-  hashlock?: string;
 };
 
 export function formatTimestamp(ts: number): string {
@@ -33,25 +32,14 @@ export function receiptToDmText(
 ): string {
   const payload = subscription
     ? {
-        type: "cashu_subscription_payment",
-        subscription_id: subscription.subscription_id,
-        tier_id: subscription.tier_id,
-        month_index: subscription.month_index,
-        total_months: subscription.total_months,
         token: receipt.token,
         receiver_p2pk: receipt.receiver_p2pk ?? receipt.pubkey,
         unlock_time: receipt.unlock_time ?? receipt.locktime ?? null,
-        hashlock: receipt.hashlock ?? null,
       }
     : {
         token: receipt.token,
-        amount: receipt.amount,
-        unlockTime: receipt.locktime ?? null,
-        bucketId: receipt.bucketId,
-        referenceId: receipt.id,
         receiver_p2pk: receipt.receiver_p2pk ?? receipt.pubkey,
         unlock_time: receipt.unlock_time ?? receipt.locktime ?? null,
-        hashlock: receipt.hashlock ?? null,
       };
   return JSON.stringify(payload);
 }

--- a/src/stores/messenger.ts
+++ b/src/stores/messenger.ts
@@ -28,8 +28,6 @@ export interface SubscriptionPayment {
   total_months: number;
   amount: number;
   unlock_time?: number;
-  preimage?: string | null;
-  hashlock?: string | null;
 }
 
 export type MessengerMessage = {
@@ -303,8 +301,6 @@ export const useMessengerStore = defineStore("messenger", {
             total_months: payload.total_months,
             amount,
             unlock_time: payload.unlock_time,
-            preimage: payload.preimage,
-            hashlock: payload.hashlock,
           };
         }
       } catch {}
@@ -352,8 +348,6 @@ export const useMessengerStore = defineStore("messenger", {
             total_months: payload.total_months,
             amount,
             unlock_time: payload.unlock_time,
-            preimage: payload.preimage,
-            hashlock: payload.hashlock,
           };
           const unlockTs = payload.unlock_time ?? payload.unlockTime ?? 0;
           const entry: LockedToken = {

--- a/src/stores/nutzap.ts
+++ b/src/stores/nutzap.ts
@@ -44,7 +44,6 @@ export interface NutzapQueuedSend {
   token: string;
   unlockTime: number;
   receiverP2PK: string;
-  refundPubkey?: string;
   createdAt: number;
 }
 
@@ -74,7 +73,6 @@ export const useNutzapStore = defineStore("nutzap", {
         token: item.token,
         receiver_p2pk: item.receiverP2PK,
         unlock_time: item.unlockTime,
-        ...(item.refundPubkey ? { refund_pubkey: item.refundPubkey } : {}),
       } as const;
       const { success } = await messenger.sendDm(
         item.npub,
@@ -218,7 +216,6 @@ export const useNutzapStore = defineStore("nutzap", {
               token: tokenStr,
               receiver_p2pk: creator.cashuP2pk,
               unlock_time: unlockDate,
-              refund_pubkey: refundKey,
             }),
             relayList
           );
@@ -229,7 +226,6 @@ export const useNutzapStore = defineStore("nutzap", {
               token: tokenStr,
               unlockTime: unlockDate,
               receiverP2PK: creator.cashuP2pk,
-              refundPubkey: refundKey,
               createdAt: Math.floor(Date.now() / 1000),
             });
           }
@@ -242,7 +238,6 @@ export const useNutzapStore = defineStore("nutzap", {
             token: tokenStr,
             unlockTime: unlockDate,
             receiverP2PK: creator.cashuP2pk,
-            refundPubkey: refundKey,
             createdAt: Math.floor(Date.now() / 1000),
           });
         }
@@ -368,7 +363,6 @@ export const useNutzapStore = defineStore("nutzap", {
                 token,
                 receiver_p2pk: creatorP2pk,
                 unlock_time: unlockDate,
-                refund_pubkey: refundKey,
               }),
               trustedRelays
             );
@@ -379,7 +373,6 @@ export const useNutzapStore = defineStore("nutzap", {
                 token,
                 unlockTime: unlockDate,
                 receiverP2PK: creatorP2pk,
-                refundPubkey: refundKey,
                 createdAt: Math.floor(Date.now() / 1000),
               });
             }
@@ -392,7 +385,6 @@ export const useNutzapStore = defineStore("nutzap", {
               token,
               unlockTime: unlockDate,
               receiverP2PK: creatorP2pk,
-              refundPubkey: refundKey,
               createdAt: Math.floor(Date.now() / 1000),
             });
           }

--- a/src/types/subscription.ts
+++ b/src/types/subscription.ts
@@ -3,8 +3,6 @@ export interface SubscriptionPaymentPayload {
   token: string;
   receiver_p2pk: string;
   unlock_time: number;
-  hashlock: string;
-  preimage: string;
   subscription_id: string;
   tier_id: string;
   month_index: number;

--- a/src/utils/receipt-utils.ts
+++ b/src/utils/receipt-utils.ts
@@ -13,8 +13,6 @@ export function saveReceipt(msg: MessengerMessage) {
     amount,
     mintUrl,
     unlock_time: msg.subscriptionPayment.unlock_time,
-    preimage: msg.subscriptionPayment.preimage,
-    hashlock: msg.subscriptionPayment.hashlock,
   };
   const fileName = `fundstr_${msg.subscriptionPayment.subscription_id}_${dayjs().utc().format('YYYYMMDD-HHmmss')}.json`;
   exportFile(fileName, JSON.stringify(data, null, 2), 'application/json');

--- a/test/subscribeToTier.spec.ts
+++ b/test/subscribeToTier.spec.ts
@@ -40,7 +40,7 @@ beforeEach(async () => {
 });
 
 describe('subscribeToTier', () => {
-  it('includes preimage in DM payload', async () => {
+  it('sends minimal DM payload', async () => {
     const store = useNutzapStore();
     await store.subscribeToTier({
       creator: { nostrPubkey: 'c', cashuP2pk: 'pk' },
@@ -52,5 +52,11 @@ describe('subscribeToTier', () => {
     });
     expect(sendDm).toHaveBeenCalled();
     const payload = JSON.parse(sendDm.mock.calls[0][1]);
+    expect(Object.keys(payload)).toEqual([
+      'type',
+      'token',
+      'receiver_p2pk',
+      'unlock_time',
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- strip `preimage` and `hashlock` from messenger state
- simplify receipt utils payload and remove fields
- trim subscription payload definitions and stored receipts
- send subscription payments without refund key
- update tests for new payload shape

## Testing
- `pnpm install`
- `npm test` *(fails: Notify.create is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_687602544d108330a8314dd7d3563883