### PR TITLE
Add toolbar and summary components

### DIFF
--- a/src/components/BucketsToolbar.vue
+++ b/src/components/BucketsToolbar.vue
@@ -1,0 +1,76 @@
+<template>
+  <div class="buckets-toolbar row items-center q-gutter-sm">
+    <q-input
+      v-model="modelSearch"
+      dense
+      outlined
+      placeholder="Search"
+      class="bg-slate-800"
+    />
+    <q-btn-toggle
+      v-model="modelViewMode"
+      dense
+      rounded
+      unelevated
+      toggle-color="primary"
+      color="grey-9"
+      text-color="white"
+      :options="[
+        { label: 'Active', value: 'active' },
+        { label: 'Archived', value: 'archived' }
+      ]"
+    />
+    <q-select
+      v-model="modelSort"
+      dense
+      outlined
+      class="bg-slate-800"
+      :options="[
+        { label: 'Name', value: 'name' },
+        { label: 'Balance', value: 'balance' }
+      ]"
+    />
+    <q-space />
+    <q-btn color="primary" label="Move Tokens" @click="emit('move-tokens')" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+const props = defineProps<{
+  search: string;
+  viewMode: string;
+  sort: string;
+}>();
+
+const emit = defineEmits<{
+  'update:search': [string];
+  'update:viewMode': [string];
+  'update:sort': [string];
+  'move-tokens': [];
+}>();
+
+const modelSearch = computed({
+  get: () => props.search,
+  set: (val: string) => emit('update:search', val),
+});
+const modelViewMode = computed({
+  get: () => props.viewMode,
+  set: (val: string) => emit('update:viewMode', val),
+});
+const modelSort = computed({
+  get: () => props.sort,
+  set: (val: string) => emit('update:sort', val),
+});
+</script>
+
+<style scoped>
+.buckets-toolbar {
+  position: sticky;
+  top: 56px;
+  z-index: 10;
+  background-color: #111827;
+  padding: 8px;
+}
+</style>

--- a/src/components/SummaryBar.vue
+++ b/src/components/SummaryBar.vue
@@ -1,0 +1,32 @@
+<template>
+  <div class="summary-bar text-center q-mb-md">
+    <div class="text-h5 text-weight-bold text-white">
+      {{ formatCurrency(total, unit) }}
+    </div>
+    <div class="text-grey-5">
+      {{ activeCount }} Active Buckets
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useUiStore } from 'stores/ui';
+
+const props = defineProps<{
+  total: number;
+  activeCount: number;
+  unit: string;
+}>();
+
+const uiStore = useUiStore();
+
+function formatCurrency(value: number, unit: string) {
+  return uiStore.formatCurrency(value, unit);
+}
+</script>
+
+<style scoped>
+.summary-bar {
+  /* simple wrapper */
+}
+</style>


### PR DESCRIPTION
## Summary
- add SummaryBar to show total balance and active bucket count
- add BucketsToolbar for searching and sorting buckets

## Testing
- `pnpm install`
- `pnpm run test:ci` *(fails: many tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_687f506d289c833095d360e25d19860d