### PR TITLE
Add toast helper

### DIFF
--- a/src/composables/useClipboard.ts
+++ b/src/composables/useClipboard.ts
@@ -1,27 +1,16 @@
-import { useQuasar } from 'quasar'
 import { useI18n } from 'vue-i18n'
+import { toastSuccess, toastError } from 'src/js/toast'
 
 export function useClipboard() {
-  const $q = useQuasar()
   const { t } = useI18n()
 
   const copy = (text: string, message?: string) => {
     navigator.clipboard.writeText(text).then(
       () => {
-        $q.notify({
-          type: 'positive',
-          message: message || t('copied_to_clipboard'),
-          timeout: 1000,
-          position: 'top',
-        })
+        toastSuccess(message || t('copied_to_clipboard'))
       },
       () => {
-        $q.notify({
-          type: 'negative',
-          message: t('copy_failed'),
-          timeout: 1000,
-          position: 'top',
-        })
+        toastError(t('copy_failed'))
       }
     )
   }

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -155,3 +155,9 @@ body.body--dark .received {
 .no-horizontal-scroll {
   overflow-x: hidden;
 }
+
+.cashu-toast {
+  border-radius: 4px;
+  padding: 4px 12px;
+  font-weight: 500;
+}

--- a/src/js/toast.ts
+++ b/src/js/toast.ts
@@ -1,0 +1,19 @@
+import { Notify, QNotifyCreateOptions } from 'quasar'
+
+const baseOpts: QNotifyCreateOptions = {
+  timeout: 1500,
+  position: 'top',
+  classes: 'cashu-toast',
+}
+
+export function toastSuccess(message: string) {
+  Notify.create({ ...baseOpts, type: 'positive', message })
+}
+
+export function toastError(message: string) {
+  Notify.create({ ...baseOpts, type: 'negative', message })
+}
+
+export function toast(message: string) {
+  Notify.create({ ...baseOpts, message })
+}

--- a/src/pages/SubscriptionsOverview.vue
+++ b/src/pages/SubscriptionsOverview.vue
@@ -313,6 +313,7 @@ import { formatDistanceToNow } from "date-fns";
 import { shortenString } from "src/js/string-utils";
 import { useI18n } from "vue-i18n";
 import { notifySuccess, notifyError } from "src/js/notify";
+import { toastSuccess } from "src/js/toast";
 import type { Proof } from "@cashu/cashu-ts";
 import { useProofsStore } from "stores/proofs";
 import { useSendTokensStore } from "stores/sendTokensStore";
@@ -652,7 +653,7 @@ function confirmCancel() {
   subscriptionsStore
     .cancelSubscription(pubkey)
     .then(() =>
-      notifySuccess(t("SubscriptionsOverview.notifications.cancel_success"))
+      toastSuccess(t("SubscriptionsOverview.notifications.cancel_success"))
     )
     .catch((e: any) => notifyError(e.message))
     .finally(() => {


### PR DESCRIPTION
## Summary
- add a simple `toast` helper using Quasar Notify
- style toast notification
- update clipboard composable to use toast
- show toast when canceling a subscription

## Testing
- `pnpm install`
- `pnpm test` *(fails: many tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_687ccb92eb6c8330acf7c39aa3c848ac