### PR TITLE
Remove refund pubkey fields

### DIFF
--- a/src/components/LockedTokensTable.vue
+++ b/src/components/LockedTokensTable.vue
@@ -22,13 +22,6 @@
               })
             }}
           </q-item-label>
-          <q-item-label caption v-if="token.refundPubkey">
-            {{
-              $t("LockedTokensTable.row.refund_label", {
-                value: shortenString(pubkeyNpub(token.refundPubkey), 15, 6),
-              })
-            }}
-          </q-item-label>
           <q-item-label caption v-if="token.locktime">
             {{
               $t("LockedTokensTable.row.unlock_label", {

--- a/src/components/ReceiveTokenDialog.vue
+++ b/src/components/ReceiveTokenDialog.vue
@@ -153,13 +153,6 @@
                 })
               }}
             </q-chip>
-            <q-chip v-if="refundPubkey" outline icon="undo" class="q-ml-sm">
-              {{
-                $t("LockedTokensTable.row.refund_label", {
-                  value: shortenString(pubkeyNpub(refundPubkey), 15, 6),
-                })
-              }}
-            </q-chip>
           </div>
           <div class="row q-pt-sm">
             <q-select
@@ -457,12 +450,6 @@ export default defineComponent({
         return "";
       }
       return this.getTokenPubkey(this.receiveData.tokensBase64) || "";
-    },
-    refundPubkey: function () {
-      if (!this.tokenDecodesCorrectly) {
-        return "";
-      }
-      return this.getTokenRefundPubkey(this.receiveData.tokensBase64) || "";
     },
     unlockDate: function () {
       const ts = this.getTokenLocktime(this.receiveData.tokensBase64);

--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -219,13 +219,6 @@
                   dense
                   class="col-12 q-mb-sm"
                 />
-                <q-input
-                  v-model="sendData.refundPubkey"
-                  :label="$t('SendTokenDialog.inputs.refund_pubkey.label')"
-                  outlined
-                  dense
-                  class="col-12"
-                />
               </div>
             </div>
           </transition>
@@ -1208,9 +1201,6 @@ export default defineComponent({
         this.sendData.p2pkPubkey = ensureCompressed(
           this.sendData.p2pkPubkey
         );
-        this.sendData.refundPubkey = ensureCompressed(
-          this.sendData.refundPubkey
-        );
         let { _, sendProofs } = await this.sendToLock(
           proofsForBucket,
           mintWallet,
@@ -1286,7 +1276,6 @@ export default defineComponent({
           pubkey: this.sendData.p2pkPubkey,
           creatorP2PK: this.sendData.p2pkPubkey,
           locktime: this.sendData.locktime || undefined,
-          refundPubkey: this.sendData.refundPubkey || undefined,
           bucketId,
         });
         const historyToken = {

--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -854,9 +854,6 @@ export default {
         locktime: {
           label: "Unlock time",
         },
-        refund_pubkey: {
-          label: "Refund public key",
-        },
       },
     },
     actions: {

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -860,9 +860,6 @@ export default {
       locktime: {
         label: "Unlock time",
       },
-      refund_pubkey: {
-        label: "Refund public key",
-      },
     },
     actions: {
       close: {

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -862,9 +862,6 @@ export default {
         locktime: {
           label: "Unlock time",
         },
-        refund_pubkey: {
-          label: "Refund public key",
-        },
       },
     },
     actions: {

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -901,9 +901,6 @@ export const messages = {
       locktime: {
         label: "Unlock time",
       },
-      refund_pubkey: {
-        label: "Refund public key",
-      },
       memo: {
         label: "Message",
       },
@@ -997,7 +994,6 @@ export const messages = {
     timelock: {
       unlock_date_label: "Unlocks { value }",
       receiver_label: "Receiver { value }",
-      refund_label: "Refund { value }",
     },
     errors: {
       invalid_token: {
@@ -1545,7 +1541,6 @@ export const messages = {
       date_label: "{ value } ago",
       unlock_label: "Unlocks { value }",
       receiver_label: "Receiver { value }",
-      refund_label: "Refund { value }",
     },
     actions: {
       copy: { tooltip_text: "Copy" },

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -860,9 +860,6 @@ export default {
         locktime: {
           label: "Unlock time",
         },
-        refund_pubkey: {
-          label: "Refund public key",
-        },
       },
     },
     actions: {

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -858,9 +858,6 @@ export default {
         locktime: {
           label: "Unlock time",
         },
-        refund_pubkey: {
-          label: "Refund public key",
-        },
       },
     },
     actions: {

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -853,9 +853,6 @@ export default {
         locktime: {
           label: "Unlock time",
         },
-        refund_pubkey: {
-          label: "Refund public key",
-        },
       },
     },
     actions: {

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -851,9 +851,6 @@ export default {
         locktime: {
           label: "Unlock time",
         },
-        refund_pubkey: {
-          label: "Refund public key",
-        },
       },
     },
     actions: {

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -852,9 +852,6 @@ export default {
         locktime: {
           label: "Unlock time",
         },
-        refund_pubkey: {
-          label: "Refund public key",
-        },
       },
     },
     actions: {

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -850,9 +850,6 @@ export default {
         locktime: {
           label: "Unlock time",
         },
-        refund_pubkey: {
-          label: "Refund public key",
-        },
       },
     },
     actions: {

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -854,9 +854,6 @@ export default {
         locktime: {
           label: "Unlock time",
         },
-        refund_pubkey: {
-          label: "Refund public key",
-        },
       },
     },
     actions: {

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -843,9 +843,6 @@ export default {
         locktime: {
           label: "Unlock time",
         },
-        refund_pubkey: {
-          label: "Refund public key",
-        },
       },
     },
     actions: {


### PR DESCRIPTION
## Summary
- strip refund key UI from SendTokenDialog and other views
- clean up i18n messages for refund fields

## Testing
- `pnpm test` *(fails: Test failed. See above for more details.)*

------
https://chatgpt.com/codex/tasks/task_e_68775fc372888330835328d9686c2d0a