### PR TITLE
Redesign Buckets UI

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## Unreleased
+- Buckets UI redesign – Phase9

--- a/quasar.config.js
+++ b/quasar.config.js
@@ -31,7 +31,7 @@ module.exports = configure(function (/* ctx */) {
     boot: ["polyfills", "ndk", "base", "global-components", "cashu", "i18n"],
 
     // https://v2.quasar.dev/quasar-cli-vite/quasar-config-js#css
-    css: ["app.scss", "base.scss"],
+    css: ["app.scss", "base.scss", "buckets.scss"],
 
     // https://github.com/quasarframework/quasar/tree/dev/extras
     extras: ["roboto-font", "material-icons"],
@@ -82,7 +82,13 @@ module.exports = configure(function (/* ctx */) {
 
     // https://v2.quasar.dev/quasar-cli-vite/quasar-config-js#framework
     framework: {
-      config: {},
+      config: {
+        brand: {
+          dark: '#0e141b',
+          'dark-page': '#0e141b',
+          accent: '#f54dd0'
+        }
+      },
 
       iconSet: "material-icons", // Quasar icon set
       // lang: 'en-US', // Quasar language pack

--- a/src/components/BucketDialog.vue
+++ b/src/components/BucketDialog.vue
@@ -8,11 +8,12 @@
           outlined
           class="q-mb-sm"
         />
-        <q-input
+        <q-color
           v-model="form.color"
-          :label="t('bucket.color')"
-          type="color"
-          outlined
+          :palette="COLOR_PALETTE"
+          default-view="palette"
+          no-header
+          no-footer
           class="q-mb-sm"
         />
         <q-input
@@ -48,10 +49,9 @@
 </template>
 
 <script setup lang="ts">
-import { computed, reactive } from 'vue'
+import { computed, reactive, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
-import { useBucketsStore } from 'stores/buckets'
-import { DEFAULT_COLOR } from 'src/js/constants'
+import { useBucketsStore, COLOR_PALETTE, hashColor } from 'stores/buckets'
 
 const props = defineProps<{ modelValue: boolean }>()
 const emit = defineEmits(['update:modelValue'])
@@ -63,7 +63,7 @@ const showLocal = computed({
 
 const form = reactive({
   name: '',
-  color: DEFAULT_COLOR,
+  color: hashColor(''),
   goal: null as number | null,
   desc: ''
 })
@@ -71,11 +71,22 @@ const form = reactive({
 const { t } = useI18n()
 const buckets = useBucketsStore()
 
-const canSave = computed(() => form.name.trim().length > 0)
+const nameTaken = computed(() =>
+  buckets.bucketList.some(b => b.name.toLowerCase() === form.name.trim().toLowerCase())
+)
+const canSave = computed(() =>
+  form.name.trim().length > 0 &&
+  !nameTaken.value &&
+  (form.goal === null || form.goal >= 0)
+)
+
+watch(() => form.name, val => {
+  form.color = hashColor(val)
+})
 
 function reset () {
   form.name = ''
-  form.color = DEFAULT_COLOR
+  form.color = hashColor('')
   form.goal = null
   form.desc = ''
 }

--- a/src/components/BucketManager.vue
+++ b/src/components/BucketManager.vue
@@ -1,69 +1,15 @@
 <template>
   <div class="w-full max-w-7xl mx-auto flex flex-col">
-    <header class="q-mb-lg text-center">
-      <div class="text-h5 text-weight-bold text-white">
-        {{ formatCurrency(totalActiveBalance, activeUnit.value) }}
-      </div>
-      <div class="text-grey-5 q-mb-md">
-        {{ activeBucketCount }} Active Buckets
-      </div>
-      <div class="row items-center justify-center q-gutter-xs">
-        <q-input
-          v-model="searchTerm"
-          dark
-          borderless
-          dense
-          class="bg-slate-800 rounded-lg q-px-md q-py-sm"
-          placeholder="Search by name or description..."
-          aria-label="Search buckets by name or description"
-        />
-        <q-btn-toggle
-          v-model="viewMode"
-          no-caps
-          rounded
-          unelevated
-          toggle-color="pink-6"
-          color="grey-9"
-          text-color="white"
-          :options="[
-            { label: 'Active', value: 'all' },
-            { label: 'Archived', value: 'archived' }
-          ]"
-        />
-        <q-select
-          v-model="sortBy"
-          borderless
-          dense
-          dark
-          class="bg-slate-800 rounded-lg q-px-md"
-          :options="[
-            { label: 'Name', value: 'name' },
-            { label: 'Balance', value: 'balance' }
-          ]"
-          label="Sort By"
-        />
-        <q-checkbox
-          dense
-          dark
-          class="q-ml-sm"
-          :model-value="multiSelectMode"
-          @update:model-value="toggleMultiSelect"
-          data-test="multi-select-toggle"
-          aria-label="Toggle multi select"
-        />
-        <q-btn
-          flat
-          dense
-          round
-          class="q-ml-sm"
-          :color="multiSelectMode ? 'pink-6' : 'grey-5'"
-          :icon="multiSelectMode ? 'close' : 'select_all'"
-          @click="toggleMultiSelect"
-          :aria-pressed="multiSelectMode"
-          aria-label="Toggle bucket selection mode"
-        />
-      </div>
-    </header>
+    <div class="buckets-toolbar q-mb-md">
+      <slot name="toolbar"
+        :search-term="searchTerm"
+        :view-mode="viewMode"
+        :sort-by="sortBy"
+        :multi-select-mode="multiSelectMode"
+        :toggle-multi-select="toggleMultiSelect"
+        :move-selected="moveSelected"
+      />
+    </div>
 
     <q-banner
       v-if="selectedBucketIds.length > 0"
@@ -140,17 +86,6 @@
       <div class="text-h6 q-mb-sm">No Buckets Yet</div>
       <p class="q-mb-md">Create your first bucket to organize your tokens.</p>
       <q-btn color="pink-6" icon="add" label="Create Bucket" @click="openAdd" />
-    </div>
-    <div class="sticky-bar">
-      <div class="action-container">
-        <q-btn color="pink-6" icon="add" label="Create Bucket" @click="openAdd" />
-        <q-btn
-          color="pink-6"
-          icon="swap_horiz"
-          :label="$t('BucketDetail.move')"
-          @click="moveSelected"
-        />
-      </div>
     </div>
   </div>
 
@@ -388,7 +323,12 @@ export default defineComponent({
         secrets = data.split(',');
       }
       if (Array.isArray(secrets) && secrets.length) {
-        await proofsStore.moveProofs(secrets, id);
+        try {
+          await proofsStore.moveProofs(secrets, id);
+          $q.notify({ type: 'positive', message: t('BucketManager.notifications.move_success') });
+        } catch (e) {
+          $q.notify({ type: 'negative', message: 'Move failed' });
+        }
       }
     };
 
@@ -482,19 +422,4 @@ export default defineComponent({
   }
 }
 
-.sticky-bar {
-  position: sticky;
-  bottom: 0;
-  z-index: 10;
-  background-color: #111827;
-  padding: 0.5rem 0;
-}
-
-.action-container {
-  max-width: 80rem;
-  margin: 0 auto;
-  display: flex;
-  justify-content: center;
-  gap: 0.5rem;
-}
 </style>

--- a/src/components/EditBucketModal.vue
+++ b/src/components/EditBucketModal.vue
@@ -11,13 +11,12 @@
           :label="$t('bucket.name')"
           class="q-mb-sm"
         />
-        <q-input
+        <q-color
           v-model="local.color"
-          outlined
-          color="accent"
-          rounded
-          :label="$t('bucket.color')"
-          type="color"
+          :palette="COLOR_PALETTE"
+          default-view="palette"
+          no-header
+          no-footer
           class="q-mb-sm"
         />
         <q-input
@@ -50,7 +49,7 @@
           </template>
         </q-input>
         <div class="row q-mt-md">
-          <q-btn color="accent" rounded @click="onSave">{{ $t('global.actions.save.label') }}</q-btn>
+          <q-btn color="accent" rounded :disable="!canSave" @click="onSave">{{ $t('global.actions.save.label') }}</q-btn>
           <q-btn flat rounded color="grey" class="q-ml-auto" v-close-popup>{{ $t('global.actions.cancel.label') }}</q-btn>
         </div>
       </q-form>
@@ -61,13 +60,14 @@
 <script lang="ts" setup>
 import { reactive, watch, computed } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { DEFAULT_COLOR } from 'src/js/constants';
+import { COLOR_PALETTE, hashColor, useBucketsStore } from 'stores/buckets';
 import type { Bucket } from 'stores/buckets';
 
 const props = defineProps<{ modelValue: boolean; bucket: Bucket | null }>();
 const emit = defineEmits(['update:modelValue', 'save']);
 
 const { t } = useI18n();
+const bucketsStore = useBucketsStore();
 
 const showLocal = computed({
   get: () => props.modelValue,
@@ -76,18 +76,31 @@ const showLocal = computed({
 
 const local = reactive({
   name: '',
-  color: DEFAULT_COLOR,
+  color: hashColor(''),
   description: '',
   goal: null as number | null,
   creatorPubkey: ''
 });
+
+const nameTaken = computed(() =>
+  props.bucket ?
+    false :
+    bucketsStore.bucketList.some(
+      b => b.id !== props.bucket?.id && b.name.toLowerCase() === local.name.trim().toLowerCase()
+    )
+);
+const canSave = computed(() =>
+  local.name.trim().length > 0 &&
+  !nameTaken.value &&
+  (local.goal === null || local.goal >= 0)
+);
 
 watch(
   () => props.bucket,
   (b) => {
     if (!b) return;
     local.name = b.name;
-    local.color = b.color || DEFAULT_COLOR;
+    local.color = b.color || hashColor(b.name);
     local.description = b.description || '';
     local.goal = b.goal ?? null;
     local.creatorPubkey = b.creatorPubkey || '';
@@ -99,8 +112,8 @@ watch(
   () => props.modelValue,
   (val) => {
     if (val && props.bucket) {
-      local.name = props.bucket.name;
-      local.color = props.bucket.color || DEFAULT_COLOR;
+        local.name = props.bucket.name;
+        local.color = props.bucket.color || hashColor(props.bucket.name);
       local.description = props.bucket.description || '';
       local.goal = props.bucket.goal ?? null;
       local.creatorPubkey = props.bucket.creatorPubkey || '';
@@ -109,6 +122,7 @@ watch(
 );
 
 function onSave() {
+  if (!canSave.value) return;
   emit('save', { ...local });
   emit('update:modelValue', false);
 }

--- a/src/components/SummaryStats.vue
+++ b/src/components/SummaryStats.vue
@@ -1,0 +1,35 @@
+<template>
+  <div class="summary-stats row items-center justify-between q-pa-sm q-mb-md">
+    <div class="text-h6 text-weight-bold">{{ formatCurrency(total) }}</div>
+    <div class="text-caption">{{ activeCount }} Active Buckets</div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useUiStore } from 'stores/ui'
+import { useMintsStore } from 'stores/mints'
+import { storeToRefs } from 'pinia'
+
+const props = defineProps<{ total: number; activeCount: number }>()
+
+const ui = useUiStore()
+const { activeUnit } = storeToRefs(useMintsStore())
+
+function formatCurrency (val: number) {
+  return ui.formatCurrency(val, activeUnit.value)
+}
+</script>
+
+<style scoped>
+.summary-stats {
+  background-color: #1b2330;
+  border-radius: 8px;
+  color: #DDE2E6;
+}
+@media (max-width: 600px) {
+  .summary-stats {
+    flex-direction: column;
+    text-align: center;
+  }
+}
+</style>

--- a/src/css/buckets.scss
+++ b/src/css/buckets.scss
@@ -1,0 +1,30 @@
+.bucket-card {
+  background-color: #1b2330;
+  border-radius: 12px;
+  border-top: 4px solid var(--bucket-color);
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  position: relative;
+}
+.bucket-avatar {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+}
+.progress-section {
+  min-height: 48px;
+}
+.buckets-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.bucket-fab {
+  bottom: 64px !important;
+}

--- a/src/css/tokens.scss
+++ b/src/css/tokens.scss
@@ -1,5 +1,5 @@
 $primary-pink: #ff2d75;
-$primary-navy: #0d0f25;
+$primary-navy: #0e141b;
 $surface-light: #f5f5f7;
 $accent-green: #15c972;
 $accent-orange: #ff9f0a;
@@ -13,7 +13,7 @@ $spacing-base: 8px;
 
 :root {
   --color-primary-pink: #ff2d75;
-  --color-primary-navy: #0d0f25;
+  --color-primary-navy: #0e141b;
   --color-surface-light: #f5f5f7;
   --color-accent-green: #15c972;
   --color-accent-orange: #ff9f0a;

--- a/src/pages/BucketsPage.vue
+++ b/src/pages/BucketsPage.vue
@@ -1,113 +1,38 @@
 <template>
-  <q-page class="q-pa-md">
-    <div class="row items-center q-gutter-sm q-mb-md">
-      <q-input v-model="searchTerm" dense outlined label="Search" />
-      <q-select
-        v-model="viewMode"
-        dense
-        outlined
-        :options="[
-          { label: 'Active', value: 'active' },
-          { label: 'Archived', value: 'archived' }
-        ]"
-        label="View"
-      />
-      <q-select
-        v-model="sortBy"
-        dense
-        outlined
-        :options="[
-          { label: 'Name', value: 'name' },
-          { label: 'Balance', value: 'balance' }
-        ]"
-        label="Sort By"
-      />
-      <q-btn color="primary" icon="add" label="Add" @click="openAdd" />
-    </div>
-    <div class="row q-col-gutter-md">
-      <div
-        v-for="bucket in filteredBuckets"
-        :key="bucket.id"
-        class="col-12 col-sm-6 col-md-4 col-lg-3"
-      >
-        <BucketCard
-          :bucket="bucket"
-          :balance="bucketBalances[bucket.id] || 0"
-          :active-unit="activeUnit"
-          @menu-action="handleMenuAction"
-        />
-      </div>
-    </div>
+  <q-page class="q-pa-md text-white">
+    <h1>Buckets</h1>
+    <p class="text-grey-5 q-mb-md">Organize your tokens</p>
+    <SummaryStats :total="totalActiveBalance" :active-count="activeCount" />
+    <BucketManager>
+      <template #toolbar="{ searchTerm, viewMode, sortBy, toggleMultiSelect, multiSelectMode, moveSelected }">
+        <div class="row items-center q-gutter-sm buckets-toolbar">
+          <q-input v-model="searchTerm" outlined dense placeholder="Search buckets…" />
+          <q-btn-toggle v-model="viewMode" dense :options="[{label:'Active',value:'all'},{label:'Archived',value:'archived'}]" />
+          <q-select v-model="sortBy" outlined dense label="Sort" :options="['Name (A–Z)','Name (Z–A)','Balance (↓)','Balance (↑)']" />
+          <q-btn color="primary" icon="swap_horiz" label="Move Tokens" @click="moveSelected" aria-label="Move Tokens" />
+          <q-btn flat dense round class="q-ml-sm" :icon="multiSelectMode ? 'close' : 'select_all'" @click="toggleMultiSelect" :aria-pressed="multiSelectMode" aria-label="Toggle selection" />
+        </div>
+      </template>
+    </BucketManager>
+    <q-page-sticky position="bottom-right" :offset="[18,18]" class="bucket-fab" scroll-target="body">
+      <q-btn fab color="primary" icon="add" @click="dialogOpen = true" aria-label="Create bucket" />
+    </q-page-sticky>
     <BucketDialog v-model="dialogOpen" />
-    <EditBucketModal v-model="editModalOpen" :bucket="editBucket" @save="saveEdit" />
   </q-page>
 </template>
 
 <script setup lang="ts">
-import { ref, computed } from 'vue';
-import { storeToRefs } from 'pinia';
-import BucketCard from 'components/BucketCard.vue';
-import BucketDialog from 'components/BucketDialog.vue';
-import EditBucketModal from 'components/EditBucketModal.vue';
-import { useBucketsStore } from 'stores/buckets';
-import { useMintsStore } from 'stores/mints';
+import { ref } from 'vue'
+import { storeToRefs } from 'pinia'
+import BucketManager from 'components/BucketManager.vue'
+import BucketDialog from 'components/BucketDialog.vue'
+import SummaryStats from 'components/SummaryStats.vue'
+import { useBucketsStore } from 'stores/buckets'
 
-const bucketsStore = useBucketsStore();
-const mintsStore = useMintsStore();
+const bucketsStore = useBucketsStore()
+const { totalActiveBalance, activeCount } = storeToRefs(bucketsStore)
 
-const { bucketList, bucketBalances } = storeToRefs(bucketsStore);
-const { activeUnit } = storeToRefs(mintsStore);
-
-const searchTerm = ref('');
-const viewMode = ref<'active' | 'archived'>('active');
-const sortBy = ref<'name' | 'balance'>('name');
-
-const dialogOpen = ref(false);
-const editModalOpen = ref(false);
-const editBucket = ref(null as any);
-
-function openAdd() {
-  dialogOpen.value = true;
-}
-function handleMenuAction({ action, bucket }: any) {
-  switch (action) {
-    case 'edit':
-      editBucket.value = bucket;
-      editModalOpen.value = true;
-      break;
-    case 'delete':
-      bucketsStore.deleteBucket(bucket.id);
-      break;
-    case 'archive':
-      bucketsStore.editBucket(bucket.id, { isArchived: !bucket.isArchived });
-      break;
-  }
-}
-function saveEdit(data: any) {
-  if (editBucket.value) {
-    bucketsStore.editBucket(editBucket.value.id, { ...data });
-  }
-  editModalOpen.value = false;
-}
-
-const filteredBuckets = computed(() => {
-  const term = searchTerm.value.toLowerCase();
-  const list = bucketList.value.filter(b =>
-    viewMode.value === 'archived' ? b.isArchived : !b.isArchived
-  );
-  const filtered = list.filter(b => {
-    const name = (b.name || '').toLowerCase();
-    const desc = (b.description || '').toLowerCase();
-    return name.includes(term) || desc.includes(term);
-  });
-  const sorted = [...filtered];
-  if (sortBy.value === 'balance') {
-    sorted.sort((a, b) => (bucketBalances.value[b.id] || 0) - (bucketBalances.value[a.id] || 0));
-  } else {
-    sorted.sort((a, b) => (a.name || '').localeCompare(b.name || ''));
-  }
-  return sorted;
-});
+const dialogOpen = ref(false)
 </script>
 
 <style scoped>

--- a/src/stores/buckets.ts
+++ b/src/stores/buckets.ts
@@ -8,6 +8,24 @@ import { useLockedTokensStore } from "./lockedTokens";
 import { ref, watch } from "vue";
 import { notifySuccess } from "src/js/notify";
 
+export const COLOR_PALETTE = [
+  "#ec4899",
+  "#3b82f6",
+  "#10b981",
+  "#f59e0b",
+  "#8b5cf6",
+  "#ef4444",
+];
+
+export function hashColor(name: string): string {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = name.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  const idx = Math.abs(hash) % COLOR_PALETTE.length;
+  return COLOR_PALETTE[idx];
+}
+
 export type Bucket = {
   id: string;
   name: string;
@@ -139,6 +157,16 @@ export const useBucketsStore = defineStore("buckets", {
       });
       return balances;
     },
+    totalActiveBalance(): number {
+      const balances = this.bucketBalances;
+      return this.activeBuckets.reduce(
+        (sum, b) => sum + (balances[b.id] || 0),
+        0
+      );
+    },
+    activeCount(): number {
+      return this.activeBuckets.length;
+    },
     autoBucketFor:
       (state) =>
       (mint?: string, memo?: string): string | undefined => {
@@ -184,6 +212,7 @@ export const useBucketsStore = defineStore("buckets", {
       const newBucket: Bucket = {
         id: uuidv4(),
         isArchived: false,
+        color: bucket.color || hashColor(bucket.name),
         ...bucket,
       };
       this.buckets.push(newBucket);

--- a/test/vitest/__tests__/BucketCard.spec.ts
+++ b/test/vitest/__tests__/BucketCard.spec.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import BucketCard from '../../../src/components/BucketCard.vue'
+import { hashColor } from '../../../src/stores/buckets'
+
+describe('BucketCard progress section', () => {
+  const base = { id: 'b1', name: 'Test', isArchived: false }
+  it('reserves space when goal missing', () => {
+    const wrapper = mount(BucketCard, { props: { bucket: base, balance: 0, activeUnit: 'sat' } })
+    expect(wrapper.find('[data-test="progress-section"]').exists()).toBe(true)
+    expect(wrapper.find('q-linear-progress-stub').exists()).toBe(false)
+  })
+})
+
+describe('hashColor util', () => {
+  it('returns hex color', () => {
+    const c = hashColor('My Bucket')
+    expect(c).toMatch(/^#([0-9a-fA-F]{6})$/)
+  })
+})


### PR DESCRIPTION
## Summary
- new summary bar component
- refactor buckets page layout
- add color pickers for bucket modals
- overhaul bucket card visuals
- styling updates
- expose hashColor and totals getters
- document Phase9 UI redesign

## Testing
- `npx eslint --fix src/components/BucketCard.vue src/components/BucketManager.vue src/components/BucketDialog.vue src/components/EditBucketModal.vue src/pages/BucketsPage.vue test/vitest/__tests__/BucketCard.spec.ts src/stores/buckets.ts src/components/SummaryStats.vue quasar.config.js src/css/tokens.scss src/css/buckets.scss docs/CHANGELOG.md`
- `pnpm test` *(fails: 30 failed, 25 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687f4c6d0734833098b0bf634d540414