### PR TITLE
Refactor buckets dashboard

### DIFF
--- a/src/components/BucketDetailModal.vue
+++ b/src/components/BucketDetailModal.vue
@@ -1,6 +1,6 @@
 <template>
-  <q-dialog v-model="showLocal">
-    <q-card class="q-pa-md bucket-modal" style="max-width: 600px">
+  <q-dialog v-model="showLocal" persistent>
+    <q-card dark class="modal-card q-pa-lg">
       <h6 class="q-mt-none q-mb-md bucket-accent">{{ bucket?.name }}</h6>
       <q-list bordered>
         <q-item v-for="p in bucketProofs" :key="p.secret">

--- a/src/components/BucketDialog.vue
+++ b/src/components/BucketDialog.vue
@@ -1,6 +1,6 @@
 <template>
   <q-dialog v-model="showLocal" persistent>
-    <q-card class="q-pa-lg bucket-modal" style="max-width: 500px">
+    <q-card dark class="modal-card q-pa-lg">
       <q-form @submit.prevent="save">
         <q-input
           v-model="form.name"

--- a/src/components/BucketManager.vue
+++ b/src/components/BucketManager.vue
@@ -1,18 +1,33 @@
 <template>
-  <div style="max-width: 800px; margin: 0 auto">
+  <div class="w-full max-w-7xl mx-auto flex flex-col">
+    <header class="q-mb-lg text-center">
+      <h1 class="text-h4 text-weight-bold text-white q-mb-md">Buckets Dashboard</h1>
+      <q-btn-toggle
+        v-model="viewMode"
+        no-caps
+        rounded
+        unelevated
+        toggle-color="pink-6"
+        color="grey-9"
+        text-color="white"
+        :options="[
+          {label: 'Active', value: 'all'},
+          {label: 'Archived', value: 'archived'}
+        ]"
+        class="q-mb-md"
+      />
+      <q-input
+        v-model="searchTerm"
+        dark
+        borderless
+        dense
+        class="q-mb-md bg-slate-800 rounded-lg q-px-md q-py-sm"
+        placeholder="Search by name or description..."
+        aria-label="Search buckets by name or description"
+      />
+    </header>
     <div class="text-body2 q-mb-md">{{ $t("BucketManager.helper.intro") }}</div>
-    <q-input
-      v-model="searchTerm"
-      outlined
-      dense
-      class="q-mb-md"
-      :placeholder="$t('bucketManager.inputs.search.placeholder')"
-    />
-    <q-tabs v-model="viewMode" dense class="q-mb-md" no-caps>
-      <q-tab name="all" :label="$t('BucketManager.view.all')" />
-      <q-tab name="archived" :label="$t('BucketManager.view.archived')" />
-    </q-tabs>
-    <div class="row q-col-gutter-md q-mb-md">
+    <div v-if="filteredBuckets.length > 0" class="row q-col-gutter-md q-mb-md">
       <div
         v-for="bucket in filteredBuckets"
         :key="bucket.id"
@@ -31,36 +46,32 @@
         />
       </div>
     </div>
-    <q-item>
-        <q-item-section>
-          <q-btn
-            color="primary"
-            icon="add"
-            outline
-            @click="openAdd"
-            :label="$t('bucketManager.actions.add')"
-          >
-            <q-tooltip>{{ $t("BucketManager.tooltips.add_button") }}</q-tooltip>
-          </q-btn>
-        </q-item-section>
-      </q-item>
-      <q-item>
-        <q-item-section>
-          <q-btn color="primary" outline :icon="multiSelectMode ? 'close' : 'select_all'" @click="toggleMultiSelect">
-            <q-tooltip>{{ multiSelectMode ? $t('global.actions.cancel.label') : 'Select buckets' }}</q-tooltip>
-          </q-btn>
-        </q-item-section>
-      </q-item>
-      <q-item>
-        <q-item-section>
-          <q-btn color="primary" outline @click="moveSelected" :disable="!selectedBucketIds.length">
-            {{ $t("BucketDetail.move") }}
-            <q-tooltip>{{
-              $t("BucketManager.tooltips.move_button")
-            }}</q-tooltip>
-          </q-btn>
-        </q-item-section>
-      </q-item>
+    <div v-else class="text-center text-grey-6 q-py-xl">
+      <q-icon name="o_search" size="4em" class="q-mb-md" />
+      <div class="text-h6">No Buckets Found</div>
+      <p>Try adjusting your search or filter.</p>
+    </div>
+    <footer class="row justify-center q-mt-xl q-gutter-md">
+      <q-btn
+        @click="openAdd"
+        label="+ New Bucket"
+        no-caps
+        unelevated
+        padding="12px 32px"
+        text-color="white"
+        class="font-semibold"
+        style="background-image: linear-gradient(to right, #db2777, #9333ea);"
+      />
+      <q-btn
+        @click="moveSelected"
+        label="Move Tokens"
+        no-caps
+        unelevated
+        padding="12px 32px"
+        :disable="!selectedBucketIds.length"
+        class="bg-grey-8 font-semibold"
+      />
+    </footer>
   </div>
 
   <q-dialog v-model="showDelete">

--- a/src/components/EditBucketModal.vue
+++ b/src/components/EditBucketModal.vue
@@ -1,6 +1,6 @@
 <template>
-  <q-dialog v-model="showLocal">
-    <q-card class="q-pa-lg bucket-modal" style="max-width: 500px">
+  <q-dialog v-model="showLocal" persistent>
+    <q-card dark class="modal-card q-pa-lg" :style="{ borderTopColor: bucket.color }">
       <h6 class="q-mt-none q-mb-md bucket-accent">{{ $t('BucketManager.actions.edit') }}</h6>
       <q-form>
         <q-input

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -182,3 +182,19 @@ body.body--dark .received {
 .bucket-accent {
   color: var(--bucket-accent);
 }
+
+/* Utility classes for revamped Buckets UI */
+.w-full { width: 100%; }
+.max-w-7xl { max-width: 80rem; }
+.mx-auto { margin-left: auto; margin-right: auto; }
+.flex { display: flex; }
+.flex-col { flex-direction: column; }
+
+/* Shared modal card styling */
+.modal-card {
+  background-color: #1e293b !important; // bg-slate-800
+  border-radius: 16px !important;
+  border-top: 4px solid #db2777; // Default to pink accent
+  width: 100%;
+  max-width: 500px;
+}

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1663,6 +1663,4 @@ export const messages = {
 export default {
   ...(defaultLang as any),
   ...messages,
-  BucketManager: { helper: { intro: "" } },
-  MoveTokens: { title: "", helper: "" },
 };


### PR DESCRIPTION
## Summary
- remove bucket translation overrides so text renders
- add utility classes and modal card style
- redesign bucket dashboard header, grid empty state, and footer
- overhaul bucket cards with new layout, computed progress, and styles
- adjust bucket modals to use new modal-card styling

## Testing
- `npm run lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687deb0faa60833090da6b1b5c54103d