### PR TITLE
Handle pending DM messages

### DIFF
--- a/src/components/ChatMessageBubble.vue
+++ b/src/components/ChatMessageBubble.vue
@@ -39,8 +39,27 @@
         {{ time }}
         <q-tooltip>{{ isoTime }}</q-tooltip>
       </span>
+      <template v-if="message.outgoing">
+        <q-spinner-dots
+          v-if="message.status === 'pending'"
+          size="16px"
+          class="q-ml-xs"
+        />
+        <q-icon
+          v-else-if="deliveryStatus"
+          :name="deliveryIcon"
+          size="16px"
+          class="q-ml-xs"
+        />
+        <q-icon
+          v-else-if="message.status === 'failed'"
+          name="error"
+          size="16px"
+          class="q-ml-xs text-negative"
+        />
+      </template>
       <q-icon
-        v-if="deliveryStatus"
+        v-else-if="deliveryStatus"
         :name="deliveryIcon"
         size="16px"
         class="q-ml-xs"


### PR DESCRIPTION
## Summary
- insert outgoing placeholder before NIP-04 publish
- update placeholder with event id after success or mark failure
- show pending spinner for unsent messages

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm test` *(fails: 25 failed, 23 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687a23705ddc83309843078672509942