### PR TITLE
Fix messenger drawer behavior on mobile

### DIFF
--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -5,17 +5,17 @@
   >
     <q-responsive>
       <q-drawer
-        :model-value="true"
+        v-model="drawerOpen"
         side="left"
-        show-if-above
         :breakpoint="600"
+        :behavior="$q.screen.lt.sm ? 'mobile' : 'default'"
         bordered
-        :width="drawerOpen ? 240 : 64"
+        :width="$q.screen.lt.sm ? 240 : drawerOpen ? 240 : 64"
         class="drawer-transition drawer-container"
         :style="{ overflowX: 'hidden' }"
         :class="[
           $q.screen.gt.xs ? 'q-pa-lg column' : 'q-pa-md column',
-          { 'drawer-collapsed': !drawerOpen },
+          { 'drawer-collapsed': $q.screen.gt.xs && !drawerOpen },
         ]"
       >
         <template v-if="drawerOpen">
@@ -235,7 +235,10 @@ export default defineComponent({
       }
     };
 
-    const drawerOpen = computed(() => messenger.drawerOpen);
+    const drawerOpen = computed({
+      get: () => messenger.drawerOpen,
+      set: (val: boolean) => messenger.setDrawer(val),
+    });
     const selected = ref("");
     const chatSendTokenDialogRef = ref<InstanceType<
       typeof ChatSendTokenDialog


### PR DESCRIPTION
## Summary
- overlay drawer on small screens instead of shrinking the chat
- keep drawerOpen state in the messenger store

## Testing
- `pnpm run lint` *(fails: Invalid option '--ext' - perhaps you meant '-c'?)*
- `pnpm run test:ci` *(fails: several test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68821769ec748330bbb3397c44aa471f