### PR TITLE
Fix bucket menu layering and toolbar wiring

### DIFF
--- a/src/components/BucketCard.vue
+++ b/src/components/BucketCard.vue
@@ -70,8 +70,9 @@
       self="top right"
       dark
       class="bg-slate-800"
-      style="min-width: 200px"
+      style="min-width: 200px; z-index: 2000"
       :target="menuTarget"
+      separate
     >
       <q-list dense>
         <q-item clickable v-close-popup @click.stop="emitAction('view')" data-test="view">

--- a/src/components/BucketManager.vue
+++ b/src/components/BucketManager.vue
@@ -1,13 +1,11 @@
 <template>
   <div class="w-full max-w-7xl mx-auto flex flex-col">
     <q-toolbar class="bg-transparent q-pl-md q-pr-md q-gutter-md row items-center buckets-toolbar q-mb-md">
-      <slot name="toolbar"
-        :search-term="searchTerm"
-        :view-mode="viewMode"
-        :sort-by="sortBy"
-        :multi-select-mode="multiSelectMode"
-        :toggle-multi-select="toggleMultiSelect"
-        :move-selected="moveSelected"
+      <BucketsToolbar
+        v-model:search="searchTerm"
+        v-model:viewMode="viewMode"
+        v-model:sort="sortBy"
+        @move-tokens="moveSelected"
       />
     </q-toolbar>
 
@@ -145,6 +143,7 @@ import BucketDialog from './BucketDialog.vue';
 import EditBucketModal from './EditBucketModal.vue';
 import BucketDetailModal from './BucketDetailModal.vue';
 import MoveTokensModal from './MoveTokensModal.vue';
+import BucketsToolbar from './BucketsToolbar.vue';
 
 export default defineComponent({
   name: 'BucketManager',
@@ -154,6 +153,7 @@ export default defineComponent({
     EditBucketModal,
     BucketDetailModal,
     MoveTokensModal,
+    BucketsToolbar,
   },
   setup() {
     const bucketsStore = useBucketsStore();

--- a/src/pages/BucketsPage.vue
+++ b/src/pages/BucketsPage.vue
@@ -3,74 +3,7 @@
     <h1>Buckets</h1>
     <p class="text-grey-5 q-mb-md">Organize your tokens</p>
     <SummaryStats :total="totalActiveBalance" :active-count="activeCount" />
-    <BucketManager>
-      <template
-        #toolbar="{
-          searchTerm,
-          viewMode,
-          sortBy,
-          toggleMultiSelect,
-          multiSelectMode,
-          moveSelected,
-        }"
-      >
-        <q-toolbar
-          class="bg-transparent q-pl-md q-pr-md q-gutter-md row items-center"
-        >
-          <q-input
-            :model-value="searchTerm.value"
-            @update:model-value="(val) => (searchTerm.value = val)"
-            outlined
-            dense
-            placeholder="Search buckets…"
-          />
-          <q-btn-toggle
-            v-model="viewMode.value"
-            dense
-            unelevated
-            toggle-color="primary"
-            :options="[
-              { label: 'Active', value: 'active' },
-              { label: 'Archived', value: 'archived' },
-            ]"
-          />
-          <q-select
-            :model-value="sortBy.value"
-            @update:model-value="(val) => (sortBy.value = val)"
-            outlined
-            dense
-            label="Sort"
-            aria-label="Sort buckets"
-            emit-value
-            map-options
-            :options="[
-              { label: 'Name (A–Z)', value: 'name-asc' },
-              { label: 'Name (Z–A)', value: 'name-desc' },
-              { label: 'Balance (↓)', value: 'balance-desc' },
-              { label: 'Balance (↑)', value: 'balance-asc' },
-            ]"
-          />
-          <q-btn
-            color="white"
-            text-color="black"
-            icon="swap_horiz"
-            label="Move Tokens"
-            @click="moveSelected"
-            aria-label="Move Tokens"
-          />
-          <q-btn
-            flat
-            dense
-            round
-            class="q-ml-sm"
-            :icon="multiSelectMode ? 'close' : 'select_all'"
-            @click="toggleMultiSelect"
-            :aria-pressed="multiSelectMode"
-            aria-label="Toggle selection"
-          />
-        </q-toolbar>
-      </template>
-    </BucketManager>
+    <BucketManager />
     <q-page-sticky
       position="bottom-right"
       :offset="[18, 18]"

--- a/test/vitest/__tests__/bucketCardMenu.spec.ts
+++ b/test/vitest/__tests__/bucketCardMenu.spec.ts
@@ -17,6 +17,7 @@ describe('BucketCard menu actions', () => {
     });
 
     await wrapper.find('[data-test="bucket-menu-btn"]').trigger('click');
+    expect(wrapper.find('q-menu-stub').attributes('style')).toContain('z-index: 2000');
     await wrapper.find('[data-test="view"]').trigger('click');
     await wrapper.find('[data-test="edit"]').trigger('click');
     await wrapper.find('[data-test="archive"]').trigger('click');

--- a/test/vitest/__tests__/bucketManagerArchive.spec.ts
+++ b/test/vitest/__tests__/bucketManagerArchive.spec.ts
@@ -1,10 +1,13 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { reactive, ref } from 'vue';
 import BucketManager from '../../../src/components/BucketManager.vue';
 import BucketCard from '../../../src/components/BucketCard.vue';
 
-const bucketsData = reactive([{ id: 'b1', name: 'Bucket', isArchived: false }]);
+const bucketsData = reactive([
+  { id: 'b1', name: 'Bucket', isArchived: false },
+  { id: 'b2', name: 'Old Bucket', isArchived: true }
+]);
 
 const editBucketMock = vi.fn((id: string, updates: any) => {
   const idx = bucketsData.findIndex(b => b.id === id);
@@ -42,6 +45,11 @@ vi.mock('../../../src/js/notify', () => ({
 
 const qMenuStub = { template: '<div><slot /></div>' };
 
+beforeEach(() => {
+  bucketsData[0].isArchived = false;
+  bucketsData[1].isArchived = true;
+});
+
 describe('BucketManager archive action', () => {
   it('opens menu and archives bucket', async () => {
     const wrapper = mount(BucketManager, {
@@ -58,5 +66,18 @@ describe('BucketManager archive action', () => {
 
     expect(editBucketMock).toHaveBeenCalledWith('b1', { isArchived: true });
     expect(bucketsData[0].isArchived).toBe(true);
+  });
+
+  it('filters to archived buckets when toggle clicked', async () => {
+    const wrapper = mount(BucketManager, {
+      global: { stubs: { 'q-menu': qMenuStub } },
+    });
+
+    await wrapper.find('button[aria-label="Archived"]').trigger('click');
+    const cards = wrapper.findAllComponents(BucketCard);
+    expect(cards.length).toBeGreaterThan(0);
+    cards.forEach(card => {
+      expect((card.props('bucket') as any).isArchived).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- detach menu from bucket cards so it's properly layered
- embed toolbar into BucketManager and sync view filter
- drop toolbar slot from BucketsPage
- update popup menu test for style
- add archive filter test

## Testing
- `pnpm run lint` *(fails: Invalid option '--ext')*
- `pnpm run test` *(fails to run all tests)*

------
https://chatgpt.com/codex/tasks/task_e_6880bb78d1c48330a5296f40af70375a