### PR TITLE
Add Move Tokens toolbar action

### DIFF
--- a/src/components/BucketManager.vue
+++ b/src/components/BucketManager.vue
@@ -49,6 +49,17 @@
           ]"
           label="Sort By"
         />
+        <q-btn
+          color="pink-6"
+          class="q-ml-sm"
+          icon="swap_horiz"
+          :label="$t('BucketDetail.move')"
+          @click="moveSelected"
+          :title="$t('BucketManager.tooltips.move_button')"
+          :aria-label="$t('BucketManager.tooltips.move_button')"
+        >
+          <q-tooltip>{{ $t('BucketManager.tooltips.move_button') }}</q-tooltip>
+        </q-btn>
         <q-checkbox
           dense
           dark
@@ -305,9 +316,7 @@ export default defineComponent({
     };
 
     const moveSelected = () => {
-      if (selectedBucketIds.value.length) {
-        moveTokensOpen.value = true;
-      }
+      moveTokensOpen.value = true;
     };
 
     const handleEditSave = (data: any) => {

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1435,6 +1435,7 @@ export const messages = {
       archive: "Archive",
       unarchive: "Unarchive",
       view_tokens: "View tokens",
+      move: "Move tokens",
       deselect_all: "Deselect All",
     },
     inputs: {


### PR DESCRIPTION
## Summary
- add toolbar button to open Move Tokens modal
- always open MoveTokensModal even when no buckets are selected
- add i18n entry for new action label

## Testing
- `pnpm test` *(fails: mocked modules and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_687e30ccc2ac833088997a59ae38852f