### PR TITLE
Add custom bucket theme

### DIFF
--- a/src/components/BucketCard.vue
+++ b/src/components/BucketCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <q-card class="shadow-2 rounded-borders bg-grey-9 text-white q-pa-md">
+  <q-card class="shadow-2 rounded-borders bucket-card text-white q-pa-md">
     <div class="row items-center">
       <router-link
         :to="`/buckets/${bucket.id}`"

--- a/src/components/BucketDetailModal.vue
+++ b/src/components/BucketDetailModal.vue
@@ -1,7 +1,7 @@
 <template>
   <q-dialog v-model="showLocal">
-    <q-card class="q-pa-md" style="max-width: 600px">
-      <h6 class="q-mt-none q-mb-md">{{ bucket?.name }}</h6>
+    <q-card class="q-pa-md bucket-modal" style="max-width: 600px">
+      <h6 class="q-mt-none q-mb-md bucket-accent">{{ bucket?.name }}</h6>
       <q-list bordered>
         <q-item v-for="p in bucketProofs" :key="p.secret">
           <q-item-section>

--- a/src/components/BucketDialog.vue
+++ b/src/components/BucketDialog.vue
@@ -1,6 +1,6 @@
 <template>
   <q-dialog v-model="showLocal" persistent>
-    <q-card class="q-pa-lg" style="max-width: 500px">
+    <q-card class="q-pa-lg bucket-modal" style="max-width: 500px">
       <q-form @submit.prevent="save">
         <q-input
           v-model="form.name"

--- a/src/components/BucketManager.vue
+++ b/src/components/BucketManager.vue
@@ -54,7 +54,7 @@
   </div>
 
   <q-dialog v-model="showDelete">
-    <q-card class="q-pa-md" style="max-width: 400px">
+    <q-card class="q-pa-md bucket-modal" style="max-width: 400px">
       <q-card-section class="row items-center">
         <q-icon name="warning" color="red" size="2rem" />
         <span class="q-ml-sm">{{

--- a/src/components/EditBucketModal.vue
+++ b/src/components/EditBucketModal.vue
@@ -1,7 +1,7 @@
 <template>
   <q-dialog v-model="showLocal">
-    <q-card class="q-pa-lg" style="max-width: 500px">
-      <h6 class="q-mt-none q-mb-md">{{ $t('BucketManager.actions.edit') }}</h6>
+    <q-card class="q-pa-lg bucket-modal" style="max-width: 500px">
+      <h6 class="q-mt-none q-mb-md bucket-accent">{{ $t('BucketManager.actions.edit') }}</h6>
       <q-form>
         <q-input v-model="local.name" outlined :label="$t('bucket.name')" class="q-mb-sm" />
         <q-input v-model="local.color" outlined :label="$t('bucket.color')" type="color" class="q-mb-sm" />

--- a/src/components/MoveTokensModal.vue
+++ b/src/components/MoveTokensModal.vue
@@ -1,7 +1,7 @@
 <template>
   <q-dialog v-model="showLocal">
-    <q-card class="q-pa-md" style="max-width: 800px">
-      <h5 class="q-my-none q-mb-md">{{ $t('MoveTokens.title') }}</h5>
+    <q-card class="q-pa-md bucket-modal" style="max-width: 800px">
+      <h5 class="q-my-none q-mb-md bucket-accent">{{ $t('MoveTokens.title') }}</h5>
       <div class="row q-col-gutter-md">
         <div class="col-7">
           <div v-for="bucket in bucketList" :key="bucket.id" class="q-mb-md">

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -94,6 +94,10 @@ body,
   --panel-light: var(--q-color-grey-2);
   --conversation-hover-dark: var(--q-color-grey-8);
   --conversation-hover-light: var(--q-color-grey-3);
+  --bucket-bg-dark: #2E202B;
+  --bucket-bg-light: #f9f5f8;
+  --bucket-accent-dark: #EC4899;
+  --bucket-accent-light: #EC4899;
 }
 
 body.body--dark {
@@ -104,6 +108,8 @@ body.body--dark {
   --muted-color: var(--muted-dark);
   --panel-bg-color: var(--panel-dark);
   --conversation-hover-color: var(--conversation-hover-dark);
+  --bucket-background: var(--bucket-bg-dark);
+  --bucket-accent: var(--bucket-accent-dark);
 }
 
 body.body--light {
@@ -114,6 +120,8 @@ body.body--light {
   --muted-color: var(--muted-light);
   --panel-bg-color: var(--panel-light);
   --conversation-hover-color: var(--conversation-hover-light);
+  --bucket-background: var(--bucket-bg-light);
+  --bucket-accent: var(--bucket-accent-light);
 }
 
 /* utility background classes */
@@ -160,4 +168,17 @@ body.body--dark .received {
   border-radius: 4px;
   padding: 4px 12px;
   font-weight: 500;
+}
+
+.bucket-card,
+.bucket-modal {
+  background-color: var(--bucket-background);
+}
+
+.bucket-modal {
+  padding: 1rem;
+}
+
+.bucket-accent {
+  color: var(--bucket-accent);
 }

--- a/src/css/quasar.variables.scss
+++ b/src/css/quasar.variables.scss
@@ -14,10 +14,10 @@
 
 $primary: #7e22ce;
 $secondary: #4b5563;
-$accent: #06b6d4;
+$accent: #EC4899;
 
-$dark: #1f2937;
-$dark-page: #1f2937;
+$dark: #2E202B;
+$dark-page: #2E202B;
 
 $positive: #21ba45;
 $negative: #c10015;


### PR DESCRIPTION
## Summary
- integrate new bucket color variables in app.scss
- set Quasar accent and dark variables
- style bucket-related cards and dialogs with new classes

## Testing
- `pnpm exec eslint .` *(fails: A config object is using the "root" key, which is not supported in flat config system)*
- `pnpm test` *(fails: multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_687d495314f08330b1c0fd566309bf0f