### PR TITLE
Fix ReceiveEcash P2PK button visibility

### DIFF
--- a/src/components/ReceiveEcashDrawer.vue
+++ b/src/components/ReceiveEcashDrawer.vue
@@ -87,7 +87,7 @@
           </q-btn>
 
           <q-btn
-            v-if="showP2PkButtonInDrawer"
+            v-if="showP2PkButtonInDrawer && p2pkKeys.length"
             class="full-width custom-btn"
             @click="handleLockBtn"
           >

--- a/src/components/SettingsView.vue
+++ b/src/components/SettingsView.vue
@@ -916,6 +916,10 @@
               <q-item-label caption
                 >{{ $t("Settings.p2pk_features.quick_access.description") }}
               </q-item-label>
+              <q-item-label caption class="q-mt-xs">
+                The button appears in Receive Ecash after you generate or import a
+                key.
+              </q-item-label>
             </q-item>
           </q-list>
           <q-item v-if="p2pkKeys.length">


### PR DESCRIPTION
## Summary
- lock button in ReceiveEcashDrawer only shows when there are P2PK keys
- document key requirement for quick access lock button in settings

## Testing
- `pnpm run test:ci` *(fails: 32 failed, 24 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68832af984748330937a3efd3b72137b