### PR TITLE
Fix bucket card style property

### DIFF
--- a/src/components/BucketCard.vue
+++ b/src/components/BucketCard.vue
@@ -72,7 +72,7 @@
       dark
       separate
       class="bg-slate-800 elevated-menu"
-      style="min-width: 200px; z-index: 100"
+      style="min-width: 200px; z-index: 100;"
       :target="menuTarget"
     >
       <q-list dense>


### PR DESCRIPTION
## Summary
- correct menu style semicolon in `BucketCard.vue`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68812b7e47788330a173dfc5de7ec7f6