### PR TITLE
Refactor wallet sections

### DIFF
--- a/src/components/EditBucketModal.vue
+++ b/src/components/EditBucketModal.vue
@@ -61,7 +61,7 @@
 import { reactive, watch, computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { COLOR_PALETTE, hashColor, useBucketsStore } from 'stores/buckets';
-import type { Bucket } from 'stores/buckets';
+import type { Bucket } from 'src/types/buckets';
 
 const props = defineProps<{ modelValue: boolean; bucket: Bucket | null }>();
 const emit = defineEmits(['update:modelValue', 'save']);

--- a/src/components/InvoicesTable.vue
+++ b/src/components/InvoicesTable.vue
@@ -106,6 +106,7 @@ import { shortenString } from "src/js/string-utils";
 import { mapWritableState, mapActions } from "pinia";
 import { useUiStore } from "src/stores/ui";
 import { useWalletStore } from "src/stores/wallet";
+import { useInvoiceHistoryStore } from "src/stores/invoiceHistory";
 import { useInvoicesWorkerStore } from "src/stores/invoicesWorker";
 import { formatDistanceToNow, parseISO } from "date-fns";
 
@@ -127,11 +128,8 @@ export default defineComponent({
   },
   computed: {
     ...mapWritableState(useUiStore, ["showInvoiceDetails"]),
-    ...mapWritableState(useWalletStore, [
-      "invoiceHistory",
-      "invoiceData",
-      "payInvoiceData",
-    ]),
+    ...mapWritableState(useInvoiceHistoryStore, ["invoiceHistory"]),
+    ...mapWritableState(useWalletStore, ["invoiceData", "payInvoiceData"]),
     maxPages() {
       return Math.ceil(this.invoiceHistory.length / this.pageSize);
     },

--- a/src/components/RestoreView.vue
+++ b/src/components/RestoreView.vue
@@ -177,6 +177,7 @@ import { mapActions, mapState, mapWritableState } from "pinia";
 import { useMintsStore, MintClass } from "src/stores/mints";
 import { useRestoreStore } from "src/stores/restore";
 import { useWalletStore } from "src/stores/wallet";
+import { useMnemonicStore } from "src/stores/mnemonic";
 import { useUiStore } from "src/stores/ui";
 import { notifyError, notifySuccess } from "src/js/notify";
 
@@ -193,7 +194,7 @@ export default defineComponent({
   },
   computed: {
     ...mapState(useMintsStore, ["mints"]),
-    ...mapWritableState(useWalletStore, ["mnemonic"]),
+    ...mapWritableState(useMnemonicStore, ["mnemonic"]),
     ...mapWritableState(useRestoreStore, [
       "mnemonicToRestore",
       "restoreProgress",

--- a/src/components/SendDialog.vue
+++ b/src/components/SendDialog.vue
@@ -84,6 +84,7 @@ import { useReceiveTokensStore } from "src/stores/receiveTokensStore";
 import { mapActions, mapState, mapWritableState } from "pinia";
 import { useUiStore } from "src/stores/ui";
 import { useWalletStore } from "src/stores/wallet";
+import { useInvoiceHistoryStore } from "src/stores/invoiceHistory";
 import { useCameraStore } from "src/stores/camera";
 import { useSendTokensStore } from "src/stores/sendTokensStore";
 import { useSettingsStore } from "../stores/settings";
@@ -122,11 +123,8 @@ export default defineComponent({
       "showSendDialog",
       "showReceiveDialog",
     ]),
-    ...mapWritableState(useWalletStore, [
-      "invoiceHistory",
-      "invoiceData",
-      "payInvoiceData",
-    ]),
+    ...mapWritableState(useInvoiceHistoryStore, ["invoiceHistory"]),
+    ...mapWritableState(useWalletStore, ["invoiceData", "payInvoiceData"]),
     ...mapWritableState(useCameraStore, ["camera"]),
     ...mapWritableState(useSendTokensStore, [
       "showSendTokens",

--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -908,7 +908,6 @@ export default defineComponent({
     ...mapActions(useWorkersStore, ["clearAllWorkers"]),
     ...mapActions(useWalletStore, [
       "send",
-      "sendToLock",
       "coinSelect",
       "spendableProofs",
       "getFeesForProofs",
@@ -922,7 +921,7 @@ export default defineComponent({
       "setTokenPaid",
       "deleteToken",
     ]),
-    ...mapActions(useP2PKStore, ["isValidPubkey"]),
+    ...mapActions(useP2PKStore, ["isValidPubkey", "sendToLock"]),
     ...mapActions(useCameraStore, ["closeCamera", "showCamera"]),
     ...mapActions(useMintsStore, ["toggleUnit"]),
     onDialogShown() {

--- a/src/components/SettingsView.vue
+++ b/src/components/SettingsView.vue
@@ -1786,6 +1786,7 @@ import { getShortUrl } from "src/js/wallet-helpers";
 import { mapActions, mapState, mapWritableState } from "pinia";
 import { useMintsStore, MintClass } from "src/stores/mints";
 import { useWalletStore } from "src/stores/wallet";
+import { useMnemonicStore } from "src/stores/mnemonic";
 import { map } from "underscore";
 import { useSettingsStore } from "src/stores/settings";
 import {
@@ -1893,7 +1894,7 @@ export default defineComponent({
       "signerType",
       "seedSignerPrivateKeyNsecComputed",
     ]),
-    ...mapState(useWalletStore, ["mnemonic"]),
+    ...mapState(useMnemonicStore, ["mnemonic"]),
     ...mapState(useUiStore, ["ndefSupported"]),
     ...mapWritableState(useNPCStore, ["npcAddress"]),
     ...mapWritableState(useNPCStore, ["npcEnabled", "automaticClaim"]),
@@ -1986,8 +1987,8 @@ export default defineComponent({
       "activateMintUrl",
       "updateMint",
     ]),
+    ...mapActions(useMnemonicStore, ["newMnemonic"]),
     ...mapActions(useWalletStore, [
-      "newMnemonic",
       "decodeRequest",
       "checkProofsSpendable",
       "increaseKeysetCounter",

--- a/src/components/WelcomeDialog.vue
+++ b/src/components/WelcomeDialog.vue
@@ -101,6 +101,7 @@ import { defineComponent } from "vue";
 import { mapActions, mapState } from "pinia";
 import { useClipboard } from "src/composables/useClipboard";
 import { useWalletStore } from "src/stores/wallet";
+import { useMnemonicStore } from "src/stores/mnemonic";
 import { useStorageStore } from "src/stores/storage";
 
 export default defineComponent({
@@ -122,7 +123,7 @@ export default defineComponent({
   },
   watch: {},
   computed: {
-    ...mapState(useWalletStore, ["mnemonic"]),
+    ...mapState(useMnemonicStore, ["mnemonic"]),
   },
   methods: {
     ...mapActions(useStorageStore, ["restoreFromBackup"]),

--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -280,6 +280,8 @@ import { useReceiveTokensStore } from "src/stores/receiveTokensStore";
 import { useWorkersStore } from "src/stores/workers";
 import { useTokensStore } from "src/stores/tokens";
 import { useWalletStore } from "src/stores/wallet";
+import { useMnemonicStore } from "src/stores/mnemonic";
+import { useInvoiceHistoryStore } from "src/stores/invoiceHistory";
 import { useUiStore } from "src/stores/ui";
 import { useProofsStore } from "src/stores/proofs";
 import { useCameraStore } from "src/stores/camera";
@@ -388,11 +390,8 @@ export default {
       "mints",
       "activeMint",
     ]),
-    ...mapWritableState(useWalletStore, [
-      "invoiceHistory",
-      "invoiceData",
-      "payInvoiceData",
-    ]),
+    ...mapWritableState(useInvoiceHistoryStore, ["invoiceHistory"]),
+    ...mapWritableState(useWalletStore, ["invoiceData", "payInvoiceData"]),
     ...mapWritableState(useMintsStore, ["addMintData", "showAddMintDialog"]),
     ...mapWritableState(useWorkersStore, [
       "invoiceCheckListener",
@@ -434,12 +433,12 @@ export default {
     ]),
     ...mapActions(useWorkersStore, ["clearAllWorkers", "invoiceCheckWorker"]),
     ...mapActions(useTokensStore, ["setTokenPaid"]),
+    ...mapActions(useMnemonicStore, ["initializeMnemonic"]),
     ...mapActions(useWalletStore, [
       "setInvoicePaid",
       "mint",
       "checkPendingTokens",
       "decodeRequest",
-      "initializeMnemonic",
     ]),
     ...mapActions(useCameraStore, ["closeCamera", "showCamera"]),
     ...mapActions(useNWCStore, ["listenToNWCCommands"]),

--- a/src/pages/welcome/WelcomeSlide3.vue
+++ b/src/pages/welcome/WelcomeSlide3.vue
@@ -37,7 +37,7 @@
             dense
             icon="content_copy"
             class="cursor-pointer q-mt-md"
-            @click="copy(walletStore.mnemonic)"
+            @click="copy(mnemonicStore.mnemonic)"
             :aria-label="$t('global.actions.copy.label')"
             :title="$t('global.actions.copy.label')"
           ></q-btn>
@@ -59,6 +59,7 @@
 <script>
 import { useWelcomeStore } from "src/stores/welcome";
 import { useWalletStore } from "src/stores/wallet";
+import { useMnemonicStore } from "src/stores/mnemonic";
 import { ref, computed } from "vue";
 import { useQuasar } from "quasar";
 import { useClipboard } from "src/composables/useClipboard";
@@ -69,18 +70,19 @@ export default {
   setup() {
     const welcomeStore = useWelcomeStore();
     const walletStore = useWalletStore();
+    const mnemonicStore = useMnemonicStore();
     const $q = useQuasar();
     const { copy } = useClipboard();
     let hideMnemonic = ref(true);
 
     const hiddenMnemonic = computed(() => {
       if (hideMnemonic.value) {
-        return walletStore.mnemonic
+        return mnemonicStore.mnemonic
           .split(" ")
           .map((w) => "*".repeat(6))
           .join(" ");
       }
-      return walletStore.mnemonic;
+      return mnemonicStore.mnemonic;
     });
 
     const toggleMnemonicVisibility = () => {

--- a/src/stores/buckets.ts
+++ b/src/stores/buckets.ts
@@ -7,6 +7,7 @@ import { useTokensStore } from "./tokens";
 import { useLockedTokensStore } from "./lockedTokens";
 import { ref, watch } from "vue";
 import { notifySuccess } from "src/js/notify";
+import { Bucket, BucketRule } from "src/types/buckets";
 
 export const COLOR_PALETTE = [
   "#ec4899",
@@ -26,22 +27,6 @@ export function hashColor(name: string): string {
   return COLOR_PALETTE[idx];
 }
 
-export type Bucket = {
-  id: string;
-  name: string;
-  color?: string;
-  description?: string;
-  goal?: number;
-  creatorPubkey?: string;
-  isArchived?: boolean;
-};
-
-export type BucketRule = {
-  id: string;
-  bucketId: string;
-  mint?: string;
-  memo?: string;
-};
 
 export const DEFAULT_BUCKET_ID = "unassigned";
 export const DEFAULT_BUCKET_NAME = "Default";

--- a/src/stores/donationPresets.ts
+++ b/src/stores/donationPresets.ts
@@ -72,7 +72,7 @@ export const useDonationPresetsStore = defineStore("donationPresets", {
       const tokens: LockedToken[] = [];
 
       if (!months || months <= 0) {
-        const { locked } = await walletStore.sendToLock(
+        const { locked } = await p2pkStore.sendToLock(
           amount,
           convertedPubkey,
           0
@@ -83,7 +83,7 @@ export const useDonationPresetsStore = defineStore("donationPresets", {
       const base = startDate ?? Math.floor(Date.now() / 1000);
       for (let i = 0; i < months; i++) {
         const locktime = base + i * 30 * 24 * 60 * 60;
-        const { locked } = await walletStore.sendToLock(
+        const { locked } = await p2pkStore.sendToLock(
           amount,
           convertedPubkey,
           locktime

--- a/src/stores/invoiceHistory.ts
+++ b/src/stores/invoiceHistory.ts
@@ -1,0 +1,51 @@
+import { defineStore } from 'pinia';
+import { useLocalStorage } from '@vueuse/core';
+import { LOCAL_STORAGE_KEYS } from 'src/constants/localStorageKeys';
+import { InvoiceHistory } from 'src/types/invoice';
+import { MeltQuoteResponse } from '@cashu/cashu-ts';
+
+export const useInvoiceHistoryStore = defineStore('invoiceHistory', {
+  state: () => ({
+    invoiceHistory: useLocalStorage<InvoiceHistory[]>(
+      LOCAL_STORAGE_KEYS.CASHU_INVOICEHISTORY,
+      []
+    ),
+  }),
+  actions: {
+    setInvoicePaid(quoteId: string) {
+      const invoice = this.invoiceHistory.find((i) => i.quote === quoteId);
+      if (invoice) invoice.status = 'paid';
+    },
+    addOutgoingPendingInvoiceToHistory(quote: MeltQuoteResponse) {
+      this.invoiceHistory.push({
+        amount: -(quote.amount + quote.fee_reserve),
+        bolt11: '',
+        quote: quote.quote,
+        memo: 'Outgoing invoice',
+        date: new Date().toISOString(),
+        status: 'pending',
+        mint: '',
+        unit: '',
+        meltQuote: quote,
+      });
+    },
+    removeOutgoingInvoiceFromHistory(quote: string) {
+      const index = this.invoiceHistory.findIndex((i) => i.quote === quote);
+      if (index >= 0) this.invoiceHistory.splice(index, 1);
+    },
+    updateOutgoingInvoiceInHistory(
+      quote: MeltQuoteResponse,
+      options?: { status?: 'pending' | 'paid'; amount?: number }
+    ) {
+      this.invoiceHistory
+        .filter((i) => i.quote === quote.quote)
+        .forEach((i) => {
+          if (options) {
+            if (options.status) i.status = options.status;
+            if (options.amount) i.amount = options.amount;
+            i.meltQuote = quote;
+          }
+        });
+    },
+  },
+});

--- a/src/stores/invoicesWorker.ts
+++ b/src/stores/invoicesWorker.ts
@@ -1,6 +1,7 @@
 import { debug } from "src/js/logger";
 import { defineStore } from "pinia";
 import { useWalletStore } from "./wallet";
+import { useInvoiceHistoryStore } from "./invoiceHistory";
 import { useLocalStorage } from "@vueuse/core";
 import { useSettingsStore } from "./settings";
 interface InvoiceQuote {
@@ -127,7 +128,7 @@ export const useInvoicesWorkerStore = defineStore("invoicesWorker", {
       )
         return;
       const walletStore = useWalletStore();
-      const quotesToCheck = walletStore.invoiceHistory.filter(
+      const quotesToCheck = useInvoiceHistoryStore().invoiceHistory.filter(
         (q) =>
           q.status === "pending" &&
           q.amount > 0 &&

--- a/src/stores/mints.ts
+++ b/src/stores/mints.ts
@@ -22,6 +22,7 @@ import { useUiStore } from "./ui";
 import { cashuDb } from "src/stores/dexie";
 import { liveQuery } from "dexie";
 import { ref, computed, watch } from "vue";
+import { WalletProof } from "src/types/proofs";
 import { useProofsStore } from "./proofs";
 import { useI18n } from "vue-i18n";
 import { maybeRepublishNutzapProfile } from "./creatorHub";
@@ -90,13 +91,7 @@ export class MintClass {
   }
 }
 
-// type that extends type Proof with reserved boolean
-export type WalletProof = Proof & {
-  reserved: boolean;
-  quote?: string;
-  bucketId?: string;
-  label?: string;
-};
+
 
 export type Balances = {
   [unit: string]: number;

--- a/src/stores/mnemonic.ts
+++ b/src/stores/mnemonic.ts
@@ -1,0 +1,35 @@
+import { defineStore } from 'pinia';
+import { useLocalStorage } from '@vueuse/core';
+import { generateMnemonic, mnemonicToSeedSync } from '@scure/bip39';
+import { wordlist } from '@scure/bip39/wordlists/english';
+import { LOCAL_STORAGE_KEYS } from 'src/constants/localStorageKeys';
+
+export const useMnemonicStore = defineStore('mnemonic', {
+  state: () => ({
+    mnemonic: useLocalStorage<string>(LOCAL_STORAGE_KEYS.CASHU_MNEMONIC, ''),
+    oldMnemonicCounters: useLocalStorage<{ mnemonic: string; keysetCounters: any[] }[]>(
+      LOCAL_STORAGE_KEYS.CASHU_OLDMNEMONICCOUNTERS,
+      []
+    ),
+  }),
+  getters: {
+    seed(state): Uint8Array {
+      return mnemonicToSeedSync(state.mnemonic);
+    },
+  },
+  actions: {
+    mnemonicToSeedSync(mnemonic: string): Uint8Array {
+      return mnemonicToSeedSync(mnemonic);
+    },
+    initializeMnemonic() {
+      if (this.mnemonic === '') {
+        this.mnemonic = generateMnemonic(wordlist);
+      }
+      return this.mnemonic;
+    },
+    newMnemonic(keysetCounters: any[]) {
+      this.oldMnemonicCounters.push({ mnemonic: this.mnemonic, keysetCounters });
+      this.mnemonic = generateMnemonic(wordlist);
+    },
+  },
+});

--- a/src/stores/nutzap.ts
+++ b/src/stores/nutzap.ts
@@ -202,7 +202,7 @@ export const useNutzapStore = defineStore("nutzap", {
           throw new Error(
             "Insufficient balance in a mint that the creator trusts."
           );
-        const { sendProofs, locked } = await wallet.sendToLock(
+        const { sendProofs, locked } = await useP2PKStore().sendToLock(
           price,
           creator.cashuP2pk,
           unlockDate
@@ -349,7 +349,7 @@ export const useNutzapStore = defineStore("nutzap", {
               "Insufficient balance in a mint that the creator trusts."
             );
 
-          const { sendProofs, locked } = await wallet.sendToLock(
+          const { sendProofs, locked } = await useP2PKStore().sendToLock(
             amount,
             creatorP2pk,
             unlockDate

--- a/src/stores/nwc.ts
+++ b/src/stores/nwc.ts
@@ -14,7 +14,9 @@ import { bytesToHex, hexToBytes } from "@noble/hashes/utils"; // already an inst
 import { generateSecretKey, getPublicKey } from "nostr-tools";
 import { v2 as nip44 } from "nostr-tools/nip44";
 import { useMintsStore } from "./mints";
-import { useWalletStore, InvoiceHistory } from "./wallet";
+import { useWalletStore } from "./wallet";
+import { useInvoiceHistoryStore } from "./invoiceHistory";
+import { InvoiceHistory } from "src/types/invoice";
 import { useProofsStore } from "./proofs";
 import { notify, notifyError, notifyWarning } from "../js/notify";
 import { useSettingsStore } from "./settings";
@@ -230,7 +232,7 @@ export const useNWCStore = defineStore("nwc", {
       const unpaid = nwcCommand.params.unpaid || false;
       const type = nwcCommand.params.type || undefined;
 
-      const invoiceHistory = walletStore.invoiceHistory;
+      const invoiceHistory = useInvoiceHistoryStore().invoiceHistory;
       const transactionsHistory = invoiceHistory
         .filter((invoice) => {
           const date = new Date(invoice.date);
@@ -289,7 +291,7 @@ export const useNWCStore = defineStore("nwc", {
 
       debug("### lookup_invoice");
       const walletStore = useWalletStore();
-      const invoiceHistory = walletStore.invoiceHistory;
+      const invoiceHistory = useInvoiceHistoryStore().invoiceHistory;
 
       for (const inv of invoiceHistory) {
         const decoded = decodeBolt11(nwcCommand.params.invoice);

--- a/src/stores/restore.ts
+++ b/src/stores/restore.ts
@@ -4,6 +4,7 @@ import { useLocalStorage } from "@vueuse/core";
 import { generateSecretKey, getPublicKey } from "nostr-tools";
 import { bytesToHex } from "@noble/hashes/utils"; // already an installed dependency
 import { useWalletStore } from "./wallet";
+import { useMnemonicStore } from "./mnemonic";
 import { CashuMint, CashuWallet, CheckStateEnum, Proof } from "@cashu/cashu-ts";
 import { useMintsStore } from "./mints";
 import { notify, notifyError, notifySuccess } from "src/js/notify";
@@ -73,7 +74,7 @@ export const useRestoreStore = defineStore("restore", {
 
       for (const keyset of keysets) {
         debug(`Restoring keyset ${keyset.id} with unit ${keyset.unit}`);
-        const bip39Seed = walletStore.mnemonicToSeedSync(mnemonic);
+        const bip39Seed = useMnemonicStore().mnemonicToSeedSync(mnemonic);
         const wallet = new CashuWallet(mint, {
           bip39seed: bip39Seed,
           unit: keyset.unit,

--- a/src/stores/storage.ts
+++ b/src/stores/storage.ts
@@ -8,6 +8,7 @@ import { useTokensStore } from "./tokens";
 import { currentDateStr } from "src/js/utils";
 import { useProofsStore } from "./proofs";
 import { useBucketsStore } from "./buckets";
+import { useInvoiceHistoryStore } from "./invoiceHistory";
 
 export const useStorageStore = defineStore("storage", {
   state: () => ({
@@ -120,7 +121,7 @@ export const useStorageStore = defineStore("storage", {
 
       // from all paid invoices in this.invoiceHistory, delete the oldest so that only max 100 remain
       const max_history = 200;
-      let paidInvoices = walletStore.invoiceHistory.filter(
+      let paidInvoices = useInvoiceHistoryStore().invoiceHistory.filter(
         (i) => i.status == "paid"
       );
 
@@ -132,7 +133,8 @@ export const useStorageStore = defineStore("storage", {
           0,
           sortedInvoices.length - max_history
         );
-        walletStore.invoiceHistory = walletStore.invoiceHistory.filter(
+        const invStore = useInvoiceHistoryStore();
+        invStore.invoiceHistory = invStore.invoiceHistory.filter(
           (i) => !deleteInvoices.includes(i)
         );
       }

--- a/src/types/buckets.ts
+++ b/src/types/buckets.ts
@@ -1,0 +1,16 @@
+export interface Bucket {
+  id: string;
+  name: string;
+  color?: string;
+  description?: string;
+  goal?: number;
+  creatorPubkey?: string;
+  isArchived?: boolean;
+}
+
+export interface BucketRule {
+  id: string;
+  bucketId: string;
+  mint?: string;
+  memo?: string;
+}

--- a/src/types/invoice.ts
+++ b/src/types/invoice.ts
@@ -1,0 +1,17 @@
+import { MeltQuoteResponse, MintQuoteResponse } from "@cashu/cashu-ts";
+
+export interface Invoice {
+  amount: number;
+  bolt11: string;
+  quote: string;
+  memo: string;
+}
+
+export interface InvoiceHistory extends Invoice {
+  date: string;
+  status: "pending" | "paid";
+  mint: string;
+  unit: string;
+  mintQuote?: MintQuoteResponse;
+  meltQuote?: MeltQuoteResponse;
+}

--- a/src/types/proofs.ts
+++ b/src/types/proofs.ts
@@ -1,0 +1,8 @@
+import { Proof } from "@cashu/cashu-ts";
+
+export interface WalletProof extends Proof {
+  reserved: boolean;
+  quote?: string;
+  bucketId?: string;
+  label?: string;
+}


### PR DESCRIPTION
## Summary
- split wallet functionality into sub stores
- move mnemonic handling to `mnemonic` store
- manage invoices via new `invoiceHistory` store
- extract shared interfaces under `src/types`
- move lock sending to `p2pk` store
- update components and stores to use new stores

## Testing
- `npm run types` *(fails: Dynamic imports only supported with certain module settings)*

------
https://chatgpt.com/codex/tasks/task_e_68807aff0c2483309baf17717ea3a865