### PR TITLE
Add toast helper for subscription actions

### DIFF
--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1537,6 +1537,7 @@ export const messages = {
     notifications: {
       cancel_success: "Subscription canceled",
       extend_success: "Subscription extended",
+      export_success: "Tokens exported",
     },
     row: {
       next_unlock_label: "Next unlock in { value }",

--- a/src/js/toast.ts
+++ b/src/js/toast.ts
@@ -17,3 +17,11 @@ export function toastError(message: string) {
 export function toast(message: string) {
   Notify.create({ ...baseOpts, message })
 }
+
+export function showToast(
+  message: string,
+  type?: QNotifyCreateOptions['type']
+) {
+  Notify.create({ ...baseOpts, type, message })
+}
+

--- a/src/pages/SubscriptionsOverview.vue
+++ b/src/pages/SubscriptionsOverview.vue
@@ -346,8 +346,8 @@ import { nip19 } from "nostr-tools";
 import { formatDistanceToNow } from "date-fns";
 import { shortenString } from "src/js/string-utils";
 import { useI18n } from "vue-i18n";
-import { notifySuccess, notifyError } from "src/js/notify";
-import { toastSuccess } from "src/js/toast";
+import { notifyError } from "src/js/notify";
+import { showToast } from "src/js/toast";
 import type { Proof } from "@cashu/cashu-ts";
 import { useProofsStore } from "stores/proofs";
 import { useSendTokensStore } from "stores/sendTokensStore";
@@ -644,9 +644,9 @@ function extendSubscription(pubkey: string) {
       });
       receiptList.value = receipts as any[];
       showReceiptDialog.value = true;
-      notifySuccess(t("SubscriptionsOverview.notifications.extend_success"));
+      showToast(t("SubscriptionsOverview.notifications.extend_success"), "positive");
     } catch (e: any) {
-      notifyError(e.message);
+      showToast(e.message, 'negative');
     }
   });
 }
@@ -680,6 +680,7 @@ function exportTokens(pubkey: string) {
   a.download = `tokens_${pubkey}.csv`;
   a.click();
   URL.revokeObjectURL(url);
+  showToast(t('SubscriptionsOverview.notifications.export_success'), 'positive');
 }
 
 function confirmCancel() {
@@ -688,9 +689,9 @@ function confirmCancel() {
   subscriptionsStore
     .cancelSubscription(pubkey)
     .then(() =>
-      toastSuccess(t("SubscriptionsOverview.notifications.cancel_success"))
+      showToast(t("SubscriptionsOverview.notifications.cancel_success"), "positive")
     )
-    .catch((e: any) => notifyError(e.message))
+    .catch((e: any) => showToast(e.message, 'negative'))
     .finally(() => {
       showConfirmDialog.value = false;
     });


### PR DESCRIPTION
## Summary
- add a `showToast` helper for quasar notifications
- use `showToast` for extending, canceling and exporting subscriptions
- add translation string for export success

## Testing
- `pnpm test:ci` *(fails: vitest reports multiple failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_687cdba525348330b750a59204e659f3