### PR TITLE
Add spacing below buckets toolbar

### DIFF
--- a/src/css/buckets.scss
+++ b/src/css/buckets.scss
@@ -24,6 +24,7 @@
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
+  margin-bottom: 16px;
 }
 .bucket-fab {
   bottom: 64px !important;


### PR DESCRIPTION
## Summary
- add margin to `.buckets-toolbar` in `src/css/buckets.scss`

## Testing
- `pnpm test` *(fails: 30 failed, 26 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688136e04d6c8330b8d7555d58f3fcdf