### PR TITLE
Remove redundant dark mode toggle

### DIFF
--- a/src/components/ActiveChatHeader.vue
+++ b/src/components/ActiveChatHeader.vue
@@ -47,13 +47,6 @@
         <div class="text-grey-6">Select a conversation to start chatting.</div>
       </template>
     </div>
-    <q-btn
-      flat
-      dense
-      round
-      :icon="$q.dark.isActive ? 'wb_sunny' : 'brightness_3'"
-      @click="$q.dark.toggle()"
-    />
     <ChatSendTokenDialog
       ref="chatSendTokenDialogRef"
       :recipient="props.pubkey"


### PR DESCRIPTION
## Summary
- remove the chat header dark mode toggle

## Testing
- `pnpm install` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b703418c48330bd5482bfbe52ee4f