### PR TITLE
Enable multi-select for bucket actions

### DIFF
--- a/src/components/BucketCard.vue
+++ b/src/components/BucketCard.vue
@@ -2,12 +2,23 @@
   <q-card
     class="shadow-2 rounded-borders bucket-card text-white q-pa-md"
     :style="{ opacity: bucket.isArchived ? 0.5 : 1 }"
+    @click="handleClick"
   >
     <div class="row items-center">
+      <q-checkbox
+        v-if="multiSelectMode"
+        :model-value="selected"
+        color="white"
+        class="q-mr-sm"
+        @update:model-value="emitToggle"
+        @click.stop
+      />
       <router-link
+        v-if="!multiSelectMode"
         :to="`/buckets/${bucket.id}`"
         style="text-decoration: none"
         class="row items-center text-white ellipsis"
+        @click.stop
       >
         <q-avatar square size="56px" :style="avatarStyle" class="q-mr-md">
           {{ bucket.name.charAt(0).toUpperCase() }}
@@ -22,6 +33,23 @@
           </div>
         </div>
       </router-link>
+      <div
+        v-else
+        class="row items-center text-white ellipsis"
+      >
+        <q-avatar square size="56px" :style="avatarStyle" class="q-mr-md">
+          {{ bucket.name.charAt(0).toUpperCase() }}
+        </q-avatar>
+        <div class="column items-start">
+          <div class="text-weight-bold row items-center no-wrap">
+            <span>{{ bucket.name }}</span>
+            <q-icon v-if="bucket.description" name="info" class="q-ml-sm" />
+          </div>
+          <div class="text-caption" v-if="bucket.description">
+            {{ bucket.description }}
+          </div>
+        </div>
+      </div>
       <div class="q-ml-auto" v-if="bucket.id !== DEFAULT_BUCKET_ID">
         <q-btn
           flat
@@ -90,8 +118,10 @@ export default defineComponent({
     bucket: { type: Object as () => any, required: true },
     balance: { type: Number, default: 0 },
     activeUnit: { type: String, required: true },
+    multiSelectMode: { type: Boolean, default: false },
+    selected: { type: Boolean, default: false },
   },
-  emits: ["menu-action"],
+  emits: ["menu-action", "toggle-select"],
   setup(props, { emit }) {
     const uiStore = useUiStore();
     const { t } = useI18n();
@@ -122,10 +152,20 @@ export default defineComponent({
       emit("menu-action", { action, bucket: props.bucket });
     };
 
+    const emitToggle = () => {
+      emit("toggle-select", props.bucket.id);
+    };
+
+    const handleClick = () => {
+      if (props.multiSelectMode) emitToggle();
+    };
+
     return {
       formatCurrency,
       menu,
       emitAction,
+      emitToggle,
+      handleClick,
       bucketColor,
       avatarStyle,
       DEFAULT_BUCKET_ID,

--- a/src/components/BucketManager.vue
+++ b/src/components/BucketManager.vue
@@ -24,6 +24,9 @@
           :bucket="bucket"
           :balance="bucketBalances[bucket.id] || 0"
           :activeUnit="activeUnit.value"
+          :multi-select-mode="multiSelectMode"
+          :selected="selectedBucketIds.includes(bucket.id)"
+          @toggle-select="toggleBucketSelection"
           @menu-action="handleMenuAction"
         />
       </div>
@@ -43,7 +46,14 @@
       </q-item>
       <q-item>
         <q-item-section>
-          <q-btn color="primary" outline @click="moveTokensOpen = true">
+          <q-btn color="primary" outline :icon="multiSelectMode ? 'close' : 'select_all'" @click="toggleMultiSelect">
+            <q-tooltip>{{ multiSelectMode ? $t('global.actions.cancel.label') : 'Select buckets' }}</q-tooltip>
+          </q-btn>
+        </q-item-section>
+      </q-item>
+      <q-item>
+        <q-item-section>
+          <q-btn color="primary" outline @click="moveSelected" :disable="!selectedBucketIds.length">
             {{ $t("BucketDetail.move") }}
             <q-tooltip>{{
               $t("BucketManager.tooltips.move_button")
@@ -75,7 +85,7 @@
   <BucketDialog v-model="dialogOpen" />
   <EditBucketModal v-model="editModalOpen" @save="handleEditSave" :bucket="editBucket" />
   <BucketDetailModal v-model="detailModalOpen" :bucket-id="detailBucketId" />
-  <MoveTokensModal v-model="moveTokensOpen" />
+  <MoveTokensModal v-model="moveTokensOpen" :bucket-ids="selectedBucketIds" />
 </template>
 
 <script lang="ts">
@@ -113,6 +123,8 @@ export default defineComponent({
     const editModalOpen = ref(false);
     const detailModalOpen = ref(false);
     const moveTokensOpen = ref(false);
+    const multiSelectMode = ref(false);
+    const selectedBucketIds = ref<string[]>([]);
     const editBucket = ref<any>(null);
     const detailBucketId = ref<string | null>(null);
 
@@ -151,6 +163,25 @@ export default defineComponent({
     const openDetail = (bucket: any) => {
       detailBucketId.value = bucket.id;
       detailModalOpen.value = true;
+    };
+
+    const toggleBucketSelection = (id: string) => {
+      if (selectedBucketIds.value.includes(id)) {
+        selectedBucketIds.value = selectedBucketIds.value.filter((b) => b !== id);
+      } else {
+        selectedBucketIds.value.push(id);
+      }
+    };
+
+    const toggleMultiSelect = () => {
+      multiSelectMode.value = !multiSelectMode.value;
+      if (!multiSelectMode.value) selectedBucketIds.value = [];
+    };
+
+    const moveSelected = () => {
+      if (selectedBucketIds.value.length) {
+        moveTokensOpen.value = true;
+      }
     };
 
     const handleEditSave = (data: any) => {
@@ -226,6 +257,11 @@ export default defineComponent({
       formatCurrency,
       handleDrop,
       handleMenuAction,
+      multiSelectMode,
+      selectedBucketIds,
+      toggleBucketSelection,
+      toggleMultiSelect,
+      moveSelected,
     };
   },
 });

--- a/src/components/MoveTokensModal.vue
+++ b/src/components/MoveTokensModal.vue
@@ -76,7 +76,7 @@ import { useUiStore } from "stores/ui";
 import { storeToRefs } from "pinia";
 import { notifyError } from "src/js/notify";
 
-const props = defineProps<{ modelValue: boolean }>();
+const props = defineProps<{ modelValue: boolean; bucketIds?: string[] }>();
 const emit = defineEmits(["update:modelValue"]);
 
 const showLocal = computed({
@@ -90,7 +90,12 @@ const mintsStore = useMintsStore();
 const uiStore = useUiStore();
 const { activeUnit } = storeToRefs(mintsStore);
 
-const bucketList = computed(() => bucketsStore.bucketList);
+const bucketList = computed(() => {
+  if (props.bucketIds && props.bucketIds.length) {
+    return bucketsStore.bucketList.filter((b) => props.bucketIds!.includes(b.id));
+  }
+  return bucketsStore.bucketList;
+});
 
 const proofsByBucket = computed<Record<string, WalletProof[]>>(() => {
   const map: Record<string, WalletProof[]> = {};


### PR DESCRIPTION
## Summary
- allow multi-select mode when managing buckets
- show checkboxes on bucket cards while multi-select is active
- filter Move Tokens modal by selected buckets

## Testing
- `pnpm install`
- `pnpm test` *(fails: Module not found / constraint errors)*

------
https://chatgpt.com/codex/tasks/task_e_687ddf31d388833085d9a57ec33d36b0