### PR TITLE
Add bucket modals

### DIFF
--- a/src/components/BucketDetailModal.vue
+++ b/src/components/BucketDetailModal.vue
@@ -1,0 +1,51 @@
+<template>
+  <q-dialog v-model="showLocal">
+    <q-card class="q-pa-md" style="max-width: 600px">
+      <h6 class="q-mt-none q-mb-md">{{ bucket?.name }}</h6>
+      <q-list bordered>
+        <q-item v-for="p in bucketProofs" :key="p.secret">
+          <q-item-section>
+            <q-item-label class="text-weight-bold">{{ formatCurrency(p.amount, activeUnit.value) }}</q-item-label>
+            <q-item-label caption v-if="p.label">{{ p.label }}</q-item-label>
+          </q-item-section>
+        </q-item>
+      </q-list>
+      <div class="row q-mt-md">
+        <q-btn flat rounded color="grey" class="q-ml-auto" v-close-popup>{{ $t('global.actions.close.label') }}</q-btn>
+      </div>
+    </q-card>
+  </q-dialog>
+</template>
+
+<script lang="ts" setup>
+import { computed } from 'vue';
+import { useProofsStore } from 'stores/proofs';
+import { useBucketsStore } from 'stores/buckets';
+import { useMintsStore } from 'stores/mints';
+import { storeToRefs } from 'pinia';
+import { useUiStore } from 'stores/ui';
+import { useI18n } from 'vue-i18n';
+
+const props = defineProps<{ modelValue: boolean; bucketId: string | null }>();
+const emit = defineEmits(['update:modelValue']);
+const { t } = useI18n();
+
+const showLocal = computed({
+  get: () => props.modelValue,
+  set: val => emit('update:modelValue', val)
+});
+
+const bucketsStore = useBucketsStore();
+const proofsStore = useProofsStore();
+const mintsStore = useMintsStore();
+const uiStore = useUiStore();
+const { activeUnit } = storeToRefs(mintsStore);
+
+const bucket = computed(() =>
+  bucketsStore.bucketList.find(b => b.id === props.bucketId) || null
+);
+const bucketProofs = computed(() =>
+  proofsStore.proofs.filter(p => p.bucketId === props.bucketId && !p.reserved)
+);
+const formatCurrency = (a:number, unit:string) => uiStore.formatCurrency(a, unit);
+</script>

--- a/src/components/EditBucketModal.vue
+++ b/src/components/EditBucketModal.vue
@@ -1,0 +1,85 @@
+<template>
+  <q-dialog v-model="showLocal">
+    <q-card class="q-pa-lg" style="max-width: 500px">
+      <h6 class="q-mt-none q-mb-md">{{ $t('BucketManager.actions.edit') }}</h6>
+      <q-form>
+        <q-input v-model="local.name" outlined :label="$t('bucket.name')" class="q-mb-sm" />
+        <q-input v-model="local.color" outlined :label="$t('bucket.color')" type="color" class="q-mb-sm" />
+        <q-input
+          v-model="local.description"
+          outlined
+          type="textarea"
+          autogrow
+          class="q-mb-sm"
+        >
+          <template #label>
+            <div class="row items-center no-wrap">
+              <span>{{ $t('bucket.description') }}</span>
+            </div>
+          </template>
+        </q-input>
+        <q-input v-model.number="local.goal" outlined type="number" class="q-mb-sm">
+          <template #label>
+            <div class="row items-center no-wrap">
+              <span>{{ $t('bucket.goal') }}</span>
+            </div>
+          </template>
+        </q-input>
+        <q-input v-model="local.creatorPubkey" outlined class="q-mb-sm">
+          <template #label>
+            <div class="row items-center no-wrap">
+              <span>{{ $t('BucketManager.inputs.creator_pubkey') }}</span>
+            </div>
+          </template>
+        </q-input>
+        <div class="row q-mt-md">
+          <q-btn color="primary" rounded @click="onSave">{{ $t('global.actions.save.label') }}</q-btn>
+          <q-btn flat rounded color="grey" class="q-ml-auto" v-close-popup>{{ $t('global.actions.cancel.label') }}</q-btn>
+        </div>
+      </q-form>
+    </q-card>
+  </q-dialog>
+</template>
+
+<script lang="ts" setup>
+import { reactive, watch, computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { DEFAULT_COLOR } from 'src/js/constants';
+import type { Bucket } from 'stores/buckets';
+
+const props = defineProps<{ modelValue: boolean; bucket: Bucket | null }>();
+const emit = defineEmits(['update:modelValue', 'save']);
+
+const { t } = useI18n();
+
+const showLocal = computed({
+  get: () => props.modelValue,
+  set: val => emit('update:modelValue', val)
+});
+
+const local = reactive({
+  name: '',
+  color: DEFAULT_COLOR,
+  description: '',
+  goal: null as number | null,
+  creatorPubkey: ''
+});
+
+watch(
+  () => props.bucket,
+  (b) => {
+    if (!b) return;
+    local.name = b.name;
+    local.color = b.color || DEFAULT_COLOR;
+    local.description = b.description || '';
+    local.goal = b.goal ?? null;
+    local.creatorPubkey = b.creatorPubkey || '';
+  },
+  { immediate: true, deep: true }
+);
+
+function onSave() {
+  emit('save', { ...local });
+  emit('update:modelValue', false);
+}
+</script>

--- a/test/vitest/__tests__/bucketModals.spec.ts
+++ b/test/vitest/__tests__/bucketModals.spec.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mount, shallowMount } from '@vue/test-utils';
+import EditBucketModal from '../../../src/components/EditBucketModal.vue';
+import BucketManager from '../../../src/components/BucketManager.vue';
+
+const bucket = { id: 'b1', name: 'Bucket', color: '#fff', description: '', goal: null };
+
+vi.mock('../../../src/stores/proofs', () => ({
+  useProofsStore: () => ({ moveProofs: vi.fn(), proofs: [] }),
+}));
+
+const editBucketMock = vi.fn();
+
+vi.mock('../../../src/stores/buckets', () => ({
+  useBucketsStore: () => ({
+    bucketList: [bucket],
+    bucketBalances: {},
+    editBucket: editBucketMock,
+    deleteBucket: vi.fn(),
+  }),
+  DEFAULT_BUCKET_ID: 'b1',
+}));
+
+vi.mock('../../../src/stores/mints', () => ({
+  useMintsStore: () => ({ activeUnit: 'sat' }),
+}));
+
+vi.mock('../../../src/stores/ui', () => ({
+  useUiStore: () => ({ formatCurrency: (a:number) => String(a) }),
+}));
+
+vi.mock('../../../src/js/notify', () => ({ notifyError: vi.fn() }));
+
+describe('EditBucketModal', () => {
+  it('emits save with form data', () => {
+    const wrapper = mount(EditBucketModal, { props: { modelValue: true, bucket } });
+    (wrapper.vm as any).onSave();
+    expect(wrapper.emitted('save')).toBeTruthy();
+    expect(wrapper.emitted('update:modelValue')?.[0]).toEqual([false]);
+  });
+});
+
+describe('BucketManager modals', () => {
+  it('opens edit modal and saves', async () => {
+    const wrapper = shallowMount(BucketManager);
+    const vm:any = wrapper.vm;
+    vm.handleMenuAction({ action: 'edit', bucket });
+    await wrapper.vm.$nextTick();
+    expect(vm.editModalOpen).toBe(true);
+    const modal = wrapper.findComponent(EditBucketModal);
+    modal.vm.$emit('save', { name: 'New' });
+    await wrapper.vm.$nextTick();
+    expect(editBucketMock).toHaveBeenCalled();
+    expect(vm.editModalOpen).toBe(false);
+  });
+
+  it('opens detail modal on view', async () => {
+    const wrapper = shallowMount(BucketManager);
+    const vm:any = wrapper.vm;
+    vm.handleMenuAction({ action: 'view', bucket });
+    await wrapper.vm.$nextTick();
+    expect(vm.detailModalOpen).toBe(true);
+    wrapper.findComponent({ name: 'BucketDetailModal' }).vm.$emit('update:modelValue', false);
+    await wrapper.vm.$nextTick();
+    expect(vm.detailModalOpen).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add EditBucketModal and BucketDetailModal components
- integrate new modals into BucketManager
- provide tests for modal logic

## Testing
- `pnpm exec vitest run test/vitest/__tests__/bucketModals.spec.ts`

------
https://chatgpt.com/codex/tasks/task_e_687d41e9259c8330beca68546eccff60