### PR TITLE
Update messenger drawer width

### DIFF
--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -10,8 +10,9 @@
         show-if-above
         :breakpoint="600"
         bordered
-        :width="drawerOpen ? 320 : 72"
+        :width="drawerOpen ? 240 : 64"
         class="drawer-transition drawer-container"
+        :style="{ overflowX: 'hidden' }"
         :class="[
           $q.screen.gt.xs ? 'q-pa-lg column' : 'q-pa-md column',
           { 'drawer-collapsed': !drawerOpen },


### PR DESCRIPTION
## Summary
- shrink width of the messenger drawer to save space
- hide any horizontal overflow within the drawer

## Testing
- `pnpm install --frozen-lockfile`
- `pnpm lint` *(fails: Invalid option '--ext')*
- `pnpm test` *(fails to complete)*

------
https://chatgpt.com/codex/tasks/task_e_68821427a5208330a07758a64da26a5d