### PR TITLE
Centralize subscription receipt parsing

### DIFF
--- a/src/stores/messenger.ts
+++ b/src/stores/messenger.ts
@@ -19,14 +19,11 @@ import { useNostrStore } from "./nostr";
 import { cashuDb, type LockedToken } from "./dexie";
 import { DEFAULT_BUCKET_ID } from "./buckets";
 import token from "src/js/token";
-import { subscriptionPayload } from "src/utils/receipt-utils";
+import {
+  subscriptionPayload,
+  parseSubscriptionPayload,
+} from "src/utils/receipt-utils";
 
-function parseSubscriptionPaymentPayload(
-  obj: any,
-): { token: string; unlock_time?: number } | undefined {
-  if (obj?.type !== "cashu_subscription_payment" || !obj.token) return;
-  return { token: obj.token, unlock_time: obj.unlock_time };
-}
 
 export interface SubscriptionPayment {
   token: string;
@@ -294,7 +291,7 @@ export const useMessengerStore = defineStore("messenger", {
       if (!msg) return;
       try {
         const payload = JSON.parse(msg.content);
-        const sub = parseSubscriptionPaymentPayload(payload);
+        const sub = parseSubscriptionPayload(payload);
         if (sub) {
           const decoded = token.decode(sub.token);
           const amount = decoded
@@ -338,7 +335,7 @@ export const useMessengerStore = defineStore("messenger", {
           console.warn("[messenger.addIncomingMessage] invalid JSON", e);
           continue;
         }
-        const sub = parseSubscriptionPaymentPayload(payload);
+        const sub = parseSubscriptionPayload(payload);
         if (sub) {
           const decoded = token.decode(sub.token);
           const amount = decoded

--- a/src/utils/receipt-utils.ts
+++ b/src/utils/receipt-utils.ts
@@ -69,19 +69,25 @@ export function formatTimestamp(ts: number): string {
   )}`;
 }
 
+export function parseSubscriptionPayload(
+  obj: any,
+): SubscriptionDmPayload | undefined {
+  if (obj?.type !== "cashu_subscription_payment" || !obj.token) return;
+  return {
+    type: "cashu_subscription_payment",
+    token: obj.token,
+    unlock_time: obj.unlock_time ?? null,
+    subscription_id: obj.subscription_id,
+    tier_id: obj.tier_id,
+    month_index: obj.month_index,
+    total_months: obj.total_months,
+  };
+}
+
 export function parseSubscriptionDm(text: string): SubscriptionDmPayload | undefined {
   try {
     const obj = JSON.parse(text);
-    if (obj?.type !== "cashu_subscription_payment" || !obj.token) return;
-    return {
-      type: "cashu_subscription_payment",
-      token: obj.token,
-      unlock_time: obj.unlock_time ?? null,
-      subscription_id: obj.subscription_id,
-      tier_id: obj.tier_id,
-      month_index: obj.month_index,
-      total_months: obj.total_months,
-    };
+    return parseSubscriptionPayload(obj);
   } catch {
     return;
   }


### PR DESCRIPTION
## Summary
- create `parseSubscriptionPayload` helper in receipt utils
- reuse that helper inside the messenger store

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a253e2ea0833091ab53be25694b83