### PR TITLE
Handle redeemed locked tokens

### DIFF
--- a/src/components/CreatorLockedTokensTable.vue
+++ b/src/components/CreatorLockedTokensTable.vue
@@ -129,7 +129,10 @@ export default defineComponent({
         redeemed: true,
       });
       await receiveStore.enqueue(() => wallet.receive(token.tokenString));
-      await cashuDb.lockedTokens.update(token.id, { status: "claimed" });
+      await cashuDb.lockedTokens.update(token.id, {
+        status: "redeemed",
+        redeemedAt: Date.now(),
+      });
       if (token.subscriptionId) {
         const sub = await cashuDb.subscriptions.get(token.subscriptionId);
         const idx = sub?.intervals.findIndex(

--- a/src/stores/dexie.ts
+++ b/src/stores/dexie.ts
@@ -70,7 +70,13 @@ export interface LockedToken {
   tierId: string;
   intervalKey: string;
   unlockTs: number;
-  status: "pending" | "unlockable" | "claimed" | "expired";
+  status:
+    | "pending"
+    | "processing"
+    | "unlockable"
+    | "claimed"
+    | "redeemed"
+    | "expired";
   subscriptionEventId: string | null;
   subscriptionId?: string;
   monthIndex?: number;
@@ -78,6 +84,7 @@ export interface LockedToken {
   label?: string;
   autoRedeem?: boolean;
   redeemed?: boolean;
+  redeemedAt?: number | null;
 }
 
 // export interface Proof {
@@ -402,6 +409,16 @@ export class CashuDexie extends Dexie {
               delete i[pre];
               if (i.redeemed === undefined) i.redeemed = false;
             });
+          });
+      });
+
+    this.version(17)
+      .upgrade(async (tx) => {
+        await tx
+          .table("lockedTokens")
+          .toCollection()
+          .modify((entry: any) => {
+            if (entry.redeemedAt === undefined) entry.redeemedAt = null;
           });
       });
   }

--- a/src/stores/lockedTokensDexie.ts
+++ b/src/stores/lockedTokensDexie.ts
@@ -9,7 +9,11 @@ export const useDexieLockedTokensStore = defineStore(
   () => {
     const lockedTokens = ref<LockedToken[]>([]);
 
-    liveQuery(() => cashuDb.lockedTokens.toArray()).subscribe({
+    liveQuery(() =>
+      cashuDb.lockedTokens
+        .filter((t) => t.status !== "redeemed")
+        .toArray(),
+    ).subscribe({
       next: (rows) => {
         lockedTokens.value = rows;
       },


### PR DESCRIPTION
## Summary
- mark locked tokens as redeemed after successful receive
- track redemption time in the Dexie model
- ignore redeemed tokens in workers and UI

## Testing
- `pnpm lint` *(fails: Invalid option '--ext')*
- `pnpm test` *(fails with multiple test errors)*

------
https://chatgpt.com/codex/tasks/task_e_68794f7581cc8330ba36b546d5b2a18c