### PR TITLE
Elevate Bucket menu

### DIFF
--- a/src/components/BucketCard.vue
+++ b/src/components/BucketCard.vue
@@ -69,7 +69,8 @@
       anchor="bottom right"
       self="top right"
       dark
-      class="bg-slate-800"
+      separate
+      class="bg-slate-800 elevated-menu"
       style="min-width: 200px"
       :target="menuTarget"
     >

--- a/src/css/buckets.scss
+++ b/src/css/buckets.scss
@@ -39,3 +39,7 @@
   white-space: normal;
   word-break: break-word;
 }
+
+.elevated-menu {
+  z-index: 2000;
+}

--- a/test/vitest/__tests__/bucketCardMenu.spec.ts
+++ b/test/vitest/__tests__/bucketCardMenu.spec.ts
@@ -3,7 +3,12 @@ import { mount } from '@vue/test-utils';
 import BucketCard from '../../../src/components/BucketCard.vue';
 import * as quasar from 'quasar';
 
-const qMenuStub = { template: '<div><slot /></div>' };
+const qMenuStub = {
+  props: ['modelValue'],
+  emits: ['update:modelValue'],
+  template:
+    '<div v-if="modelValue" :class="$attrs.class" data-test="q-menu"><slot /></div>'
+};
 
 const bucket = { id: 'b1', name: 'Bucket', isArchived: false };
 
@@ -46,10 +51,14 @@ describe('BucketCard menu responsive behaviour', () => {
         global: { stubs: { 'q-menu': qMenuStub } },
       });
       expect(wrapper.vm.menu).toBe(false);
+      expect(wrapper.find('.elevated-menu').exists()).toBe(false);
       await wrapper.find('[data-test="bucket-menu-btn"]').trigger('click');
       expect(wrapper.vm.menu).toBe(true);
+      const menuEl = wrapper.find('.elevated-menu');
+      expect(menuEl.exists()).toBe(true);
       await wrapper.find('[data-test="bucket-menu-btn"]').trigger('click');
       expect(wrapper.vm.menu).toBe(false);
+      expect(wrapper.find('.elevated-menu').exists()).toBe(false);
       wrapper.unmount();
     }
   });


### PR DESCRIPTION
## Summary
- add `separate` and elevated class to BucketCard menu
- style `.elevated-menu` with high z-index
- pass class through q-menu test stub and check menu element class

## Testing
- `pnpm install`
- `npm test` *(fails: 31 failed, 25 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6880c0fabbe4833085b4ed307243989c