### PR TITLE
Fix header z-index and cleanup console logs

### DIFF
--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -302,7 +302,6 @@ export default defineComponent({
     const messenger = useMessengerStore();
     const $q = useQuasar();
     const toggleDarkMode = () => {
-      console.log("toggleDarkMode", $q.dark.isActive);
       $q.dark.toggle();
       $q.localStorage.set("cashu.darkMode", $q.dark.isActive);
       vm?.notifySuccess(
@@ -370,7 +369,6 @@ export default defineComponent({
     });
 
     const toggleMessengerDrawer = () => {
-      console.log("toggleMessengerDrawer", messenger.drawerOpen);
       messenger.toggleDrawer();
       vm?.notify(
         messenger.drawerOpen ? "Messenger closed" : "Messenger opened"
@@ -382,13 +380,6 @@ export default defineComponent({
     };
 
     const reload = () => {
-      console.log(
-        "reload",
-        "countdown:",
-        countdown.value,
-        "mutex:",
-        uiStore.globalMutexLock
-      );
       if (countdown.value > 0) {
         try {
           clearInterval(countdownInterval);
@@ -491,7 +482,7 @@ export default defineComponent({
 .q-header {
   position: sticky; /* or fixed */
   top: 0;
-  z-index: 1000; /* ensures header stays above page content */
+  z-index: 1200; /* ensures header stays above page content */
   overflow-x: hidden;
 }
 

--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -68,7 +68,7 @@
     </q-responsive>
 
     <div :class="['col column', $q.screen.gt.xs ? 'q-pa-lg' : 'q-pa-md']">
-      <q-header elevated class="q-mb-md bg-transparent">
+      <q-header elevated class="messenger-header q-mb-md bg-transparent">
         <q-toolbar>
           <q-btn flat round dense icon="menu" @click="messenger.toggleDrawer()" />
           <q-btn flat round dense icon="arrow_back" @click="goBack" />
@@ -412,6 +412,12 @@ export default defineComponent({
 .drawer-collapsed .conversation-item q-avatar {
   width: 40px;
   height: 40px;
+}
+
+.messenger-header {
+  position: sticky;
+  top: 50px;
+  z-index: 900;
 }
 
 @media (max-width: 320px) {


### PR DESCRIPTION
## Summary
- ensure MainHeader stays on top and remove console logs
- keep messenger header underneath main header using sticky position

## Testing
- `pnpm run test:ci` *(fails: Test Files 30 failed | 26 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6881df95d4008330a7bed91abe70c048