### PR TITLE
Add optional metadata to Subscription

### DIFF
--- a/src/components/SubscribeDialog.vue
+++ b/src/components/SubscribeDialog.vue
@@ -213,6 +213,10 @@ export default defineComponent({
           months: months.value,
           startDate: Math.floor(new Date(startDate.value).getTime() / 1000),
           relayList: profile.relays ?? [],
+          tierName: props.tier?.name,
+          benefits: props.tier?.benefits,
+          creatorName: profile?.name,
+          creatorAvatar: profile?.picture,
         });
         if (success) {
           notifySuccess(t("FindCreators.notifications.subscription_success"));

--- a/src/stores/dexie.ts
+++ b/src/stores/dexie.ts
@@ -55,6 +55,10 @@ export interface Subscription {
   frequency: "monthly" | "weekly";
   startDate: number;
   commitmentLength: number;
+  tierName?: string;
+  benefits?: string[];
+  creatorName?: string;
+  creatorAvatar?: string;
   intervals: SubscriptionInterval[];
   status: "active" | "pending_renewal" | "cancelled" | "completed";
   createdAt: number;
@@ -420,6 +424,16 @@ export class CashuDexie extends Dexie {
             if (i.htlcHash === undefined) i.htlcHash = null;
             if (i.htlcSecret === undefined) i.htlcSecret = null;
           });
+        });
+      });
+
+    this.version(18)
+      .upgrade(async (tx) => {
+        await tx.table("subscriptions").toCollection().modify((entry: any) => {
+          if (entry.tierName === undefined) entry.tierName = null;
+          if (entry.benefits === undefined) entry.benefits = [];
+          if (entry.creatorName === undefined) entry.creatorName = null;
+          if (entry.creatorAvatar === undefined) entry.creatorAvatar = null;
         });
       });
   }

--- a/src/stores/nutzap.ts
+++ b/src/stores/nutzap.ts
@@ -171,6 +171,10 @@ export const useNutzapStore = defineStore("nutzap", {
       startDate,
       relayList,
       htlc,
+      tierName,
+      benefits,
+      creatorName,
+      creatorAvatar,
     }: SubscribeTierOptions): Promise<boolean> {
       const wallet = useWalletStore();
       const mints = useMintsStore();
@@ -281,6 +285,10 @@ export const useNutzapStore = defineStore("nutzap", {
         frequency: "monthly",
         startDate,
         commitmentLength: months,
+        ...(tierName ? { tierName } : {}),
+        ...(benefits ? { benefits } : {}),
+        ...(creatorName ? { creatorName } : {}),
+        ...(creatorAvatar ? { creatorAvatar } : {}),
         intervals: lockedTokens.map((t, idx) => ({
           intervalKey: String(idx + 1),
           lockedTokenId: t.id,

--- a/src/stores/subscriptions.ts
+++ b/src/stores/subscriptions.ts
@@ -24,6 +24,10 @@ export const useSubscriptionsStore = defineStore("subscriptions", () => {
     const entry: Subscription = {
       id: data.id ?? uuidv4(),
       ...data,
+      tierName: data.tierName ?? null,
+      benefits: data.benefits ?? [],
+      creatorName: data.creatorName ?? null,
+      creatorAvatar: data.creatorAvatar ?? null,
       intervals: data.intervals.map((i) => ({
         ...i,
         redeemed: i.redeemed ?? false,

--- a/src/types/creator.ts
+++ b/src/types/creator.ts
@@ -15,4 +15,8 @@ export interface SubscribeTierOptions {
   startDate: number;
   relayList: string[];
   htlc?: boolean;
+  tierName?: string;
+  benefits?: string[];
+  creatorName?: string;
+  creatorAvatar?: string;
 }


### PR DESCRIPTION
## Summary
- extend `Subscription` with optional metadata fields
- default new metadata in `addSubscription`
- allow passing metadata to `subscribeToTier`
- migrate existing records to include new fields

## Testing
- `pnpm types` *(fails: Cannot find module ../../../src/components/InfoTooltip.vue)*
- `pnpm test` *(fails: 25 failed, 24 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687cd6f2d91c83309ab80e0c2ac4c7e7