### PR TITLE
Add description field for history tokens

### DIFF
--- a/src/components/SendTokenDialog.vue
+++ b/src/components/SendTokenDialog.vue
@@ -1265,6 +1265,7 @@ export default defineComponent({
           unit: this.activeUnit,
           mint: this.activeMintUrl,
           label: "",
+          description: this.sendData.memo || "",
           bucketId,
         };
         this.addPendingToken({ ...historyToken, tokenStr: historyToken.token });
@@ -1413,6 +1414,7 @@ export default defineComponent({
           paymentRequest: this.sendData.paymentRequest,
           status: "pending",
           label: "",
+          description: this.sendData.memo || "",
           bucketId,
         };
         this.addPendingToken({ ...historyToken, tokenStr: historyToken.token });

--- a/src/stores/messenger.ts
+++ b/src/stores/messenger.ts
@@ -309,6 +309,7 @@ export const useMessengerStore = defineStore("messenger", {
             tokenStr: tokenStr,
             unit: mints.activeUnit,
             mint: mints.activeMintUrl,
+            description: memo ?? "",
             bucketId,
           });
         }
@@ -373,6 +374,7 @@ export const useMessengerStore = defineStore("messenger", {
             tokenStr: tokenStr,
             unit: mints.activeUnit,
             mint: mints.activeMintUrl,
+            description: memo ?? "",
             bucketId,
           });
         }

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -1502,6 +1502,7 @@ export const useNostrStore = defineStore("nostr", {
         mint: token.getMint(decodedToken),
         unit: token.getUnit(decodedToken),
         label: "",
+        description: receiveStore.receiveData.description ?? "",
         bucketId: DEFAULT_BUCKET_ID,
       });
       receiveStore.showReceiveTokens = false;

--- a/src/stores/npubcash.ts
+++ b/src/stores/npubcash.ts
@@ -219,6 +219,7 @@ export const useNPCStore = defineStore("npc", {
         mint: mintUrl,
         unit: unit,
         label: "",
+        description: receiveStore.receiveData.description ?? "",
         bucketId: DEFAULT_BUCKET_ID,
       });
       receiveStore.showReceiveTokens = false;

--- a/src/stores/p2pk.ts
+++ b/src/stores/p2pk.ts
@@ -411,6 +411,7 @@ export const useP2PKStore = defineStore("p2pk", {
         mint: mintUrl,
         unit,
         label,
+        description: entry?.description ?? "",
         bucketId,
       });
     },

--- a/src/stores/wallet.ts
+++ b/src/stores/wallet.ts
@@ -579,6 +579,7 @@ export const useWalletStore = defineStore("wallet", {
         unit: unitInToken,
         mint: mintInToken,
         label: receiveStore.receiveData.label ?? "",
+        description: receiveStore.receiveData.description ?? "",
         fee: fee,
         bucketId,
       } as HistoryToken;
@@ -830,6 +831,7 @@ export const useWalletStore = defineStore("wallet", {
           unit: invoice.unit,
           mint: invoice.mint,
           label: "",
+          description: invoice.memo ?? "",
           bucketId,
         });
         useInvoicesWorkerStore().removeInvoiceFromChecker(invoice.quote);
@@ -1006,6 +1008,7 @@ export const useWalletStore = defineStore("wallet", {
           unit: mintWallet.unit,
           mint: mintWallet.mint.mintUrl,
           label: "",
+          description: this.payInvoiceData.invoice?.description ?? "",
           bucketId,
         });
 
@@ -1093,6 +1096,7 @@ export const useWalletStore = defineStore("wallet", {
               unit: wallet.unit,
               mint: wallet.mint.mintUrl,
               label: "",
+              description: "",
               bucketId,
             });
           }
@@ -1166,6 +1170,7 @@ export const useWalletStore = defineStore("wallet", {
               unit: historyToken2.unit,
               mint: historyToken2.mint,
               label: historyToken2.label ?? "",
+              description: historyToken2.description ?? "",
               bucketId: historyToken2.bucketId,
             });
           }


### PR DESCRIPTION
## Summary
- include descriptions on history token objects across stores and dialogs
- forward description to addPaidToken/addPendingToken calls

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883dca192b48330aa17031f88e988d8