### PR TITLE
Fix BucketCard menu layout

### DIFF
--- a/src/components/BucketCard.vue
+++ b/src/components/BucketCard.vue
@@ -67,7 +67,8 @@
       self="top right"
       dark
       class="bg-slate-800"
-      style="min-width:200px"
+      :style="{ minWidth: '200px', zIndex: 10 }"
+      :offset="[0, 8]"
     >
       <q-list dense>
         <q-item clickable v-close-popup @click.stop="emitAction('view')" data-test="view">

--- a/test/vitest/__tests__/bucketCardMenu.spec.ts
+++ b/test/vitest/__tests__/bucketCardMenu.spec.ts
@@ -1,6 +1,9 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
 import BucketCard from '../../../src/components/BucketCard.vue';
+import * as quasar from 'quasar';
+
+const qMenuStub = { template: '<div><slot /></div>' };
 
 const bucket = { id: 'b1', name: 'Bucket', isArchived: false };
 
@@ -25,5 +28,29 @@ describe('BucketCard menu actions', () => {
     expect(events?.[1][0].action).toBe('edit');
     expect(events?.[2][0].action).toBe('archive');
     expect(events?.[3][0].action).toBe('delete');
+  });
+});
+
+describe('BucketCard menu responsive behaviour', () => {
+  const spy = vi.spyOn(quasar, 'useQuasar');
+
+  afterEach(() => {
+    spy.mockReset();
+  });
+
+  it('toggles menu on large and small screens', async () => {
+    for (const small of [false, true]) {
+      spy.mockReturnValue({ screen: { lt: { sm: small } } });
+      const wrapper = mount(BucketCard, {
+        props: { bucket, balance: 0, activeUnit: 'sat' },
+        global: { stubs: { 'q-menu': qMenuStub } },
+      });
+      expect(wrapper.vm.menu).toBe(false);
+      await wrapper.find('[data-test="bucket-menu-btn"]').trigger('click');
+      expect(wrapper.vm.menu).toBe(true);
+      await wrapper.find('[data-test="bucket-menu-btn"]').trigger('click');
+      expect(wrapper.vm.menu).toBe(false);
+      wrapper.unmount();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- tweak BucketCard q-menu style to avoid stacking issues
- add responsive menu unit test

## Testing
- `pnpm test` *(fails: Vitest reported many failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_688094a86dd48330847b6eb11e13160d