### PR TITLE
Use CSS variables for bucket styles

### DIFF
--- a/src/components/BucketCard.vue
+++ b/src/components/BucketCard.vue
@@ -219,7 +219,8 @@ export default defineComponent({
 
 <style scoped>
 .bucket-card {
-  background-color: #1b2330;
+  background-color: var(--bucket-background);
+  color: var(--bucket-text-color);
   padding: 12px;
   border-radius: 16px;
   border-top: 4px solid;

--- a/src/components/SummaryStats.vue
+++ b/src/components/SummaryStats.vue
@@ -22,9 +22,9 @@ function formatCurrency (val: number) {
 
 <style scoped>
 .summary-stats {
-  background-color: #1b2330;
+  background-color: var(--bucket-background);
   border-radius: 8px;
-  color: #DDE2E6;
+  color: var(--bucket-text-color);
 }
 @media (max-width: 600px) {
   .summary-stats {

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -97,6 +97,8 @@ body,
   --conversation-hover-light: var(--q-color-grey-3);
   --bucket-bg-dark: #2e202b;
   --bucket-bg-light: #f9f5f8;
+  --bucket-text-dark: #ffffff;
+  --bucket-text-light: #000000;
   --bucket-accent-dark: #ec4899;
   --bucket-accent-light: #ec4899;
 }
@@ -110,6 +112,7 @@ body.body--dark {
   --panel-bg-color: var(--panel-dark);
   --conversation-hover-color: var(--conversation-hover-dark);
   --bucket-background: var(--bucket-bg-dark);
+  --bucket-text-color: var(--bucket-text-dark);
   --bucket-accent: var(--bucket-accent-dark);
 }
 
@@ -122,6 +125,7 @@ body.body--light {
   --panel-bg-color: var(--panel-light);
   --conversation-hover-color: var(--conversation-hover-light);
   --bucket-background: var(--bucket-bg-light);
+  --bucket-text-color: var(--bucket-text-light);
   --bucket-accent: var(--bucket-accent-light);
 }
 


### PR DESCRIPTION
## Summary
- reference CSS vars for BucketCard and SummaryStats colors
- define `--bucket-text-color` for dark and light modes

## Testing
- `pnpm install`
- `pnpm test` *(fails: Test failed. See above for more details)*

------
https://chatgpt.com/codex/tasks/task_e_688211fd1c94833091fd9e8d5122730d