### PR TITLE
Update media preview docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,9 @@ mint URLs to use.
 
 ### Media Previews for Tiers
 
-Creators can attach media links to each tier so supporters can preview what they’ll receive. Simply add trusted URLs (e.g. YouTube, IPFS, or other HTTPS resources) when defining your tiers in the Creator Hub. The app doesn’t host any files itself – it only stores the links you provide and renders previews from those sources.
+Creators can attach media links to each tier so supporters can preview what they’ll receive. Simply add trusted URLs (e.g. YouTube, IPFS, or other HTTPS resources) when defining your tiers in the Creator Hub. The app doesn’t host any files itself – it only stores the links you provide and renders previews from those sources. 
+
+You can also supply raw `<iframe>` snippets for custom embeds or include a `nostr:` link that references an event ID. If a `nostr:` link is provided, the preview displays the linked event’s content. These previews appear both on a creator’s profile and when browsing tiers from the **find creators** page.
 
 Example `kind:30000` event content:
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,3 +7,4 @@
   for backward compatibility. Navigate to `/buckets` and select
   "Manage" on a bucket to open the modal.
 - Bucket detail modal includes a History tab.
+- Documented iframe snippet support and Nostr event link embedding for media previews. These previews also show when viewing tiers from the find creators page.


### PR DESCRIPTION
## Summary
- document iframe snippet and nostr event link previews
- note visibility on the find creators page
- update changelog

## Testing
- `pnpm test --silent` *(fails: `windowMixin is not defined` and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_688bb9996550833097cbcfe080c90e33