### PR TITLE
Fix bucket menu anchor

### DIFF
--- a/src/components/BucketCard.vue
+++ b/src/components/BucketCard.vue
@@ -1,6 +1,7 @@
 <template>
   <div
     class="bucket-card"
+    ref="menuTarget"
     :class="{
       'opacity-50': bucket.isArchived,
       selected,
@@ -69,8 +70,8 @@
       self="top right"
       dark
       class="bg-slate-800"
-      :style="{ minWidth: '200px', zIndex: 10 }"
-      :offset="[0, 8]"
+      style="min-width: 200px"
+      :target="menuTarget"
     >
       <q-list dense>
         <q-item clickable v-close-popup @click.stop="emitAction('view')" data-test="view">
@@ -168,6 +169,7 @@ export default defineComponent({
     };
 
     const menu = ref(false);
+    const menuTarget = ref<HTMLElement | null>(null);
     const dragOver = ref(false);
 
     const progressRatio = computed(() => {
@@ -214,6 +216,7 @@ export default defineComponent({
       DEFAULT_BUCKET_ID,
       t,
       progressRatio,
+      menuTarget,
     };
   },
 });

--- a/src/css/buckets.scss
+++ b/src/css/buckets.scss
@@ -33,3 +33,9 @@
   white-space: normal; // allow wrapping within menu items
   word-break: break-word; // prevent overflow for long words
 }
+
+/* ensure menu text wraps and doesn't overflow */
+.bucket-card .q-menu .q-item__section--main {
+  white-space: normal;
+  word-break: break-word;
+}


### PR DESCRIPTION
## Summary
- keep bucket card menu anchored by referencing the card element
- allow menu text to wrap in buckets stylesheet

## Testing
- `pnpm install`
- `pnpm test` *(fails: Test Files  31 failed | 25 passed (56))*

------
https://chatgpt.com/codex/tasks/task_e_6880ad89b70483309eaa43831f9911de