### PR TITLE
Fix AboutPage styling based on dark mode

### DIFF
--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -1,5 +1,5 @@
 <template>
-  <q-page class="bg-dark text-white q-pa-md">
+  <q-page :class="[$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark', 'q-pa-md']">
     <div class="text-h5 q-mb-md">{{ $t("AboutPage.title") }}</div>
     <p>
       Cashu.me is a free and open-source Bitcoin wallet built on the Cashu ecash


### PR DESCRIPTION
## Summary
- make `AboutPage` background and text respond to dark mode settings

## Testing
- `pnpm test` *(fails: Tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68820c18e6c48330b20ddea918148d98