### PR TITLE
Remove preimage references

### DIFF
--- a/src/lib/cashu-ts/etc/cashu-ts.api.md
+++ b/src/lib/cashu-ts/etc/cashu-ts.api.md
@@ -302,7 +302,6 @@ export function hasValidDleq(proof: Proof, keyset: MintKeys): boolean;
 
 // @public
 export type HTLCWitness = {
-    preimage: string;
     signatures?: Array<string>;
 };
 
@@ -582,7 +581,6 @@ export type PartialMeltQuoteResponse = {
     fee_reserve: number;
     state: MeltQuoteState;
     expiry: number;
-    payment_preimage: string | null;
     change?: Array<SerializedBlindedSignature>;
     request?: string;
     unit?: string;

--- a/src/lib/cashu-ts/examples/simpleWallet_example.ts
+++ b/src/lib/cashu-ts/examples/simpleWallet_example.ts
@@ -208,12 +208,7 @@ const runWalletExample = async () => {
 					console.error(quote.error, quote.code, quote.detail);
 					return;
 				}
-				if (quote.state === MeltQuoteState.PAID) {
-					// if the request has succeeded, we should receive the preimage for the paid invoice.
-					console.log(
-						'success! here is the payment preimage (if its null, the mints lightning backend did not forward the preimage): ',
-						quote.payment_preimage
-					);
+                                if (quote.state === MeltQuoteState.PAID) {
 
 					console.log(`Ecash left: ${sumProofs(proofs)}`);
 					console.log(`Spent ecash notes: ${sumProofs(sentProofs)}`);

--- a/src/lib/cashu-ts/src/model/types/mint/responses.ts
+++ b/src/lib/cashu-ts/src/model/types/mint/responses.ts
@@ -142,14 +142,10 @@ export type PartialMeltQuoteResponse = {
 	 * Timestamp of when the quote expires
 	 */
 	expiry: number;
-	/**
-	 * preimage of the paid invoice. is null if it the invoice has not been paid yet. can be null, depending on which LN-backend the mint uses
-	 */
-	payment_preimage: string | null;
-	/**
-	 * Return/Change from overpaid fees. This happens due to Lighting fee estimation being inaccurate
-	 */
-	change?: Array<SerializedBlindedSignature>;
+       /**
+        * Return/Change from overpaid fees. This happens due to Lighting fee estimation being inaccurate
+        */
+       change?: Array<SerializedBlindedSignature>;
 	/**
 	 *  Payment request for the melt quote.
 	 */

--- a/src/lib/cashu-ts/src/model/types/wallet/index.ts
+++ b/src/lib/cashu-ts/src/model/types/wallet/index.ts
@@ -49,14 +49,10 @@ export type P2PKWitness = {
  * HTLC witness
  */
 export type HTLCWitness = {
-	/**
-	 * preimage
-	 */
-	preimage: string;
-	/**
-	 * An array of signatures in hex format
-	 */
-	signatures?: Array<string>;
+        /**
+         * An array of signatures in hex format
+         */
+        signatures?: Array<string>;
 };
 
 /**

--- a/src/lib/cashu-ts/test/request.test.ts
+++ b/src/lib/cashu-ts/test/request.test.ts
@@ -31,13 +31,12 @@ describe('requests', () => {
 		server.use(
 			http.get(mintUrl + '/v1/melt/quote/bolt11/test', ({ request }) => {
 				headers = request.headers;
-				return HttpResponse.json({
-					quote: 'test_melt_quote_id',
-					amount: 2000,
-					fee_reserve: 20,
-					payment_preimage: null,
-					state: 'UNPAID'
-				});
+                                return HttpResponse.json({
+                                        quote: 'test_melt_quote_id',
+                                        amount: 2000,
+                                        fee_reserve: 20,
+                                        state: 'UNPAID'
+                                });
 			})
 		);
 		const wallet = new CashuWallet(mint, { unit });
@@ -54,13 +53,12 @@ describe('requests', () => {
 		server.use(
 			http.get(mintUrl + '/v1/melt/quote/bolt11/test', ({ request }) => {
 				headers = request.headers;
-				return HttpResponse.json({
-					quote: 'test_melt_quote_id',
-					amount: 2000,
-					fee_reserve: 20,
-					payment_preimage: null,
-					state: 'UNPAID'
-				});
+                                return HttpResponse.json({
+                                        quote: 'test_melt_quote_id',
+                                        amount: 2000,
+                                        fee_reserve: 20,
+                                        state: 'UNPAID'
+                                });
 			})
 		);
 

--- a/src/lib/cashu-ts/test/wallet.test.ts
+++ b/src/lib/cashu-ts/test/wallet.test.ts
@@ -154,13 +154,12 @@ describe('test fees', () => {
 	test('test melt quote fees', async () => {
 		server.use(
 			http.get(mintUrl + '/v1/melt/quote/bolt11/test', () => {
-				return HttpResponse.json({
-					quote: 'test_melt_quote_id',
-					amount: 2000,
-					fee_reserve: 20,
-					payment_preimage: null,
-					state: 'UNPAID'
-				} as MeltQuoteResponse);
+                                return HttpResponse.json({
+                                        quote: 'test_melt_quote_id',
+                                        amount: 2000,
+                                        fee_reserve: 20,
+                                        state: 'UNPAID'
+                                } as MeltQuoteResponse);
 			})
 		);
 		const wallet = new CashuWallet(mint, { unit });
@@ -833,13 +832,12 @@ describe('multi mint', async () => {
 						fee_reserve: 2,
 						paid: false,
 						state: 'UNPAID',
-						expiry: 1673972705,
-						payment_preimage: null,
-						change: null
-					});
-				}
-			)
-		);
+                                                expiry: 1673972705,
+                                                change: null
+                                        });
+                                }
+                        )
+                );
 		const mint = new CashuMint(mintUrl);
 		const wallet = new CashuWallet(mint);
 		const invoice =


### PR DESCRIPTION
## Summary
- remove `preimage` field from HTLC witness types
- drop `payment_preimage` from melt quote types
- scrub references to preimage from API docs, tests and example

## Testing
- `pnpm test:ci` *(fails: Vitest test suite errors)*

------
https://chatgpt.com/codex/tasks/task_e_687895b3bdb48330b42de872a31b4372