### PR TITLE
Improve conversation list UI

### DIFF
--- a/src/components/ConversationList.vue
+++ b/src/components/ConversationList.vue
@@ -13,7 +13,7 @@
     />
     <q-list bordered>
       <template v-if="filteredPinned.length">
-        <q-item-label header>Pinned</q-item-label>
+        <q-item-label header class="q-px-md q-pt-sm q-pb-xs">Pinned</q-item-label>
         <ConversationListItem
           v-for="item in filteredPinned"
           :key="'pinned-' + item.pubkey"
@@ -24,10 +24,10 @@
           @pin="togglePin(item.pubkey)"
           @delete="deleteConversation(item.pubkey)"
         />
-        <q-separator spaced />
+        <q-separator v-if="filteredRegular.length" spaced />
       </template>
 
-      <q-item-label header>All Conversations</q-item-label>
+      <q-item-label header class="q-px-md q-pt-sm q-pb-xs">All Conversations</q-item-label>
       <ConversationListItem
         v-for="item in filteredRegular"
         :key="'reg-' + item.pubkey"

--- a/src/components/ConversationListItem.vue
+++ b/src/components/ConversationListItem.vue
@@ -29,6 +29,13 @@
           :class="{ 'text-weight-bold': unreadCount > 0 }"
           :title="displayName"
         >
+          <q-icon
+            v-if="isPinned"
+            name="star"
+            size="xs"
+            color="warning"
+            class="q-mr-xs"
+          />
           {{ displayName }}
         </q-item-label>
         <q-item-label
@@ -83,7 +90,9 @@
         size="sm"
         :icon="isPinned ? 'star' : 'star_outline'"
         @click.stop="togglePin"
-      />
+      >
+        <q-tooltip>{{ isPinned ? 'Unpin' : 'Pin' }}</q-tooltip>
+      </q-btn>
       <q-btn
         flat
         dense
@@ -92,7 +101,9 @@
         class="q-ml-sm"
         @click.stop="menu = true"
         aria-label="Conversation options"
-      />
+      >
+        <q-tooltip>Options</q-tooltip>
+      </q-btn>
       <q-menu v-model="menu" anchor="bottom right" self="top right">
         <q-list style="min-width: 120px">
           <q-item clickable v-close-popup @click.stop="togglePin">


### PR DESCRIPTION
## Summary
- add padding to conversation section headers
- show star icon on pinned conversations
- add pin & options tooltips
- only show separator when both sections present

## Testing
- `pnpm test` *(fails: 25 failed, 24 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687c9571a77483309f9377fb2b9da3c4