### PR TITLE
Fix menu text overflow

### DIFF
--- a/src/css/buckets.scss
+++ b/src/css/buckets.scss
@@ -30,5 +30,6 @@
 }
 
 .q-item__section--main {
-  white-space: nowrap;
+  white-space: normal; // allow wrapping within menu items
+  word-break: break-word; // prevent overflow for long words
 }


### PR DESCRIPTION
## Summary
- allow menu item text to wrap so long labels fit

## Testing
- `pnpm run test:ci` *(fails: InfoTooltip test and others)*

------
https://chatgpt.com/codex/tasks/task_e_687f8063bca88330b494cbcfc4af60f9