### PR TITLE
Add bucket menu

### DIFF
--- a/src/components/BucketManager.vue
+++ b/src/components/BucketManager.vue
@@ -24,8 +24,7 @@
           :bucket="bucket"
           :balance="bucketBalances[bucket.id] || 0"
           :activeUnit="activeUnit.value"
-          @edit="openEdit"
-          @delete="openDelete"
+          @menu-action="handleMenuAction"
         />
       </div>
       <q-item>
@@ -165,12 +164,14 @@ import { notifyError } from "src/js/notify";
 import { DEFAULT_COLOR } from "src/js/constants";
 import BucketCard from "./BucketCard.vue";
 import BucketDialog from "./BucketDialog.vue";
+import { useRouter } from "vue-router";
 
 export default defineComponent({
   name: "BucketManager",
   components: { BucketCard, BucketDialog },
   setup() {
     const bucketsStore = useBucketsStore();
+    const router = useRouter();
     const uiStore = useUiStore();
     const { t } = useI18n();
     const showForm = ref(false);
@@ -276,6 +277,23 @@ export default defineComponent({
       showDelete.value = false;
     };
 
+    const handleMenuAction = ({ action, bucket }) => {
+      switch (action) {
+        case "view":
+          router.push(`/buckets/${bucket.id}`);
+          break;
+        case "edit":
+          openEdit(bucket);
+          break;
+        case "archive":
+          bucketsStore.editBucket(bucket.id, { isArchived: !bucket.isArchived });
+          break;
+        case "delete":
+          openDelete(bucket.id);
+          break;
+      }
+    };
+
     return {
       DEFAULT_BUCKET_ID,
       bucketList,
@@ -299,6 +317,7 @@ export default defineComponent({
       deleteBucket,
       formatCurrency,
       handleDrop,
+      handleMenuAction,
       DEFAULT_COLOR,
     };
   },

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1432,6 +1432,9 @@ export const messages = {
       add: "Create new Bucket",
       delete: "Delete",
       edit: "Edit",
+      archive: "Archive",
+      unarchive: "Unarchive",
+      view_tokens: "View tokens",
     },
     inputs: {
       name: "Name",

--- a/test/vitest/__tests__/bucketCardMenu.spec.ts
+++ b/test/vitest/__tests__/bucketCardMenu.spec.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import BucketCard from '../../../src/components/BucketCard.vue';
+
+const bucket = { id: 'b1', name: 'Bucket', isArchived: false };
+
+describe('BucketCard menu actions', () => {
+  it('emits menu-action for each option', async () => {
+    const wrapper = mount(BucketCard, {
+      props: { bucket, balance: 0, activeUnit: 'sat' },
+      global: {
+        stubs: { 'q-menu': { template: '<div><slot /></div>' } }
+      }
+    });
+
+    await wrapper.find('[data-test="bucket-menu-btn"]').trigger('click');
+    await wrapper.find('[data-test="view"]').trigger('click');
+    await wrapper.find('[data-test="edit"]').trigger('click');
+    await wrapper.find('[data-test="archive"]').trigger('click');
+    await wrapper.find('[data-test="delete"]').trigger('click');
+
+    const events = wrapper.emitted('menu-action');
+    expect(events).toHaveLength(4);
+    expect(events?.[0][0].action).toBe('view');
+    expect(events?.[1][0].action).toBe('edit');
+    expect(events?.[2][0].action).toBe('archive');
+    expect(events?.[3][0].action).toBe('delete');
+  });
+});


### PR DESCRIPTION
## Summary
- add a kebab menu to BucketCard with options
- handle new `menu-action` in BucketManager
- translate menu actions
- test BucketCard menu

## Testing
- `pnpm install`
- `pnpm test` *(fails: Cannot access mocking modules and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_687d32aad4288330ac33bf284d2128d6