### PR TITLE
Fix bucket view modes

### DIFF
--- a/src/components/BucketManager.vue
+++ b/src/components/BucketManager.vue
@@ -185,7 +185,7 @@ export default defineComponent({
       isLoading.value = false;
     });
 
-    const viewMode = ref('all');
+    const viewMode = ref('active');
 
     const bucketList = computed(() => bucketsStore.bucketList);
     const searchTerm = ref('');
@@ -208,9 +208,11 @@ export default defineComponent({
     const filteredBuckets = computed(() => {
       const term = searchTerm.value.toLowerCase();
       const list = bucketList.value
-        .filter((b) =>
-          viewMode.value === 'archived' ? b.isArchived : !b.isArchived
-        )
+        .filter((b) => {
+          if (viewMode.value === 'archived') return b.isArchived;
+          if (viewMode.value === 'active') return !b.isArchived;
+          return true;
+        })
         .filter((b) => {
           const name = (b.name || '').toLowerCase();
           const description = (b.description || '').toLowerCase();

--- a/src/pages/BucketsPage.vue
+++ b/src/pages/BucketsPage.vue
@@ -27,7 +27,7 @@
             @update:model-value="(val) => (viewMode.value = val)"
             dense
             :options="[
-              { label: 'Active', value: 'all' },
+              { label: 'Active', value: 'active' },
               { label: 'Archived', value: 'archived' },
             ]"
           />


### PR DESCRIPTION
## Summary
- use `active`/`archived` toggle values in `BucketsPage`
- default bucket manager view to `active`
- filter buckets according to the new values

## Testing
- `pnpm test` *(fails: "Test failed. See above for more details")*

------
https://chatgpt.com/codex/tasks/task_e_687f782c70e08330ac9113fd9b6c8236