### PR TITLE
Fix mocks for messenger and creators tests

### DIFF
--- a/test/vitest/__tests__/creators.spec.ts
+++ b/test/vitest/__tests__/creators.spec.ts
@@ -23,8 +23,7 @@ vi.mock("../../../src/stores/nostr", async (importOriginal) => {
 vi.mock("nostr-tools", () => ({
   nip19: { decode: vi.fn() },
 }));
-
-const { nip19 } = require("nostr-tools");
+import { nip19 } from "nostr-tools";
 
 beforeEach(() => {
   vi.clearAllMocks();

--- a/test/vitest/__tests__/messenger-send-token.spec.ts
+++ b/test/vitest/__tests__/messenger-send-token.spec.ts
@@ -23,6 +23,7 @@ vi.mock("../../../src/stores/nostr", async (importOriginal) => {
       signerType: "seed",
       connected: true,
       relays: [] as string[],
+      resolvePubkey: (pk: string) => pk,
       get privKeyHex() {
         return this.privateKeySignerPrivateKey;
       },
@@ -72,6 +73,7 @@ import { useMessengerStore } from "../../../src/stores/messenger";
 beforeEach(() => {
   localStorage.clear();
   vi.clearAllMocks();
+  useMessengerStore().$reset();
 });
 
 describe("messenger.sendToken", () => {

--- a/test/vitest/__tests__/messenger.spec.ts
+++ b/test/vitest/__tests__/messenger.spec.ts
@@ -29,6 +29,7 @@ vi.mock("../../../src/stores/nostr", async (importOriginal) => {
     pubkey: "pub",
     connected: true,
     relays: [] as string[],
+    resolvePubkey: (pk: string) => pk,
   };
   Object.defineProperty(store, "privKeyHex", {
     get() {
@@ -56,6 +57,7 @@ import { useNostrStore } from "../../../src/stores/nostr";
 beforeEach(() => {
   localStorage.clear();
   vi.clearAllMocks();
+  useMessengerStore().$reset();
 });
 
 describe("messenger store", () => {


### PR DESCRIPTION
## Summary
- repair messenger test mocks so resolvePubkey is available
- reset messenger store between tests
- import nip19 correctly in creators tests

## Testing
- `pnpm install`
- `npm test -- --run` *(fails: Cannot access 'MockNDKEvent' before initialization)*

------
https://chatgpt.com/codex/tasks/task_e_687cbc190f6c833083f7d8426ed273f8