### PR TITLE
Fix menu anchor

### DIFF
--- a/src/components/BucketCard.vue
+++ b/src/components/BucketCard.vue
@@ -66,8 +66,9 @@
 
     <q-menu
       v-model="menu"
-      anchor="bottom right"
+      anchor="top right"
       self="top right"
+      :offset="[0, 8]"
       dark
       separate
       class="bg-slate-800 elevated-menu"


### PR DESCRIPTION
## Summary
- fix spacing of bucket card menu so it lines up with button

## Testing
- `pnpm lint` *(fails: Cannot find module '@typescript-eslint/parser')*
- `pnpm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_688122f0401c83308a1cd6ba8a02fc02