### PR TITLE
Remove unused refund_pubkey translations

### DIFF
--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -221,7 +221,7 @@
                 />
                 <q-input
                   v-model="sendData.refundPubkey"
-                  :label="$t('SendTokenDialog.inputs.refund_pubkey.label')"
+                  label="Refund public key"
                   outlined
                   dense
                   class="col-12"

--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -854,9 +854,6 @@ export default {
         locktime: {
           label: "Unlock time",
         },
-        refund_pubkey: {
-          label: "Refund public key",
-        },
       },
     },
     actions: {

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -860,9 +860,6 @@ export default {
       locktime: {
         label: "Unlock time",
       },
-      refund_pubkey: {
-        label: "Refund public key",
-      },
     },
     actions: {
       close: {

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -862,9 +862,6 @@ export default {
         locktime: {
           label: "Unlock time",
         },
-        refund_pubkey: {
-          label: "Refund public key",
-        },
       },
     },
     actions: {

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -901,9 +901,6 @@ export const messages = {
       locktime: {
         label: "Unlock time",
       },
-      refund_pubkey: {
-        label: "Refund public key",
-      },
       memo: {
         label: "Message",
       },

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -860,9 +860,6 @@ export default {
         locktime: {
           label: "Unlock time",
         },
-        refund_pubkey: {
-          label: "Refund public key",
-        },
       },
     },
     actions: {

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -858,9 +858,6 @@ export default {
         locktime: {
           label: "Unlock time",
         },
-        refund_pubkey: {
-          label: "Refund public key",
-        },
       },
     },
     actions: {

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -853,9 +853,6 @@ export default {
         locktime: {
           label: "Unlock time",
         },
-        refund_pubkey: {
-          label: "Refund public key",
-        },
       },
     },
     actions: {

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -851,9 +851,6 @@ export default {
         locktime: {
           label: "Unlock time",
         },
-        refund_pubkey: {
-          label: "Refund public key",
-        },
       },
     },
     actions: {

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -852,9 +852,6 @@ export default {
         locktime: {
           label: "Unlock time",
         },
-        refund_pubkey: {
-          label: "Refund public key",
-        },
       },
     },
     actions: {

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -850,9 +850,6 @@ export default {
         locktime: {
           label: "Unlock time",
         },
-        refund_pubkey: {
-          label: "Refund public key",
-        },
       },
     },
     actions: {

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -854,9 +854,6 @@ export default {
         locktime: {
           label: "Unlock time",
         },
-        refund_pubkey: {
-          label: "Refund public key",
-        },
       },
     },
     actions: {

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -843,9 +843,6 @@ export default {
         locktime: {
           label: "Unlock time",
         },
-        refund_pubkey: {
-          label: "Refund public key",
-        },
       },
     },
     actions: {


### PR DESCRIPTION
## Summary
- delete `refund_pubkey` message from all locales
- update SendTokenDialog to use a static label

## Testing
- `pnpm lint` *(fails: Invalid option '--ext')*
- `pnpm test` *(fails: 45 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68762be8cb5c8330a0af51df70026ec8