### PR TITLE
Show hex P2PK key in token details

### DIFF
--- a/src/components/TokenInformation.vue
+++ b/src/components/TokenInformation.vue
@@ -44,7 +44,7 @@
       </div>
       <div v-if="tokenPubkey" class="q-my-sm text-caption">
         <q-icon name="vpn_key" size="xs" color="grey" class="q-mr-sm" />
-        Locked to: {{ shortenString(pubkeyNpub(tokenPubkey), 15, 6) }}
+        Locked to: {{ shortenString(formatPubkey(tokenPubkey), 15, 6) }}
       </div>
       <div v-if="tokenLocktimeISO" class="q-my-sm text-caption">
         <q-icon name="schedule" size="xs" color="grey" class="q-mr-sm" />
@@ -59,7 +59,7 @@ import { getShortUrl } from "src/js/wallet-helpers";
 import { mapActions, mapState } from "pinia";
 import { useMintsStore } from "stores/mints";
 import { useP2PKStore } from "src/stores/p2pk";
-import { nip19 } from "nostr-tools";
+import { ensureCompressed } from "src/utils/ecash";
 import { shortenString } from "src/js/string-utils";
 import token from "src/js/token";
 
@@ -124,10 +124,10 @@ export default defineComponent({
       "getTokenPubkey",
       "getTokenLocktime",
     ]),
-    pubkeyNpub(hex) {
+    formatPubkey(hex) {
       try {
         if (!hex) return "";
-        return nip19.npubEncode(hex);
+        return ensureCompressed(hex);
       } catch (e) {
         return hex;
       }


### PR DESCRIPTION
## Summary
- show P2PK lock key directly in TokenInformation
- format the key using `ensureCompressed`

## Testing
- `pnpm test` *(fails: 25 failed, 23 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687a28d7812483309c6f6df30590dd03