### PR TITLE
Improve messenger drawer layout

### DIFF
--- a/src/components/ConversationList.vue
+++ b/src/components/ConversationList.vue
@@ -1,16 +1,5 @@
 <template>
   <div>
-    <q-toolbar>
-      <q-toolbar-title>Conversations</q-toolbar-title>
-    </q-toolbar>
-    <q-input
-      dense
-      rounded
-      debounce="300"
-      v-model="filterQuery"
-      placeholder="Search…"
-      class="q-px-md q-mt-sm"
-    />
     <q-list bordered>
       <template v-if="filteredPinned.length">
         <q-item-label header class="q-px-md q-pt-sm q-pb-xs">Pinned</q-item-label>
@@ -55,13 +44,19 @@ import { useMessengerStore } from "src/stores/messenger";
 import { useNostrStore } from "src/stores/nostr";
 import ConversationListItem from "./ConversationListItem.vue";
 
-const props = defineProps<{ selectedPubkey: string }>();
+const props = defineProps<{ selectedPubkey: string; search?: string }>();
 
 const emit = defineEmits(["select"]);
 const messenger = useMessengerStore();
 const nostr = useNostrStore();
 const { conversations } = storeToRefs(messenger);
-const filterQuery = ref("");
+const filterQuery = ref(props.search || "");
+watch(
+  () => props.search,
+  (val) => {
+    filterQuery.value = val || "";
+  }
+);
 
 const uniqueConversations = computed(() => {
   return Object.entries(conversations.value)


### PR DESCRIPTION
## Summary
- redesign messenger drawer with new header, search and footer
- support external search input in `ConversationList`
- remove floating action button for new chat

## Testing
- `npx vitest run` *(fails: Need to install vitest)*

------
https://chatgpt.com/codex/tasks/task_e_687c9d7042448330ae1b3074518535dc