### PR TITLE
Add alias support for messenger contacts

### DIFF
--- a/src/components/ActiveChatHeader.vue
+++ b/src/components/ActiveChatHeader.vue
@@ -89,11 +89,13 @@ watch(
   () => {
     loadProfile();
   },
-  { immediate: true },
+  { immediate: true }
 );
 
 const displayName = computed(() => {
   if (!props.pubkey) return "";
+  const alias = messenger.aliases[props.pubkey];
+  if (alias) return alias;
   const p: any = profile.value;
   if (p?.display_name) return p.display_name;
   if (p?.name) return p.name;

--- a/src/components/ConversationListItem.vue
+++ b/src/components/ConversationListItem.vue
@@ -96,13 +96,16 @@ export default defineComponent({
     const isOnline = computed(() => messenger.connected);
     const isPinned = computed(() => messenger.pinned[props.pubkey]);
     const unreadCount = computed(
-      () => messenger.unreadCounts[props.pubkey] || 0,
+      () => messenger.unreadCounts[props.pubkey] || 0
     );
     const profile = computed(() => {
       const entry: any = (nostr.profiles as any)[props.pubkey];
       return entry?.profile ?? entry ?? {};
     });
+    const alias = computed(() => messenger.aliases[props.pubkey]);
     const displayName = computed(() => {
+      const a = alias.value;
+      if (a) return a;
       const p: any = profile.value;
       return (
         p?.name ||

--- a/src/components/NostrIdentityManager.vue
+++ b/src/components/NostrIdentityManager.vue
@@ -31,6 +31,29 @@
               </q-item>
             </q-list>
           </div>
+          <div class="q-mt-md">
+            <div class="text-subtitle2 q-mb-sm">Aliases</div>
+            <q-input v-model="aliasPubkey" label="Pubkey" dense />
+            <q-input
+              v-model="aliasName"
+              label="Alias"
+              dense
+              class="q-mt-sm"
+              @keyup.enter="saveAlias"
+            />
+            <q-btn class="q-mt-sm" flat label="Add" @click="saveAlias" />
+            <q-list bordered class="q-mt-sm">
+              <q-item v-for="(alias, key) in aliases" :key="key">
+                <q-item-section>
+                  <div class="text-caption">{{ key }}</div>
+                  <q-input v-model="aliases[key]" dense />
+                </q-item-section>
+                <q-item-section side>
+                  <q-btn flat dense icon="delete" @click="removeAlias(key)" />
+                </q-item-section>
+              </q-item>
+            </q-list>
+          </div>
         </q-card-section>
         <q-card-actions align="right">
           <q-btn flat v-close-popup label="Close" />
@@ -44,6 +67,7 @@
 <script lang="ts" setup>
 import { ref } from "vue";
 import { useNostrStore } from "src/stores/nostr";
+import { useMessengerStore } from "src/stores/messenger";
 
 const nostr = useNostrStore();
 
@@ -52,6 +76,10 @@ const privKey = ref(nostr.activePrivateKeyNsec);
 const pubKey = ref(nostr.npub);
 const relayInput = ref("");
 const relays = ref<string[]>([...nostr.relays]);
+const messenger = useMessengerStore();
+const aliases = messenger.aliases as any;
+const aliasPubkey = ref("");
+const aliasName = ref("");
 
 const addRelay = () => {
   if (relayInput.value.trim()) {
@@ -62,6 +90,17 @@ const addRelay = () => {
 
 const removeRelay = (index: number) => {
   relays.value.splice(index, 1);
+};
+
+const saveAlias = () => {
+  if (!aliasPubkey.value.trim()) return;
+  messenger.setAlias(aliasPubkey.value.trim(), aliasName.value.trim());
+  aliasPubkey.value = "";
+  aliasName.value = "";
+};
+
+const removeAlias = (key: string) => {
+  messenger.setAlias(key, "");
 };
 
 const save = async () => {


### PR DESCRIPTION
## Summary
- maintain alias mapping in messenger store
- show alias in conversation list and chat header
- manage aliases in Nostr identity manager

## Testing
- `pnpm test` *(fails: Test Files 7 failed | 3 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687b59299fa08330bf3ec5ecc682fe1d