### PR TITLE
Fix missing div end tag

### DIFF
--- a/src/components/ChatMessageBubble.vue
+++ b/src/components/ChatMessageBubble.vue
@@ -78,6 +78,7 @@
       <span v-else>{{ initials }}</span>
     </q-avatar>
   </div>
+  </div>
 </template>
 
 <script lang="ts" setup>


### PR DESCRIPTION
## Summary
- close missing div in ChatMessageBubble to fix template parser error

## Testing
- `npm run lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cbc8d7a0c83308af580c0a654df04