### PR TITLE
Fix layout backgrounds for dark mode

### DIFF
--- a/src/layouts/BlankLayout.vue
+++ b/src/layouts/BlankLayout.vue
@@ -1,5 +1,8 @@
 <template>
-  <q-layout view="lHh Lpr lFf" class="bg-dark">
+  <q-layout
+    view="lHh Lpr lFf"
+    :class="$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark'"
+  >
     <MainHeader />
     <q-page-container>
       <router-view />

--- a/src/layouts/FullscreenLayout.vue
+++ b/src/layouts/FullscreenLayout.vue
@@ -1,5 +1,8 @@
 <template>
-  <q-layout view="lHh Lpr lFf" class="bg-dark">
+  <q-layout
+    view="lHh Lpr lFf"
+    :class="$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark'"
+  >
     <MainHeader />
     <q-page-container>
       <router-view />

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -1,5 +1,8 @@
 <template>
-  <q-layout view="lHh Lpr lFf" class="bg-dark">
+  <q-layout
+    view="lHh Lpr lFf"
+    :class="$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark'"
+  >
     <!-- global utility dialogs – mount once -->
     <MissingSignerModal />
     <NdkErrorDialog />


### PR DESCRIPTION
## Summary
- make background colors reactive to `$q.dark.isActive`

## Testing
- `pnpm run test:ci` *(fails: InfoTooltip shows tooltip on hover, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68820b660c608330bf45a534dbf092db