### PR TITLE
Add IPFS gateway support for media URLs

### DIFF
--- a/src/components/MediaPreview.vue
+++ b/src/components/MediaPreview.vue
@@ -8,12 +8,8 @@
       allowfullscreen
       class="q-mb-sm"
     ></iframe>
-    <video v-else-if="type === 'video'" controls class="q-mb-sm">
-      <source :src="src" />
-    </video>
-    <audio v-else-if="type === 'audio'" controls class="q-mb-sm">
-      <source :src="src" />
-    </audio>
+    <video v-else-if="type === 'video'" :src="src" controls class="q-mb-sm"></video>
+    <audio v-else-if="type === 'audio'" :src="src" controls class="q-mb-sm"></audio>
   </div>
 </template>
 

--- a/src/utils/validateMedia.ts
+++ b/src/utils/validateMedia.ts
@@ -14,8 +14,15 @@ export function normalizeYouTube(url: string): string {
   return url;
 }
 
+export function ipfsToGateway(url: string): string {
+  if (url.trim().toLowerCase().startsWith('ipfs://')) {
+    return url.replace(/^ipfs:\/\//i, 'https://nftstorage.link/ipfs/');
+  }
+  return url;
+}
+
 export function normalizeMediaUrl(url: string): string {
-  return normalizeYouTube(url.trim());
+  return normalizeYouTube(ipfsToGateway(url.trim()));
 }
 
 export function determineMediaType(url: string): 'youtube' | 'video' | 'audio' | 'image' {

--- a/test/vitest/__tests__/validateMedia.spec.ts
+++ b/test/vitest/__tests__/validateMedia.spec.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from 'vitest';
 import {
   isTrustedUrl,
   normalizeYouTube,
+  ipfsToGateway,
+  normalizeMediaUrl,
   determineMediaType,
   filterValidMedia,
 } from '../../../src/utils/validateMedia';
@@ -21,6 +23,12 @@ describe('validateMedia', () => {
   it('normalizes youtube links', () => {
     const url = 'https://youtu.be/abcd1234efg';
     expect(normalizeYouTube(url)).toBe('https://www.youtube.com/embed/abcd1234efg');
+  });
+
+  it('converts ipfs links to gateway', () => {
+    const url = 'ipfs://bafy123/file.png';
+    expect(ipfsToGateway(url)).toBe('https://nftstorage.link/ipfs/bafy123/file.png');
+    expect(normalizeMediaUrl(url)).toBe('https://nftstorage.link/ipfs/bafy123/file.png');
   });
 
   it('detects media type', () => {


### PR DESCRIPTION
## Summary
- add `ipfsToGateway` helper
- normalize media URLs via IPFS gateway conversion
- use normalized src in MediaPreview for video/audio tags
- test IPFS gateway conversions

## Testing
- `pnpm run test:ci` *(fails: "@vitejs/plugin-vue" resolved to an ESM file)*

------
https://chatgpt.com/codex/tasks/task_e_688ba3c888248330ba0916be8ba4df02