### PR TITLE
Add token edit dialog in BucketDetailModal

### DIFF
--- a/src/components/BucketDetailModal.vue
+++ b/src/components/BucketDetailModal.vue
@@ -35,6 +35,16 @@
                   p.label
                 }}</q-item-label>
               </q-item-section>
+              <q-item-section side>
+                <q-btn
+                  flat
+                  dense
+                  icon="edit"
+                  @click.stop="openEdit(p)"
+                  aria-label="Edit"
+                  title="Edit"
+                />
+              </q-item-section>
             </q-item>
           </q-list>
           <LockedTokensTable
@@ -73,6 +83,24 @@
       :bucket-id="props.bucketId ?? ''"
       :prefill-npub="bucket?.creatorPubkey"
     />
+    <q-dialog v-model="editDialog.show">
+      <q-card class="q-pa-md" style="max-width: 400px">
+        <h6 class="q-mt-none q-mb-md">Edit token</h6>
+        <q-input v-model="editDialog.label" outlined :label="t('ReceiveTokenDialog.inputs.label.label')" />
+        <q-input
+          v-model="editDialog.description"
+          outlined
+          class="q-mt-md"
+          :label="t('ReceiveTokenDialog.inputs.description.label')"
+        />
+        <div class="row q-mt-md">
+          <q-btn color="primary" rounded @click="saveEdit">{{ t('global.actions.update.label') }}</q-btn>
+          <q-btn flat rounded color="grey" class="q-ml-auto" v-close-popup>{{
+            t('global.actions.cancel.label')
+          }}</q-btn>
+        </div>
+      </q-card>
+    </q-dialog>
   </q-dialog>
 </template>
 
@@ -81,6 +109,7 @@ import { computed, ref } from "vue";
 import { useProofsStore } from "stores/proofs";
 import { useBucketsStore } from "stores/buckets";
 import { useMintsStore } from "stores/mints";
+import { useTokensStore } from "stores/tokens";
 import { storeToRefs } from "pinia";
 import { useUiStore } from "stores/ui";
 import { useI18n } from "vue-i18n";
@@ -104,9 +133,16 @@ const activeTab = ref<"overview" | "history">("overview");
 const bucketsStore = useBucketsStore();
 const proofsStore = useProofsStore();
 const mintsStore = useMintsStore();
+const tokensStore = useTokensStore();
 const uiStore = useUiStore();
 const { activeUnit } = storeToRefs(mintsStore);
 const sendDmDialogRef = ref<InstanceType<typeof SendBucketDmDialog> | null>(null);
+const editDialog = ref({
+  show: false,
+  label: "",
+  description: "",
+  secret: "",
+});
 
 const bucket = computed(
   () => bucketsStore.bucketList.find((b) => b.id === props.bucketId) || null
@@ -120,6 +156,21 @@ const bucketBalance = computed(() =>
 
 const formatCurrency = (a: number, unit: string) =>
   uiStore.formatCurrency(a, unit);
+
+function openEdit(token: any) {
+  editDialog.value.show = true;
+  editDialog.value.label = token.label || "";
+  editDialog.value.description = token.description || "";
+  editDialog.value.secret = token.secret;
+}
+
+function saveEdit() {
+  tokensStore.editHistoryToken(editDialog.value.secret, {
+    newLabel: editDialog.value.label,
+    newDescription: editDialog.value.description,
+  });
+  editDialog.value.show = false;
+}
 
 function openSendDmDialog() {
   const npub = bucket.value?.creatorPubkey;

--- a/test/vitest/__tests__/bucketDetailModal.spec.ts
+++ b/test/vitest/__tests__/bucketDetailModal.spec.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import BucketDetailModal from '../../../src/components/BucketDetailModal.vue';
+
+var tokenStore: any;
+
+vi.mock('../../../src/stores/proofs', () => ({
+  useProofsStore: () => ({ proofs: [{ secret: 's1', amount: 1, bucketId: 'b1', reserved: false, label: 'foo', description: 'bar' }] }),
+}));
+
+vi.mock('../../../src/stores/buckets', () => ({
+  useBucketsStore: () => ({ bucketList: [{ id: 'b1', name: 'Bucket' }] }),
+  DEFAULT_BUCKET_ID: 'b1',
+}));
+
+import { ref } from 'vue';
+vi.mock('../../../src/stores/mints', () => ({
+  useMintsStore: () => ({ activeUnit: ref('sat') }),
+}));
+
+vi.mock('../../../src/components/LockedTokensTable.vue', () => ({ default: { template: '<div />' } }));
+vi.mock('../../../src/components/CreatorLockedTokensTable.vue', () => ({ default: { template: '<div />' } }));
+vi.mock('../../../src/components/HistoryTable.vue', () => ({ default: { template: '<div />' } }));
+vi.mock('../../../src/components/SendBucketDmDialog.vue', () => ({ default: { template: '<div />', methods: { show: vi.fn() } } }));
+
+vi.mock('../../../src/stores/tokens', () => {
+  tokenStore = { editHistoryToken: vi.fn() };
+  return { useTokensStore: () => tokenStore };
+});
+
+vi.mock('../../../src/stores/ui', () => ({
+  useUiStore: () => ({ formatCurrency: (a:number) => String(a) }),
+}));
+
+vi.mock('../../../src/js/notify', () => ({ notifyError: vi.fn() }));
+
+describe('BucketDetailModal openEdit', () => {
+  it('calls editHistoryToken with new values', async () => {
+    const wrapper = mount(BucketDetailModal, { props: { modelValue: true, bucketId: 'b1' } });
+    const vm: any = wrapper.vm;
+    vm.openEdit({ secret: 's1', label: 'foo', description: 'bar' });
+    vm.editDialog.label = 'new';
+    vm.editDialog.description = 'desc';
+    vm.saveEdit();
+    expect(tokenStore.editHistoryToken).toHaveBeenCalledWith('s1', { newLabel: 'new', newDescription: 'desc' });
+  });
+});


### PR DESCRIPTION
## Summary
- add edit button for tokens in BucketDetailModal
- show a dialog for editing label and description
- implement openEdit/saveEdit methods
- test openEdit/saveEdit workflow

## Testing
- `npx vitest run test/vitest/__tests__/bucketDetailModal.spec.ts`

------
https://chatgpt.com/codex/tasks/task_e_68833e4e42308330a88e15a01a85da6f