### PR TITLE
Update SendBucketDmDialog i18n label

### DIFF
--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1428,7 +1428,7 @@ export const messages = {
     },
     options: {
       amount: "Amount",
-      proofs: "Select Proofs",
+      proofs: "Select Tokens",
     },
     actions: {
       cancel: { label: "@:global.actions.cancel.label" },


### PR DESCRIPTION
## Summary
- tweak English translation for bucket DM dialog to say "Select Tokens"

## Testing
- `pnpm test` *(fails: Vitest caught 2 unhandled errors)*

------
https://chatgpt.com/codex/tasks/task_e_6883321c38cc83308b4476e7195d579e