### PR TITLE
Remove refund data from subscription messages

### DIFF
--- a/src/js/receipt-utils.ts
+++ b/src/js/receipt-utils.ts
@@ -41,7 +41,6 @@ export function receiptToDmText(
         token: receipt.token,
         receiver_p2pk: receipt.receiver_p2pk ?? receipt.pubkey,
         unlock_time: receipt.unlock_time ?? receipt.locktime ?? null,
-        hashlock: receipt.hashlock ?? null,
       }
     : {
         token: receipt.token,
@@ -51,7 +50,6 @@ export function receiptToDmText(
         referenceId: receipt.id,
         receiver_p2pk: receipt.receiver_p2pk ?? receipt.pubkey,
         unlock_time: receipt.unlock_time ?? receipt.locktime ?? null,
-        hashlock: receipt.hashlock ?? null,
       };
   return JSON.stringify(payload);
 }

--- a/src/pages/SubscriptionsOverview.vue
+++ b/src/pages/SubscriptionsOverview.vue
@@ -576,7 +576,6 @@ const rows = computed(() => {
       pubkey: sub.creatorNpub,
       locktime: i.unlockTs,
       bucketId: sub.tierId,
-      refundPubkey: "",
       date: "",
       status: i.status,
       redeemed: i.redeemed ?? false,

--- a/src/stores/lockedTokens.ts
+++ b/src/stores/lockedTokens.ts
@@ -13,7 +13,6 @@ export type LockedToken = {
   unlockTs?: number;
   label?: string;
   locktime?: number;
-  refundPubkey?: string;
   bucketId: string;
   date: string;
 };

--- a/src/stores/messenger.ts
+++ b/src/stores/messenger.ts
@@ -303,8 +303,6 @@ export const useMessengerStore = defineStore("messenger", {
             total_months: payload.total_months,
             amount,
             unlock_time: payload.unlock_time,
-            preimage: payload.preimage,
-            hashlock: payload.hashlock,
           };
         }
       } catch {}
@@ -352,8 +350,6 @@ export const useMessengerStore = defineStore("messenger", {
             total_months: payload.total_months,
             amount,
             unlock_time: payload.unlock_time,
-            preimage: payload.preimage,
-            hashlock: payload.hashlock,
           };
           const unlockTs = payload.unlock_time ?? payload.unlockTime ?? 0;
           const entry: LockedToken = {

--- a/src/stores/nutzap.ts
+++ b/src/stores/nutzap.ts
@@ -44,7 +44,6 @@ export interface NutzapQueuedSend {
   token: string;
   unlockTime: number;
   receiverP2PK: string;
-  refundPubkey?: string;
   createdAt: number;
 }
 
@@ -74,7 +73,6 @@ export const useNutzapStore = defineStore("nutzap", {
         token: item.token,
         receiver_p2pk: item.receiverP2PK,
         unlock_time: item.unlockTime,
-        ...(item.refundPubkey ? { refund_pubkey: item.refundPubkey } : {}),
       } as const;
       const { success } = await messenger.sendDm(
         item.npub,
@@ -216,7 +214,6 @@ export const useNutzapStore = defineStore("nutzap", {
               token: tokenStr,
               receiver_p2pk: creator.cashuP2pk,
               unlock_time: unlockDate,
-              refund_pubkey: refundKey,
             }),
             relayList
           );
@@ -227,7 +224,6 @@ export const useNutzapStore = defineStore("nutzap", {
               token: tokenStr,
               unlockTime: unlockDate,
               receiverP2PK: creator.cashuP2pk,
-              refundPubkey: refundKey,
               createdAt: Math.floor(Date.now() / 1000),
             });
           }
@@ -240,7 +236,6 @@ export const useNutzapStore = defineStore("nutzap", {
             token: tokenStr,
             unlockTime: unlockDate,
             receiverP2PK: creator.cashuP2pk,
-            refundPubkey: refundKey,
             createdAt: Math.floor(Date.now() / 1000),
           });
         }
@@ -362,7 +357,6 @@ export const useNutzapStore = defineStore("nutzap", {
                 token,
                 receiver_p2pk: creatorP2pk,
                 unlock_time: unlockDate,
-                refund_pubkey: refundKey,
               }),
               trustedRelays
             );
@@ -373,7 +367,6 @@ export const useNutzapStore = defineStore("nutzap", {
                 token,
                 unlockTime: unlockDate,
                 receiverP2PK: creatorP2pk,
-                refundPubkey: refundKey,
                 createdAt: Math.floor(Date.now() / 1000),
               });
             }
@@ -386,7 +379,6 @@ export const useNutzapStore = defineStore("nutzap", {
               token,
               unlockTime: unlockDate,
               receiverP2PK: creatorP2pk,
-              refundPubkey: refundKey,
               createdAt: Math.floor(Date.now() / 1000),
             });
           }

--- a/src/stores/sendTokensStore.ts
+++ b/src/stores/sendTokensStore.ts
@@ -17,7 +17,6 @@ export const useSendTokensStore = defineStore("sendTokensStore", {
       tokensBase64: "",
       p2pkPubkey: "",
       locktime: null,
-      refundPubkey: "",
       paymentRequest: undefined,
       historyToken: undefined,
       bucketId: DEFAULT_BUCKET_ID,
@@ -29,7 +28,6 @@ export const useSendTokensStore = defineStore("sendTokensStore", {
       tokensBase64: string;
       p2pkPubkey: string;
       locktime: number | null;
-      refundPubkey: string;
       paymentRequest?: PaymentRequest;
       historyToken: HistoryToken | undefined;
       bucketId?: string;
@@ -44,7 +42,6 @@ export const useSendTokensStore = defineStore("sendTokensStore", {
       this.sendData.tokensBase64 = "";
       this.sendData.p2pkPubkey = "";
       this.sendData.locktime = null;
-      this.sendData.refundPubkey = "";
       this.sendData.paymentRequest = undefined;
       this.sendData.historyToken = undefined;
       this.sendData.bucketId = DEFAULT_BUCKET_ID;

--- a/src/types/subscription.ts
+++ b/src/types/subscription.ts
@@ -3,8 +3,6 @@ export interface SubscriptionPaymentPayload {
   token: string;
   receiver_p2pk: string;
   unlock_time: number;
-  hashlock: string;
-  preimage: string;
   subscription_id: string;
   tier_id: string;
   month_index: number;

--- a/src/utils/receipt-utils.ts
+++ b/src/utils/receipt-utils.ts
@@ -13,8 +13,6 @@ export function saveReceipt(msg: MessengerMessage) {
     amount,
     mintUrl,
     unlock_time: msg.subscriptionPayment.unlock_time,
-    preimage: msg.subscriptionPayment.preimage,
-    hashlock: msg.subscriptionPayment.hashlock,
   };
   const fileName = `fundstr_${msg.subscriptionPayment.subscription_id}_${dayjs().utc().format('YYYYMMDD-HHmmss')}.json`;
   exportFile(fileName, JSON.stringify(data, null, 2), 'application/json');

--- a/test/subscribeToTier.spec.ts
+++ b/test/subscribeToTier.spec.ts
@@ -40,7 +40,7 @@ beforeEach(async () => {
 });
 
 describe('subscribeToTier', () => {
-  it('includes preimage in DM payload', async () => {
+  it('sends minimal DM payload', async () => {
     const store = useNutzapStore();
     await store.subscribeToTier({
       creator: { nostrPubkey: 'c', cashuP2pk: 'pk' },
@@ -52,5 +52,8 @@ describe('subscribeToTier', () => {
     });
     expect(sendDm).toHaveBeenCalled();
     const payload = JSON.parse(sendDm.mock.calls[0][1]);
+    expect(payload).not.toHaveProperty('refund_pubkey');
+    expect(payload).not.toHaveProperty('preimage');
+    expect(payload).not.toHaveProperty('hashlock');
   });
 });


### PR DESCRIPTION
## Summary
- clean up SubscriptionPaymentPayload type
- drop refundPubkey from stores and UI
- stop sending refund key in Nutzap DMs
- remove hashlock/preimage handling in messenger
- update receipt utilities
- adjust minimal DM payload test

## Testing
- `pnpm run test:ci` *(fails: Unhandled Errors, 24 failed | 24 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6877843da0ec8330804d33c19027ad60