### PR TITLE
Refactor addPendingToken usage

### DIFF
--- a/src/components/ReceiveTokenDialog.vue
+++ b/src/components/ReceiveTokenDialog.vue
@@ -582,7 +582,7 @@ export default defineComponent({
 
       tokensStore.addPendingToken({
         amount: amount,
-        token: tokenStr,
+        tokenStr: tokenStr,
         mint: mintInToken,
         unit: unitInToken,
         label: this.receiveData.label,

--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -1267,7 +1267,7 @@ export default defineComponent({
           label: "",
           bucketId,
         };
-        this.addPendingToken(historyToken);
+        this.addPendingToken({ ...historyToken, tokenStr: historyToken.token });
         this.sendData.historyToken = historyToken;
         Dialog.create({
           message: this.$t(
@@ -1415,7 +1415,7 @@ export default defineComponent({
           label: "",
           bucketId,
         };
-        this.addPendingToken(historyToken);
+        this.addPendingToken({ ...historyToken, tokenStr: historyToken.token });
         this.sendData.historyToken = historyToken;
 
         if (!this.g.offline) {

--- a/src/stores/messenger.ts
+++ b/src/stores/messenger.ts
@@ -306,7 +306,7 @@ export const useMessengerStore = defineStore("messenger", {
           }
           tokens.addPendingToken({
             amount: -sendAmount,
-            token: tokenStr,
+            tokenStr: tokenStr,
             unit: mints.activeUnit,
             mint: mints.activeMintUrl,
             bucketId,
@@ -370,7 +370,7 @@ export const useMessengerStore = defineStore("messenger", {
         if (success && event) {
           tokens.addPendingToken({
             amount: -sendAmount,
-            token: tokenStr,
+            tokenStr: tokenStr,
             unit: mints.activeUnit,
             mint: mints.activeMintUrl,
             bucketId,

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -1498,7 +1498,7 @@ export const useNostrStore = defineStore("nostr", {
 
       tokensStore.addPendingToken({
         amount: amount,
-        token: tokenStr,
+        tokenStr: tokenStr,
         mint: token.getMint(decodedToken),
         unit: token.getUnit(decodedToken),
         label: "",

--- a/src/stores/npubcash.ts
+++ b/src/stores/npubcash.ts
@@ -215,7 +215,7 @@ export const useNPCStore = defineStore("npc", {
       const unit = token.getUnit(decodedToken);
       tokensStore.addPendingToken({
         amount: amount,
-        token: tokenStr,
+        tokenStr: tokenStr,
         mint: mintUrl,
         unit: unit,
         label: "",

--- a/src/stores/tokens.ts
+++ b/src/stores/tokens.ts
@@ -74,7 +74,7 @@ export const useTokensStore = defineStore("tokens", {
     },
     addPendingToken({
       amount,
-      token,
+      tokenStr,
       mint,
       unit,
       fee,
@@ -85,7 +85,7 @@ export const useTokensStore = defineStore("tokens", {
       bucketId = DEFAULT_BUCKET_ID,
     }: {
       amount: number;
-      token: string;
+      tokenStr: string;
       mint: string;
       unit: string;
       fee?: number;
@@ -99,7 +99,7 @@ export const useTokensStore = defineStore("tokens", {
         status: "pending",
         amount,
         date: currentDateStr(),
-        token: token,
+        token: tokenStr,
         mint,
         unit,
         label,

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -1162,7 +1162,7 @@ export const useWalletStore = defineStore("wallet", {
           if (historyToken2) {
             tokenStore.addPendingToken({
               amount: unspentAmount * Math.sign(historyToken2.amount),
-              token: serializedUnspentProofs,
+              tokenStr: serializedUnspentProofs,
               unit: historyToken2.unit,
               mint: historyToken2.mint,
               label: historyToken2.label ?? "",


### PR DESCRIPTION
## Summary
- refactor `addPendingToken` signature to accept `tokenStr`
- pass encoded token string from callers

## Testing
- `npx vitest` *(fails: `npm ERR! canceled`)*

------
https://chatgpt.com/codex/tasks/task_e_6883d911c5008330b1eac1b8d92b48f1