### PR TITLE
Fix missing div close tag

### DIFF
--- a/src/pages/PublicCreatorProfilePage.vue
+++ b/src/pages/PublicCreatorProfilePage.vue
@@ -78,6 +78,7 @@
         </q-card>
       </div>
       </div>
+      </div>
     </template>
     <template #fallback>
       <q-skeleton height="100vh" square />


### PR DESCRIPTION
## Summary
- add missing closing div in PublicCreatorProfilePage.vue

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm run test` *(fails: Donation presets > calls sendToLock with sequential locktimes, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687c8bc45e6483308e0a4f4f67fe0ad6