### PR TITLE
Fix send lock toggle

### DIFF
--- a/src/components/SendDialog.vue
+++ b/src/components/SendDialog.vue
@@ -96,6 +96,7 @@ import {
   Coins as CoinsIcon,
 } from "lucide-vue-next";
 import { notifyWarning } from "src/js/notify";
+import { DEFAULT_BUCKET_ID } from "src/stores/buckets";
 
 export default defineComponent({
   name: "SendDialog",
@@ -184,6 +185,7 @@ export default defineComponent({
       this.sendData.memo = "";
       this.sendData.p2pkPubkey = "";
       this.sendData.paymentRequest = undefined;
+      this.sendData.bucketId = DEFAULT_BUCKET_ID;
       this.showSendDialog = false;
       this.showSendTokens = true;
       this.showLockInput = false;

--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -148,6 +148,12 @@
             v-model.trim="sendData.memo"
             :label="$t('SendTokenDialog.inputs.memo.label')"
           />
+          <q-toggle
+            v-model="showLockInput"
+            color="primary"
+            :label="$t('SendTokenDialog.inputs.lock_toggle.label')"
+            class="q-mt-md"
+          />
           <transition
             appear
             enter-active-class="animated fadeIn"
@@ -261,28 +267,6 @@
                 <!-- <q-btn rounded flat color="primary" icon="lock">Locked</q-btn> -->
               </transition>
             </div>
-            <transition
-              appear
-              enter-active-class="animated fadeIn"
-              leave-active-class="animated fadeOut"
-            >
-              <q-btn
-                v-if="
-                  sendData.amount > 0 &&
-                  !showLockInput &&
-                  activeBalance >= sendData.amount
-                "
-                :disable="sendData.p2pkPubkey == null || sendData.amount <= 0"
-                color="primary"
-                class="q-ml-sm"
-                rounded
-                flat
-                @click="showLockInput = true"
-              >
-                <!-- <q-icon size="xs" class="q-mr-xs" name="lock" />  -->
-                {{ $t("SendTokenDialog.actions.lock.label") }}</q-btn
-              >
-            </transition>
             <q-btn v-close-popup rounded flat color="grey" class="q-ml-auto">{{
               $t("SendTokenDialog.actions.close.label")
             }}</q-btn>
@@ -915,7 +899,8 @@ export default defineComponent({
       const bucket = this.bucketList.find((b) => b.id === val);
       if (bucket && bucket.creatorPubkey) {
         this.sendData.p2pkPubkey = bucket.creatorPubkey;
-        this.showLockInput = true;
+      } else {
+        this.showLockInput = false;
       }
     },
   },

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -901,6 +901,9 @@ export const messages = {
       locktime: {
         label: "Unlock time",
       },
+      lock_toggle: {
+        label: "Lock to pubkey/timelock",
+      },
       memo: {
         label: "Message",
       },


### PR DESCRIPTION
## Summary
- reset bucket when opening send tokens dialog
- toggle lock inputs with a checkbox
- stop auto-locking when switching buckets

## Testing
- `pnpm test:ci` *(fails: ConstraintError, MODULE_NOT_FOUND, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687795c146a4833097b455c0a57e13a2