### PR TITLE
Remove header move/create actions

### DIFF
--- a/src/components/BucketManager.vue
+++ b/src/components/BucketManager.vue
@@ -30,13 +30,6 @@
             { label: 'Archived', value: 'archived' }
           ]"
         />
-        <q-btn
-          color="pink-6"
-          class="q-ml-sm"
-          icon="add"
-          label="Create Bucket"
-          @click="openAdd"
-        />
         <q-select
           v-model="sortBy"
           borderless
@@ -49,17 +42,6 @@
           ]"
           label="Sort By"
         />
-        <q-btn
-          color="pink-6"
-          class="q-ml-sm"
-          icon="swap_horiz"
-          :label="$t('BucketDetail.move')"
-          @click="moveSelected"
-          :title="$t('BucketManager.tooltips.move_button')"
-          :aria-label="$t('BucketManager.tooltips.move_button')"
-        >
-          <q-tooltip>{{ $t('BucketManager.tooltips.move_button') }}</q-tooltip>
-        </q-btn>
         <q-checkbox
           dense
           dark


### PR DESCRIPTION
## Summary
- clean up header button clutter in `BucketManager`

## Testing
- `pnpm lint` *(fails: Invalid option '--ext')*
- `pnpm test` *(fails: many failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_687e6d41c4248330abf08ec4adc55709