### PR TITLE
Fix toolbar model binding

### DIFF
--- a/src/pages/BucketsPage.vue
+++ b/src/pages/BucketsPage.vue
@@ -4,36 +4,96 @@
     <p class="text-grey-5 q-mb-md">Organize your tokens</p>
     <SummaryStats :total="totalActiveBalance" :active-count="activeCount" />
     <BucketManager>
-      <template #toolbar="{ searchTerm, viewMode, sortBy, toggleMultiSelect, multiSelectMode, moveSelected }">
+      <template
+        #toolbar="{
+          searchTerm,
+          viewMode,
+          sortBy,
+          toggleMultiSelect,
+          multiSelectMode,
+          moveSelected,
+        }"
+      >
         <div class="row items-center q-gutter-sm buckets-toolbar">
-          <q-input v-model="searchTerm" outlined dense placeholder="Search buckets…" />
-          <q-btn-toggle v-model="viewMode" dense :options="[{label:'Active',value:'all'},{label:'Archived',value:'archived'}]" />
-          <q-select v-model="sortBy" outlined dense label="Sort" :options="['Name (A–Z)','Name (Z–A)','Balance (↓)','Balance (↑)']" />
-          <q-btn color="primary" icon="swap_horiz" label="Move Tokens" @click="moveSelected" aria-label="Move Tokens" />
-          <q-btn flat dense round class="q-ml-sm" :icon="multiSelectMode ? 'close' : 'select_all'" @click="toggleMultiSelect" :aria-pressed="multiSelectMode" aria-label="Toggle selection" />
+          <q-input
+            :model-value="searchTerm.value"
+            @update:model-value="(val) => (searchTerm.value = val)"
+            outlined
+            dense
+            placeholder="Search buckets…"
+          />
+          <q-btn-toggle
+            :model-value="viewMode.value"
+            @update:model-value="(val) => (viewMode.value = val)"
+            dense
+            :options="[
+              { label: 'Active', value: 'all' },
+              { label: 'Archived', value: 'archived' },
+            ]"
+          />
+          <q-select
+            :model-value="sortBy.value"
+            @update:model-value="(val) => (sortBy.value = val)"
+            outlined
+            dense
+            label="Sort"
+            :options="[
+              'Name (A–Z)',
+              'Name (Z–A)',
+              'Balance (↓)',
+              'Balance (↑)',
+            ]"
+          />
+          <q-btn
+            color="primary"
+            icon="swap_horiz"
+            label="Move Tokens"
+            @click="moveSelected"
+            aria-label="Move Tokens"
+          />
+          <q-btn
+            flat
+            dense
+            round
+            class="q-ml-sm"
+            :icon="multiSelectMode ? 'close' : 'select_all'"
+            @click="toggleMultiSelect"
+            :aria-pressed="multiSelectMode"
+            aria-label="Toggle selection"
+          />
         </div>
       </template>
     </BucketManager>
-    <q-page-sticky position="bottom-right" :offset="[18,18]" class="bucket-fab" scroll-target="body">
-      <q-btn fab color="primary" icon="add" @click="dialogOpen = true" aria-label="Create bucket" />
+    <q-page-sticky
+      position="bottom-right"
+      :offset="[18, 18]"
+      class="bucket-fab"
+      scroll-target="body"
+    >
+      <q-btn
+        fab
+        color="primary"
+        icon="add"
+        @click="dialogOpen = true"
+        aria-label="Create bucket"
+      />
     </q-page-sticky>
     <BucketDialog v-model="dialogOpen" />
   </q-page>
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
-import { storeToRefs } from 'pinia'
-import BucketManager from 'components/BucketManager.vue'
-import BucketDialog from 'components/BucketDialog.vue'
-import SummaryStats from 'components/SummaryStats.vue'
-import { useBucketsStore } from 'stores/buckets'
+import { ref } from "vue";
+import { storeToRefs } from "pinia";
+import BucketManager from "components/BucketManager.vue";
+import BucketDialog from "components/BucketDialog.vue";
+import SummaryStats from "components/SummaryStats.vue";
+import { useBucketsStore } from "stores/buckets";
 
-const bucketsStore = useBucketsStore()
-const { totalActiveBalance, activeCount } = storeToRefs(bucketsStore)
+const bucketsStore = useBucketsStore();
+const { totalActiveBalance, activeCount } = storeToRefs(bucketsStore);
 
-const dialogOpen = ref(false)
+const dialogOpen = ref(false);
 </script>
 
-<style scoped>
-</style>
+<style scoped></style>


### PR DESCRIPTION
## Summary
- convert `v-model` usage in `BucketsPage` toolbar to `:model-value`/`@update:model-value`

## Testing
- `pnpm test:ci --silent` *(fails: 30 failed, 25 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687f56783dc4833093e41d82e0cf6921