### PR TITLE
Add i18n for Manage menu and modal message

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,3 +2,7 @@
 
 ## Unreleased
 - Buckets UI redesign – Phase9
+- Bucket detail opens in a modal from the Buckets page.
+  Direct links to `/buckets/:id` still work but are only kept
+  for backward compatibility. Navigate to `/buckets` and select
+  "Manage" on a bucket to open the modal.

--- a/src/components/BucketCard.vue
+++ b/src/components/BucketCard.vue
@@ -77,7 +77,7 @@
     >
       <q-list dense>
         <q-item clickable v-close-popup @click.stop="emitAction('manage')" data-test="manage">
-          <q-item-section>Manage</q-item-section>
+          <q-item-section>{{ t('BucketManager.actions.manage') }}</q-item-section>
         </q-item>
         <template v-if="bucket.id !== DEFAULT_BUCKET_ID">
           <q-item clickable v-close-popup @click.stop="emitAction('edit')" data-test="edit">

--- a/src/components/MoveTokensModal.vue
+++ b/src/components/MoveTokensModal.vue
@@ -91,12 +91,15 @@ import { useBucketsStore } from "stores/buckets";
 import { useProofsStore } from "stores/proofs";
 import { useMintsStore, WalletProof } from "stores/mints";
 import { useUiStore } from "stores/ui";
+import { useI18n } from "vue-i18n";
 import { DEFAULT_COLOR } from "src/js/constants";
 import { storeToRefs } from "pinia";
 import { notifyError } from "src/js/notify";
 
 const props = defineProps<{ modelValue: boolean; bucketIds?: string[] }>();
 const emit = defineEmits(["update:modelValue", "move"]);
+
+const { t } = useI18n();
 
 const showLocal = computed({
   get: () => props.modelValue,
@@ -154,7 +157,7 @@ function formatCurrency(amount: number, unit: string) {
 
 async function moveSelected() {
   if (!targetBucketId.value) {
-    notifyError("Please select a bucket");
+    notifyError(t('MoveTokens.errors.select_bucket'));
     return;
   }
   const bucketExists = bucketsStore.bucketList.find(

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1434,6 +1434,7 @@ export const messages = {
       edit: "Edit",
       archive: "Archive",
       unarchive: "Unarchive",
+      manage: "Manage",
       view_tokens: "View tokens",
       move: "Move tokens",
       deselect_all: "Deselect All",
@@ -1499,6 +1500,9 @@ export const messages = {
     select_tokens: "Select tokens to move",
     empty: "No tokens",
     helper: "Move tokens between buckets to organize them.",
+    errors: {
+      select_bucket: "Please select a bucket",
+    },
   },
   SubscriptionsOverview: {
     title: "Subscriptions",

--- a/src/pages/BucketDetail.vue
+++ b/src/pages/BucketDetail.vue
@@ -155,8 +155,10 @@ import LockedTokensTable from "components/LockedTokensTable.vue";
 import CreatorLockedTokensTable from "components/CreatorLockedTokensTable.vue";
 import { notifyError } from "src/js/notify";
 import { DEFAULT_COLOR } from "src/js/constants";
+import { useI18n } from "vue-i18n";
 
 const route = useRoute();
+const { t } = useI18n();
 const bucketsStore = useBucketsStore();
 const proofsStore = useProofsStore();
 const mintsStore = useMintsStore();
@@ -293,7 +295,7 @@ function saveEdit() {
 
 async function moveSelected() {
   if (!targetBucketId.value) {
-    notifyError("Please select a bucket");
+    notifyError(t('MoveTokens.errors.select_bucket'));
     return;
   }
   const bucketExists = bucketsStore.bucketList.find(


### PR DESCRIPTION
## Summary
- localize Manage action and missing bucket errors
- open bucket details via Manage menu entry
- note modal workflow and fallback routing

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm run test:ci` *(fails: Unhandled Errors, 32 failed suites)*

------
https://chatgpt.com/codex/tasks/task_e_6881e5aef40083309fca5e09a2d4b812