### PR TITLE
Update buckets page layout

### DIFF
--- a/src/pages/Buckets.vue
+++ b/src/pages/Buckets.vue
@@ -1,22 +1,46 @@
 <template>
-  <q-page
-    :class="[
-      $q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark',
-      'q-pa-md q-pb-xl',
-    ]"
-  >
-    <BucketManager />
-  </q-page>
+  <q-layout view="lHh Lpr lFf" class="wallet-layout">
+    <Sidebar />
+    <HeaderBar />
+    <q-page-container class="q-pa-md">
+      <BucketManager />
+      <q-fab
+        v-if="selectedCount > 0"
+        icon="swap_horiz"
+        label="Move Tokens"
+        color="primary"
+        class="move-fab"
+        @click="moveSelected"
+      />
+    </q-page-container>
+  </q-layout>
 </template>
 
-<script>
-import { defineComponent } from "vue";
+<script setup lang="ts">
+import { computed } from "vue";
+import { storeToRefs } from "pinia";
+import Sidebar from "components/Sidebar.vue";
+import HeaderBar from "components/HeaderBar.vue";
 import BucketManager from "components/BucketManager.vue";
+import { useBucketsStore } from "stores/buckets";
 
-export default defineComponent({
-  name: "BucketsPage",
-  components: {
-    BucketManager,
-  },
-});
+const bucketsStore = useBucketsStore();
+const { selectedBucketIds } = storeToRefs(bucketsStore);
+
+const selectedCount = computed(() => selectedBucketIds.value.length);
+
+function moveSelected() {
+  bucketsStore.moveSelectedBuckets();
+}
 </script>
+
+<style scoped lang="scss">
+.wallet-layout {
+  min-height: 100vh;
+}
+.move-fab {
+  position: fixed;
+  bottom: $spacing-base * 2;
+  right: $spacing-base * 2;
+}
+</style>


### PR DESCRIPTION
## Summary
- use sidebar and header components for buckets page
- add move tokens FAB when buckets selected

## Testing
- `npm test` *(fails: Vitest tests fail with missing environment)*

------
https://chatgpt.com/codex/tasks/task_e_687e90c13e5c8330a306977e926f8f4b