### PR TITLE
Update Creator Hub icon color

### DIFF
--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -158,7 +158,7 @@
       </q-item>
       <q-item clickable @click="gotoCreatorHub">
         <q-item-section avatar>
-          <q-icon name="img:icons/creator-hub.svg" />
+          <q-icon name="img:icons/creator-hub.svg" color="white" />
         </q-item-section>
         <q-item-section>
           <q-item-label>{{


### PR DESCRIPTION
## Summary
- ensure the Creator Hub menu item icon is always white

## Testing
- `pnpm run lint` *(fails: Invalid option '--ext')*
- `pnpm run test:ci` *(fails: 30 failed, 26 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6881d3d01cf88330b84702bad6c27558