### PR TITLE
Add bucket archival feature

### DIFF
--- a/test/vitest/__tests__/buckets.spec.ts
+++ b/test/vitest/__tests__/buckets.spec.ts
@@ -180,4 +180,27 @@ describe("Buckets store", () => {
 
     expect(buckets.notifiedGoals[bucket.id]).toBe(false);
   });
+
+  it("defaults isArchived to false and toggles", () => {
+    const buckets = useBucketsStore();
+    const defaultBucket = buckets.bucketList.find(
+      (b) => b.id === DEFAULT_BUCKET_ID
+    );
+    expect(defaultBucket?.isArchived).toBe(false);
+
+    const bucket = buckets.addBucket({ name: "Archive Me" })!;
+    expect(bucket.isArchived).toBe(false);
+    expect(buckets.activeBuckets.find((b) => b.id === bucket.id)).toBeDefined();
+    expect(buckets.archivedBuckets.find((b) => b.id === bucket.id)).toBeUndefined();
+
+    buckets.editBucket(bucket.id, { isArchived: true });
+    expect(buckets.archivedBuckets.find((b) => b.id === bucket.id)).toBeDefined();
+    expect(buckets.activeBuckets.find((b) => b.id === bucket.id)).toBeUndefined();
+
+    // default bucket cannot be archived
+    buckets.editBucket(DEFAULT_BUCKET_ID, { isArchived: true });
+    expect(
+      buckets.activeBuckets.find((b) => b.id === DEFAULT_BUCKET_ID)?.isArchived
+    ).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- add `isArchived` field to `Bucket`
- default new buckets to not archived and add archive filters
- prevent default bucket from being archived via edit
- expose active/archived bucket getters
- test archival behavior

## Testing
- `pnpm install`
- `pnpm run test:ci` *(fails: 46 failed, 205 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687d29ec5f4883309bcad8d14d9f7bd4