### PR TITLE
Add create bucket button and fix FAB

### DIFF
--- a/src/components/BucketManager.vue
+++ b/src/components/BucketManager.vue
@@ -30,6 +30,13 @@
             { label: 'Archived', value: 'archived' }
           ]"
         />
+        <q-btn
+          color="pink-6"
+          class="q-ml-sm"
+          icon="add"
+          label="Create Bucket"
+          @click="openAdd"
+        />
         <q-select
           v-model="sortBy"
           borderless
@@ -146,6 +153,7 @@
       icon="add"
       @click="openAdd"
       aria-label="Create new bucket"
+      style="position: fixed; bottom: 16px; right: 16px;"
     />
   </div>
 


### PR DESCRIPTION
## Summary
- add a visible "Create Bucket" button in `BucketManager.vue`
- keep FAB but fix its positioning so it's always visible

## Testing
- `pnpm test` *(fails: 31 failed, 23 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687e2d9bdc8483309aeb79abce6b1ce6