### PR TITLE
Fix menu z-index

### DIFF
--- a/src/components/BucketCard.vue
+++ b/src/components/BucketCard.vue
@@ -72,7 +72,7 @@
       dark
       separate
       class="bg-slate-800 elevated-menu"
-      style="min-width: 200px; z-index: 100;"
+      style="min-width: 200px;"
       :target="menuTarget"
     >
       <q-list dense>


### PR DESCRIPTION
## Summary
- rely on CSS for menu z-index in BucketCard

## Testing
- `pnpm run test:ci` *(fails: 6 errors)*
- `pnpm build` *(fails: Buffer is not exported by __vite-browser-external)*

------
https://chatgpt.com/codex/tasks/task_e_68812ef30f24833095d9a3a93ab33436