### PR TITLE
Implement bucket drag-to-move

### DIFF
--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1466,6 +1466,13 @@ export const messages = {
     delete_confirm: {
       title: "Delete bucket?",
     },
+    move_confirm: {
+      title: "Move tokens?",
+      text: "Move all tokens from {from} to {to}?",
+    },
+    notifications: {
+      move_success: "Tokens moved",
+    },
     view: {
       all: "All",
       archived: "Archived",


### PR DESCRIPTION
## Summary
- allow dragging buckets themselves by making the bucket cards draggable
- when dropping a bucket on another, confirm move via `$q.dialog`
- after confirmation, move all proofs and show success notification
- add English strings for move confirmation

## Testing
- `pnpm run test:ci` *(fails: ConstraintError and other test failures)*

------
https://chatgpt.com/codex/tasks/task_e_687e986357a083308cedd42cff2203e2