### PR TITLE
Fix BucketCard menu accessibility

### DIFF
--- a/src/components/BucketCard.vue
+++ b/src/components/BucketCard.vue
@@ -31,13 +31,16 @@
       </div>
       <q-btn
         v-if="!multiSelectMode"
+        ref="menuBtn"
         flat
         round
         dense
         color="grey-6"
         icon="more_vert"
-        @click.stop="menu = !menu"
+        @click.stop="menu = true"
         aria-label="Bucket actions"
+        aria-haspopup="menu"
+        :aria-expanded="menu"
         data-test="bucket-menu-btn"
       />
     </div>
@@ -63,11 +66,12 @@
 
     <q-menu
       v-model="menu"
+      :target="menuBtn"
       anchor="bottom right"
       self="top right"
       dark
       class="bg-slate-800"
-      :style="{ minWidth: '200px', zIndex: 10 }"
+      :style="{ minWidth: '200px', zIndex: 100 }"
       :offset="[0, 8]"
     >
       <q-list dense>
@@ -166,6 +170,7 @@ export default defineComponent({
     };
 
     const menu = ref(false);
+    const menuBtn = ref(null);
     const dragOver = ref(false);
 
     const progressRatio = computed(() => {
@@ -212,6 +217,7 @@ export default defineComponent({
       DEFAULT_BUCKET_ID,
       t,
       progressRatio,
+      menuBtn,
     };
   },
 });

--- a/test/vitest/__tests__/bucketCardMenu.spec.ts
+++ b/test/vitest/__tests__/bucketCardMenu.spec.ts
@@ -38,7 +38,7 @@ describe('BucketCard menu responsive behaviour', () => {
     spy.mockReset();
   });
 
-  it('toggles menu on large and small screens', async () => {
+  it('opens menu when clicked on large and small screens', async () => {
     for (const small of [false, true]) {
       spy.mockReturnValue({ screen: { lt: { sm: small } } });
       const wrapper = mount(BucketCard, {
@@ -48,8 +48,6 @@ describe('BucketCard menu responsive behaviour', () => {
       expect(wrapper.vm.menu).toBe(false);
       await wrapper.find('[data-test="bucket-menu-btn"]').trigger('click');
       expect(wrapper.vm.menu).toBe(true);
-      await wrapper.find('[data-test="bucket-menu-btn"]').trigger('click');
-      expect(wrapper.vm.menu).toBe(false);
       wrapper.unmount();
     }
   });


### PR DESCRIPTION
## Summary
- ensure BucketCard menu button opens menu using `menu = true`
- connect QMenu to button with ref and higher z-index
- add accessibility attributes
- update unit tests

## Testing
- `pnpm test --silent` *(fails: Cannot read properties of undefined (reading 'value'))*

------
https://chatgpt.com/codex/tasks/task_e_6880a2db0dd48330b8620a6ec13e188e