### PR TITLE
Add media previews to tier dialog

### DIFF
--- a/src/pages/FindCreators.vue
+++ b/src/pages/FindCreators.vue
@@ -78,6 +78,14 @@
                   </div>
                 </div>
                 <div class="q-mt-sm">{{ t.description }}</div>
+                <div v-if="t.media && t.media.length">
+                  <MediaPreview
+                    v-for="(m, idx) in t.media"
+                    :key="idx"
+                    :url="m.url"
+                    class="q-mt-sm"
+                  />
+                </div>
                 <ul class="q-pl-md q-mt-xs text-caption">
                   <li v-for="b in t.benefits" :key="b">{{ b }}</li>
                 </ul>
@@ -110,6 +118,9 @@ import {
 import DonateDialog from "components/DonateDialog.vue";
 import SubscribeDialog from "components/SubscribeDialog.vue";
 import SendTokenDialog from "components/SendTokenDialog.vue";
+import MediaPreview from "components/MediaPreview.vue";
+
+defineOptions({ components: { MediaPreview } });
 import { useSendTokensStore } from "stores/sendTokensStore";
 import { useDonationPresetsStore } from "stores/donationPresets";
 import { useCreatorsStore } from "stores/creators";


### PR DESCRIPTION
## Summary
- show media previews for each tier in the Find Creators page
- register the MediaPreview component

## Testing
- `pnpm run test:ci` *(fails: Cannot read properties of undefined, assertion errors)*

------
https://chatgpt.com/codex/tasks/task_e_688bb76d04908330b0727fe2cec7b6e1