### PR TITLE
Add description support for proofs and tokens

### DIFF
--- a/src/components/HistoryTable.vue
+++ b/src/components/HistoryTable.vue
@@ -55,6 +55,9 @@
           <q-item-label caption v-if="token.label">
             {{ token.label }}
           </q-item-label>
+          <q-item-label caption v-if="token.description">
+            {{ token.description }}
+          </q-item-label>
         </q-item-section>
 
         <q-item-section side top class="q-gutter-xs">
@@ -154,6 +157,12 @@
           class="q-mt-md"
           :label="$t('bucket.color')"
         />
+        <q-input
+          v-model="editDialog.description"
+          outlined
+          class="q-mt-md"
+          :label="$t('ReceiveTokenDialog.inputs.description.label')"
+        />
         <div class="row q-mt-md">
           <q-btn color="primary" rounded @click="saveLabel">{{
             $t("global.actions.update.label")
@@ -198,6 +207,7 @@ export default defineComponent({
         show: false,
         label: "",
         color: DEFAULT_COLOR,
+        description: "",
         token: null,
       },
     };
@@ -279,6 +289,7 @@ export default defineComponent({
       this.editDialog.token = token;
       this.editDialog.label = token.label || "";
       this.editDialog.color = token.color || DEFAULT_COLOR;
+      this.editDialog.description = token.description || "";
       this.editDialog.show = true;
     },
     saveLabel() {
@@ -286,6 +297,7 @@ export default defineComponent({
       this.editHistoryToken(this.editDialog.token.token, {
         newLabel: this.editDialog.label,
         newColor: this.editDialog.color,
+        newDescription: this.editDialog.description,
       });
       this.editDialog.show = false;
     },

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -995,6 +995,9 @@ export const messages = {
       label: {
         label: "Label",
       },
+      description: {
+        label: "Description",
+      },
     },
     timelock: {
       unlock_date_label: "Unlocks { value }",

--- a/src/pages/BucketDetail.vue
+++ b/src/pages/BucketDetail.vue
@@ -35,6 +35,9 @@
           <q-item-label class="text-weight-bold">{{
             group.label || "(No label)"
           }}</q-item-label>
+          <q-item-label caption v-if="group.tokens[0]?.description">
+            {{ group.tokens[0]?.description }}
+          </q-item-label>
           <q-item-label caption>
             {{ formatCurrency(group.total, activeUnit) }}
           </q-item-label>
@@ -122,6 +125,12 @@
           class="q-mt-md"
           label="Color"
         />
+        <q-input
+          v-model="editDialog.description"
+          outlined
+          class="q-mt-md"
+          :label="$t('ReceiveTokenDialog.inputs.description.label')"
+        />
         <div class="row q-mt-md">
           <q-btn color="primary" rounded @click="saveEdit">Update</q-btn>
           <q-btn flat rounded color="grey" class="q-ml-auto" v-close-popup
@@ -187,6 +196,7 @@ const editDialog = ref({
   show: false,
   label: "",
   color: DEFAULT_COLOR,
+  description: "",
   originalLabel: "",
 });
 
@@ -272,6 +282,7 @@ function openEditGroup(group: ProofGroup) {
   editDialog.value.show = true;
   editDialog.value.label = group.label;
   editDialog.value.color = group.color;
+  editDialog.value.description = group.tokens[0]?.description || "";
   editDialog.value.originalLabel = group.label;
 }
 
@@ -285,6 +296,7 @@ function saveEdit() {
     tokensStore.editHistoryToken(t.token, {
       newLabel: editDialog.value.label,
       newColor: editDialog.value.color,
+      newDescription: editDialog.value.description,
     });
   });
   editDialog.value.show = false;

--- a/src/stores/dexie.ts
+++ b/src/stores/dexie.ts
@@ -436,6 +436,25 @@ export class CashuDexie extends Dexie {
           if (entry.creatorAvatar === undefined) entry.creatorAvatar = null;
         });
       });
+
+    this.version(19)
+      .stores({
+        proofs:
+          "secret, id, C, amount, reserved, quote, bucketId, label, description",
+        profiles: "pubkey",
+        creatorsTierDefinitions: "&creatorNpub, eventId, updatedAt",
+        subscriptions: "&id, creatorNpub, tierId, status, createdAt, updatedAt",
+        lockedTokens:
+          "&id, tokenString, owner, tierId, intervalKey, unlockTs, status, subscriptionEventId, subscriptionId, monthIndex, totalMonths, autoRedeem",
+      })
+      .upgrade(async (tx) => {
+        await tx
+          .table("proofs")
+          .toCollection()
+          .modify((entry: any) => {
+            if (entry.description === undefined) entry.description = "";
+          });
+      });
   }
 }
 

--- a/src/stores/proofs.ts
+++ b/src/stores/proofs.ts
@@ -91,7 +91,8 @@ export const useProofsStore = defineStore("proofs", {
       proofs: Proof[],
       quote?: string,
       bucketId: string = "unassigned",
-      label: string = ""
+      label: string = "",
+      description: string = ""
     ): WalletProof[] {
       return proofs.map((p) => {
         return {
@@ -100,6 +101,7 @@ export const useProofsStore = defineStore("proofs", {
           quote: quote,
           bucketId,
           label,
+          description,
         } as WalletProof;
       });
     },
@@ -107,7 +109,8 @@ export const useProofsStore = defineStore("proofs", {
       proofs: Proof[],
       quote?: string,
       bucketId: string = "unassigned",
-      label: string = ""
+      label: string = "",
+      description: string = ""
     ) {
       const bucketsStore = useBucketsStore();
       const mintsStore = useMintsStore();
@@ -128,7 +131,8 @@ export const useProofsStore = defineStore("proofs", {
         proofs,
         quote,
         bucketId,
-        label
+        label,
+        description
       );
       await cashuDb.transaction("rw", cashuDb.proofs, async () => {
         walletProofs.forEach(async (p) => {
@@ -232,6 +236,16 @@ export const useProofsStore = defineStore("proofs", {
       await cashuDb.transaction("rw", cashuDb.proofs, async () => {
         for (const secret of secrets) {
           await cashuDb.proofs.where("secret").equals(secret).modify({ label });
+        }
+      });
+    },
+    async updateProofDescriptions(secrets: string[], description: string) {
+      await cashuDb.transaction("rw", cashuDb.proofs, async () => {
+        for (const secret of secrets) {
+          await cashuDb.proofs
+            .where("secret")
+            .equals(secret)
+            .modify({ description });
         }
       });
     },

--- a/src/stores/tokens.ts
+++ b/src/stores/tokens.ts
@@ -20,6 +20,7 @@ export type HistoryToken = {
   unit: string;
   label?: string;
   color?: string;
+  description?: string;
   paymentRequest?: PaymentRequest;
   fee?: number;
   bucketId: string;
@@ -113,6 +114,7 @@ export const useTokensStore = defineStore("tokens", {
         newFee?: number;
         newLabel?: string;
         newColor?: string;
+        newDescription?: string;
       }
     ): HistoryToken | undefined {
       const index = this.historyTokens.findIndex(
@@ -154,6 +156,22 @@ export const useTokensStore = defineStore("tokens", {
               }
             } catch (e) {
               console.warn("Could not update proof labels", e);
+            }
+          }
+          if (options.newDescription !== undefined) {
+            this.historyTokens[index].description = options.newDescription;
+            try {
+              const tokenJson = token.decode(this.historyTokens[index].token);
+              if (tokenJson) {
+                const proofs = token.getProofs(tokenJson);
+                const proofsStore = useProofsStore();
+                proofsStore.updateProofDescriptions(
+                  proofs.map((p) => p.secret),
+                  options.newDescription
+                );
+              }
+            } catch (e) {
+              console.warn("Could not update proof descriptions", e);
             }
           }
           if (options.newColor !== undefined) {

--- a/src/types/proofs.ts
+++ b/src/types/proofs.ts
@@ -5,4 +5,5 @@ export interface WalletProof extends Proof {
   quote?: string;
   bucketId?: string;
   label?: string;
+  description?: string;
 }

--- a/test/vitest/__tests__/tokens.spec.ts
+++ b/test/vitest/__tests__/tokens.spec.ts
@@ -22,4 +22,11 @@ describe("Tokens store", () => {
     store.editHistoryToken("t2", { newColor: "#ff0000" });
     expect(store.historyTokens[0].color).toBe("#ff0000");
   });
+
+  it("edits token description", () => {
+    const store = useTokensStore();
+    store.addPaidToken({ amount: 1, token: "t3", mint: "m1", unit: "sat" });
+    store.editHistoryToken("t3", { newDescription: "foo" });
+    expect(store.historyTokens[0].description).toBe("foo");
+  });
 });


### PR DESCRIPTION
## Summary
- extend `WalletProof` and `HistoryToken` with a `description` field
- migrate Dexie database to add the new column
- allow specifying descriptions when creating wallet proofs
- update tokens and proofs stores to edit proof descriptions
- support editing descriptions from BucketDetail and HistoryTable components
- show descriptions in UI when available
- provide English translation for description input
- test editing token descriptions

## Testing
- `pnpm test` *(fails: vitest not found / multiple test errors)*

------
https://chatgpt.com/codex/tasks/task_e_68832f958a6483308d9dbe38ed3ca6b7