### PR TITLE
Fix resendQueued to push events

### DIFF
--- a/src/stores/nutzap.ts
+++ b/src/stores/nutzap.ts
@@ -74,11 +74,12 @@ export const useNutzapStore = defineStore("nutzap", {
         month_index: 0,
         total_months: 0,
       });
-      const { success } = await messenger.sendDm(
+      const { success, event } = await messenger.sendDm(
         item.npub,
         JSON.stringify(payload)
       );
       if (success) {
+        if (event) messenger.pushOwnMessage(event as any);
         const idx = this.sendQueue.findIndex(
           (q) => q.createdAt === item.createdAt
         );


### PR DESCRIPTION
## Summary
- capture the event from `messenger.sendDm` in `resendQueued`
- push the message using `messenger.pushOwnMessage` before removing the queue entry

## Testing
- `pnpm test` *(fails: Test failed. See above for more details)*

------
https://chatgpt.com/codex/tasks/task_e_687a2103c3f48330ac610bd10cc702a7