### PR TITLE
Add expandable token details

### DIFF
--- a/src/components/BucketDetailModal.vue
+++ b/src/components/BucketDetailModal.vue
@@ -26,26 +26,37 @@
       <q-tab-panels v-model="activeTab" animated>
         <q-tab-panel name="overview" class="q-pa-none">
           <q-list bordered>
-            <q-item v-for="p in bucketProofs" :key="p.secret">
-              <q-item-section>
-                <q-item-label class="text-weight-bold">{{
-                  formatCurrency(p.amount, activeUnit.value)
-                }}</q-item-label>
-                <q-item-label caption v-if="p.label">{{
-                  p.label
-                }}</q-item-label>
-              </q-item-section>
-              <q-item-section side>
-                <q-btn
-                  flat
-                  dense
-                  icon="edit"
-                  @click.stop="openEdit(p)"
-                  aria-label="Edit"
-                  title="Edit"
-                />
-              </q-item-section>
-            </q-item>
+            <q-expansion-item
+              v-for="p in bucketProofs"
+              :key="p.secret"
+              expand-icon-class="hidden"
+              dense
+              dense-toggle
+            >
+              <template #header>
+                <q-item>
+                  <q-item-section>
+                    <q-item-label class="text-weight-bold">{{
+                      formatCurrency(p.amount, activeUnit.value)
+                    }}</q-item-label>
+                    <q-item-label caption v-if="p.label">{{ p.label }}</q-item-label>
+                  </q-item-section>
+                  <q-item-section side>
+                    <q-btn
+                      flat
+                      dense
+                      icon="edit"
+                      @click.stop="openEdit(p)"
+                      aria-label="Edit"
+                      title="Edit"
+                    />
+                  </q-item-section>
+                </q-item>
+              </template>
+              <div class="q-pa-sm" v-if="p.description">
+                <q-item-label caption>{{ p.description }}</q-item-label>
+              </div>
+            </q-expansion-item>
           </q-list>
           <LockedTokensTable
             :bucket-id="props.bucketId ?? ''"

--- a/test/vitest/__tests__/bucketDetailModal.spec.ts
+++ b/test/vitest/__tests__/bucketDetailModal.spec.ts
@@ -44,4 +44,13 @@ describe('BucketDetailModal openEdit', () => {
     vm.saveEdit();
     expect(tokenStore.editHistoryToken).toHaveBeenCalledWith('s1', { newLabel: 'new', newDescription: 'desc' });
   });
+
+  it('shows description when token item expanded', async () => {
+    const wrapper = mount(BucketDetailModal, { props: { modelValue: true, bucketId: 'b1' } });
+    expect(wrapper.text()).not.toContain('bar');
+    const item = wrapper.find('.q-expansion-item');
+    await item.trigger('click');
+    await wrapper.vm.$nextTick();
+    expect(wrapper.text()).toContain('bar');
+  });
 });


### PR DESCRIPTION
## Summary
- expand tokens in bucket detail with a description section
- test expansion of token description

## Testing
- `npm test --silent` *(fails: 19 failed, 67 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6883cacf6dbc8330bcd521ac4064d43a