### PR TITLE
Fix translation key references

### DIFF
--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -1275,7 +1275,7 @@ export default defineComponent({
             "FindCreators.notifications.donation_sent"
           ) as string,
           ok: {
-            label: this.$t("FindCreators.actions.back_to_search") as string,
+            label: this.$t("FindCreators.actions.back_to_search.label") as string,
           },
         }).onOk(() => {
           this.showSendTokens = false;

--- a/src/pages/SubscriptionsOverview.vue
+++ b/src/pages/SubscriptionsOverview.vue
@@ -130,7 +130,7 @@
               class="q-ml-xs"
               :to="`/creator/${pubkeyNpub(row.creator)}`"
             >
-              {{ $t("FindCreators.actions.view_profile") }}
+              {{ $t("FindCreators.actions.view_profile.label") }}
             </q-btn>
             <q-btn
               flat
@@ -358,7 +358,7 @@
           class="q-ml-xs"
           :to="`/creator/${pubkeyNpub(props.row.creator)}`"
         >
-          {{ $t("FindCreators.actions.view_profile") }}
+          {{ $t("FindCreators.actions.view_profile.label") }}
         </q-btn>
         <q-btn
           flat


### PR DESCRIPTION
## Summary
- update SubscriptionsOverview to reference the view_profile label
- fix SendTokenDialog to use back_to_search.label

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*
- `npm run test:ci` *(fails: numerous test failures)*

------
https://chatgpt.com/codex/tasks/task_e_687c8f3b8304833094569a8e289bd6db