### PR TITLE
Add user info section with dark mode toggle

### DIFF
--- a/src/components/UserInfo.vue
+++ b/src/components/UserInfo.vue
@@ -1,0 +1,56 @@
+<template>
+  <div class="row items-center justify-between q-mt-md">
+    <div class="row items-center">
+      <q-avatar size="32px" class="q-mr-sm">
+        <img v-if="profile?.picture" :src="profile.picture" />
+        <span v-else>{{ initials }}</span>
+      </q-avatar>
+      <div class="row items-center no-wrap">
+        <span class="text-caption ellipsis" style="max-width: 100px">{{ truncatedNpub }}</span>
+        <q-btn flat dense round icon="content_copy" size="sm" class="q-ml-xs" @click="copyPubkey" />
+      </div>
+    </div>
+    <q-btn
+      flat
+      dense
+      round
+      size="0.8em"
+      :icon="$q.dark.isActive ? 'brightness_3' : 'wb_sunny'"
+      color="primary"
+      aria-label="Toggle Dark Mode"
+      @click="toggleDark"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useQuasar } from 'quasar';
+import { useNostrStore } from 'src/stores/nostr';
+import { shortenString } from 'src/js/string-utils';
+
+const $q = useQuasar();
+const nostr = useNostrStore();
+
+const profile = computed(() => {
+  const entry: any = (nostr.profiles as any)[nostr.pubkey];
+  return entry?.profile ?? entry ?? {};
+});
+
+const initials = computed(() => {
+  const name = profile.value.display_name || profile.value.name || '';
+  const parts = name.split(/\s+/).filter(Boolean);
+  return parts.slice(0, 2).map(w => w[0]).join('').toUpperCase();
+});
+
+const truncatedNpub = computed(() => shortenString(nostr.npub, 12, 6) || nostr.npub);
+
+function copyPubkey() {
+  navigator.clipboard.writeText(nostr.npub);
+}
+
+function toggleDark() {
+  $q.dark.toggle();
+  $q.localStorage.set('cashu.darkMode', $q.dark.isActive);
+}
+</script>

--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -46,19 +46,7 @@
                 </template>
               </Suspense>
             </q-scroll-area>
-            <div class="row items-center justify-between q-mt-md">
-              <div class="row items-center">
-                <q-avatar size="32px" class="q-mr-sm">
-                  <img v-if="myProfile?.picture" :src="myProfile.picture" />
-                  <span v-else>{{ myInitials }}</span>
-                </q-avatar>
-                <div class="row items-center no-wrap">
-                  <span class="text-caption ellipsis" style="max-width: 100px">{{ truncatedNpub }}</span>
-                  <q-btn flat dense round icon="content_copy" size="sm" class="q-ml-xs" @click="copy(nostr.npub)" />
-                </div>
-              </div>
-              <ThemeToggle />
-            </div>
+            <UserInfo />
           </div>
         </template>
         <template v-else>
@@ -148,8 +136,7 @@ import MessageList from "components/MessageList.vue";
 import MessageInput from "components/MessageInput.vue";
 import ChatSendTokenDialog from "components/ChatSendTokenDialog.vue";
 import NostrSetupWizard from "components/NostrSetupWizard.vue";
-import ThemeToggle from "components/ThemeToggle.vue";
-import { useClipboard } from "src/composables/useClipboard";
+import UserInfo from "components/UserInfo.vue";
 import { shortenString } from "src/js/string-utils";
 
 export default defineComponent({
@@ -162,7 +149,7 @@ export default defineComponent({
     MessageInput,
     ChatSendTokenDialog,
     NostrSetupWizard,
-    ThemeToggle,
+    UserInfo,
   },
   setup() {
     const loading = ref(true);
@@ -247,20 +234,6 @@ export default defineComponent({
       typeof NewChatDialog
     > | null>(null);
     const conversationSearch = ref("");
-    const { copy } = useClipboard();
-    const myProfile = computed(() => {
-      const entry: any = (nostr.profiles as any)[nostr.pubkey];
-      return entry?.profile ?? entry ?? {};
-    });
-    const myInitials = computed(() => {
-      const name =
-        myProfile.value.display_name || myProfile.value.name || "";
-      const parts = name.split(/\s+/).filter(Boolean);
-      return parts.slice(0, 2).map((w) => w[0]).join("").toUpperCase();
-    });
-    const truncatedNpub = computed(
-      () => shortenString(nostr.npub, 12, 6) || nostr.npub
-    );
     const messages = computed(
       () => messenger.conversations[selected.value] || []
     );
@@ -402,10 +375,6 @@ export default defineComponent({
       chatSendTokenDialogRef,
       newChatDialogRef,
       conversationSearch,
-      copy,
-      myProfile,
-      myInitials,
-      truncatedNpub,
       messages,
       showSetupWizard,
       selectConversation,


### PR DESCRIPTION
## Summary
- create `UserInfo.vue` component showing avatar, pubkey copy and dark mode toggle
- use new `UserInfo` in `NostrMessenger.vue`

## Testing
- `pnpm test:ci` *(fails: Vitest tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_687ca256f6f88330abc8a0de1d717b25