### PR TITLE
Add token bubble rendering

### DIFF
--- a/src/components/ChatMessageBubble.vue
+++ b/src/components/ChatMessageBubble.vue
@@ -34,6 +34,15 @@
           @update:model-value="updateAutoRedeem"
         />
       </template>
+      <template v-else-if="message.tokenPayload">
+        <TokenInformation
+          :encodedToken="message.tokenPayload.token"
+          :showAmount="true"
+        />
+        <div v-if="message.tokenPayload.memo" class="q-mt-sm">
+          {{ message.tokenPayload.memo }}
+        </div>
+      </template>
       <template v-else>
         <q-img
           v-if="imageSrc"
@@ -88,6 +97,7 @@ import { formatDistanceToNow } from "date-fns";
 import { mdiCheck, mdiCheckAll, mdiAlertCircleOutline } from "@quasar/extras/mdi-v6";
 import type { MessengerMessage } from "src/stores/messenger";
 import TokenCarousel from "components/TokenCarousel.vue";
+import TokenInformation from "components/TokenInformation.vue";
 import { useReceiveTokensStore } from "src/stores/receiveTokensStore";
 import { useWalletStore } from "src/stores/wallet";
 import { notifyError } from "src/js/notify";


### PR DESCRIPTION
## Summary
- store token payload on incoming messages
- attach token payload to outgoing token messages
- show token information bubbles

## Testing
- `npx vitest` *(fails: Need to install vitest)*
- `npm run lint` *(fails: Cannot find module '@typescript-eslint/parser')*

------
https://chatgpt.com/codex/tasks/task_e_68831dcf70cc8330b9ed69eba70f6f54