### PR TITLE
Add margin to BucketsToolbar

### DIFF
--- a/src/components/BucketsToolbar.vue
+++ b/src/components/BucketsToolbar.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="buckets-toolbar row items-center q-gutter-sm">
+  <div class="buckets-toolbar row items-center q-gutter-sm q-mb-md">
     <q-input
       v-model="modelSearch"
       dense


### PR DESCRIPTION
## Summary
- update BucketsToolbar vue markup to include q-mb-md class

## Testing
- `pnpm lint` *(fails: Invalid option '--ext')*
- `npx eslint ./` *(fails: config uses unsupported "root" key)*
- `pnpm run test:ci` *(fails: 30 failed, 26 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68813593608c833084f03766f4264cd5