### PR TITLE
Add isPureP2PK helper

### DIFF
--- a/src/components/TokenInformation.vue
+++ b/src/components/TokenInformation.vue
@@ -28,7 +28,7 @@
           class="q-ml-xs"
         />
       </q-chip>
-      <q-chip v-if="isLocked(proofsToShow)" outline icon="lock" class="q-pa-md">
+      <q-chip v-if="isPureP2PK(proofsToShow)" outline icon="lock" class="q-pa-md">
         P2PK
         <q-icon
           v-if="showP2PKCheck || isLockedToUs(proofsToShow)"
@@ -127,7 +127,7 @@ export default defineComponent({
   },
   methods: {
     ...mapActions(useP2PKStore, [
-      "isLocked",
+      "isPureP2PK",
       "isLockedToUs",
       "getTokenPubkey",
       "getTokenLocktime",

--- a/src/stores/p2pk.ts
+++ b/src/stores/p2pk.ts
@@ -272,6 +272,22 @@ export const useP2PKStore = defineStore("p2pk", {
       }
       return false;
     },
+    isPureP2PK: function (proofs: WalletProof[]) {
+      const secrets = proofs.map((p) => p.secret);
+      for (const secret of secrets) {
+        try {
+          const obj = JSON.parse(secret);
+          if (!Array.isArray(obj)) continue;
+          if (obj[0] !== "P2PK") continue;
+          // ignore HTLC style objects
+          if (obj[1] && typeof obj[1] === "object" && "receiverP2PK" in obj[1]) {
+            continue;
+          }
+          return true;
+        } catch {}
+      }
+      return false;
+    },
     isHTLC: function (proofs: WalletProof[]) {
       const secrets = proofs.map((p) => p.secret);
       for (const secret of secrets) {


### PR DESCRIPTION
## Summary
- add `isPureP2PK` utility to p2pk store
- display P2PK chip only for pure P2PK tokens
- test pure P2PK detection logic and chip rendering

## Testing
- `npm test` *(fails: vitest not found)*
- `npx vitest run test/vitest/__tests__/p2pk.spec.ts --passWithNoTests` *(fails to run due to module mocks)*

------
https://chatgpt.com/codex/tasks/task_e_6883419bdb10833097e243f13922609a