### PR TITLE
Enhance bucket filtering by description

### DIFF
--- a/src/components/BucketManager.vue
+++ b/src/components/BucketManager.vue
@@ -187,9 +187,11 @@ export default defineComponent({
     const searchTerm = ref("");
     const filteredBuckets = computed(() => {
       const term = searchTerm.value.toLowerCase();
-      return bucketList.value.filter((b) =>
-        b.name.toLowerCase().includes(term)
-      );
+      return bucketList.value.filter((b) => {
+        const name = (b.name || "").toLowerCase();
+        const description = (b.description || "").toLowerCase();
+        return name.includes(term) || description.includes(term);
+      });
     });
     const bucketBalances = computed(() => bucketsStore.bucketBalances);
 

--- a/test/vitest/__tests__/bucketManagerForm.spec.ts
+++ b/test/vitest/__tests__/bucketManagerForm.spec.ts
@@ -3,8 +3,8 @@ import { shallowMount } from "@vue/test-utils";
 import BucketManager from "../../../src/components/BucketManager.vue";
 
 const mockBuckets = [
-  { id: "b1", name: "Alpha" },
-  { id: "b2", name: "Beta" },
+  { id: "b1", name: "Alpha", description: "First bucket" },
+  { id: "b2", name: "Beta", description: "Second bucket" },
 ];
 
 vi.mock("../../../src/stores/proofs", () => ({
@@ -47,6 +47,14 @@ describe("BucketManager form", () => {
     const wrapper = shallowMount(BucketManager);
     expect(wrapper.findAll("bucket-card-stub").length).toBe(2);
     (wrapper.vm as any).searchTerm = "Beta";
+    await wrapper.vm.$nextTick();
+    expect(wrapper.findAll("bucket-card-stub").length).toBe(1);
+  });
+
+  it("filters buckets by description text", async () => {
+    const wrapper = shallowMount(BucketManager);
+    expect(wrapper.findAll("bucket-card-stub").length).toBe(2);
+    (wrapper.vm as any).searchTerm = "Second";
     await wrapper.vm.$nextTick();
     expect(wrapper.findAll("bucket-card-stub").length).toBe(1);
   });


### PR DESCRIPTION
## Summary
- search bucket descriptions as well as names
- test filtering by bucket description

## Testing
- `pnpm test` *(fails: Vitest reported many failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_687d2b394e108330a3adb239e64aaadd