### PR TITLE
Add tier media support with previews

### DIFF
--- a/src/components/MediaPreview.vue
+++ b/src/components/MediaPreview.vue
@@ -1,0 +1,38 @@
+<template>
+  <div v-if="src">
+    <img v-if="type === 'image'" :src="src" class="q-mb-sm" />
+    <iframe
+      v-else-if="type === 'youtube'"
+      :src="src"
+      frameborder="0"
+      allowfullscreen
+      class="q-mb-sm"
+    ></iframe>
+    <video v-else-if="type === 'video'" controls class="q-mb-sm">
+      <source :src="src" />
+    </video>
+    <audio v-else-if="type === 'audio'" controls class="q-mb-sm">
+      <source :src="src" />
+    </audio>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import {
+  isTrustedUrl,
+  normalizeMediaUrl,
+  determineMediaType,
+} from 'src/utils/validateMedia';
+
+const props = defineProps<{ url: string }>();
+
+const src = computed(() => {
+  const n = normalizeMediaUrl(props.url);
+  return isTrustedUrl(n) ? n : '';
+});
+
+const type = computed(() => (src.value ? determineMediaType(src.value) : 'image'));
+</script>
+
+<style scoped></style>

--- a/src/components/TierCard.vue
+++ b/src/components/TierCard.vue
@@ -25,6 +25,14 @@
       </template>
       <q-card-section>
         {{ tierLocal.description }}
+        <div v-if="tierLocal.media && tierLocal.media.length" class="q-mt-sm">
+          <MediaPreview
+            v-for="(m, idx) in tierLocal.media"
+            :key="idx"
+            :url="m.url"
+            class="q-mt-sm"
+          />
+        </div>
       </q-card-section>
     </q-expansion-item>
   </q-card>
@@ -33,6 +41,7 @@
 <script setup lang="ts">
 import { reactive, watch } from "vue";
 import type { Tier } from "stores/creatorHub";
+import MediaPreview from "./MediaPreview.vue";
 
 const props = defineProps<{ tier: Tier }>();
 const emit = defineEmits(["edit", "delete", "update:tier"]);

--- a/src/pages/PublicCreatorProfilePage.vue
+++ b/src/pages/PublicCreatorProfilePage.vue
@@ -54,6 +54,14 @@
           </q-card-section>
           <q-card-section>
             <div class="text-body1 q-mb-sm">{{ t.description }}</div>
+            <div v-if="t.media && t.media.length">
+              <MediaPreview
+                v-for="(m, idx) in t.media"
+                :key="idx"
+                :url="m.url"
+                class="q-mt-sm"
+              />
+            </div>
             <ul class="q-pl-md q-mb-none">
               <li v-for="benefit in t.benefits" :key="benefit">
                 {{ benefit }}
@@ -101,10 +109,11 @@ import SubscriptionReceipt from "components/SubscriptionReceipt.vue";
 import { useI18n } from "vue-i18n";
 import { renderMarkdown as renderMarkdownFn } from "src/js/simple-markdown";
 import PaywalledContent from "components/PaywalledContent.vue";
+import MediaPreview from "components/MediaPreview.vue";
 
 export default defineComponent({
   name: "PublicCreatorProfilePage",
-  components: { PaywalledContent, SubscriptionReceipt },
+  components: { PaywalledContent, SubscriptionReceipt, MediaPreview },
   setup() {
     const route = useRoute();
     const creatorNpub = route.params.npub as string;

--- a/src/stores/creators.ts
+++ b/src/stores/creators.ts
@@ -14,6 +14,7 @@ import { useNdk } from "src/composables/useNdk";
 import { nip19 } from "nostr-tools";
 import { Event as NostrEvent } from "nostr-tools";
 import { notifyWarning } from "src/js/notify";
+import type { TierMedia } from "./creatorHub";
 
 interface Tier {
   id: string;
@@ -21,6 +22,7 @@ interface Tier {
   price_sats: number;
   description: string;
   benefits: string[];
+  media?: TierMedia[];
 }
 
 export const FEATURED_CREATORS = [
@@ -195,6 +197,7 @@ export const useCreatorsStore = defineStore("creators", {
         this.tiersMap[hex] = cached.tiers.map((t: any) => ({
           ...t,
           price_sats: t.price_sats ?? t.price ?? 0,
+          media: t.media ? [...t.media] : [],
         }));
         void rawEvent; // parsed for potential use
       }
@@ -259,6 +262,7 @@ export const useCreatorsStore = defineStore("creators", {
           const tiersArray: Tier[] = JSON.parse(event.content).map((t: any) => ({
             ...t,
             price_sats: t.price_sats ?? t.price ?? 0,
+            media: t.media ? [...t.media] : [],
           }));
           this.tiersMap[hex] = tiersArray;
           await db.creatorsTierDefinitions.put({
@@ -293,6 +297,7 @@ export const useCreatorsStore = defineStore("creators", {
             const tiersArray: Tier[] = JSON.parse(event.content).map((t: any) => ({
               ...t,
               price_sats: t.price_sats ?? t.price ?? 0,
+              media: t.media ? [...t.media] : [],
             }));
             this.tiersMap[hex] = tiersArray;
             await db.creatorsTierDefinitions.put({

--- a/src/utils/validateMedia.ts
+++ b/src/utils/validateMedia.ts
@@ -1,0 +1,31 @@
+export function isTrustedUrl(url: string): boolean {
+  return /^(https:\/\/|ipfs:\/\/|nostr:)/i.test(url.trim());
+}
+
+export function normalizeYouTube(url: string): string {
+  const idMatch = url
+    .replace('https://', '')
+    .match(/(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/|shorts\/))(\w{11})/i);
+  if (idMatch) {
+    return `https://www.youtube.com/embed/${idMatch[1]}`;
+  }
+  return url;
+}
+
+export function normalizeMediaUrl(url: string): string {
+  return normalizeYouTube(url.trim());
+}
+
+export function determineMediaType(url: string): 'youtube' | 'video' | 'audio' | 'image' {
+  const lower = url.toLowerCase();
+  if (lower.includes('youtube.com/embed/')) {
+    return 'youtube';
+  }
+  if (/(\.mp3|\.wav|\.ogg)(\?.*)?$/.test(lower)) {
+    return 'audio';
+  }
+  if (/(\.mp4|\.webm|\.mov|\.ogv)(\?.*)?$/.test(lower)) {
+    return 'video';
+  }
+  return 'image';
+}

--- a/test/vitest/__tests__/MediaPreview.spec.ts
+++ b/test/vitest/__tests__/MediaPreview.spec.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import MediaPreview from '../../../src/components/MediaPreview.vue';
+
+describe('MediaPreview component', () => {
+  it('renders img for image url', () => {
+    const wrapper = mount(MediaPreview, { props: { url: 'https://example.com/img.png' } });
+    expect(wrapper.find('img').exists()).toBe(true);
+  });
+
+  it('renders iframe for youtube url', () => {
+    const wrapper = mount(MediaPreview, { props: { url: 'https://youtu.be/abcd1234efg' } });
+    expect(wrapper.find('iframe').exists()).toBe(true);
+  });
+
+  it('renders video tag for mp4', () => {
+    const wrapper = mount(MediaPreview, { props: { url: 'https://example.com/movie.mp4' } });
+    expect(wrapper.find('video').exists()).toBe(true);
+  });
+});

--- a/test/vitest/__tests__/creatorHub.spec.ts
+++ b/test/vitest/__tests__/creatorHub.spec.ts
@@ -120,7 +120,7 @@ describe("publishTierDefinitions", () => {
   it("creates a 30000 event with correct tags and content", async () => {
     const store = useCreatorHubStore();
     store.tiers = {
-      t1: { id: "t1", name: "Tier", price: 1, description: "", welcomeMessage: "" },
+      t1: { id: "t1", name: "Tier", price: 1, description: "", welcomeMessage: "", media: [] },
     } as any;
     store.tierOrder = ["t1"];
 
@@ -132,7 +132,7 @@ describe("publishTierDefinitions", () => {
     expect(ev.tags).toEqual([["d", "tiers"]]);
     expect(ev.content).toBe(
       JSON.stringify([
-        { id: "t1", name: "Tier", price: 1, description: "", welcomeMessage: "" },
+        { id: "t1", name: "Tier", price: 1, description: "", welcomeMessage: "", media: [] },
       ])
     );
     expect(signMock).toHaveBeenCalledWith(nostrStoreMock.signer);

--- a/test/vitest/__tests__/validateMedia.spec.ts
+++ b/test/vitest/__tests__/validateMedia.spec.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { isTrustedUrl, normalizeYouTube, determineMediaType } from '../../../src/utils/validateMedia';
+
+describe('validateMedia', () => {
+  it('accepts trusted schemes', () => {
+    expect(isTrustedUrl('https://example.com')).toBe(true);
+    expect(isTrustedUrl('ipfs://cid')).toBe(true);
+    expect(isTrustedUrl('nostr:foo')).toBe(true);
+  });
+
+  it('rejects untrusted schemes', () => {
+    expect(isTrustedUrl('http://example.com')).toBe(false);
+    expect(isTrustedUrl('ftp://example.com')).toBe(false);
+  });
+
+  it('normalizes youtube links', () => {
+    const url = 'https://youtu.be/abcd1234efg';
+    expect(normalizeYouTube(url)).toBe('https://www.youtube.com/embed/abcd1234efg');
+  });
+
+  it('detects media type', () => {
+    expect(determineMediaType('https://example.com/video.mp4')).toBe('video');
+    expect(determineMediaType('https://example.com/song.mp3')).toBe('audio');
+    expect(determineMediaType('https://www.youtube.com/embed/id')).toBe('youtube');
+    expect(determineMediaType('https://example.com/image.png')).toBe('image');
+  });
+});


### PR DESCRIPTION
## Summary
- allow tiers to include media urls
- publish media arrays in creator hub store
- parse tier media in creators store
- show media with new MediaPreview component in tier cards and public profiles
- validate media urls and normalize YouTube links
- test media validation and preview rendering

## Testing
- `npm test` *(fails: TSConfckParseError and multiple failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_688b5a1017b88330b25d8a9e011fd952