### PR TITLE
Fix bucket card menu positioning

### DIFF
--- a/src/components/BucketCard.vue
+++ b/src/components/BucketCard.vue
@@ -31,12 +31,13 @@
       </div>
       <q-btn
         v-if="!multiSelectMode"
+        ref="menuBtnRef"
         flat
         round
         dense
         color="grey-6"
         icon="more_vert"
-        @click.stop="menu = !menu"
+        @click.stop="menu = true"
         aria-label="Bucket actions"
         data-test="bucket-menu-btn"
       />
@@ -63,6 +64,7 @@
 
     <q-menu
       v-model="menu"
+      :target="menuBtnRef"
       anchor="bottom right"
       self="top right"
       dark
@@ -166,6 +168,7 @@ export default defineComponent({
     };
 
     const menu = ref(false);
+    const menuBtnRef = ref<HTMLElement | null>(null);
     const dragOver = ref(false);
 
     const progressRatio = computed(() => {
@@ -212,6 +215,7 @@ export default defineComponent({
       DEFAULT_BUCKET_ID,
       t,
       progressRatio,
+      menuBtnRef,
     };
   },
 });

--- a/test/vitest/__tests__/bucketCardMenu.spec.ts
+++ b/test/vitest/__tests__/bucketCardMenu.spec.ts
@@ -38,7 +38,7 @@ describe('BucketCard menu responsive behaviour', () => {
     spy.mockReset();
   });
 
-  it('toggles menu on large and small screens', async () => {
+  it('opens and reopens menu on large and small screens', async () => {
     for (const small of [false, true]) {
       spy.mockReturnValue({ screen: { lt: { sm: small } } });
       const wrapper = mount(BucketCard, {
@@ -48,8 +48,10 @@ describe('BucketCard menu responsive behaviour', () => {
       expect(wrapper.vm.menu).toBe(false);
       await wrapper.find('[data-test="bucket-menu-btn"]').trigger('click');
       expect(wrapper.vm.menu).toBe(true);
+      wrapper.vm.menu = false;
+      await wrapper.vm.$nextTick();
       await wrapper.find('[data-test="bucket-menu-btn"]').trigger('click');
-      expect(wrapper.vm.menu).toBe(false);
+      expect(wrapper.vm.menu).toBe(true);
       wrapper.unmount();
     }
   });


### PR DESCRIPTION
## Summary
- open bucket menu by setting `menu` to true
- anchor the bucket card menu to the overflow button via `target` ref
- adapt bucket card menu tests for new behaviour

## Testing
- `pnpm test:ci` *(fails: 31 failed, 24 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6880a1144aa4833085c7e5f0a18fdf13