### PR TITLE
Refactor sendToLock and update usage

### DIFF
--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -1202,12 +1202,9 @@ export default defineComponent({
           this.sendData.p2pkPubkey
         );
         let { _, sendProofs } = await this.sendToLock(
-          proofsForBucket,
-          mintWallet,
           sendAmount,
           this.sendData.p2pkPubkey,
-          bucketId,
-          this.sendData.locktime || undefined
+          this.sendData.locktime || 0
         );
         // update UI
         this.sendData.tokens = sendProofs;

--- a/src/stores/donationPresets.ts
+++ b/src/stores/donationPresets.ts
@@ -73,11 +73,9 @@ export const useDonationPresetsStore = defineStore("donationPresets", {
 
       if (!months || months <= 0) {
         const { locked } = await walletStore.sendToLock(
-          proofs,
-          wallet,
           amount,
           convertedPubkey,
-          bucketId
+          0
         );
         tokens.push(locked);
         return detailed ? tokens : locked.tokenString;
@@ -86,11 +84,8 @@ export const useDonationPresetsStore = defineStore("donationPresets", {
       for (let i = 0; i < months; i++) {
         const locktime = base + i * 30 * 24 * 60 * 60;
         const { locked } = await walletStore.sendToLock(
-          proofs,
-          wallet,
           amount,
           convertedPubkey,
-          bucketId,
           locktime
         );
         tokens.push(locked);

--- a/src/stores/nutzap.ts
+++ b/src/stores/nutzap.ts
@@ -194,14 +194,9 @@ export const useNutzapStore = defineStore("nutzap", {
           throw new Error(
             "Insufficient balance in a mint that the creator trusts."
           );
-        const mintWallet = wallet.mintWallet(mint.url, mints.activeUnit);
-        const proofs = mints.mintUnitProofs(mint, mints.activeUnit);
         const { sendProofs, locked } = await wallet.sendToLock(
-          proofs,
-          mintWallet,
           price,
           creator.cashuP2pk,
-          "nutzap",
           unlockDate
         );
 
@@ -337,14 +332,9 @@ export const useNutzapStore = defineStore("nutzap", {
               "Insufficient balance in a mint that the creator trusts."
             );
 
-          const mintWallet = wallet.mintWallet(mint.url, mints.activeUnit);
-          const proofs = mints.mintUnitProofs(mint, mints.activeUnit);
           const { sendProofs, locked } = await wallet.sendToLock(
-            proofs,
-            mintWallet,
             amount,
             creatorP2pk,
-            "nutzap",
             unlockDate
           );
           const token = proofsStore.serializeProofs(sendProofs);

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -449,14 +449,17 @@ export const useWalletStore = defineStore("wallet", {
       return this.wallet.getFeesForProofs(proofs);
     },
     sendToLock: async function (
-      proofs: WalletProof[],
-      wallet: CashuWallet,
       amount: number,
       receiverPubkey: string,
-      bucketId: string = DEFAULT_BUCKET_ID,
-      locktime?: number
+      locktime: number
     ) {
       const mintStore = useMintsStore();
+      const wallet = this.wallet;
+      const sendTokensStore = useSendTokensStore();
+      const bucketId = sendTokensStore.sendData.bucketId || DEFAULT_BUCKET_ID;
+      const proofs = mintStore.activeProofs.filter(
+        (p) => p.bucketId === bucketId
+      );
       const info = mintStore.activeInfo || {};
       const nuts = Array.isArray(info.nut_supports)
         ? info.nut_supports
@@ -484,8 +487,10 @@ export const useWalletStore = defineStore("wallet", {
           proofsToSend,
           {
             keysetId,
-            pubkey: ensureCompressed(receiverPubkey),
-            locktime,
+            p2pk: {
+              pubkey: ensureCompressed(receiverPubkey),
+              locktime,
+            },
           }
         ));
         await proofsStore.removeProofs(proofsToSend);

--- a/test/vitest/__tests__/donationPresets.spec.ts
+++ b/test/vitest/__tests__/donationPresets.spec.ts
@@ -46,9 +46,9 @@ describe("Donation presets", () => {
     const spy = wallet.sendToLock as any;
     await store.createDonationPreset(3, 1, validPub, "b");
     expect(spy).toHaveBeenCalledTimes(3);
-    const first = spy.mock.calls[0][5];
-    const second = spy.mock.calls[1][5];
-    const third = spy.mock.calls[2][5];
+    const first = spy.mock.calls[0][2];
+    const second = spy.mock.calls[1][2];
+    const third = spy.mock.calls[2][2];
     expect(second).toBeGreaterThan(first);
     expect(third).toBeGreaterThan(second);
   });
@@ -59,7 +59,7 @@ describe("Donation presets", () => {
     const spy = wallet.sendToLock as any;
     const token = await store.createDonationPreset(0, 5, validPub, "b");
     expect(spy).toHaveBeenCalledTimes(1);
-    expect(spy.mock.calls[0][2]).toBe(5);
+    expect(spy.mock.calls[0][0]).toBe(5);
     expect(token).toBe("tok");
   });
 
@@ -70,9 +70,9 @@ describe("Donation presets", () => {
     const start = 1000;
     await store.createDonationPreset(3, 1, validPub, "b", start);
     expect(spy).toHaveBeenCalledTimes(3);
-    expect(spy.mock.calls[0][5]).toBe(start);
-    expect(spy.mock.calls[1][5]).toBe(start + 30 * 24 * 60 * 60);
-    expect(spy.mock.calls[2][5]).toBe(start + 2 * 30 * 24 * 60 * 60);
+    expect(spy.mock.calls[0][2]).toBe(start);
+    expect(spy.mock.calls[1][2]).toBe(start + 30 * 24 * 60 * 60);
+    expect(spy.mock.calls[2][2]).toBe(start + 2 * 30 * 24 * 60 * 60);
   });
 
   it("returns locked token data when detailed is true", async () => {

--- a/test/vitest/__tests__/nutzap.spec.ts
+++ b/test/vitest/__tests__/nutzap.spec.ts
@@ -78,7 +78,7 @@ beforeEach(async () => {
   }));
   publishNutzap = vi.fn();
   createHTLC = vi.fn(() => ({ token: "htlc-token", hash: "htlc-hash" }));
-  sendToLock = vi.fn(async (_p, _w, _a, _pk, _b, timelock) => ({
+  sendToLock = vi.fn(async (_amt, _pk, timelock) => ({
     sendProofs: [`tok-${timelock}`],
     locked: { id: `lock-${timelock}` },
   }));
@@ -105,7 +105,7 @@ describe("Nutzap store", () => {
     });
 
     expect(sendToLock).toHaveBeenCalledTimes(3);
-    const times = sendToLock.mock.calls.map((c: any[]) => c[5]);
+    const times = sendToLock.mock.calls.map((c: any[]) => c[2]);
     const expected = [0, 1, 2].map((i) => calcUnlock(start, i));
     expect(times).toEqual(expected);
   });

--- a/test/vitest/__tests__/p2pk.spec.ts
+++ b/test/vitest/__tests__/p2pk.spec.ts
@@ -89,19 +89,13 @@ describe("P2PK store", () => {
         send: [],
       })),
     } as any;
+    vi.spyOnProperty(walletStore, "wallet", "get").mockReturnValue(wallet);
 
-    await walletStore.sendToLock(
-      [{ secret: "s", amount: 1, id: "a", C: "c" } as any],
-      wallet,
-      1,
-      "pk",
-      "b",
-      123
-    );
+    await walletStore.sendToLock(1, "pk", 123);
     expect(wallet.send).toHaveBeenCalledWith(
       1,
       [{ secret: "s", amount: 1, id: "a", C: "c" }],
-      { keysetId: "kid", pubkey: "pk", locktime: 123 }
+      { keysetId: "kid", p2pk: { pubkey: "pk", locktime: 123 } }
     );
   });
 
@@ -198,12 +192,12 @@ describe("P2PK store", () => {
       }),
     } as any;
 
+    vi.spyOnProperty(walletStore, "wallet", "get").mockReturnValue(wallet);
+
     const { sendProofs } = await walletStore.sendToLock(
-      [{ secret: "s", amount: 1, id: "a", C: "c" } as any],
-      wallet,
       1,
       pubHex,
-      "b"
+      0
     );
     const tokenObj = { token: [{ proofs: sendProofs, mint: "m" }] };
     const encoded =

--- a/test/vitest/__tests__/subscriptions.spec.ts
+++ b/test/vitest/__tests__/subscriptions.spec.ts
@@ -121,7 +121,7 @@ beforeEach(async () => {
   serializeProofs = vi.fn((p: any) => `tok-${p[0]}`);
   updateActiveProofs = vi.fn();
   addMany = vi.fn();
-  sendToLock = vi.fn(async (_p, _w, _a, _pk, _b, u) => ({
+  sendToLock = vi.fn(async (_a, _pk, u) => ({
     sendProofs: [u],
     locked: { id: `id-${u}`, tokenString: `lock-${u}` },
   }));

--- a/test/vitest/__tests__/timelock.spec.ts
+++ b/test/vitest/__tests__/timelock.spec.ts
@@ -33,19 +33,13 @@ describe("Timelock", () => {
       unit: "sat",
       send: vi.fn(async (_a, _p, opts) => ({ keep: [], send: [] })),
     } as any;
+    vi.spyOnProperty(walletStore, "wallet", "get").mockReturnValue(wallet);
 
-    await walletStore.sendToLock(
-      [{ secret: "s", amount: 1, id: "a", C: "c" } as any],
-      wallet,
-      1,
-      "pk",
-      "b",
-      99
-    );
+    await walletStore.sendToLock(1, "pk", 99);
     expect(wallet.send).toHaveBeenCalledWith(
       1,
       [{ secret: "s", amount: 1, id: "a", C: "c" }],
-      { keysetId: "kid", pubkey: "pk", locktime: 99 }
+      { keysetId: "kid", p2pk: { pubkey: "pk", locktime: 99 } }
     );
   });
 


### PR DESCRIPTION
## Summary
- refactor `sendToLock` to select proofs internally and always pass p2pk options
- update wallet helpers to use the new call signature
- adjust donation presets, Nutzap store and SendTokenDialog
- update unit tests for the new function signature

## Testing
- `pnpm install`
- `npm test` *(fails: numerous errors)*

------
https://chatgpt.com/codex/tasks/task_e_68778712f40083308fdd25ccb34efa6f