### PR TITLE
Add nostr event viewer embed handling

### DIFF
--- a/src/components/MediaPreview.vue
+++ b/src/components/MediaPreview.vue
@@ -14,6 +14,12 @@
       frameborder="0"
       class="q-mb-sm"
     ></iframe>
+    <iframe
+      v-else-if="type === 'nostr'"
+      :src="src"
+      frameborder="0"
+      class="q-mb-sm"
+    ></iframe>
     <video v-else-if="type === 'video'" :src="src" controls class="q-mb-sm"></video>
     <audio v-else-if="type === 'audio'" :src="src" controls class="q-mb-sm"></audio>
   </div>

--- a/src/utils/validateMedia.ts
+++ b/src/utils/validateMedia.ts
@@ -22,6 +22,21 @@ export function ipfsToGateway(url: string): string {
   return url;
 }
 
+export function normalizeNostrEventUrl(url: string): string {
+  const match = url
+    .trim()
+    .match(/^https:\/\/(primal\.net|snort\.social)\/e\/([a-z0-9]+)/i);
+  if (match) {
+    const [, host, id] = match;
+    return `https://${host}/e/${id}?embed=1`;
+  }
+  return url;
+}
+
+export function isNostrEventUrl(url: string): boolean {
+  return /^https:\/\/(primal\.net|snort\.social)\/e\/[a-z0-9]+/i.test(url.trim());
+}
+
 export function extractIframeSrc(input: string): string {
   const match = input
     .trim()
@@ -31,12 +46,12 @@ export function extractIframeSrc(input: string): string {
 
 export function normalizeMediaUrl(url: string): string {
   const cleaned = extractIframeSrc(url);
-  return normalizeYouTube(ipfsToGateway(cleaned));
+  return normalizeYouTube(ipfsToGateway(normalizeNostrEventUrl(cleaned)));
 }
 
 export function determineMediaType(
   url: string,
-): 'youtube' | 'video' | 'audio' | 'image' | 'iframe' {
+): 'youtube' | 'video' | 'audio' | 'image' | 'iframe' | 'nostr' {
   const lower = url.toLowerCase();
   if (lower.includes('youtube.com/embed/')) {
     return 'youtube';
@@ -49,6 +64,9 @@ export function determineMediaType(
   }
   if (/(\.png|\.jpe?g|\.gif|\.svg|\.webp|\.bmp|\.avif)(\?.*)?$/.test(lower)) {
     return 'image';
+  }
+  if (isNostrEventUrl(lower)) {
+    return 'nostr';
   }
   return 'iframe';
 }

--- a/test/vitest/__tests__/MediaPreview.spec.ts
+++ b/test/vitest/__tests__/MediaPreview.spec.ts
@@ -23,4 +23,9 @@ describe('MediaPreview component', () => {
     const iframes = wrapper.findAll('iframe');
     expect(iframes.length).toBe(1);
   });
+
+  it('renders iframe for nostr event link', () => {
+    const wrapper = mount(MediaPreview, { props: { url: 'https://primal.net/e/abc123' } });
+    expect(wrapper.find('iframe').exists()).toBe(true);
+  });
 });

--- a/test/vitest/__tests__/validateMedia.spec.ts
+++ b/test/vitest/__tests__/validateMedia.spec.ts
@@ -46,6 +46,11 @@ describe('validateMedia', () => {
     expect(determineMediaType('https://example.com/page')).toBe('iframe');
   });
 
+  it('detects nostr event links', () => {
+    expect(determineMediaType('https://primal.net/e/abc123')).toBe('nostr');
+    expect(determineMediaType('https://snort.social/e/def456')).toBe('nostr');
+  });
+
   it('filters invalid media entries', () => {
     const media = filterValidMedia([
       { url: '' },


### PR DESCRIPTION
## Summary
- allow embedding Nostr event viewers from primal.net or snort.social
- render those links as iframes in MediaPreview
- test detection of Nostr event links

## Testing
- `pnpm test` *(fails: 52 failed, 71 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688bb47a96e88330a9d2a00dbefed998