### PR TITLE
Use BucketsToolbar in BucketManager

### DIFF
--- a/src/components/BucketManager.vue
+++ b/src/components/BucketManager.vue
@@ -1,15 +1,11 @@
 <template>
   <div class="w-full max-w-7xl mx-auto flex flex-col">
-    <q-toolbar class="bg-transparent q-pl-md q-pr-md q-gutter-md row items-center buckets-toolbar q-mb-md">
-      <slot name="toolbar"
-        :search-term="searchTerm"
-        :view-mode="viewMode"
-        :sort-by="sortBy"
-        :multi-select-mode="multiSelectMode"
-        :toggle-multi-select="toggleMultiSelect"
-        :move-selected="moveSelected"
-      />
-    </q-toolbar>
+    <BucketsToolbar
+      v-model:search="searchTerm"
+      v-model:viewMode="viewMode"
+      v-model:sort="sortBy"
+      @move-tokens="moveSelected"
+    />
 
     <q-banner
       v-if="selectedBucketIds.length > 0"
@@ -145,6 +141,7 @@ import BucketDialog from './BucketDialog.vue';
 import EditBucketModal from './EditBucketModal.vue';
 import BucketDetailModal from './BucketDetailModal.vue';
 import MoveTokensModal from './MoveTokensModal.vue';
+import BucketsToolbar from './BucketsToolbar.vue';
 
 export default defineComponent({
   name: 'BucketManager',
@@ -154,6 +151,7 @@ export default defineComponent({
     EditBucketModal,
     BucketDetailModal,
     MoveTokensModal,
+    BucketsToolbar,
   },
   setup() {
     const bucketsStore = useBucketsStore();

--- a/src/pages/BucketsPage.vue
+++ b/src/pages/BucketsPage.vue
@@ -3,74 +3,7 @@
     <h1>Buckets</h1>
     <p class="text-grey-5 q-mb-md">Organize your tokens</p>
     <SummaryStats :total="totalActiveBalance" :active-count="activeCount" />
-    <BucketManager>
-      <template
-        #toolbar="{
-          searchTerm,
-          viewMode,
-          sortBy,
-          toggleMultiSelect,
-          multiSelectMode,
-          moveSelected,
-        }"
-      >
-        <q-toolbar
-          class="bg-transparent q-pl-md q-pr-md q-gutter-md row items-center"
-        >
-          <q-input
-            :model-value="searchTerm.value"
-            @update:model-value="(val) => (searchTerm.value = val)"
-            outlined
-            dense
-            placeholder="Search buckets…"
-          />
-          <q-btn-toggle
-            v-model="viewMode.value"
-            dense
-            unelevated
-            toggle-color="primary"
-            :options="[
-              { label: 'Active', value: 'active' },
-              { label: 'Archived', value: 'archived' },
-            ]"
-          />
-          <q-select
-            :model-value="sortBy.value"
-            @update:model-value="(val) => (sortBy.value = val)"
-            outlined
-            dense
-            label="Sort"
-            aria-label="Sort buckets"
-            emit-value
-            map-options
-            :options="[
-              { label: 'Name (A–Z)', value: 'name-asc' },
-              { label: 'Name (Z–A)', value: 'name-desc' },
-              { label: 'Balance (↓)', value: 'balance-desc' },
-              { label: 'Balance (↑)', value: 'balance-asc' },
-            ]"
-          />
-          <q-btn
-            color="white"
-            text-color="black"
-            icon="swap_horiz"
-            label="Move Tokens"
-            @click="moveSelected"
-            aria-label="Move Tokens"
-          />
-          <q-btn
-            flat
-            dense
-            round
-            class="q-ml-sm"
-            :icon="multiSelectMode ? 'close' : 'select_all'"
-            @click="toggleMultiSelect"
-            :aria-pressed="multiSelectMode"
-            aria-label="Toggle selection"
-          />
-        </q-toolbar>
-      </template>
-    </BucketManager>
+    <BucketManager />
     <q-page-sticky
       position="bottom-right"
       :offset="[18, 18]"


### PR DESCRIPTION
## Summary
- embed `BucketsToolbar` directly in `BucketManager`
- remove toolbar slot usage on `BucketsPage`
- update archive view test to use built-in toolbar

## Testing
- `pnpm run test:ci` *(fails: 30 failed | 26 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6880c50f07588330b76dea00c1aac619