### PR TITLE
Add new translation key for moving tokens

### DIFF
--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -1328,6 +1328,7 @@ export default {
   },
   MoveTokens: {
     title: "Move tokens",
+    select_tokens: "Select tokens to move",
     empty: "No tokens",
     helper: "Move tokens between buckets to organize them.",
   },

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -1334,6 +1334,7 @@ export default {
   },
   MoveTokens: {
     title: "Move tokens",
+    select_tokens: "Select tokens to move",
     empty: "No tokens",
     helper: "Move tokens between buckets to organize them.",
   },

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -1338,6 +1338,7 @@ export default {
   },
   MoveTokens: {
     title: "Move tokens",
+    select_tokens: "Select tokens to move",
     empty: "No tokens",
     helper: "Move tokens between buckets to organize them.",
   },

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1487,6 +1487,7 @@ export const messages = {
   },
   MoveTokens: {
     title: "Move tokens",
+    select_tokens: "Select tokens to move",
     empty: "No tokens",
     helper: "Move tokens between buckets to organize them.",
   },

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -1335,6 +1335,7 @@ export default {
   },
   MoveTokens: {
     title: "Move tokens",
+    select_tokens: "Select tokens to move",
     empty: "No tokens",
     helper: "Move tokens between buckets to organize them.",
   },

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -1324,6 +1324,7 @@ export default {
   },
   MoveTokens: {
     title: "Move tokens",
+    select_tokens: "Select tokens to move",
     empty: "No tokens",
     helper: "Move tokens between buckets to organize them.",
   },

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -1317,6 +1317,7 @@ export default {
   },
   MoveTokens: {
     title: "Move tokens",
+    select_tokens: "Select tokens to move",
     empty: "No tokens",
     helper: "Move tokens between buckets to organize them.",
   },

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -1318,6 +1318,7 @@ export default {
   },
   MoveTokens: {
     title: "Move tokens",
+    select_tokens: "Select tokens to move",
     empty: "No tokens",
     helper: "Move tokens between buckets to organize them.",
   },

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -1317,6 +1317,7 @@ export default {
   },
   MoveTokens: {
     title: "Move tokens",
+    select_tokens: "Select tokens to move",
     empty: "No tokens",
     helper: "Move tokens between buckets to organize them.",
   },

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -1315,6 +1315,7 @@ export default {
   },
   MoveTokens: {
     title: "Move tokens",
+    select_tokens: "Select tokens to move",
     empty: "No tokens",
     helper: "Move tokens between buckets to organize them.",
   },

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -1320,6 +1320,7 @@ export default {
   },
   MoveTokens: {
     title: "Move tokens",
+    select_tokens: "Select tokens to move",
     empty: "No tokens",
     helper: "Move tokens between buckets to organize them.",
   },

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -1307,6 +1307,7 @@ export default {
   },
   MoveTokens: {
     title: "Move tokens",
+    select_tokens: "Select tokens to move",
     empty: "No tokens",
     helper: "Move tokens between buckets to organize them.",
   },


### PR DESCRIPTION
## Summary
- add `select_tokens` translation for new move tokens modal
- update all locale files

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687de756cccc8330a97a1ac492c19acf