### PR TITLE
Fix Buckets page layout for new bottom bar

### DIFF
--- a/src/pages/Buckets.vue
+++ b/src/pages/Buckets.vue
@@ -1,12 +1,12 @@
 <template>
-  <div
+  <q-page
     :class="[
       $q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark',
-      'text-center q-pa-md flex flex-center',
+      'q-pa-md q-pb-xl',
     ]"
   >
     <BucketManager />
-  </div>
+  </q-page>
 </template>
 
 <script>


### PR DESCRIPTION
## Summary
- update Buckets page to use `q-page`
- add bottom padding so the sticky action bar doesn't overlap content

## Testing
- `pnpm install`
- `pnpm run test:ci` *(fails: 56 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_687e700b0a988330bf6ea574a558db14