### PR TITLE
Remove unused refundKey

### DIFF
--- a/src/stores/nutzap.ts
+++ b/src/stores/nutzap.ts
@@ -181,7 +181,6 @@ export const useNutzapStore = defineStore("nutzap", {
       const messenger = useMessengerStore();
       const p2pk = useP2PKStore();
       if (!p2pk.firstKey) await p2pk.generateKeypair();
-      const refundKey = p2pk.firstKey!.publicKey;
       const proofsStore = useProofsStore();
       const lockedTokens: DexieLockedToken[] = [];
 
@@ -311,7 +310,6 @@ export const useNutzapStore = defineStore("nutzap", {
         const wallet = useWalletStore();
         const p2pk = useP2PKStore();
         if (!p2pk.firstKey) await p2pk.generateKeypair();
-        const refundKey = p2pk.firstKey!.publicKey;
         const mints = useMintsStore();
         const proofsStore = useProofsStore();
         const messenger = useMessengerStore();


### PR DESCRIPTION
## Summary
- clean up `src/stores/nutzap.ts` by removing unused `refundKey` variable

## Testing
- `pnpm types` *(fails: Command "types" not found)*
- `pnpm test` *(fails: 24 failed | 24 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6878ae0add14833099ba6cfc8f4fcb50