### PR TITLE
Fix BucketCard menu z-index

### DIFF
--- a/src/components/BucketCard.vue
+++ b/src/components/BucketCard.vue
@@ -72,7 +72,7 @@
       dark
       separate
       class="bg-slate-800 elevated-menu"
-      style="min-width: 200px"
+      style="min-width: 200px; z-index: 100"
       :target="menuTarget"
     >
       <q-list dense>


### PR DESCRIPTION
## Summary
- ensure bucket card action menu overlays sibling cards by bumping z-index

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm run test:ci` *(fails: InfoTooltip test and others)*

------
https://chatgpt.com/codex/tasks/task_e_6881266b3a648330b12cf2849ca7b927