### PR TITLE
Update bucket detail modal

### DIFF
--- a/src/components/BucketCard.vue
+++ b/src/components/BucketCard.vue
@@ -76,8 +76,8 @@
       :target="menuTarget"
     >
       <q-list dense>
-        <q-item clickable v-close-popup @click.stop="emitAction('view')" data-test="view">
-          <q-item-section>View Tokens</q-item-section>
+        <q-item clickable v-close-popup @click.stop="emitAction('manage')" data-test="manage">
+          <q-item-section>Manage</q-item-section>
         </q-item>
         <template v-if="bucket.id !== DEFAULT_BUCKET_ID">
           <q-item clickable v-close-popup @click.stop="emitAction('edit')" data-test="edit">

--- a/src/components/BucketManager.vue
+++ b/src/components/BucketManager.vue
@@ -364,7 +364,7 @@ export default defineComponent({
 
     const handleMenuAction = ({ action, bucket }: any) => {
       switch (action) {
-        case 'view':
+        case 'manage':
           openDetail(bucket);
           break;
         case 'edit':

--- a/test/vitest/__tests__/bucketModals.spec.ts
+++ b/test/vitest/__tests__/bucketModals.spec.ts
@@ -56,10 +56,10 @@ describe('BucketManager modals', () => {
     expect(vm.editModalOpen).toBe(false);
   });
 
-  it('opens detail modal on view', async () => {
+  it('opens detail modal on manage', async () => {
     const wrapper = shallowMount(BucketManager);
     const vm:any = wrapper.vm;
-    vm.handleMenuAction({ action: 'view', bucket });
+    vm.handleMenuAction({ action: 'manage', bucket });
     await wrapper.vm.$nextTick();
     expect(vm.detailModalOpen).toBe(true);
     wrapper.findComponent({ name: 'BucketDetailModal' }).vm.$emit('update:modelValue', false);


### PR DESCRIPTION
## Summary
- trigger the detail modal with `manage` action
- rename BucketCard menu item to "Manage"
- adjust unit tests to expect the new action

## Testing
- `pnpm run test:ci` *(fails: various test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6881e2301858833095f42ace5c6ab817