### PR TITLE
Adjust Bucket card grid layout

### DIFF
--- a/src/components/BucketManager.vue
+++ b/src/components/BucketManager.vue
@@ -31,7 +31,7 @@
       <div
         v-for="bucket in filteredBuckets"
         :key="bucket.id"
-        class="col-12 col-md-6 col-lg-4"
+        class="col-12 col-sm-6 col-md-4 col-lg-3"
         @dragover.prevent
         @drop="handleDrop($event, bucket.id)"
       >


### PR DESCRIPTION
## Summary
- allow up to four bucket cards per row by tweaking column classes

## Testing
- `pnpm run test:ci` *(fails: vitest reports 55 failed, 203 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687e08679d808330b41f7b440cca72f3