### PR TITLE
Fix Quasar config for ESM

### DIFF
--- a/quasar.config.js
+++ b/quasar.config.js
@@ -8,10 +8,10 @@
 // Configuration for your app
 // https://v2.quasar.dev/quasar-cli-vite/quasar-config-js
 
-const { configure } = require("quasar/wrappers");
-const path = require("path");
+import { configure } from "quasar/wrappers";
+import path from "path";
 
-module.exports = configure(function (/* ctx */) {
+export default configure(function (/* ctx */) {
   return {
     eslint: {
       // fix: true,


### PR DESCRIPTION
## Summary
- use `import`/`export default` in `quasar.config.js`

## Testing
- `pnpm test` *(fails: cannot load ESM packages)*
- `pnpm run dev`

------
https://chatgpt.com/codex/tasks/task_e_688b997a815083308d3e9a0faa15f864