### PR TITLE
Add title tooltips and responsive ellipsis for conversation list

### DIFF
--- a/src/components/ConversationListItem.vue
+++ b/src/components/ConversationListItem.vue
@@ -27,6 +27,7 @@
         <q-item-label
           class="text-subtitle1 ellipsis"
           :class="{ 'text-weight-bold': unreadCount > 0 }"
+          :title="displayName"
         >
           {{ displayName }}
         </q-item-label>
@@ -48,6 +49,7 @@
         caption
         class="snippet ellipsis"
         :class="{ 'text-weight-bold': unreadCount > 0 }"
+        :title="snippet.text"
       >
         <template v-if="loaded">
           <q-icon
@@ -244,6 +246,15 @@ export default defineComponent({
 .snippet {
   font-size: 0.8rem;
   white-space: normal;
+}
+
+.conversation-item .ellipsis {
+  flex: 1;
+  min-width: 0;
+}
+
+.drawer-collapsed .conversation-item .ellipsis {
+  display: none;
 }
 .status-dot {
   position: absolute;


### PR DESCRIPTION
## Summary
- add tooltips to display name and snippet in ConversationListItem
- ensure ellipsis text truncates properly and hide labels when drawer collapsed

## Testing
- `pnpm test` *(fails: 47 failed, 203 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687c915ffb6c83308b3203a005c0ce96