### PR TITLE
Add global Dexie cleanup for tests

### DIFF
--- a/test/dexie-migration-v11.spec.ts
+++ b/test/dexie-migration-v11.spec.ts
@@ -4,8 +4,6 @@ import { cashuDb } from '../src/stores/dexie';
 
 beforeEach(async () => {
   localStorage.clear();
-  await cashuDb.close();
-  await Dexie.delete('cashuDatabase');
 });
 
 describe('dexie migration v11', () => {

--- a/test/setupDexie.ts
+++ b/test/setupDexie.ts
@@ -1,0 +1,8 @@
+import Dexie from 'dexie';
+import { afterEach } from 'vitest';
+
+afterEach(async () => {
+  const { cashuDb } = await import('../src/stores/dexie');
+  await cashuDb.close();
+  await Dexie.delete('cashuDatabase');
+});

--- a/test/subscribeToTier.spec.ts
+++ b/test/subscribeToTier.spec.ts
@@ -30,8 +30,6 @@ vi.mock('../src/stores/proofs', () => ({
 
 beforeEach(async () => {
   localStorage.clear();
-  await cashuDb.close();
-  await cashuDb.delete();
   await cashuDb.open();
   sendDm = vi.fn(async () => ({ success: true, event: { id: '1', content: '{}' } }));
   createHTLC = vi.fn(() => ({ token: JSON.stringify({ lockSecret: 'pre' }), hash: 'h' }));

--- a/test/vitest/__tests__/buckets.spec.ts
+++ b/test/vitest/__tests__/buckets.spec.ts
@@ -10,7 +10,6 @@ import { cashuDb } from "../../../src/stores/dexie";
 
 beforeEach(async () => {
   localStorage.clear();
-  await cashuDb.close();   // close() is safe under fake-indexeddb
   await cashuDb.open();
 });
 

--- a/test/vitest/__tests__/dexie.spec.ts
+++ b/test/vitest/__tests__/dexie.spec.ts
@@ -16,7 +16,6 @@ vi.mock("../../../src/stores/proofs", () => ({
 
 beforeEach(async () => {
   localStorage.clear();
-  await cashuDb.close();   // close() is safe under fake-indexeddb
   await cashuDb.open();
 });
 

--- a/test/vitest/__tests__/nutzap.spec.ts
+++ b/test/vitest/__tests__/nutzap.spec.ts
@@ -66,7 +66,6 @@ vi.mock("../../../src/boot/ndk", () => ({
 
 beforeEach(async () => {
   localStorage.clear();
-  await cashuDb.close(); // close() is safe under fake-indexeddb
   await cashuDb.open();
 
   fetchNutzapProfile = vi.fn(async () => ({

--- a/test/vitest/__tests__/receiveTokensStore.spec.ts
+++ b/test/vitest/__tests__/receiveTokensStore.spec.ts
@@ -7,7 +7,6 @@ const VALID_TOKEN =
 
 beforeEach(async () => {
   localStorage.clear();
-  await cashuDb.close();   // close() is safe under fake-indexeddb
   await cashuDb.open();
 });
 

--- a/test/vitest/__tests__/subscribeP2pkToken.spec.ts
+++ b/test/vitest/__tests__/subscribeP2pkToken.spec.ts
@@ -60,8 +60,6 @@ vi.mock("../../../src/js/token", () => ({
 
 beforeEach(async () => {
   localStorage.clear();
-  await cashuDb.close();
-  await cashuDb.delete();
   await cashuDb.open();
   sendDm = vi.fn(async () => ({ success: true }));
   sendToLock = vi.fn(async () => ({

--- a/test/vitest/__tests__/subscriptions.spec.ts
+++ b/test/vitest/__tests__/subscriptions.spec.ts
@@ -104,8 +104,6 @@ vi.mock("../../../src/js/token", () => ({
 
 beforeEach(async () => {
   localStorage.clear();
-  await cashuDb.close();
-  await cashuDb.delete();
   await cashuDb.open();
   useNutzapStore().$reset();
   sendDm = vi.fn(async () => ({}));

--- a/test/vitest/__tests__/tokens.spec.ts
+++ b/test/vitest/__tests__/tokens.spec.ts
@@ -4,7 +4,6 @@ import { cashuDb } from "../../../src/stores/dexie";
 
 beforeEach(async () => {
   localStorage.clear();
-  await cashuDb.close();   // close() is safe under fake-indexeddb
   await cashuDb.open();
 });
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,7 +16,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "happy-dom",
-    setupFiles: ["./test/vitest/setup-file.js"],
+    setupFiles: ["./test/setupDexie.ts", "./test/vitest/setup-file.js"],
     exclude: [
       "src/lib/cashu-ts/test/integration.test.ts",
       "src/lib/cashu-ts/test/auth.test.ts",


### PR DESCRIPTION
## Summary
- ensure Dexie database is cleaned up after every test
- load new cleanup setup in Vitest config
- remove DB cleanup from individual specs

## Testing
- `pnpm test` *(fails: Cannot read properties of undefined (reading 'deleteDatabase'))*

------
https://chatgpt.com/codex/tasks/task_e_68795416b8fc8330aa510a15d799a7fa