### PR TITLE
Improve conversation list item style

### DIFF
--- a/src/components/ConversationListItem.vue
+++ b/src/components/ConversationListItem.vue
@@ -78,7 +78,7 @@
       </div>
       <div
         :class="[
-          'text-caption ellipsis',
+          'text-caption ellipsis snippet',
           { 'text-weight-bold': unreadCount > 0 },
         ]"
         class="q-mt-xs"
@@ -212,12 +212,13 @@ export default defineComponent({
 <style scoped>
 .conversation-item {
   border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+  padding: 12px 16px;
 }
 .conversation-item.selected {
   background: rgba(0, 0, 0, 0.05);
 }
 .conversation-item:hover {
-  background: rgba(0, 0, 0, 0.03);
+  background: var(--conversation-hover-color);
 }
 .conversation-item:focus {
   border-left: 2px solid var(--q-primary);
@@ -233,6 +234,10 @@ export default defineComponent({
 }
 .timestamp {
   white-space: nowrap;
+  font-size: 0.7rem;
+}
+.snippet {
+  font-size: 0.75rem;
 }
 .status-dot {
   position: absolute;

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -92,6 +92,8 @@ body,
   --muted-light: var(--q-color-grey-6);
   --panel-dark: var(--q-color-grey-9);
   --panel-light: var(--q-color-grey-2);
+  --conversation-hover-dark: var(--q-color-grey-8);
+  --conversation-hover-light: var(--q-color-grey-3);
 }
 
 body.body--dark {
@@ -101,6 +103,7 @@ body.body--dark {
   --divider-color: var(--divider-dark);
   --muted-color: var(--muted-dark);
   --panel-bg-color: var(--panel-dark);
+  --conversation-hover-color: var(--conversation-hover-dark);
 }
 
 body.body--light {
@@ -110,6 +113,7 @@ body.body--light {
   --divider-color: var(--divider-light);
   --muted-color: var(--muted-light);
   --panel-bg-color: var(--panel-light);
+  --conversation-hover-color: var(--conversation-hover-light);
 }
 
 /* utility background classes */


### PR DESCRIPTION
## Summary
- tweak conversation list item spacing and hover color
- shrink snippet and timestamp text
- expose color variable for messenger hover state

## Testing
- `apt-get update` *(fails: Invalid response from proxy)*
- `apt-get install -y nodejs npm` *(fails due to environment restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687bce14726c83308865066987392dfc