### PR TITLE
Update sendDm to parse own messages

### DIFF
--- a/src/stores/messenger.ts
+++ b/src/stores/messenger.ts
@@ -165,6 +165,7 @@ export const useMessengerStore = defineStore("messenger", {
               event.created_at,
               event.id,
             );
+            this.pushOwnMessage(event as any);
             return { success: true, event } as any;
           }
           console.warn(`[messenger.sendDm] failed via ${r}`);

--- a/src/stores/nutzap.ts
+++ b/src/stores/nutzap.ts
@@ -213,7 +213,6 @@ export const useNutzapStore = defineStore("nutzap", {
             ),
             relayList
           );
-          if (event) messenger.pushOwnMessage(event as any);
           if (!success) {
             this.queueSend({
               npub: creator.nostrPubkey,
@@ -349,7 +348,6 @@ export const useNutzapStore = defineStore("nutzap", {
               ),
               trustedRelays
             );
-            if (event) messenger.pushOwnMessage(event as any);
             if (!success) {
               this.queueSend({
                 npub: profile.hexPub,


### PR DESCRIPTION
## Summary
- parse own DMs automatically when sending messages
- cleanup unused pushOwnMessage calls in Nutzap store

## Testing
- `pnpm install`
- `pnpm test` *(fails: 25 failed, 23 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687a273c06648330b116de3df5349c74