### PR TITLE
fix: remove duplicate receiveStore declaration

### DIFF
--- a/src/components/CreatorLockedTokensTable.vue
+++ b/src/components/CreatorLockedTokensTable.vue
@@ -112,7 +112,6 @@ export default defineComponent({
     async redeem(token) {
       const receiveStore = useReceiveTokensStore();
       const wallet = useWalletStore();
-      const receiveStore = useReceiveTokensStore();
       const p2pkStore = useP2PKStore();
       receiveStore.receiveData.tokensBase64 = token.tokenString;
       receiveStore.receiveData.bucketId = token.tierId;


### PR DESCRIPTION
## Summary
- remove extra `receiveStore` declaration

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*

------
https://chatgpt.com/codex/tasks/task_e_6877d9ef50a88330bf2d5ed2fa00609f