### PR TITLE
Update creator hub icon

### DIFF
--- a/public/icons/creator-hub.svg
+++ b/public/icons/creator-hub.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
   <!-- Central Hub Node -->
   <circle cx="12" cy="12" r="3"></circle>
   


### PR DESCRIPTION
## Summary
- update the Creator Hub icon's stroke color to white

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881d5ad97848330a14fc905b25d2539