### PR TITLE
Fix dark mode text color on Buckets page

### DIFF
--- a/src/pages/BucketsPage.vue
+++ b/src/pages/BucketsPage.vue
@@ -1,5 +1,5 @@
 <template>
-  <q-page class="q-pa-md text-white">
+  <q-page :class="[$q.dark.isActive ? 'text-white' : 'text-dark', 'q-pa-md']">
     <h1>Buckets</h1>
     <p class="text-grey-5 q-mb-md">Organize your tokens</p>
     <SummaryStats :total="totalActiveBalance" :active-count="activeCount" />


### PR DESCRIPTION
## Summary
- make Buckets page text color react to theme

## Testing
- `pnpm run test:ci` *(fails: 32 failed, 24 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6882113cfd70833099444d7a3796fb6e