### PR TITLE
Add stop modifiers to header buttons

### DIFF
--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -36,7 +36,7 @@
         icon="menu"
         color="primary"
         aria-label="Toggle Chat Menu"
-        @click="toggleMessengerDrawer"
+        @click.stop="toggleMessengerDrawer"
         class="q-mr-sm"
       />
       <transition
@@ -91,7 +91,7 @@
         :icon="countdown > 0 ? 'close' : 'refresh'"
         :color="countdown > 0 ? 'negative' : 'primary'"
         aria-label="Refresh"
-        @click="reload"
+        @click.stop="reload"
         :loading="reloading"
         :disable="uiStore.globalMutexLock && countdown === 0"
       >
@@ -108,7 +108,7 @@
         :icon="darkIcon"
         color="primary"
         aria-label="Toggle Dark Mode"
-        @click="toggleDarkMode"
+        @click.stop="toggleDarkMode"
         class="q-ml-sm"
       />
     </q-toolbar>


### PR DESCRIPTION
## Summary
- prevent event bubbling when clicking messenger, reload, and dark mode buttons

## Testing
- `pnpm run test:ci` *(fails: multiple tests and suites fail)*

------
https://chatgpt.com/codex/tasks/task_e_687c8db54f2c8330835375921380b582