### PR TITLE
Implement subscriptionPayload helper

### DIFF
--- a/src/js/receipt-utils.ts
+++ b/src/js/receipt-utils.ts
@@ -17,6 +17,29 @@ export interface SubscriptionDmPayload {
   total_months: number;
 }
 
+export interface SubscriptionMeta {
+  subscription_id: string;
+  tier_id: string;
+  month_index: number;
+  total_months: number;
+}
+
+export function subscriptionPayload(
+  token: string,
+  unlock_time: number | null,
+  meta: SubscriptionMeta,
+) {
+  return {
+    type: "cashu_subscription_payment" as const,
+    token,
+    unlock_time,
+    subscription_id: meta.subscription_id,
+    tier_id: meta.tier_id,
+    month_index: meta.month_index,
+    total_months: meta.total_months,
+  };
+}
+
 export function formatTimestamp(ts: number): string {
   const d = new Date(ts * 1000);
   return `${d.getFullYear()}-${("0" + (d.getMonth() + 1)).slice(-2)}-${(

--- a/src/stores/messenger.ts
+++ b/src/stores/messenger.ts
@@ -19,6 +19,7 @@ import { useNostrStore } from "./nostr";
 import { cashuDb, type LockedToken } from "./dexie";
 import { DEFAULT_BUCKET_ID } from "./buckets";
 import token from "src/js/token";
+import { subscriptionPayload } from "src/js/receipt-utils";
 
 function parseSubscriptionPaymentPayload(
   obj: any,
@@ -216,14 +217,12 @@ export const useMessengerStore = defineStore("messenger", {
 
         const tokenStr = proofsStore.serializeProofs(sendProofs);
         const payload = subscription
-          ? {
-              type: "cashu_subscription_payment",
+          ? subscriptionPayload(tokenStr, null, {
               subscription_id: subscription.subscription_id,
               tier_id: subscription.tier_id,
               month_index: subscription.month_index,
               total_months: subscription.total_months,
-              token: tokenStr,
-            }
+            })
           : {
               token: tokenStr,
               amount: sendAmount,

--- a/test/subscribeToTier.spec.ts
+++ b/test/subscribeToTier.spec.ts
@@ -49,5 +49,18 @@ describe('subscribeToTier', () => {
     });
     expect(sendDm).toHaveBeenCalled();
     const payload = JSON.parse(sendDm.mock.calls[0][1]);
+    expect(Object.keys(payload).sort()).toEqual(
+      [
+        'type',
+        'token',
+        'unlock_time',
+        'subscription_id',
+        'tier_id',
+        'month_index',
+        'total_months',
+      ].sort(),
+    );
+    expect(payload.type).toBe('cashu_subscription_payment');
+    expect(payload.tier_id).toBe('tier');
   });
 });

--- a/test/vitest/__tests__/subscriptions.spec.ts
+++ b/test/vitest/__tests__/subscriptions.spec.ts
@@ -139,6 +139,17 @@ describe("Nutzap subscriptions", () => {
     expect(sendDm).toHaveBeenCalledTimes(2);
     const p1 = JSON.parse(sendDm.mock.calls[0][1]);
     const p2 = JSON.parse(sendDm.mock.calls[1][1]);
+    const keys = [
+      'type',
+      'token',
+      'unlock_time',
+      'subscription_id',
+      'tier_id',
+      'month_index',
+      'total_months',
+    ].sort();
+    expect(Object.keys(p1).sort()).toEqual(keys);
+    expect(Object.keys(p2).sort()).toEqual(keys);
     expect(p1.subscription_id).toBe(p2.subscription_id);
     expect(p1.month_index).toBe(1);
     expect(p2.month_index).toBe(2);


### PR DESCRIPTION
## Summary
- create `subscriptionPayload` helper
- update messenger and nutzap DM payloads to use helper
- verify DM payloads in subscription tests

## Testing
- `pnpm types` *(fails: Command "types" not found)*
- `pnpm test` *(fails to run vitest suite)*

------
https://chatgpt.com/codex/tasks/task_e_6878aff5e524833084c2ce9de24cde27