### PR TITLE
Use sendToLock in Nutzap subscriptions

### DIFF
--- a/src/stores/nutzap.ts
+++ b/src/stores/nutzap.ts
@@ -209,12 +209,17 @@ export const useNutzapStore = defineStore("nutzap", {
             ],
           },
         ];
-        const { send } = await mintWallet.split(price, {
+        const bucketId = proofs[0]?.bucketId;
+        const { sendProofs, locked } = await wallet.sendToLock(
           proofs,
-          secret,
-        });
-        const tokenStr = proofsStore.serializeProofs(send);
-        const locked = { id: uuidv4(), tokenString: tokenStr } as any;
+          mintWallet,
+          price,
+          creator.cashuP2pk,
+          bucketId,
+          unlockDate,
+          refundKey
+        );
+        const tokenStr = proofsStore.serializeProofs(sendProofs);
         try {
           const { success, event } = await messenger.sendDm(
             creator.nostrPubkey,


### PR DESCRIPTION
## Summary
- change Nutzap subscribeToTier to use `wallet.sendToLock`
- update proofs after locking tokens

## Testing
- `pnpm run test:ci` *(fails: Notify.create is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6876b1d5bc5c8330ae2c413f02f36785