### PR TITLE
Add unit tests for wallet & p2pk stores

### DIFF
--- a/test/p2pk-store.spec.ts
+++ b/test/p2pk-store.spec.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useP2PKStore } from 'stores/p2pk';
+import { useWalletStore } from 'stores/wallet';
+import { DEFAULT_BUCKET_ID } from 'stores/buckets';
+
+let mintsStoreMock: any;
+let proofsStoreMock: any;
+let tokensStoreMock: any;
+let walletStore: any;
+
+vi.mock('src/js/token', () => ({
+  default: {
+    decode: vi.fn(() => ({ proofs: [], mint: 'mint', unit: 'sat' })),
+    getMint: vi.fn(() => 'mint'),
+    getUnit: vi.fn(() => 'sat'),
+  },
+}));
+
+vi.mock('stores/mints', () => ({
+  useMintsStore: () => mintsStoreMock,
+}));
+
+vi.mock('stores/proofs', () => ({
+  useProofsStore: () => proofsStoreMock,
+}));
+
+vi.mock('stores/tokens', () => ({
+  useTokensStore: () => tokensStoreMock,
+}));
+
+vi.mock('stores/dexie', () => ({
+  cashuDb: {
+    lockedTokens: { where: () => ({ equals: () => ({ first: async () => null }) }) },
+  },
+}));
+
+beforeEach(() => {
+  proofsStoreMock = { addProofs: vi.fn() };
+  tokensStoreMock = { addPaidToken: vi.fn() };
+  mintsStoreMock = {
+    mints: [{ url: 'mint', keysets: [] }],
+    addMint: vi.fn(),
+    mintUnitProofs: vi.fn(() => []),
+  };
+  walletStore = useWalletStore();
+  vi.spyOn(walletStore, 'mintWallet').mockReturnValue({
+    receive: vi.fn(async () => [{ amount: 1, id: 'a', C: 'c' }]),
+  } as any);
+  vi.spyOn(walletStore, 'getKeyset').mockReturnValue('kid');
+  vi.spyOn(walletStore, 'keysetCounter').mockReturnValue(1);
+  vi.spyOn(walletStore, 'increaseKeysetCounter').mockImplementation(() => {});
+});
+
+describe('p2pk store', () => {
+  it('claims locked token using wallet.receive', async () => {
+    const p2pk = useP2PKStore();
+    p2pk.getPrivateKeyForP2PKEncodedToken = vi.fn(() => 'priv');
+
+    await p2pk.claimLockedToken('tok');
+
+    const wallet = (walletStore.mintWallet as any).mock.results[0].value;
+    expect(wallet.receive).toHaveBeenCalledWith('tok', {
+      counter: 1,
+      privkey: 'priv',
+      proofsWeHave: [],
+    });
+    expect(proofsStoreMock.addProofs).toHaveBeenCalled();
+    expect(tokensStoreMock.addPaidToken).toHaveBeenCalledWith({
+      amount: 1,
+      token: 'tok',
+      mint: 'mint',
+      unit: 'sat',
+      label: '',
+      bucketId: DEFAULT_BUCKET_ID,
+    });
+  });
+});

--- a/test/wallet-store.spec.ts
+++ b/test/wallet-store.spec.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useWalletStore } from 'stores/wallet';
+import { DEFAULT_BUCKET_ID } from 'stores/buckets';
+
+let proofsStoreMock: any;
+let uiStoreMock: any;
+
+vi.mock('stores/proofs', () => {
+  proofsStoreMock = {
+    addProofs: vi.fn(),
+    removeProofs: vi.fn(),
+    setReserved: vi.fn(),
+  };
+  return { useProofsStore: () => proofsStoreMock };
+});
+
+vi.mock('stores/mints', () => ({
+  useMintsStore: () => ({
+    activeUnit: 'sat',
+    activeMintUrl: 'mint',
+    mints: [{ url: 'mint', keys: [], keysets: [] }],
+    activeKeys: [],
+    activeKeysets: [],
+    mintUnitProofs: () => [],
+  }),
+}));
+
+vi.mock('stores/ui', () => {
+  uiStoreMock = {
+    lockMutex: vi.fn(async () => {}),
+    unlockMutex: vi.fn(),
+  };
+  return { useUiStore: () => uiStoreMock };
+});
+
+vi.mock('stores/signer', () => ({ useSignerStore: () => ({ reset: vi.fn(), method: null }) }));
+vi.mock('src/js/notify', () => ({
+  notifyApiError: vi.fn(),
+  notifyError: vi.fn(),
+  notifyWarning: vi.fn(),
+  notify: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('wallet store', () => {
+  it('calls wallet.send with selected proofs', async () => {
+    const walletStore = useWalletStore();
+    const proofs = [
+      { secret: 's1', amount: 1, id: 'a', C: 'c1' } as any,
+      { secret: 's2', amount: 1, id: 'b', C: 'c2' } as any,
+    ];
+
+    walletStore.spendableProofs = vi.fn(() => proofs);
+    walletStore.coinSelect = vi.fn(() => proofs);
+    walletStore.signP2PKIfNeeded = vi.fn((p: any) => p);
+    walletStore.getKeyset = vi.fn(() => 'kid');
+    walletStore.keysetCounter = vi.fn(() => 1);
+    walletStore.increaseKeysetCounter = vi.fn();
+
+    const wallet = {
+      mint: { mintUrl: 'mint' },
+      unit: 'sat',
+      getFeesForProofs: vi.fn(() => 0),
+      send: vi.fn(async (_a: number, _p: any, _opts: any) => ({ keep: [], send: [] })),
+    } as any;
+
+    await walletStore.send(proofs, wallet, 1, false, false, DEFAULT_BUCKET_ID);
+
+    expect(wallet.send).toHaveBeenCalledWith(1, proofs, {
+      counter: 1,
+      keysetId: 'kid',
+      proofsWeHave: proofs,
+    });
+    expect(proofsStoreMock.setReserved).toHaveBeenCalled();
+  });
+
+  it('retries redeem until attemptRedeem succeeds', async () => {
+    const walletStore = useWalletStore();
+    const attempt = vi
+      .spyOn(walletStore, 'attemptRedeem')
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+
+    await walletStore.redeem('token');
+
+    expect(attempt).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- add vitest suite for wallet store
- add vitest suite for p2pk store

## Testing
- `pnpm run test:ci` *(fails: 25 failed, 23 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687b5009ff3883308f53ad7063bfb755