### PR TITLE
Fix Dexie DB reinitialization in migration tests

### DIFF
--- a/test/dexie-migration-v11.spec.ts
+++ b/test/dexie-migration-v11.spec.ts
@@ -4,6 +4,10 @@ import { cashuDb } from '../src/stores/dexie';
 
 beforeEach(async () => {
   localStorage.clear();
+  await cashuDb.close();
+  if (await Dexie.exists('cashuDatabase')) {
+    await Dexie.delete('cashuDatabase');
+  }
 });
 
 describe('dexie migration v11', () => {


### PR DESCRIPTION
## Summary
- prevent duplicate Dexie instances by closing and deleting before each migration spec

## Testing
- `pnpm test` *(fails: Cannot read properties of undefined (reading 'deleteDatabase'))*

------
https://chatgpt.com/codex/tasks/task_e_6879faf601188330844edfed9c80c050