### PR TITLE
Implement bucket sort options

### DIFF
--- a/src/components/BucketManager.vue
+++ b/src/components/BucketManager.vue
@@ -189,7 +189,7 @@ export default defineComponent({
 
     const bucketList = computed(() => bucketsStore.bucketList);
     const searchTerm = ref('');
-    const sortBy = ref('name');
+    const sortBy = ref('name-asc');
     const bucketBalances = computed(() => bucketsStore.bucketBalances);
 
     const activeBuckets = computed(() =>
@@ -219,12 +219,26 @@ export default defineComponent({
           return name.includes(term) || description.includes(term);
         });
       const sorted = [...list];
-      if (sortBy.value === 'balance') {
-        sorted.sort(
-          (a, b) => (bucketBalances.value[b.id] || 0) - (bucketBalances.value[a.id] || 0)
-        );
-      } else {
-        sorted.sort((a, b) => (a.name || '').localeCompare(b.name || ''));
+      switch (sortBy.value) {
+        case 'name-desc':
+          sorted.sort((a, b) => (b.name || '').localeCompare(a.name || ''));
+          break;
+        case 'balance-asc':
+          sorted.sort(
+            (a, b) =>
+              (bucketBalances.value[a.id] || 0) - (bucketBalances.value[b.id] || 0)
+          );
+          break;
+        case 'balance-desc':
+          sorted.sort(
+            (a, b) =>
+              (bucketBalances.value[b.id] || 0) - (bucketBalances.value[a.id] || 0)
+          );
+          break;
+        case 'name-asc':
+        default:
+          sorted.sort((a, b) => (a.name || '').localeCompare(b.name || ''));
+          break;
       }
       return sorted;
     });

--- a/src/pages/BucketsPage.vue
+++ b/src/pages/BucketsPage.vue
@@ -41,10 +41,10 @@
             emit-value
             map-options
             :options="[
-              'Name (A–Z)',
-              'Name (Z–A)',
-              'Balance (↓)',
-              'Balance (↑)',
+              { label: 'Name (A–Z)', value: 'name-asc' },
+              { label: 'Name (Z–A)', value: 'name-desc' },
+              { label: 'Balance (↓)', value: 'balance-desc' },
+              { label: 'Balance (↑)', value: 'balance-asc' },
             ]"
           />
           <q-btn


### PR DESCRIPTION
## Summary
- add explicit label-value pairs for bucket sort options
- refine bucket sorting to handle ascending/descending order for name and balance

## Testing
- `pnpm install`
- `pnpm test` *(fails: 31 failed, 24 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687f7d9e64bc83309272cdbcfe10867e