### PR TITLE
Fix nutzap retry banner

### DIFF
--- a/src/pages/SubscriptionsOverview.vue
+++ b/src/pages/SubscriptionsOverview.vue
@@ -551,8 +551,9 @@ async function confirmMessage() {
   }
 }
 
-function retryQueuedSends() {
-  nutzap.retryQueuedSends();
+async function retryQueuedSends() {
+  await nutzap.retryQueuedSends();
+  nutzap.clearSendQueue();
 }
 
 function cancelSubscription(pubkey: string) {

--- a/src/stores/nutzap.ts
+++ b/src/stores/nutzap.ts
@@ -66,6 +66,10 @@ export const useNutzapStore = defineStore("nutzap", {
       this.sendQueue.push(data);
     },
 
+    clearSendQueue() {
+      this.sendQueue.splice(0, this.sendQueue.length);
+    },
+
     async resendQueued(item: NutzapQueuedSend) {
       const messenger = useMessengerStore();
       const payload = subscriptionPayload(item.token, item.unlockTime, {


### PR DESCRIPTION
## Summary
- watch `sendQueue` for queued Nutzap payments
- retry and clear queue on click

## Testing
- `pnpm test` *(fails: Tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_687ccdca0bc0833086e967f8381ef14f