### PR TITLE
Fix tsconfig extends path

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,19 +1,39 @@
 {
-  "extends": "@quasar/app-vite/tsconfig-preset",
+  "extends": "./node_modules/@quasar/app-vite/types/tsconfig.json",
   "compilerOptions": {
     "baseUrl": ".",
     "target": "ES2020",
     "paths": {
-      "src/*": ["src/*"],
-      "app/*": ["*"],
-      "components/*": ["src/components/*"],
-      "layouts/*": ["src/layouts/*"],
-      "pages/*": ["src/pages/*"],
-      "assets/*": ["src/assets/*"],
-      "boot/*": ["src/boot/*"],
-      "stores/*": ["src/stores/*"],
-      "vue$": ["node_modules/vue/dist/vue.runtime.esm-bundler.js"],
-      "@cashu/cashu-ts": ["src/lib/cashu-ts/src/index.ts"]
+      "src/*": [
+        "src/*"
+      ],
+      "app/*": [
+        "*"
+      ],
+      "components/*": [
+        "src/components/*"
+      ],
+      "layouts/*": [
+        "src/layouts/*"
+      ],
+      "pages/*": [
+        "src/pages/*"
+      ],
+      "assets/*": [
+        "src/assets/*"
+      ],
+      "boot/*": [
+        "src/boot/*"
+      ],
+      "stores/*": [
+        "src/stores/*"
+      ],
+      "vue$": [
+        "node_modules/vue/dist/vue.runtime.esm-bundler.js"
+      ],
+      "@cashu/cashu-ts": [
+        "src/lib/cashu-ts/src/index.ts"
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary
- fix tsconfig.json extends path so TypeScript resolves correctly

## Testing
- `npm test` *(fails: 53 failed, 211 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688b9c2bb5788330823f5f39186fb488