### PR TITLE
Support iframe media URLs

### DIFF
--- a/src/components/MediaPreview.vue
+++ b/src/components/MediaPreview.vue
@@ -8,6 +8,12 @@
       allowfullscreen
       class="q-mb-sm"
     ></iframe>
+    <iframe
+      v-else-if="type === 'iframe'"
+      :src="src"
+      frameborder="0"
+      class="q-mb-sm"
+    ></iframe>
     <video v-else-if="type === 'video'" :src="src" controls class="q-mb-sm"></video>
     <audio v-else-if="type === 'audio'" :src="src" controls class="q-mb-sm"></audio>
   </div>

--- a/test/vitest/__tests__/MediaPreview.spec.ts
+++ b/test/vitest/__tests__/MediaPreview.spec.ts
@@ -17,4 +17,10 @@ describe('MediaPreview component', () => {
     const wrapper = mount(MediaPreview, { props: { url: 'https://example.com/movie.mp4' } });
     expect(wrapper.find('video').exists()).toBe(true);
   });
+
+  it('renders generic iframe for unknown url', () => {
+    const wrapper = mount(MediaPreview, { props: { url: 'https://example.com/page' } });
+    const iframes = wrapper.findAll('iframe');
+    expect(iframes.length).toBe(1);
+  });
 });

--- a/test/vitest/__tests__/validateMedia.spec.ts
+++ b/test/vitest/__tests__/validateMedia.spec.ts
@@ -4,6 +4,7 @@ import {
   normalizeYouTube,
   ipfsToGateway,
   normalizeMediaUrl,
+  extractIframeSrc,
   determineMediaType,
   filterValidMedia,
 } from '../../../src/utils/validateMedia';
@@ -31,11 +32,18 @@ describe('validateMedia', () => {
     expect(normalizeMediaUrl(url)).toBe('https://nftstorage.link/ipfs/bafy123/file.png');
   });
 
+  it('parses iframe snippets', () => {
+    const snippet = '<iframe src="https://example.com/embed"></iframe>';
+    expect(extractIframeSrc(snippet)).toBe('https://example.com/embed');
+    expect(normalizeMediaUrl(snippet)).toBe('https://example.com/embed');
+  });
+
   it('detects media type', () => {
     expect(determineMediaType('https://example.com/video.mp4')).toBe('video');
     expect(determineMediaType('https://example.com/song.mp3')).toBe('audio');
     expect(determineMediaType('https://www.youtube.com/embed/id')).toBe('youtube');
     expect(determineMediaType('https://example.com/image.png')).toBe('image');
+    expect(determineMediaType('https://example.com/page')).toBe('iframe');
   });
 
   it('filters invalid media entries', () => {


### PR DESCRIPTION
## Summary
- allow iframe snippets when validating media
- detect generic iframe URLs
- render iframe type in `MediaPreview` component
- test iframe handling in validation and component

## Testing
- `pnpm run test:ci` *(fails: 32 failed, 28 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688bb0723df88330954e3bdb2fcbe366