### PR TITLE
Add BucketsPage layout and update routing

### DIFF
--- a/src/pages/Buckets.vue
+++ b/src/pages/Buckets.vue
@@ -1,22 +1,7 @@
 <template>
-  <q-page
-    :class="[
-      $q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark',
-      'q-pa-md q-pb-xl',
-    ]"
-  >
-    <BucketManager />
-  </q-page>
+  <BucketsPage />
 </template>
 
-<script>
-import { defineComponent } from "vue";
-import BucketManager from "components/BucketManager.vue";
-
-export default defineComponent({
-  name: "BucketsPage",
-  components: {
-    BucketManager,
-  },
-});
+<script setup lang="ts">
+import BucketsPage from './BucketsPage.vue';
 </script>

--- a/src/pages/BucketsPage.vue
+++ b/src/pages/BucketsPage.vue
@@ -1,0 +1,37 @@
+<template>
+  <q-page class="q-pa-md">
+    <BucketManager />
+    <q-fab
+      v-if="selectedCount > 0"
+      icon="swap_horiz"
+      label="Move Tokens"
+      color="primary"
+      class="move-fab"
+      @click="moveSelected"
+    />
+  </q-page>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { storeToRefs } from 'pinia';
+import BucketManager from 'components/BucketManager.vue';
+import { useBucketsStore } from 'stores/buckets';
+
+const bucketsStore = useBucketsStore();
+const { selectedBucketIds } = storeToRefs(bucketsStore);
+
+const selectedCount = computed(() => selectedBucketIds.value.length);
+
+function moveSelected() {
+  bucketsStore.moveSelectedBuckets();
+}
+</script>
+
+<style scoped lang="scss">
+.move-fab {
+  position: fixed;
+  bottom: $spacing-base * 2;
+  right: $spacing-base * 2;
+}
+</style>

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -47,7 +47,9 @@ const routes = [
   {
     path: "/buckets",
     component: () => import("layouts/FullscreenLayout.vue"),
-    children: [{ path: "", component: () => import("src/pages/Buckets.vue") }],
+    children: [
+      { path: "", component: () => import("src/pages/BucketsPage.vue") },
+    ],
   },
   {
     path: "/subscriptions",


### PR DESCRIPTION
## Summary
- add a new `BucketsPage.vue` with Quasar layout including FAB
- route `/buckets` to this new component
- keep `Buckets.vue` as a thin wrapper of `BucketsPage`

## Testing
- `pnpm lint` *(fails: Invalid option '--ext')*
- `pnpm test` *(fails: multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_687e92f9a6908330b51c2c2033494167