### PR TITLE
Update Creator Hub icon

### DIFF
--- a/public/icons/creator-hub.svg
+++ b/public/icons/creator-hub.svg
@@ -1,3 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="currentColor">
-  <path d="M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20zm1 14.93V21h-2v-4.07A8.001 8.001 0 0 1 4.07 13H0v-2h4.07A8.001 8.001 0 0 1 11 4.07V0h2v4.07A8.001 8.001 0 0 1 19.93 11H24v2h-4.07A8.001 8.001 0 0 1 13 16.93z"/>
+  <circle cx="12" cy="12" r="2" />
+  <circle cx="12" cy="4" r="1.5" />
+  <circle cx="12" cy="20" r="1.5" />
+  <circle cx="4" cy="12" r="1.5" />
+  <circle cx="20" cy="12" r="1.5" />
+  <path d="M12 10V5.5" stroke="currentColor" stroke-width="2" fill="none"/>
+  <path d="M12 14v4.5" stroke="currentColor" stroke-width="2" fill="none"/>
+  <path d="M10 12H5.5" stroke="currentColor" stroke-width="2" fill="none"/>
+  <path d="M14 12h4.5" stroke="currentColor" stroke-width="2" fill="none"/>
 </svg>


### PR DESCRIPTION
## Summary
- redesign Creator Hub icon with a hub-and-spokes layout

## Testing
- `npm run lint` *(fails: cannot find module '@typescript-eslint/parser')*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881c61c036883308649e8ac219d6e02