### PR TITLE
Fix unclosed div in SubscriptionsOverview

### DIFF
--- a/src/pages/SubscriptionsOverview.vue
+++ b/src/pages/SubscriptionsOverview.vue
@@ -291,6 +291,7 @@
       @confirm="confirmCancel"
     />
   </div>
+  </div>
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
## Summary
- fix markup by closing root `<div>` in SubscriptionsOverview.vue

## Testing
- `pnpm test` *(fails: 25 failed, 24 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687cd02cc8788330a12f1098ea30a7f6