### PR TITLE
Add floating new chat dialog

### DIFF
--- a/src/components/NewChatDialog.vue
+++ b/src/components/NewChatDialog.vue
@@ -1,0 +1,63 @@
+<template>
+  <q-dialog v-model="show" ref="dialog">
+    <q-card class="q-pa-md" style="min-width: 300px">
+      <div class="text-subtitle1 q-mb-sm">New Chat</div>
+      <q-input
+        v-model="pubkey"
+        label="Recipient Pubkey"
+        @keyup.enter="start"
+        dense
+      />
+      <q-btn
+        label="Start"
+        color="primary"
+        class="q-mt-sm"
+        @click="start"
+        :disable="!pubkey.trim()"
+        dense
+      />
+    </q-card>
+  </q-dialog>
+</template>
+
+<script lang="ts" setup>
+import { ref } from "vue";
+import { nip19 } from "nostr-tools";
+import { notifyError } from "src/js/notify";
+import { useNostrStore } from "src/stores/nostr";
+
+const emit = defineEmits(["start"]);
+const show = ref(false);
+const pubkey = ref("");
+const nostr = useNostrStore();
+
+function start() {
+  const pk = pubkey.value.trim();
+  if (!pk) return;
+  let valid = /^[0-9a-fA-F]{64}$/.test(pk);
+  if (!valid && pk.startsWith("npub")) {
+    try {
+      const decoded = nip19.decode(pk);
+      valid = decoded.type === "npub" && typeof decoded.data === "string";
+    } catch {}
+  }
+  if (!valid) {
+    notifyError("Invalid Nostr pubkey");
+    return;
+  }
+  const resolved = nostr.resolvePubkey(pk);
+  emit("start", resolved);
+  pubkey.value = "";
+  show.value = false;
+}
+
+function showDialog() {
+  show.value = true;
+}
+
+function hideDialog() {
+  show.value = false;
+}
+
+defineExpose({ show: showDialog, hide: hideDialog });
+</script>

--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -20,7 +20,6 @@
         </q-tabs>
         <q-tab-panels v-model="sidebarTab" animated class="col column no-wrap">
           <q-tab-panel name="chats" class="col column no-wrap q-pa-none">
-            <NewChat class="q-mb-md" @start="startChat" />
             <q-scroll-area class="col" style="min-height: 0">
               <Suspense>
                 <template #default>
@@ -89,6 +88,10 @@
       <MessageList :messages="messages" class="col" />
       <MessageInput @send="sendMessage" @sendToken="openSendTokenDialog" />
       <ChatSendTokenDialog ref="chatSendTokenDialogRef" :recipient="selected" />
+      <q-page-sticky position="bottom-right" :offset="[18, 18]">
+        <q-btn fab color="primary" icon="add" @click="openNewChatDialog" />
+      </q-page-sticky>
+      <NewChatDialog ref="newChatDialogRef" @start="startChat" />
     </div>
   </q-page>
   <NostrSetupWizard v-model="showSetupWizard" @complete="setupComplete" />
@@ -113,7 +116,7 @@ import type NDK from "@nostr-dev-kit/ndk";
 
 import NostrIdentityManager from "components/NostrIdentityManager.vue";
 import RelayManagerDialog from "components/RelayManagerDialog.vue";
-import NewChat from "components/NewChat.vue";
+import NewChatDialog from "components/NewChatDialog.vue";
 import ConversationList from "components/ConversationList.vue";
 import ActiveChatHeader from "components/ActiveChatHeader.vue";
 import MessageList from "components/MessageList.vue";
@@ -126,7 +129,7 @@ export default defineComponent({
   components: {
     NostrIdentityManager,
     RelayManagerDialog,
-    NewChat,
+    NewChatDialog,
     ConversationList,
     ActiveChatHeader,
     MessageList,
@@ -223,6 +226,9 @@ export default defineComponent({
     const relayManagerDialogRef = ref<InstanceType<
       typeof RelayManagerDialog
     > | null>(null);
+    const newChatDialogRef = ref<InstanceType<
+      typeof NewChatDialog
+    > | null>(null);
     const messages = computed(
       () => messenger.conversations[selected.value] || []
     );
@@ -302,6 +308,10 @@ export default defineComponent({
       (relayManagerDialogRef.value as any)?.show();
     }
 
+    function openNewChatDialog() {
+      (newChatDialogRef.value as any)?.show();
+    }
+
     const reconnectAll = async () => {
       connecting.value = true;
       try {
@@ -330,6 +340,7 @@ export default defineComponent({
       selected,
       chatSendTokenDialogRef,
       relayManagerDialogRef,
+      newChatDialogRef,
       messages,
       showSetupWizard,
       selectConversation,
@@ -337,6 +348,7 @@ export default defineComponent({
       sendMessage,
       openSendTokenDialog,
       openRelayDialog,
+      openNewChatDialog,
       goBack,
       reconnectAll,
       connectedCount,


### PR DESCRIPTION
## Summary
- move new chat form into a dialog component
- show FAB on the messenger page for starting new chats
- remove inline new chat form from the drawer

## Testing
- `pnpm test` *(fails: vitest not found / other errors)*

------
https://chatgpt.com/codex/tasks/task_e_687bcb1a29a8833099f6cb51bb90fa21