### PR TITLE
Implement media list in AddTierDialog

### DIFF
--- a/src/stores/types.ts
+++ b/src/stores/types.ts
@@ -1,6 +1,7 @@
 export interface TierMedia {
   url: string;
-  type?: 'image' | 'video' | 'audio';
+  title?: string;
+  type?: "image" | "video" | "audio";
 }
 
 export interface Tier {


### PR DESCRIPTION
## Summary
- extend `TierMedia` with optional `title`
- allow adding media in `AddTierDialog`
- validate URLs with `isTrustedUrl` and preview entries
- sanitize tier media before saving

## Testing
- `pnpm install`
- `npx vitest run` *(fails: "@vitejs/plugin-vue" resolved to an ESM file)*

------
https://chatgpt.com/codex/tasks/task_e_688ba24204948330a559502519c6b835