### PR TITLE
Remove unsupported token tests

### DIFF
--- a/src/js/__tests__/token.test.js
+++ b/src/js/__tests__/token.test.js
@@ -3,8 +3,6 @@ import { describe, expect, it } from "vitest";
 
 const VALID_V3_TOKEN =
   "cashuAeyJ0b2tlbiI6W3sicHJvb2ZzIjpbeyJpZCI6IkkyeU4raVJZZmt6VCIsImFtb3VudCI6MSwiQyI6IjAyZTRkYmJmMGZmNDI4YTU4ZDZjNjZjMTljNjI0YWRlY2MxNzg0YzdlNTU5ODZhNGVmNDQ4NDM5MzZhM2M4ZjM1OSIsInNlY3JldCI6ImZHWVpzSlVjME1mU1orVlhGandEZXNsNkJScW5wNmRSblZpUGQ2L00yQ0k9In1dLCJtaW50IjoiaHR0cHM6Ly84MzMzLnNwYWNlOjMzMzgifV19";
-const VALID_V2_TOKEN =
-  "eyJwcm9vZnMiOlt7ImlkIjoiSTJ5TitpUllma3pUIiwiYW1vdW50IjoxLCJDIjoiMDNjMzAwYzMzMzAzNTMzNDA3MjYwMzU3MzA3NzViNGM2YjRlMDRlYmVjOGY2OGVmYzVmYjY2ZDE3OTI0ZDRkMmQyIiwic2VjcmV0IjoicjE5S3I1anlwQXNaWm1tOUg3cUtFQWJsc1c1ZmsxaWsycFQwUWs2TFUxWT0ifV0sIm1pbnRzIjpbeyJ1cmwiOiJodHRwczovLzgzMzMuc3BhY2U6MzMzOCIsImlkcyI6WyJMM3p4eFJCL0k4dUUiLCJJMnlOK2lSWWZrelQiXX1dfQ==";
 
 describe("token", () => {
   describe("decode", () => {
@@ -15,12 +13,6 @@ describe("token", () => {
       expect(decoded.proofs.length).toEqual(1);
     });
 
-    it("should properly decode a V2 token", () => {
-      const decoded = token.decode(VALID_V2_TOKEN);
-      expect(decoded.proofs.length).toEqual(1);
-      expect(decoded.mint).toEqual("https://8333.space:3338");
-      expect(decoded.proofs.length).toEqual(1);
-    });
   });
 
   it("should throw if the token is invalid", () => {


### PR DESCRIPTION
## Summary
- drop legacy V2 token fixture
- remove V2 decode test expecting obsolete format

## Testing
- `pnpm test` *(fails: Tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_6879f77bd62c8330a9fcf6fdfb77828d