### PR TITLE
Add attachment support in messenger

### DIFF
--- a/src/components/ChatMessageBubble.vue
+++ b/src/components/ChatMessageBubble.vue
@@ -26,7 +26,20 @@
         />
       </template>
       <template v-else>
-        {{ message.content }}
+        <q-img
+          v-if="imageSrc"
+          :src="imageSrc"
+          style="max-width: 300px; max-height: 300px"
+          class="q-mb-sm"
+        />
+        <template v-else-if="isFile">
+          <a :href="message.content" target="_blank" :download="attachmentName">
+            {{ attachmentName }}
+          </a>
+        </template>
+        <template v-else>
+          {{ message.content }}
+        </template>
       </template>
     </div>
     <div
@@ -93,6 +106,18 @@ const isoTime = computed(() =>
 const deliveryIcon = computed(() =>
   props.deliveryStatus === "delivered" ? mdiCheckAll : mdiCheck,
 );
+
+const isDataUrl = computed(() => props.message.content.startsWith("data:"));
+const isImageDataUrl = computed(() => props.message.content.startsWith("data:image"));
+const isHttpUrl = computed(() => /^https?:\/\//.test(props.message.content));
+const isImageLink = computed(() =>
+  isHttpUrl.value && /\.(png|jpe?g|gif|webp|svg)$/i.test(props.message.content)
+);
+const imageSrc = computed(() =>
+  isImageDataUrl.value || isImageLink.value ? props.message.content : ""
+);
+const isFile = computed(() => isDataUrl.value || isHttpUrl.value);
+const attachmentName = computed(() => props.message.attachment?.name || props.message.content.split('/').pop()?.split('?')[0] || 'file');
 
 const receiveStore = useReceiveTokensStore();
 const redeemed = ref(false);

--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -210,9 +210,22 @@ export default defineComponent({
       selected.value = pubkey;
     };
 
-    const sendMessage = (text: string) => {
+    const sendMessage = (
+      payload: string | { text: string; attachment?: { dataUrl: string; name: string; type: string } }
+    ) => {
       if (!selected.value) return;
-      messenger.sendDm(selected.value, text);
+      if (typeof payload === "string") {
+        messenger.sendDm(selected.value, payload);
+        return;
+      }
+      const { text, attachment } = payload;
+      if (text) messenger.sendDm(selected.value, text);
+      if (attachment) {
+        messenger.sendDm(selected.value, attachment.dataUrl, undefined, {
+          name: attachment.name,
+          type: attachment.type,
+        });
+      }
     };
 
     function openSendTokenDialog() {


### PR DESCRIPTION
## Summary
- preview selected file before sending
- detect data URLs and file links in chat bubbles
- store attachment metadata for messages

## Testing
- `pnpm run test:ci` *(fails: Module not found errors and many failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_687b88d767c4833086eee2a6fd120376