### PR TITLE
Refactor bucket modal handling

### DIFF
--- a/src/components/MoveTokensModal.vue
+++ b/src/components/MoveTokensModal.vue
@@ -96,7 +96,7 @@ import { storeToRefs } from "pinia";
 import { notifyError } from "src/js/notify";
 
 const props = defineProps<{ modelValue: boolean; bucketIds?: string[] }>();
-const emit = defineEmits(["update:modelValue"]);
+const emit = defineEmits(["update:modelValue", "move"]);
 
 const showLocal = computed({
   get: () => props.modelValue,
@@ -164,7 +164,10 @@ async function moveSelected() {
     notifyError(`Bucket not found: ${targetBucketId.value}`);
     return;
   }
-  await proofsStore.moveProofs(selectedSecrets.value, targetBucketId.value);
+  emit("move", {
+    secrets: [...selectedSecrets.value],
+    bucketId: targetBucketId.value,
+  });
   selectedSecrets.value = [];
   emit("update:modelValue", false);
 }

--- a/test/vitest/__tests__/moveTokens.spec.ts
+++ b/test/vitest/__tests__/moveTokens.spec.ts
@@ -1,11 +1,9 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { shallowMount } from "@vue/test-utils";
 import MoveTokens from "../../../src/components/MoveTokensModal.vue";
 
-const moveProofsMock = vi.fn();
-
 vi.mock("../../../src/stores/proofs", () => ({
-  useProofsStore: () => ({ proofs: [], moveProofs: moveProofsMock }),
+  useProofsStore: () => ({ proofs: [] }),
 }));
 
 vi.mock("../../../src/stores/buckets", () => ({
@@ -29,10 +27,6 @@ vi.mock("../../../src/js/notify", () => ({
   notifyError: vi.fn(),
 }));
 
-beforeEach(() => {
-  moveProofsMock.mockReset();
-});
-
 describe("MoveTokens component", () => {
   it("toggles token selection", () => {
     const wrapper = shallowMount(MoveTokens, { props: { modelValue: true } });
@@ -53,7 +47,7 @@ describe("MoveTokens component", () => {
 
     await vm.moveSelected();
 
-    expect(moveProofsMock).toHaveBeenCalledWith(["a", "b"], "b2");
+    expect(wrapper.emitted("move")?.[0]).toEqual([{ secrets: ["a", "b"], bucketId: "b2" }]);
     expect(vm.selectedSecrets.length).toBe(0);
     expect(wrapper.emitted("update:modelValue")?.[0]).toEqual([false]);
   });


### PR DESCRIPTION
## Summary
- update MoveTokensModal to emit a `move` event instead of invoking the store
- expose bucket modal state in BucketManager and handle `move` events
- adjust tests for the new MoveTokensModal behaviour

## Testing
- `pnpm test` *(fails: vitest suite errors)*

------
https://chatgpt.com/codex/tasks/task_e_687e9b8b17f48330a7eefdea2b989043