### PR TITLE
Improve conversation list item layout

### DIFF
--- a/src/components/ConversationList.vue
+++ b/src/components/ConversationList.vue
@@ -20,6 +20,7 @@
         :selected="item.pubkey === selectedPubkey"
         @click="select(item.pubkey)"
         @pin="togglePin(item.pubkey)"
+        @delete="deleteConversation(item.pubkey)"
       />
       <div
         v-if="uniqueConversations.length === 0"
@@ -87,5 +88,9 @@ watch(uniqueConversations, loadProfiles);
 const select = (pubkey: string) => emit("select", nostr.resolvePubkey(pubkey));
 const togglePin = (pubkey: string) => {
   messenger.togglePin(nostr.resolvePubkey(pubkey));
+};
+
+const deleteConversation = (pubkey: string) => {
+  messenger.deleteConversation(nostr.resolvePubkey(pubkey));
 };
 </script>

--- a/src/stores/messenger.ts
+++ b/src/stores/messenger.ts
@@ -595,6 +595,17 @@ export const useMessengerStore = defineStore("messenger", {
       this.pinned[pubkey] = !this.pinned[pubkey];
     },
 
+    deleteConversation(pubkey: string) {
+      pubkey = this.normalizeKey(pubkey);
+      delete this.conversations[pubkey];
+      delete this.unreadCounts[pubkey];
+      delete this.pinned[pubkey];
+      delete this.aliases[pubkey];
+      if (this.currentConversation === pubkey) {
+        this.currentConversation = "";
+      }
+    },
+
     setAlias(pubkey: string, alias: string) {
       pubkey = this.normalizeKey(pubkey);
       if (alias.trim()) {


### PR DESCRIPTION
## Summary
- enlarge conversation avatar and show alias on its own line
- add context menu with pin/view key/delete actions
- expose deletion event in conversation list
- support deleting conversations in messenger store
- highlight unread count badge

## Testing
- `npm test` *(fails: `npm` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b86eead948330a2609c08aa3aa1ce