### PR TITLE
Add thicker search icon

### DIFF
--- a/public/icons/find-creators.svg
+++ b/public/icons/find-creators.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="11" cy="11" r="7" />
+  <line x1="21" y1="21" x2="16.65" y2="16.65" />
+</svg>

--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -145,7 +145,7 @@
       </q-item>
       <q-item clickable @click="gotoFindCreators">
         <q-item-section avatar>
-          <q-icon name="search" />
+          <q-icon name="img:icons/find-creators.svg" color="white" />
         </q-item-section>
         <q-item-section>
           <q-item-label>{{

--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -49,7 +49,7 @@ const mini = ref(false);
 
 const navLinks = [
   { to: "/wallet", label: "Wallet", icon: "account_balance_wallet" },
-  { to: "/find-creators", label: "Find Creators", icon: "search" },
+  { to: "/find-creators", label: "Find Creators", icon: "img:icons/find-creators.svg" },
   { to: "/nostr-messenger", label: "Chats", icon: "chat" },
 ];
 


### PR DESCRIPTION
## Summary
- add new search icon with thicker stroke
- reference new search icon in MainHeader and Sidebar

## Testing
- `npm test --silent` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881d6a1219083308bfb271da0fb17a8