### PR TITLE
Handle duplicate tokens during redemption

### DIFF
--- a/src/components/ChatMessageBubble.vue
+++ b/src/components/ChatMessageBubble.vue
@@ -158,7 +158,10 @@ async function redeemPayment() {
     if (unlockTime.value && remaining.value > 0) {
       return;
     }
-    await receiveStore.enqueue(() => wallet.redeem(payment.token));
+    await receiveStore.enqueue(
+      () => wallet.redeem(payment.token),
+      payment.token,
+    );
     if (payment.subscription_id) {
       const sub = await cashuDb.subscriptions.get(payment.subscription_id);
       const idx = sub?.intervals.findIndex(

--- a/src/components/CreatorLockedTokensTable.vue
+++ b/src/components/CreatorLockedTokensTable.vue
@@ -118,7 +118,10 @@ export default defineComponent({
       receiveStore.receiveData.bucketId = token.tierId;
       receiveStore.receiveData.p2pkPrivateKey =
         p2pkStore.getPrivateKeyForP2PKEncodedToken(token.tokenString);
-      await receiveStore.enqueue(() => wallet.redeem(token.tokenString));
+      await receiveStore.enqueue(
+        () => wallet.redeem(token.tokenString),
+        token.tokenString,
+      );
       await cashuDb.lockedTokens
         .where("tokenString")
         .equals(token.tokenString)

--- a/src/stores/lockedTokensRedeemWorker.ts
+++ b/src/stores/lockedTokensRedeemWorker.ts
@@ -153,8 +153,9 @@ export const useLockedTokensRedeemWorker = defineStore(
 
             debug("locked token redeem: sending proofs", proofs);
             try {
-              await receiveStore.enqueue(() =>
-                wallet.redeem(entry.tokenString),
+              await receiveStore.enqueue(
+                () => wallet.redeem(entry.tokenString),
+                entry.tokenString,
               );
               await cashuDb.lockedTokens
                 .where("tokenString")

--- a/src/stores/messenger.ts
+++ b/src/stores/messenger.ts
@@ -377,8 +377,9 @@ export const useMessengerStore = defineStore("messenger", {
 
           const receiveStore = useReceiveTokensStore();
           receiveStore.receiveData.tokensBase64 = payload.token;
-          await receiveStore.enqueue(() =>
-            receiveStore.receiveToken(payload.token, DEFAULT_BUCKET_ID),
+          await receiveStore.enqueue(
+            () => receiveStore.receiveToken(payload.token, DEFAULT_BUCKET_ID),
+            payload.token,
           );
         } else if (payload && payload.type === "cashu_subscription_claimed") {
           const sub = await cashuDb.subscriptions.get(payload.subscription_id);
@@ -425,11 +426,13 @@ export const useMessengerStore = defineStore("messenger", {
               receiveStore.receiveData.tokensBase64 = payload.token;
               receiveStore.receiveData.bucketId =
                 payload.bucketId ?? receiveStore.receiveData.bucketId;
-              await receiveStore.enqueue(() =>
-                receiveStore.receiveToken(
-                  payload.token,
-                  receiveStore.receiveData.bucketId,
-                ),
+              await receiveStore.enqueue(
+                () =>
+                  receiveStore.receiveToken(
+                    payload.token,
+                    receiveStore.receiveData.bucketId,
+                  ),
+                payload.token,
               );
             }
           }

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -1359,8 +1359,9 @@ export const useNostrStore = defineStore("nostr", {
           await cashuDb.lockedTokens.put(entry);
           const receiveStore = useReceiveTokensStore();
           receiveStore.receiveData.tokensBase64 = payload.token;
-          await receiveStore.enqueue(() =>
-            receiveStore.receiveToken(payload.token, DEFAULT_BUCKET_ID),
+          await receiveStore.enqueue(
+            () => receiveStore.receiveToken(payload.token, DEFAULT_BUCKET_ID),
+            payload.token,
           );
           return;
         }

--- a/src/stores/npubcash.ts
+++ b/src/stores/npubcash.ts
@@ -176,7 +176,10 @@ export const useNPCStore = defineStore("npc", {
             try {
               // redeem token automatically
               const walletStore = useWalletStore();
-              await receiveStore.enqueue(() => walletStore.redeem(token));
+              await receiveStore.enqueue(
+                () => walletStore.redeem(token),
+                token,
+              );
             } catch {
               // if it doesn't work, show the receive window
               receiveStore.showReceiveTokens = true;


### PR DESCRIPTION
## Summary
- track already-queued tokens in `receiveTokensStore`
- skip redemptions for tokens we've already queued
- update all callers with token argument

## Testing
- `pnpm test --silent` *(fails: "cashu_subscription_claimed" etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68762428c78883309a478ebe819ba0f2