### PR TITLE
Reduce messenger drawer width

### DIFF
--- a/src/components/ConversationListItem.vue
+++ b/src/components/ConversationListItem.vue
@@ -261,7 +261,8 @@ export default defineComponent({
 .snippet {
   font-size: 0.75rem;
   line-height: 1.2;
-  white-space: normal;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 .conversation-item .ellipsis {

--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -10,7 +10,7 @@
         show-if-above
         :breakpoint="600"
         bordered
-        :width="drawerOpen ? 320 : 72"
+        :width="drawerOpen ? 280 : 72"
         class="drawer-transition drawer-container"
         :class="[
           $q.screen.gt.xs ? 'q-pa-lg column' : 'q-pa-md column',
@@ -417,6 +417,7 @@ export default defineComponent({
 
 .drawer-container {
   min-width: 0;
+  overflow-x: hidden;
 }
 
 /* When the drawer is collapsed, only show the avatar */


### PR DESCRIPTION
## Summary
- shrink open width of the messenger drawer
- hide horizontal overflow for the drawer container
- prevent snippets from expanding the drawer width

## Testing
- `pnpm install`
- `pnpm run test:ci` *(fails: expected false to be true, 32 failed, 24 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6881f1e049208330883c9043aa020f84