### PR TITLE
Add windowMixin to SettingsView

### DIFF
--- a/src/components/SettingsView.vue
+++ b/src/components/SettingsView.vue
@@ -1815,6 +1815,7 @@ export default defineComponent({
     P2PKDialog,
     NWCDialog,
   },
+  mixins: [windowMixin],
   setup() {
     const { copy } = useClipboard();
     const p2pkStore = useP2PKStore();


### PR DESCRIPTION
## Summary
- extend SettingsView.vue with windowMixin

## Testing
- `pnpm test` *(fails: 30 failed, 26 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6881dea7018883309cb9f3386596ac88