### PR TITLE
Fix bucket when receiving DM token

### DIFF
--- a/src/stores/messenger.ts
+++ b/src/stores/messenger.ts
@@ -557,13 +557,9 @@ export const useMessengerStore = defineStore("messenger", {
             } else {
               const receiveStore = useReceiveTokensStore();
               receiveStore.receiveData.tokensBase64 = payload.token;
-              receiveStore.receiveData.bucketId =
-                payload.bucketId ?? receiveStore.receiveData.bucketId;
+              receiveStore.receiveData.bucketId = DEFAULT_BUCKET_ID;
               await receiveStore.enqueue(() =>
-                receiveStore.receiveToken(
-                  payload.token,
-                  receiveStore.receiveData.bucketId
-                )
+                receiveStore.receiveToken(payload.token, DEFAULT_BUCKET_ID)
               );
             }
           }


### PR DESCRIPTION
## Summary
- ignore bucketId from messenger DM payload
- always place DM tokens in default bucket

## Testing
- `pnpm test --silent` *(fails: useP2PKStore(...).sendToLock is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68832342ac3c8330a8a1cedb1758b132