### PR TITLE
Improve DM snippet parsing

### DIFF
--- a/src/components/ConversationListItem.vue
+++ b/src/components/ConversationListItem.vue
@@ -53,7 +53,15 @@
           { 'text-weight-bold': unreadCount > 0 },
         ]"
       >
-        <template v-if="loaded">{{ snippet }}</template>
+        <template v-if="loaded">
+          <q-icon
+            v-if="snippet.icon"
+            :name="snippet.icon"
+            size="xs"
+            class="q-mr-xs"
+          />
+          {{ snippet.text }}
+        </template>
         <template v-else><q-skeleton type="text" width="80%" /></template>
       </div>
     </q-item-section>
@@ -80,6 +88,7 @@ import { QBadge, QBtn } from "quasar";
 import { useMessengerStore } from "src/stores/messenger";
 import { useNostrStore } from "src/stores/nostr";
 import { formatDistanceToNow } from "date-fns";
+import { parseMessageSnippet } from "src/utils/message-snippet";
 
 export default defineComponent({
   name: "ConversationListItem",
@@ -132,7 +141,9 @@ export default defineComponent({
       return formatDistanceToNow(ts * 1000, { addSuffix: true });
     });
 
-    const snippet = computed(() => props.lastMsg?.content?.slice(0, 30) || "");
+    const snippet = computed(() =>
+      parseMessageSnippet(props.lastMsg?.content || "")
+    );
 
     const handleClick = () => emit("click", nostr.resolvePubkey(props.pubkey));
     const togglePin = () => emit("pin", nostr.resolvePubkey(props.pubkey));

--- a/src/utils/message-snippet.ts
+++ b/src/utils/message-snippet.ts
@@ -1,0 +1,22 @@
+export interface SnippetInfo {
+  text: string;
+  icon?: string;
+}
+
+const PAYLOAD_MAP: Record<string, SnippetInfo> = {
+  cashu_subscription: { text: 'Subscription', icon: 'mdi-calendar' },
+  cashu_subscription_payment: { text: 'Subscription payment', icon: 'mdi-cash' },
+  cashu_subscription_claimed: { text: 'Payment claimed', icon: 'mdi-check' },
+};
+
+export function parseMessageSnippet(content: string): SnippetInfo {
+  if (!content) return { text: '' };
+  try {
+    const obj = JSON.parse(content);
+    const mapped = PAYLOAD_MAP[obj.type];
+    if (mapped) return mapped;
+  } catch {
+    // ignore
+  }
+  return { text: content.slice(0, 30) };
+}

--- a/test/vitest/__tests__/message-snippet.spec.ts
+++ b/test/vitest/__tests__/message-snippet.spec.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import { parseMessageSnippet } from '../../../src/utils/message-snippet'
+
+describe('parseMessageSnippet', () => {
+  it('maps subscription payment payload', () => {
+    const json = JSON.stringify({ type: 'cashu_subscription_payment' })
+    const result = parseMessageSnippet(json)
+    expect(result.text).toBe('Subscription payment')
+    expect(result.icon).toBe('mdi-cash')
+  })
+
+  it('returns truncated text for invalid json', () => {
+    const result = parseMessageSnippet('hello world')
+    expect(result.text).toBe('hello world')
+  })
+
+  it('returns truncated text for unknown payload', () => {
+    const json = JSON.stringify({ type: 'unknown', foo: 1 })
+    const result = parseMessageSnippet(json)
+    expect(result.text).toBe(json.slice(0, 30))
+  })
+})


### PR DESCRIPTION
## Summary
- add helper to parse DM payloads
- show nicer snippet text and icon for subscription-related messages
- test the new parsing logic

## Testing
- `pnpm test:ci` *(fails: 25 failed, 24 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687b6a42bc1883309b997769767a31ce