### PR TITLE
Remove crypto import from nutzap store

### DIFF
--- a/src/stores/nutzap.ts
+++ b/src/stores/nutzap.ts
@@ -6,7 +6,6 @@ import { useP2PKStore } from "./p2pk";
 import { cashuDb, type LockedToken as DexieLockedToken } from "./dexie";
 import token from "src/js/token";
 import { v4 as uuidv4 } from "uuid";
-import crypto from "crypto";
 import { ensureCompressed } from "src/utils/ecash";
 import { useMintsStore } from "./mints";
 import { useProofsStore } from "./proofs";


### PR DESCRIPTION
## Summary
- clean up `src/stores/nutzap.ts` by removing the explicit `crypto` import
- rely on the global `crypto` object for `randomUUID()`

## Testing
- `pnpm run test:ci` *(fails: 47 failed tests)*
- `pnpm run build` *(fails: build error)*

------
https://chatgpt.com/codex/tasks/task_e_6876a997637c8330a70f7956bbe8b235