### PR TITLE
Update P2PK tests for irrevocable timelocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Think Patreon, but built for the Nostr ecosystem and leveraging the privacy and 
 - **Token Buckets** – Organize tokens into named categories with descriptions, colors and goals. Auto-assign incoming tokens based on mint URL or memo rules and move tokens between buckets as needed.
 - **Advanced Token Management**
   - P2PK (Pay-to-PubKey) support.
-  - Timelocked tokens for pledge-style recurring support with optional refund keys.
-  - View and manage locked tokens with unlock dates and refund information.
+  - Timelocked tokens for pledge-style recurring support with irrevocable P2PK locks.
+  - View and manage locked tokens with unlock dates.
 - **Nostr Identity Integration** – Log in with your existing npub.
   - If your private key is available (via NIP-07 or imported nsec), Fundstr automatically saves the corresponding 66-char key pair for P2PK locking.
 - **Creator Discovery** – Find creators by category, search or Nostr social graphs.

--- a/test/vitest/__tests__/nutzap.spec.ts
+++ b/test/vitest/__tests__/nutzap.spec.ts
@@ -78,12 +78,10 @@ beforeEach(async () => {
   }));
   publishNutzap = vi.fn();
   createHTLC = vi.fn(() => ({ token: "htlc-token", hash: "htlc-hash" }));
-  sendToLock = vi.fn(
-    async (_p, _w, _a, _pk, _b, timelock, _refundKey, hash) => ({
-      sendProofs: [`tok-${timelock}`],
-      locked: { id: `lock-${timelock}`, hashlock: hash },
-    }),
-  );
+  sendToLock = vi.fn(async (_p, _w, _a, _pk, _b, timelock) => ({
+    sendProofs: [`tok-${timelock}`],
+    locked: { id: `lock-${timelock}` },
+  }));
   findSpendableMint = vi.fn(() => ({ url: "mint" }));
   addMany = vi.fn();
   getTokenLocktime = vi.fn(() => 0);
@@ -146,8 +144,6 @@ describe("Nutzap store", () => {
     expect(filterHealthyRelaysFn).toHaveBeenCalled();
     expect(ndkSendFn).toHaveBeenCalled();
     expect(sendToLock).toHaveBeenCalledTimes(2);
-    expect(sendToLock.mock.calls[0][7]).toBe("htlc-hash");
-    expect(sendToLock.mock.calls[1][7]).toBe("htlc-hash");
     const tokens = await cashuDb.lockedTokens.toArray();
     expect(tokens.length).toBe(2);
     const sub = await cashuDb.subscriptions.toArray();

--- a/test/vitest/__tests__/p2pk.spec.ts
+++ b/test/vitest/__tests__/p2pk.spec.ts
@@ -26,22 +26,19 @@ describe("P2PK store", () => {
     expect(info.locktime).toBe(locktime);
   });
 
-  it("returns refund key for expired locktime secret", () => {
+  it("returns original key for expired locktime secret", () => {
     const p2pk = useP2PKStore();
     const locktime = Math.floor(Date.now() / 1000) - 1000;
     const secret = JSON.stringify([
       "P2PK",
       {
         data: "02aa",
-        tags: [
-          ["locktime", String(locktime)],
-          ["refund", "02bb", "02cc"],
-        ],
+        tags: [["locktime", String(locktime)]],
       },
     ]);
     const pub = p2pk.getSecretP2PKPubkey(secret);
     const info = p2pk.getSecretP2PKInfo(secret);
-    expect(pub).toBe("02bb");
+    expect(pub).toBe("02aa");
     expect(info.locktime).toBe(locktime);
   });
 
@@ -155,10 +152,7 @@ describe("P2PK store", () => {
       "P2PK",
       {
         data: "02aa",
-        tags: [
-          ["locktime", String(locktime)],
-          ["refund", "02bb"],
-        ],
+        tags: [["locktime", String(locktime)]],
       },
     ]);
     const tokenObj = {
@@ -167,7 +161,7 @@ describe("P2PK store", () => {
     const encoded =
       "cashuA" + Buffer.from(JSON.stringify(tokenObj)).toString("base64");
     expect(p2pk.getTokenPubkey(encoded)).toBe("02aa");
-    expect(p2pk.getTokenRefundPubkey(encoded)).toBe("02bb");
+    expect(p2pk.getTokenRefundPubkey(encoded)).toBeUndefined();
   });
 
   it("redeems token locked to converted npub", async () => {

--- a/test/vitest/__tests__/subscribeP2pkToken.spec.ts
+++ b/test/vitest/__tests__/subscribeP2pkToken.spec.ts
@@ -12,7 +12,7 @@ vi.mock("../../../src/stores/p2pk", () => ({
     isValidPubkey: () => true,
     generateRefundSecret: () => ({ hash: "h" }),
     generateKeypair: vi.fn(),
-    firstKey: { publicKey: "refund" },
+    firstKey: { publicKey: "key" },
     getTokenPubkey: (t: string) => {
       try {
         const decoded = JSON.parse(Buffer.from(t.slice(6), "base64").toString());

--- a/test/vitest/__tests__/subscriptions.spec.ts
+++ b/test/vitest/__tests__/subscriptions.spec.ts
@@ -35,7 +35,7 @@ vi.mock("../../../src/stores/p2pk", () => ({
     getTokenLocktime: vi.fn(() => 0),
     generateRefundSecret: () => ({ preimage: "pre", hash: "hash" }),
     generateKeypair: vi.fn(),
-    firstKey: { publicKey: "refund" },
+    firstKey: { publicKey: "key" },
     isValidPubkey: (...args: any[]) => isValidPubkey(...args),
   }),
 }));

--- a/test/vitest/__tests__/timelock.spec.ts
+++ b/test/vitest/__tests__/timelock.spec.ts
@@ -12,9 +12,7 @@ describe("Timelock", () => {
   it("stores locktime in sendData", () => {
     const store = useSendTokensStore();
     store.sendData.locktime = 123;
-    store.sendData.refundPubkey = "abc";
     expect(store.sendData.locktime).toBe(123);
-    expect(store.sendData.refundPubkey).toBe("abc");
   });
 
   it("forwards locktime in sendToLock", async () => {


### PR DESCRIPTION
## Summary
- update tests referencing refund keys and hashlocks
- document irrevocable P2PK timelock in README

## Testing
- `pnpm test` *(fails: Vitest reported multiple failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_687762e1f50083309c775756471d231c