### PR TITLE
Improve conversation list item responsiveness

### DIFF
--- a/src/components/ConversationListItem.vue
+++ b/src/components/ConversationListItem.vue
@@ -222,7 +222,7 @@ export default defineComponent({
   background: rgba(0, 0, 0, 0.05);
 }
 .conversation-item:hover {
-  background: var(--conversation-hover-color);
+  background: var(--hover-bg-color);
 }
 .conversation-item:focus {
   border-left: 2px solid var(--q-primary);
@@ -243,6 +243,7 @@ export default defineComponent({
 .snippet {
   font-size: 0.8rem;
   white-space: normal;
+  color: var(--muted-color);
 }
 .status-dot {
   position: absolute;
@@ -264,5 +265,15 @@ export default defineComponent({
 .timestamp-section {
   min-width: 64px;
   text-align: right;
+}
+
+@media (max-width: 320px) {
+  .conversation-item :deep(.q-avatar) {
+    width: 40px !important;
+    height: 40px !important;
+  }
+  .snippet {
+    display: none;
+  }
 }
 </style>

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -92,8 +92,11 @@ body,
   --muted-light: var(--q-color-grey-6);
   --panel-dark: var(--q-color-grey-9);
   --panel-light: var(--q-color-grey-2);
-  --conversation-hover-dark: var(--q-color-grey-8);
-  --conversation-hover-light: var(--q-color-grey-3);
+  // hover background variables for theme
+  --hover-bg-dark: var(--q-color-grey-8);
+  --hover-bg-light: var(--q-color-grey-3);
+  --conversation-hover-dark: var(--hover-bg-dark);
+  --conversation-hover-light: var(--hover-bg-light);
 }
 
 body.body--dark {
@@ -103,7 +106,8 @@ body.body--dark {
   --divider-color: var(--divider-dark);
   --muted-color: var(--muted-dark);
   --panel-bg-color: var(--panel-dark);
-  --conversation-hover-color: var(--conversation-hover-dark);
+  --hover-bg-color: var(--hover-bg-dark);
+  --conversation-hover-color: var(--hover-bg-color);
 }
 
 body.body--light {
@@ -113,7 +117,8 @@ body.body--light {
   --divider-color: var(--divider-light);
   --muted-color: var(--muted-light);
   --panel-bg-color: var(--panel-light);
-  --conversation-hover-color: var(--conversation-hover-light);
+  --hover-bg-color: var(--hover-bg-light);
+  --conversation-hover-color: var(--hover-bg-color);
 }
 
 /* utility background classes */


### PR DESCRIPTION
## Summary
- declare new CSS variables for hover backgrounds
- use new variables in light/dark mode setup
- tweak ConversationListItem to use the variables
- hide snippet and shrink avatar on very small screens

## Testing
- `npx vitest run` *(fails: needs vitest package)*

------
https://chatgpt.com/codex/tasks/task_e_687bfd65bac88330bbc7b8d832995a25