### PR TITLE
Update bucket sorting options

### DIFF
--- a/src/components/BucketManager.vue
+++ b/src/components/BucketManager.vue
@@ -189,7 +189,7 @@ export default defineComponent({
 
     const bucketList = computed(() => bucketsStore.bucketList);
     const searchTerm = ref('');
-    const sortBy = ref('name');
+    const sortBy = ref('name-asc');
     const bucketBalances = computed(() => bucketsStore.bucketBalances);
 
     const activeBuckets = computed(() =>
@@ -219,12 +219,23 @@ export default defineComponent({
           return name.includes(term) || description.includes(term);
         });
       const sorted = [...list];
-      if (sortBy.value === 'balance') {
-        sorted.sort(
-          (a, b) => (bucketBalances.value[b.id] || 0) - (bucketBalances.value[a.id] || 0)
-        );
-      } else {
-        sorted.sort((a, b) => (a.name || '').localeCompare(b.name || ''));
+      switch (sortBy.value) {
+        case 'balance-asc':
+          sorted.sort(
+            (a, b) => (bucketBalances.value[a.id] || 0) - (bucketBalances.value[b.id] || 0)
+          );
+          break;
+        case 'balance-desc':
+          sorted.sort(
+            (a, b) => (bucketBalances.value[b.id] || 0) - (bucketBalances.value[a.id] || 0)
+          );
+          break;
+        case 'name-desc':
+          sorted.sort((a, b) => (b.name || '').localeCompare(a.name || ''));
+          break;
+        case 'name-asc':
+        default:
+          sorted.sort((a, b) => (a.name || '').localeCompare(b.name || ''));
       }
       return sorted;
     });

--- a/src/components/BucketsToolbar.vue
+++ b/src/components/BucketsToolbar.vue
@@ -25,9 +25,12 @@
       dense
       outlined
       class="bg-slate-800"
+      label="Sort"
       :options="[
-        { label: 'Name', value: 'name' },
-        { label: 'Balance', value: 'balance' }
+        { label: 'Name (A–Z)', value: 'name-asc' },
+        { label: 'Name (Z–A)', value: 'name-desc' },
+        { label: 'Balance (↓)', value: 'balance-desc' },
+        { label: 'Balance (↑)', value: 'balance-asc' }
       ]"
     />
     <q-space />

--- a/src/pages/BucketsPage.vue
+++ b/src/pages/BucketsPage.vue
@@ -41,10 +41,10 @@
             emit-value
             map-options
             :options="[
-              'Name (A–Z)',
-              'Name (Z–A)',
-              'Balance (↓)',
-              'Balance (↑)',
+              { label: 'Name (A–Z)', value: 'name-asc' },
+              { label: 'Name (Z–A)', value: 'name-desc' },
+              { label: 'Balance (↓)', value: 'balance-desc' },
+              { label: 'Balance (↑)', value: 'balance-asc' },
             ]"
           />
           <q-btn


### PR DESCRIPTION
## Summary
- refine sorting controls in Buckets page and toolbar
- support ascending/descending balance sort in BucketManager

## Testing
- `pnpm run lint` *(fails: Invalid option `--ext`)*
- `pnpm run types` *(fails with type errors)*
- `pnpm run test:ci` *(fails with multiple test errors)*

------
https://chatgpt.com/codex/tasks/task_e_687f714a69fc8330915b32ae458e841c