### PR TITLE
Fix token chip wrapping

### DIFF
--- a/src/components/ChatMessageBubble.vue
+++ b/src/components/ChatMessageBubble.vue
@@ -282,4 +282,12 @@ async function updateAutoRedeem(val: boolean) {
   border-radius: 8px;
   margin-top: 4px;
 }
+
+.token-wrapper .q-chip {
+  white-space: normal;
+  word-break: break-word;
+  max-width: 100%;
+  display: block; /* optional: stack chips vertically */
+  margin-bottom: 4px; /* spacing between chips */
+}
 </style>


### PR DESCRIPTION
## Summary
- make token chips wrap inside chat bubbles for small screens

## Testing
- `pnpm run test:ci` *(fails: InfoTooltip shows tooltip on hover)*

------
https://chatgpt.com/codex/tasks/task_e_68832db1cea4833099881cf979f57853