### PR TITLE
Add token edit helper and description support

### DIFF
--- a/src/components/BucketDetailModal.vue
+++ b/src/components/BucketDetailModal.vue
@@ -26,26 +26,35 @@
       <q-tab-panels v-model="activeTab" animated>
         <q-tab-panel name="overview" class="q-pa-none">
           <q-list bordered>
-            <q-item v-for="p in bucketProofs" :key="p.secret">
-              <q-item-section>
-                <q-item-label class="text-weight-bold">{{
-                  formatCurrency(p.amount, activeUnit.value)
-                }}</q-item-label>
-                <q-item-label caption v-if="p.label">{{
-                  p.label
-                }}</q-item-label>
-              </q-item-section>
-              <q-item-section side>
-                <q-btn
-                  flat
-                  dense
-                  icon="edit"
-                  @click.stop="openEdit(p)"
-                  aria-label="Edit"
-                  title="Edit"
-                />
-              </q-item-section>
-            </q-item>
+            <q-expansion-item
+              v-for="p in bucketProofs"
+              :key="p.secret"
+              expand-separator
+            >
+              <template #header>
+                <q-item-section>
+                  <q-item-label class="text-weight-bold">{{
+                    formatCurrency(p.amount, activeUnit.value)
+                  }}</q-item-label>
+                </q-item-section>
+                <q-item-section side>
+                  <q-btn
+                    flat
+                    dense
+                    icon="edit"
+                    @click.stop="openEdit(p)"
+                    aria-label="Edit"
+                    title="Edit"
+                  />
+                </q-item-section>
+              </template>
+              <div class="q-pl-md q-pb-sm">
+                <div v-if="p.label" class="text-caption">{{ p.label }}</div>
+                <div v-if="p.description" class="text-caption">
+                  {{ p.description }}
+                </div>
+              </div>
+            </q-expansion-item>
           </q-list>
           <LockedTokensTable
             :bucket-id="props.bucketId ?? ''"
@@ -165,7 +174,7 @@ function openEdit(token: any) {
 }
 
 function saveEdit() {
-  tokensStore.editHistoryToken(editDialog.value.secret, {
+  tokensStore.editHistoryTokenBySecret(editDialog.value.secret, {
     newLabel: editDialog.value.label,
     newDescription: editDialog.value.description,
   });

--- a/src/components/ReceiveTokenDialog.vue
+++ b/src/components/ReceiveTokenDialog.vue
@@ -171,6 +171,13 @@
               class="q-mt-sm"
               :label="$t('ReceiveTokenDialog.inputs.label.label')"
             />
+            <q-input
+              v-model="receiveData.description"
+              outlined
+              dense
+              class="q-mt-sm"
+              :label="$t('ReceiveTokenDialog.inputs.description.label')"
+            />
           </div>
           <div class="row q-pt-md" v-if="!swapSelected">
             <q-btn
@@ -579,6 +586,7 @@ export default defineComponent({
         mint: mintInToken,
         unit: unitInToken,
         label: this.receiveData.label,
+        description: this.receiveData.description,
         bucketId: this.receiveData.bucketId,
       });
       this.showReceiveTokens = false;

--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -940,6 +940,9 @@ export default {
       label: {
         label: "Label",
       },
+      description: {
+        label: "Description",
+      },
     },
     errors: {
       invalid_token: {

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -946,6 +946,9 @@ export default {
       label: {
         label: "Label",
       },
+      description: {
+        label: "Description",
+      },
     },
     timelock: {
       unlock_date_label: "Unlocks { value }",

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -949,6 +949,9 @@ export default {
       label: {
         label: "Label",
       },
+      description: {
+        label: "Description",
+      },
     },
     errors: {
       invalid_token: {

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -947,6 +947,9 @@ export default {
       label: {
         label: "Label",
       },
+      description: {
+        label: "Description",
+      },
     },
     errors: {
       invalid_token: {

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -945,6 +945,9 @@ export default {
       label: {
         label: "Label",
       },
+      description: {
+        label: "Description",
+      },
     },
     errors: {
       invalid_token: {

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -939,6 +939,9 @@ export default {
       label: {
         label: "Label",
       },
+      description: {
+        label: "Description",
+      },
     },
     errors: {
       invalid_token: {

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -938,6 +938,9 @@ export default {
       label: {
         label: "Label",
       },
+      description: {
+        label: "Description",
+      },
     },
     errors: {
       invalid_token: {

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -939,6 +939,9 @@ export default {
       label: {
         label: "Label",
       },
+      description: {
+        label: "Description",
+      },
     },
     errors: {
       invalid_token: {

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -936,6 +936,9 @@ export default {
       label: {
         label: "Label",
       },
+      description: {
+        label: "Description",
+      },
     },
     errors: {
       invalid_token: {

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -941,6 +941,9 @@ export default {
       label: {
         label: "Label",
       },
+      description: {
+        label: "Description",
+      },
     },
     errors: {
       invalid_token: {

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -929,6 +929,9 @@ export default {
       label: {
         label: "Label",
       },
+      description: {
+        label: "Description",
+      },
     },
     errors: {
       invalid_token: {

--- a/src/stores/receiveTokensStore.ts
+++ b/src/stores/receiveTokensStore.ts
@@ -42,6 +42,7 @@ export const useReceiveTokensStore = defineStore("receiveTokensStore", {
       p2pkPrivateKey: "",
       bucketId: DEFAULT_BUCKET_ID,
       label: "",
+      description: "",
     },
     scanningCard: false,
   }),

--- a/src/stores/tokens.ts
+++ b/src/stores/tokens.ts
@@ -42,6 +42,7 @@ export const useTokensStore = defineStore("tokens", {
       fee,
       paymentRequest,
       label,
+      description,
       color,
       bucketId = DEFAULT_BUCKET_ID,
     }: {
@@ -52,6 +53,7 @@ export const useTokensStore = defineStore("tokens", {
       fee?: number;
       paymentRequest?: PaymentRequest;
       label?: string;
+      description?: string;
       color?: string;
       bucketId?: string;
     }) {
@@ -63,6 +65,7 @@ export const useTokensStore = defineStore("tokens", {
         mint,
         unit,
         label,
+        description,
         color: color ?? DEFAULT_COLOR,
         fee,
         paymentRequest,
@@ -77,6 +80,7 @@ export const useTokensStore = defineStore("tokens", {
       fee,
       paymentRequest,
       label,
+      description,
       color,
       bucketId = DEFAULT_BUCKET_ID,
     }: {
@@ -87,6 +91,7 @@ export const useTokensStore = defineStore("tokens", {
       fee?: number;
       paymentRequest?: PaymentRequest;
       label?: string;
+      description?: string;
       color?: string;
       bucketId?: string;
     }) {
@@ -98,6 +103,7 @@ export const useTokensStore = defineStore("tokens", {
         mint,
         unit,
         label,
+        description,
         color: color ?? DEFAULT_COLOR,
         fee,
         paymentRequest,
@@ -183,6 +189,41 @@ export const useTokensStore = defineStore("tokens", {
       }
 
       return undefined;
+    },
+
+    findHistoryTokenBySecret(secret: string): HistoryToken | undefined {
+      for (const ht of this.historyTokens) {
+        try {
+          const tokenJson = token.decode(ht.token);
+          if (tokenJson) {
+            const proofs = token.getProofs(tokenJson);
+            if (proofs.some((p) => p.secret === secret)) {
+              return ht;
+            }
+          }
+        } catch (e) {
+          console.warn("Could not decode token", e);
+        }
+      }
+      return undefined;
+    },
+
+    editHistoryTokenBySecret(
+      secret: string,
+      options?: {
+        newAmount?: number;
+        addAmount?: number;
+        newStatus?: "paid" | "pending";
+        newToken?: string;
+        newFee?: number;
+        newLabel?: string;
+        newColor?: string;
+        newDescription?: string;
+      }
+    ): HistoryToken | undefined {
+      const ht = this.findHistoryTokenBySecret(secret);
+      if (!ht) return undefined;
+      return this.editHistoryToken(ht.token, options);
     },
     setTokenPaid(token: string) {
       const index = this.historyTokens.findIndex(

--- a/test/vitest/__tests__/bucketDetailModal.spec.ts
+++ b/test/vitest/__tests__/bucketDetailModal.spec.ts
@@ -24,7 +24,7 @@ vi.mock('../../../src/components/HistoryTable.vue', () => ({ default: { template
 vi.mock('../../../src/components/SendBucketDmDialog.vue', () => ({ default: { template: '<div />', methods: { show: vi.fn() } } }));
 
 vi.mock('../../../src/stores/tokens', () => {
-  tokenStore = { editHistoryToken: vi.fn() };
+  tokenStore = { editHistoryTokenBySecret: vi.fn() };
   return { useTokensStore: () => tokenStore };
 });
 
@@ -42,6 +42,6 @@ describe('BucketDetailModal openEdit', () => {
     vm.editDialog.label = 'new';
     vm.editDialog.description = 'desc';
     vm.saveEdit();
-    expect(tokenStore.editHistoryToken).toHaveBeenCalledWith('s1', { newLabel: 'new', newDescription: 'desc' });
+    expect(tokenStore.editHistoryTokenBySecret).toHaveBeenCalledWith('s1', { newLabel: 'new', newDescription: 'desc' });
   });
 });

--- a/test/vitest/__tests__/tokens.spec.ts
+++ b/test/vitest/__tests__/tokens.spec.ts
@@ -29,4 +29,26 @@ describe("Tokens store", () => {
     store.editHistoryToken("t3", { newDescription: "foo" });
     expect(store.historyTokens[0].description).toBe("foo");
   });
+
+  it("finds history token by secret", () => {
+    const tokenObj = {
+      token: [{ proofs: [{ id: "a", amount: 1, C: "c", secret: "sec" }], mint: "m1" }],
+    };
+    const encoded = "cashuA" + Buffer.from(JSON.stringify(tokenObj)).toString("base64");
+    const store = useTokensStore();
+    store.addPaidToken({ amount: 1, token: encoded, mint: "m1", unit: "sat" });
+    const found = store.findHistoryTokenBySecret("sec");
+    expect(found?.token).toBe(encoded);
+  });
+
+  it("edits history token by secret", () => {
+    const tokenObj = {
+      token: [{ proofs: [{ id: "a", amount: 1, C: "c", secret: "sec2" }], mint: "m1" }],
+    };
+    const encoded = "cashuA" + Buffer.from(JSON.stringify(tokenObj)).toString("base64");
+    const store = useTokensStore();
+    store.addPaidToken({ amount: 1, token: encoded, mint: "m1", unit: "sat" });
+    store.editHistoryTokenBySecret("sec2", { newLabel: "abc" });
+    expect(store.historyTokens[0].label).toBe("abc");
+  });
 });


### PR DESCRIPTION
## Summary
- allow adding descriptions when saving tokens to history
- support editing history token info by proof secret
- show token details in bucket view using expansion items
- include new description input when receiving tokens
- update store tests for new helpers
- localize description field for all locales

## Testing
- `pnpm test:ci` *(fails: useTokensStore is not a function, many suite errors)*

------
https://chatgpt.com/codex/tasks/task_e_6883d3ad7be4833081479ae3b34bbbb5