### PR TITLE
Improve conversation list item styles

### DIFF
--- a/src/components/ConversationListItem.vue
+++ b/src/components/ConversationListItem.vue
@@ -215,14 +215,15 @@ export default defineComponent({
 <style scoped>
 .conversation-item {
   border-bottom: 1px solid rgba(0, 0, 0, 0.1);
-  padding: 16px 20px;
+  padding: 12px 16px;
+  border-radius: 8px;
   transition: background-color 0.2s ease;
 }
 .conversation-item.selected {
-  background: rgba(0, 0, 0, 0.05);
+  background-color: color-mix(in srgb, var(--q-primary), transparent 85%);
 }
 .conversation-item:hover {
-  background: var(--conversation-hover-color);
+  background-color: var(--q-color-grey-3);
 }
 .conversation-item:focus {
   border-left: 2px solid var(--q-primary);
@@ -258,7 +259,7 @@ export default defineComponent({
   font-weight: bold;
   font-size: 0.75rem;
   padding: 0 6px;
-  box-shadow: 0 0 0 2px var(--q-color-white);
+  box-shadow: 0 0 0 2px var(--q-color-white), 0 2px 4px rgba(0, 0, 0, 0.15);
 }
 
 .timestamp-section {


### PR DESCRIPTION
## Summary
- tweak conversation item styling with compact padding and card-like rounding
- add subtle hover effect and stronger selected highlight
- enhance unread badge visibility

## Testing
- `pnpm run lint` *(fails: Invalid option '--ext')*
- `pnpm test` *(fails to complete: multiple failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_687c8f1c1ee483309bbfeb5a448d3bae