### PR TITLE
Add archived bucket filter

### DIFF
--- a/src/components/BucketManager.vue
+++ b/src/components/BucketManager.vue
@@ -8,6 +8,10 @@
       class="q-mb-md"
       :placeholder="$t('bucketManager.inputs.search.placeholder')"
     />
+    <q-tabs v-model="viewMode" dense class="q-mb-md" no-caps>
+      <q-tab name="all" :label="$t('BucketManager.view.all')" />
+      <q-tab name="archived" :label="$t('BucketManager.view.archived')" />
+    </q-tabs>
     <q-list padding>
       <div
         v-for="bucket in filteredBuckets"
@@ -183,15 +187,21 @@ export default defineComponent({
       creatorPubkey: "",
     });
 
+    const viewMode = ref("all");
+
     const bucketList = computed(() => bucketsStore.bucketList);
     const searchTerm = ref("");
     const filteredBuckets = computed(() => {
       const term = searchTerm.value.toLowerCase();
-      return bucketList.value.filter((b) => {
-        const name = (b.name || "").toLowerCase();
-        const description = (b.description || "").toLowerCase();
-        return name.includes(term) || description.includes(term);
-      });
+      return bucketList.value
+        .filter((b) =>
+          viewMode.value === "archived" ? b.isArchived : !b.isArchived
+        )
+        .filter((b) => {
+          const name = (b.name || "").toLowerCase();
+          const description = (b.description || "").toLowerCase();
+          return name.includes(term) || description.includes(term);
+        });
     });
     const bucketBalances = computed(() => bucketsStore.bucketBalances);
 
@@ -270,6 +280,7 @@ export default defineComponent({
       DEFAULT_BUCKET_ID,
       bucketList,
       searchTerm,
+      viewMode,
       filteredBuckets,
       bucketBalances,
       activeUnit,

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1461,6 +1461,10 @@ export const messages = {
     delete_confirm: {
       title: "Delete bucket?",
     },
+    view: {
+      all: "All",
+      archived: "Archived",
+    },
   },
   BucketDetail: {
     move: "Move tokens",

--- a/test/vitest/__tests__/bucketManagerViewMode.spec.ts
+++ b/test/vitest/__tests__/bucketManagerViewMode.spec.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi } from "vitest";
+import { shallowMount } from "@vue/test-utils";
+import BucketManager from "../../../src/components/BucketManager.vue";
+
+const mockBuckets = [
+  { id: "b1", name: "Active", isArchived: false },
+  { id: "b2", name: "Old", isArchived: true },
+];
+
+vi.mock("../../../src/stores/proofs", () => ({
+  useProofsStore: () => ({ moveProofs: vi.fn() }),
+}));
+
+vi.mock("../../../src/stores/buckets", () => ({
+  useBucketsStore: () => ({
+    bucketList: mockBuckets,
+    bucketBalances: {},
+    addBucket: vi.fn(),
+    editBucket: vi.fn(),
+    deleteBucket: vi.fn(),
+  }),
+  DEFAULT_BUCKET_ID: "b1",
+}));
+
+vi.mock("../../../src/stores/mints", () => ({
+  useMintsStore: () => ({ activeUnit: "sat" }),
+}));
+
+vi.mock("../../../src/stores/ui", () => ({
+  useUiStore: () => ({ formatCurrency: (a: number) => String(a) }),
+}));
+
+vi.mock("../../../src/js/notify", () => ({
+  notifyError: vi.fn(),
+}));
+
+describe("BucketManager view mode", () => {
+  it("switching viewMode filters buckets", async () => {
+    const wrapper = shallowMount(BucketManager);
+    expect(wrapper.findAll("bucket-card-stub").length).toBe(1);
+    (wrapper.vm as any).viewMode = "archived";
+    await wrapper.vm.$nextTick();
+    expect(wrapper.findAll("bucket-card-stub").length).toBe(1);
+    expect((wrapper.vm as any).filteredBuckets[0].id).toBe("b2");
+    (wrapper.vm as any).viewMode = "all";
+    await wrapper.vm.$nextTick();
+    expect(wrapper.findAll("bucket-card-stub").length).toBe(1);
+    expect((wrapper.vm as any).filteredBuckets[0].id).toBe("b1");
+  });
+});


### PR DESCRIPTION
## Summary
- add view mode tabs in `BucketManager`
- filter buckets based on archived state
- provide i18n strings for view tabs
- test view mode filtering

## Testing
- `npx vitest run` *(fails: 26 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_687d2f2115a88330913e56fe4dcdcbda