### PR TITLE
Move relay health checks into utility module

### DIFF
--- a/src/boot/ndk.ts
+++ b/src/boot/ndk.ts
@@ -5,6 +5,7 @@ import { useNostrStore } from "stores/nostr";
 import { NDKEvent, type NDKFilter } from "@nostr-dev-kit/ndk";
 import { useSettingsStore } from "src/stores/settings";
 import { DEFAULT_RELAYS, FREE_RELAYS } from "src/config/relays";
+import { filterHealthyRelays } from "src/utils/relayHealth";
 
 export type NdkBootErrorReason =
   | "no-signer"
@@ -33,57 +34,6 @@ export function mergeDefaultRelays(ndk: NDK) {
 
 let ndkInstance: NDK | undefined;
 let ndkPromise: Promise<NDK> | undefined;
-
-async function pingRelay(url: string): Promise<boolean> {
-  return new Promise((resolve) => {
-    let settled = false;
-    const ws = new WebSocket(url);
-    const timer = setTimeout(() => {
-      if (!settled) {
-        settled = true;
-        try {
-          ws.close();
-        } catch {}
-        resolve(false);
-      }
-    }, 1000);
-    ws.onopen = () => {
-      if (!settled) {
-        settled = true;
-        clearTimeout(timer);
-        ws.close();
-        resolve(true);
-      }
-    };
-    ws.onerror = () => {
-      if (!settled) {
-        settled = true;
-        clearTimeout(timer);
-        resolve(false);
-      }
-    };
-    ws.onmessage = (ev) => {
-      if (
-        !settled &&
-        typeof ev.data === "string" &&
-        ev.data.startsWith("restricted:")
-      ) {
-        settled = true;
-        clearTimeout(timer);
-        ws.close();
-        resolve(false);
-      }
-    };
-  });
-}
-
-export async function filterHealthyRelays(relays: string[]): Promise<string[]> {
-  const results = await Promise.all(
-    relays.map(async (u) => ((await pingRelay(u)) ? u : null))
-  );
-  const healthy = results.filter((u): u is string => !!u);
-  return healthy.length >= 2 ? healthy : FREE_RELAYS;
-}
 
 export async function safeConnect(ndk: NDK): Promise<Error | null> {
   try {

--- a/src/stores/creators.ts
+++ b/src/stores/creators.ts
@@ -9,7 +9,7 @@ import {
 } from "./nostr";
 import { useSettingsStore } from "./settings";
 import { DEFAULT_RELAYS } from "src/config/relays";
-import { filterHealthyRelays } from "src/boot/ndk";
+import { filterHealthyRelays } from "src/utils/relayHealth";
 import { useNdk } from "src/composables/useNdk";
 import { nip19 } from "nostr-tools";
 import { Event as NostrEvent } from "nostr-tools";

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -35,7 +35,7 @@ import {
   Token,
 } from "@cashu/cashu-ts";
 import { useTokensStore } from "./tokens";
-import { filterHealthyRelays } from "src/boot/ndk";
+import { filterHealthyRelays } from "src/utils/relayHealth";
 import {
   notifyApiError,
   notifyError,

--- a/src/utils/relayHealth.ts
+++ b/src/utils/relayHealth.ts
@@ -1,0 +1,52 @@
+import { FREE_RELAYS } from "src/config/relays";
+
+export async function pingRelay(url: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const ws = new WebSocket(url);
+    const timer = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        try {
+          ws.close();
+        } catch {}
+        resolve(false);
+      }
+    }, 1000);
+    ws.onopen = () => {
+      if (!settled) {
+        settled = true;
+        clearTimeout(timer);
+        ws.close();
+        resolve(true);
+      }
+    };
+    ws.onerror = () => {
+      if (!settled) {
+        settled = true;
+        clearTimeout(timer);
+        resolve(false);
+      }
+    };
+    ws.onmessage = (ev) => {
+      if (
+        !settled &&
+        typeof ev.data === "string" &&
+        ev.data.startsWith("restricted:")
+      ) {
+        settled = true;
+        clearTimeout(timer);
+        ws.close();
+        resolve(false);
+      }
+    };
+  });
+}
+
+export async function filterHealthyRelays(relays: string[]): Promise<string[]> {
+  const results = await Promise.all(
+    relays.map(async (u) => ((await pingRelay(u)) ? u : null))
+  );
+  const healthy = results.filter((u): u is string => !!u);
+  return healthy.length >= 2 ? healthy : FREE_RELAYS;
+}

--- a/test/vitest/__tests__/creators-tiers.spec.ts
+++ b/test/vitest/__tests__/creators-tiers.spec.ts
@@ -13,7 +13,7 @@ vi.mock("../../../src/stores/nostr", async (importOriginal) => {
   };
 });
 
-vi.mock("../../../src/boot/ndk", () => {
+vi.mock("../../../src/utils/relayHealth", () => {
   filterMock = vi.fn();
   return {
     filterHealthyRelays: (...args: any[]) => filterMock(...args),

--- a/test/vitest/__tests__/nutzap.spec.ts
+++ b/test/vitest/__tests__/nutzap.spec.ts
@@ -61,6 +61,9 @@ vi.mock("../../../src/js/token", () => ({
 
 vi.mock("../../../src/boot/ndk", () => ({
   ndkSend: (...args: any[]) => ndkSendFn(...args),
+}));
+
+vi.mock("../../../src/utils/relayHealth", () => ({
   filterHealthyRelays: (...args: any[]) => filterHealthyRelaysFn(...args),
 }));
 


### PR DESCRIPTION
## Summary
- add relay health check helpers in `utils/relayHealth`
- reuse new helpers inside NDK boot process
- update stores to import `filterHealthyRelays` from the shared location
- adjust test mocks to match new path

## Testing
- `pnpm test` *(fails: Vitest tests fail in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_687b4abb3e8c8330be12898dad1663ba