### PR TITLE
Implement cancelable reload toast

### DIFF
--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -65,7 +65,11 @@
         <span v-if="!isStaging()">Beta</span>
         <span v-else>Staging – don't use with real funds!</span>
       </q-badge> -->
-      <transition-group appear enter-active-class="animated pulse">
+      <transition
+        appear
+        enter-active-class="animated pulse"
+        leave-active-class="animated fadeOut"
+      >
         <q-badge
           v-if="countdown > 0"
           color="negative"
@@ -82,7 +86,7 @@
             color="white"
           />
         </q-badge>
-      </transition-group>
+      </transition>
       <q-btn
         flat
         dense
@@ -406,7 +410,7 @@ export default defineComponent({
       uiStore.lockMutex();
       reloading.value = true;
       countdown.value = 3;
-      vm?.notify("Reloading in 3 seconds…");
+      vm?.notify("Reloading in 3s…");
       countdownInterval = setInterval(() => {
         countdown.value--;
         if (countdown.value === 0) {


### PR DESCRIPTION
## Summary
- add fade transition for reload countdown badge
- show short `"Reloading in 3s…"` toast on reload

## Testing
- `pnpm install`
- `pnpm test` *(fails: Tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_687bfae774848330a6b6c3cf168a5071