### PR TITLE
EditBucketModal styling and data handling

### DIFF
--- a/src/components/EditBucketModal.vue
+++ b/src/components/EditBucketModal.vue
@@ -3,11 +3,28 @@
     <q-card class="q-pa-lg bucket-modal" style="max-width: 500px">
       <h6 class="q-mt-none q-mb-md bucket-accent">{{ $t('BucketManager.actions.edit') }}</h6>
       <q-form>
-        <q-input v-model="local.name" outlined :label="$t('bucket.name')" class="q-mb-sm" />
-        <q-input v-model="local.color" outlined :label="$t('bucket.color')" type="color" class="q-mb-sm" />
+        <q-input
+          v-model="local.name"
+          outlined
+          color="accent"
+          rounded
+          :label="$t('bucket.name')"
+          class="q-mb-sm"
+        />
+        <q-input
+          v-model="local.color"
+          outlined
+          color="accent"
+          rounded
+          :label="$t('bucket.color')"
+          type="color"
+          class="q-mb-sm"
+        />
         <q-input
           v-model="local.description"
           outlined
+          color="accent"
+          rounded
           type="textarea"
           autogrow
           class="q-mb-sm"
@@ -18,14 +35,14 @@
             </div>
           </template>
         </q-input>
-        <q-input v-model.number="local.goal" outlined type="number" class="q-mb-sm">
+        <q-input v-model.number="local.goal" outlined color="accent" rounded type="number" class="q-mb-sm">
           <template #label>
             <div class="row items-center no-wrap">
               <span>{{ $t('bucket.goal') }}</span>
             </div>
           </template>
         </q-input>
-        <q-input v-model="local.creatorPubkey" outlined class="q-mb-sm">
+        <q-input v-model="local.creatorPubkey" outlined color="accent" rounded class="q-mb-sm">
           <template #label>
             <div class="row items-center no-wrap">
               <span>{{ $t('BucketManager.inputs.creator_pubkey') }}</span>
@@ -33,7 +50,7 @@
           </template>
         </q-input>
         <div class="row q-mt-md">
-          <q-btn color="primary" rounded @click="onSave">{{ $t('global.actions.save.label') }}</q-btn>
+          <q-btn color="accent" rounded @click="onSave">{{ $t('global.actions.save.label') }}</q-btn>
           <q-btn flat rounded color="grey" class="q-ml-auto" v-close-popup>{{ $t('global.actions.cancel.label') }}</q-btn>
         </div>
       </q-form>
@@ -76,6 +93,19 @@ watch(
     local.creatorPubkey = b.creatorPubkey || '';
   },
   { immediate: true, deep: true }
+);
+
+watch(
+  () => props.modelValue,
+  (val) => {
+    if (val && props.bucket) {
+      local.name = props.bucket.name;
+      local.color = props.bucket.color || DEFAULT_COLOR;
+      local.description = props.bucket.description || '';
+      local.goal = props.bucket.goal ?? null;
+      local.creatorPubkey = props.bucket.creatorPubkey || '';
+    }
+  }
 );
 
 function onSave() {


### PR DESCRIPTION
## Summary
- restyle EditBucketModal inputs and buttons with pink accent and rounded corners
- refresh form data when dialog opens and save updated values

## Testing
- `pnpm install`
- `pnpm run test:ci` *(fails: many tests errors)*

------
https://chatgpt.com/codex/tasks/task_e_687de1f78188833098790c2470470f81