### PR TITLE
Refactor tier types

### DIFF
--- a/src/components/AddTierDialog.vue
+++ b/src/components/AddTierDialog.vue
@@ -25,7 +25,7 @@
           class="q-mb-sm"
         />
         <q-input
-          v-model.number="localTier.price"
+          v-model.number="localTier.price_sats"
           type="number"
           :label="$t('CreatorHub.dashboard.inputs.price.label')"
           outlined
@@ -36,14 +36,14 @@
             <div v-if="bitcoinPrice">
               ~{{
                 formatCurrency(
-                  (bitcoinPrice / 100000000) * localTier.price,
+                  (bitcoinPrice / 100000000) * localTier.price_sats,
                   "USD",
                 )
               }}
               /
               {{
                 formatCurrency(
-                  (bitcoinPrice / 100000000) * localTier.price,
+                  (bitcoinPrice / 100000000) * localTier.price_sats,
                   "EUR",
                 )
               }}
@@ -86,7 +86,8 @@
 
 <script lang="ts">
 import { defineComponent, computed, reactive, watch } from "vue";
-import { Tier, useCreatorHubStore } from "stores/creatorHub";
+import { useCreatorHubStore } from "stores/creatorHub";
+import type { Tier } from "stores/types";
 import { notifySuccess, notifyError } from "src/js/notify";
 import { useNostrStore } from "stores/nostr";
 import { usePriceStore } from "stores/price";

--- a/src/components/TierCard.vue
+++ b/src/components/TierCard.vue
@@ -7,7 +7,7 @@
             <q-icon name="mdi-drag" class="q-mr-sm drag-handle" />
             <div class="text-subtitle2">{{ tierLocal.name || "Tier" }}</div>
             <div class="text-caption text-grey q-ml-sm">
-              {{ tierLocal.price }} sats
+              {{ tierLocal.price_sats }} sats
             </div>
           </div>
           <div class="row items-center">
@@ -40,7 +40,7 @@
 
 <script setup lang="ts">
 import { reactive, watch } from "vue";
-import type { Tier } from "stores/creatorHub";
+import type { Tier } from "stores/types";
 import MediaPreview from "./MediaPreview.vue";
 
 const props = defineProps<{ tier: Tier }>();

--- a/src/components/TierItem.vue
+++ b/src/components/TierItem.vue
@@ -9,7 +9,7 @@
 
 <script setup lang="ts">
 import TierCard from "./TierCard.vue";
-import type { Tier } from "stores/creatorHub";
+import type { Tier } from "stores/types";
 
 const props = defineProps<{ tierData: Tier; saved: boolean }>();
 const emit = defineEmits(["save", "delete", "update:tierData"]);

--- a/src/components/TiersPanel.vue
+++ b/src/components/TiersPanel.vue
@@ -35,7 +35,8 @@
 import { ref, watch } from 'vue';
 import Draggable from 'vuedraggable';
 import TierCard from './TierCard.vue';
-import { useCreatorHubStore, type Tier } from 'stores/creatorHub';
+import { useCreatorHubStore } from 'stores/creatorHub';
+import type { Tier } from 'stores/types';
 import { v4 as uuidv4 } from 'uuid';
 
 const store = useCreatorHubStore();
@@ -57,7 +58,7 @@ function updateOrder() {
 
 function addTier() {
   const id = uuidv4();
-  store.addTier({ id, name: '', price: 0, description: '', welcomeMessage: '' });
+  store.addTier({ id, name: '', price_sats: 0, description: '', welcomeMessage: '' });
 }
 
 function confirmDelete(id: string) {

--- a/src/composables/useCreatorHub.ts
+++ b/src/composables/useCreatorHub.ts
@@ -2,7 +2,8 @@ import { ref, computed, watch, onMounted } from 'vue';
 import { useQuasar } from 'quasar';
 import { storeToRefs } from 'pinia';
 import { nip19 } from 'nostr-tools';
-import { useCreatorHubStore, type Tier } from 'stores/creatorHub';
+import { useCreatorHubStore } from 'stores/creatorHub';
+import type { Tier } from 'stores/types';
 import {
   useNostrStore,
   fetchNutzapProfile,
@@ -143,7 +144,12 @@ export function useCreatorHub() {
   }
 
   function addTier() {
-    currentTier.value = { name: '', price: 0, description: '', welcomeMessage: '' };
+    currentTier.value = {
+      name: '',
+      price_sats: 0,
+      description: '',
+      welcomeMessage: '',
+    };
     showTierDialog.value = true;
   }
 

--- a/src/pages/MyProfilePage.vue
+++ b/src/pages/MyProfilePage.vue
@@ -126,9 +126,9 @@
     >
       <div v-for="tier in tiers" :key="tier.id" class="q-mb-md">
         <div class="text-subtitle1">
-          {{ tier.name }} - {{ tier.price }} sats/month
+          {{ tier.name }} - {{ tier.price_sats }} sats/month
           <span v-if="bitcoinPrice" class="text-caption">
-            ({{ formatFiat(tier.price) }})
+            ({{ formatFiat(tier.price_sats) }})
           </span>
         </div>
         <div

--- a/src/stores/dexie.ts
+++ b/src/stores/dexie.ts
@@ -14,15 +14,11 @@ export interface CachedProfileDexie {
   fetchedAt: number;
 }
 
+import type { Tier } from "./types";
+
 export interface CreatorTierDefinition {
   creatorNpub: string;
-  tiers: {
-    id: string;
-    name: string;
-    price_sats: number;
-    description: string;
-    benefits: string[];
-  }[];
+  tiers: Tier[];
   eventId: string;
   updatedAt: number;
   /** Raw Nostr event JSON string */

--- a/src/stores/types.ts
+++ b/src/stores/types.ts
@@ -1,0 +1,14 @@
+export interface TierMedia {
+  url: string;
+  type?: 'image' | 'video' | 'audio';
+}
+
+export interface Tier {
+  id: string;
+  name: string;
+  price_sats: number;
+  description: string;
+  benefits?: string[];
+  welcomeMessage?: string;
+  media?: TierMedia[];
+}

--- a/test/vitest/__tests__/creatorHub.spec.ts
+++ b/test/vitest/__tests__/creatorHub.spec.ts
@@ -83,7 +83,7 @@ describe("CreatorHub store", () => {
   it("addTier stores tier and calls saveTier", () => {
     const store = useCreatorHubStore();
     const spy = vi.spyOn(store, "saveTier").mockResolvedValue();
-    store.addTier({ name: "Tier 1", price: 5, perks: "p" });
+    store.addTier({ name: "Tier 1", price_sats: 5, perks: "p" });
     const tier = store.getTierArray()[0];
     expect(tier.name).toBe("Tier 1");
     expect(spy).toHaveBeenCalledWith(tier);
@@ -94,7 +94,7 @@ describe("CreatorHub store", () => {
     const tier = {
       id: "id1",
       name: "T",
-      price: 1,
+      price_sats: 1,
       perks: "p",
       welcomeMessage: "w",
     };
@@ -107,10 +107,10 @@ describe("CreatorHub store", () => {
     store.tiers["id1"] = {
       id: "id1",
       name: "T",
-      price: 1,
+      price_sats: 1,
       description: "",
       welcomeMessage: "",
-    };
+    } as any;
     await store.removeTier("id1");
     expect(store.tiers["id1"]).toBeUndefined();
   });
@@ -120,7 +120,14 @@ describe("publishTierDefinitions", () => {
   it("creates a 30000 event with correct tags and content", async () => {
     const store = useCreatorHubStore();
     store.tiers = {
-      t1: { id: "t1", name: "Tier", price: 1, description: "", welcomeMessage: "", media: [] },
+      t1: {
+        id: "t1",
+        name: "Tier",
+        price_sats: 1,
+        description: "",
+        welcomeMessage: "",
+        media: [],
+      },
     } as any;
     store.tierOrder = ["t1"];
 
@@ -132,7 +139,15 @@ describe("publishTierDefinitions", () => {
     expect(ev.tags).toEqual([["d", "tiers"]]);
     expect(ev.content).toBe(
       JSON.stringify([
-        { id: "t1", name: "Tier", price: 1, description: "", welcomeMessage: "", media: [] },
+        {
+          id: "t1",
+          name: "Tier",
+          price_sats: 1,
+          price: 1,
+          description: "",
+          welcomeMessage: "",
+          media: [],
+        },
       ])
     );
     expect(signMock).toHaveBeenCalledWith(nostrStoreMock.signer);


### PR DESCRIPTION
## Summary
- centralize Tier/TierMedia definitions
- update creatorHub and creators stores to use shared tier type
- migrate components and pages to use `price_sats`
- keep backward compatibility when serializing tiers
- adjust unit tests

## Testing
- `npm test` *(fails: tsconfig preset not resolved)*

------
https://chatgpt.com/codex/tasks/task_e_688b5d4656748330ba23f354c9643832