### PR TITLE
Remove bucketId from DM token payload

### DIFF
--- a/src/stores/messenger.ts
+++ b/src/stores/messenger.ts
@@ -277,7 +277,6 @@ export const useMessengerStore = defineStore("messenger", {
               token: tokenStr,
               amount: sendAmount,
               unlockTime: null,
-              bucketId,
               referenceId: uuidv4(),
             };
 
@@ -356,7 +355,6 @@ export const useMessengerStore = defineStore("messenger", {
           token: tokenStr,
           amount: sendAmount,
           unlockTime: null,
-          bucketId,
           referenceId: uuidv4(),
           memo: memo || undefined,
         };


### PR DESCRIPTION
## Summary
- omit `bucketId` when building outgoing token DM payloads

## Testing
- `pnpm test` *(fails: Cannot access 'encryptMock' before initialization, MODULE_NOT_FOUND, and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_688324d9bd3c8330a9dc560d7fade469