### PR TITLE
Update bucket overview expansion

### DIFF
--- a/src/components/BucketDetailModal.vue
+++ b/src/components/BucketDetailModal.vue
@@ -26,26 +26,30 @@
       <q-tab-panels v-model="activeTab" animated>
         <q-tab-panel name="overview" class="q-pa-none">
           <q-list bordered>
-            <q-item v-for="p in bucketProofs" :key="p.secret">
-              <q-item-section>
-                <q-item-label class="text-weight-bold">{{
-                  formatCurrency(p.amount, activeUnit.value)
-                }}</q-item-label>
-                <q-item-label caption v-if="p.label">{{
-                  p.label
-                }}</q-item-label>
-              </q-item-section>
-              <q-item-section side>
+            <q-expansion-item
+              v-for="p in bucketProofs"
+              :key="p.secret"
+              expand-separator
+            >
+              <template #header>
+                <q-item-section class="text-weight-bold">
+                  {{ formatCurrency(p.amount, activeUnit.value) }}
+                </q-item-section>
+              </template>
+              <div class="q-pa-sm">
+                <div v-if="p.label" class="text-body2">{{ p.label }}</div>
+                <div v-if="p.description" class="text-caption">{{ p.description }}</div>
                 <q-btn
                   flat
                   dense
                   icon="edit"
+                  class="q-mt-sm"
                   @click.stop="openEdit(p)"
                   aria-label="Edit"
                   title="Edit"
                 />
-              </q-item-section>
-            </q-item>
+              </div>
+            </q-expansion-item>
           </q-list>
           <LockedTokensTable
             :bucket-id="props.bucketId ?? ''"

--- a/test/vitest/__tests__/bucketDetailModal.spec.ts
+++ b/test/vitest/__tests__/bucketDetailModal.spec.ts
@@ -34,7 +34,17 @@ vi.mock('../../../src/stores/ui', () => ({
 
 vi.mock('../../../src/js/notify', () => ({ notifyError: vi.fn() }));
 
-describe('BucketDetailModal openEdit', () => {
+describe('BucketDetailModal token list', () => {
+  it('shows metadata when expanded', async () => {
+    const wrapper = mount(BucketDetailModal, { props: { modelValue: true, bucketId: 'b1' } });
+    const item = wrapper.find('q-expansion-item');
+    expect(item.exists()).toBe(true);
+    expect(item.text()).not.toContain('foo');
+    await item.trigger('click');
+    expect(item.text()).toContain('foo');
+    expect(item.text()).toContain('bar');
+  });
+
   it('calls editHistoryToken with new values', async () => {
     const wrapper = mount(BucketDetailModal, { props: { modelValue: true, bucketId: 'b1' } });
     const vm: any = wrapper.vm;


### PR DESCRIPTION
## Summary
- use `q-expansion-item` for tokens in `BucketDetailModal`
- make token metadata visible in token list
- expand unit test coverage for `BucketDetailModal`

## Testing
- `pnpm test:ci` *(fails: useMintsStore is not a function, ConstraintError, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6883cc70c3c88330b7b484cd534f5701