### PR TITLE
Add multi-select mode toggle

### DIFF
--- a/src/components/BucketManager.vue
+++ b/src/components/BucketManager.vue
@@ -42,6 +42,15 @@
           ]"
           label="Sort By"
         />
+        <q-checkbox
+          dense
+          dark
+          class="q-ml-sm"
+          :model-value="multiSelectMode"
+          @update:model-value="toggleMultiSelect"
+          data-test="multi-select-toggle"
+          aria-label="Toggle multi select"
+        />
         <q-btn
           flat
           dense

--- a/test/vitest/__tests__/bucketManagerMultiSelect.spec.ts
+++ b/test/vitest/__tests__/bucketManagerMultiSelect.spec.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { ref } from 'vue';
+import BucketManager from '../../../src/components/BucketManager.vue';
+
+const mockBuckets = [
+  { id: 'b1', name: 'Alpha', isArchived: false },
+  { id: 'b2', name: 'Beta', isArchived: false },
+];
+
+vi.mock('../../../src/stores/proofs', () => ({
+  useProofsStore: () => ({ moveProofs: vi.fn() }),
+}));
+
+vi.mock('../../../src/stores/buckets', () => ({
+  useBucketsStore: () => ({
+    bucketList: mockBuckets,
+    bucketBalances: {},
+    addBucket: vi.fn(),
+    editBucket: vi.fn(),
+    deleteBucket: vi.fn(),
+  }),
+  DEFAULT_BUCKET_ID: 'b1',
+}));
+
+vi.mock('../../../src/stores/mints', () => ({
+  useMintsStore: () => ({ activeUnit: ref('sat') }),
+}));
+
+vi.mock('../../../src/stores/ui', () => ({
+  useUiStore: () => ({ formatCurrency: (a: number) => String(a) }),
+}));
+
+vi.mock('../../../src/js/notify', () => ({
+  notifyError: vi.fn(),
+}));
+
+describe('BucketManager multi-select', () => {
+  it('enables selection of multiple buckets', async () => {
+    const wrapper = shallowMount(BucketManager);
+
+    expect(wrapper.findAll('bucket-card-stub').length).toBe(2);
+    expect((wrapper.vm as any).multiSelectMode).toBe(false);
+
+    (wrapper.vm as any).toggleMultiSelect();
+    await wrapper.vm.$nextTick();
+
+    const cards = wrapper.findAll('bucket-card-stub');
+    cards.forEach(card => {
+      expect(card.attributes('multi-select-mode')).toBe('true');
+    });
+
+    (wrapper.vm as any).toggleBucketSelection('b1');
+    expect((wrapper.vm as any).selectedBucketIds).toEqual(['b1']);
+  });
+});


### PR DESCRIPTION
## Summary
- allow toggling multi-select mode from the toolbar via a checkbox
- test bucket manager multi-select behaviour

## Testing
- `npm test` *(fails: Tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_687e1b9c0b4483309505fda2f17520a1