### PR TITLE
Remove refund key support

### DIFF
--- a/src/components/ReceiveTokenDialog.vue
+++ b/src/components/ReceiveTokenDialog.vue
@@ -471,7 +471,6 @@ export default defineComponent({
       "showLastKey",
       "getTokenLocktime",
       "getTokenPubkey",
-      "getTokenRefundPubkey",
     ]),
     ...mapActions(useMintsStore, ["addMint"]),
     ...mapActions(useReceiveTokensStore, [


### PR DESCRIPTION
## Summary
- strip refund key logic from p2pk store
- update receive token dialog to stop mapping removed helper

## Testing
- `pnpm run test:ci` *(fails: 24 failed, 24 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68789f242f8c8330a9528485877a53a0