### PR TITLE
Add responsive aspect ratio to MediaPreview

### DIFF
--- a/src/components/MediaPreview.vue
+++ b/src/components/MediaPreview.vue
@@ -1,26 +1,20 @@
 <template>
   <div v-if="src">
-    <img v-if="type === 'image'" :src="src" class="q-mb-sm" />
-    <iframe
-      v-else-if="type === 'youtube'"
-      :src="src"
-      frameborder="0"
-      allowfullscreen
-      class="q-mb-sm"
-    ></iframe>
-    <iframe
-      v-else-if="type === 'iframe'"
-      :src="src"
-      frameborder="0"
-      class="q-mb-sm"
-    ></iframe>
-    <iframe
-      v-else-if="type === 'nostr'"
-      :src="src"
-      frameborder="0"
-      class="q-mb-sm"
-    ></iframe>
-    <video v-else-if="type === 'video'" :src="src" controls class="q-mb-sm"></video>
+    <div v-if="type === 'image'" class="media-preview-container q-mb-sm">
+      <img :src="src" />
+    </div>
+    <div v-else-if="type === 'youtube'" class="media-preview-container q-mb-sm">
+      <iframe :src="src" frameborder="0" allowfullscreen></iframe>
+    </div>
+    <div v-else-if="type === 'iframe'" class="media-preview-container q-mb-sm">
+      <iframe :src="src" frameborder="0"></iframe>
+    </div>
+    <div v-else-if="type === 'nostr'" class="media-preview-container q-mb-sm">
+      <iframe :src="src" frameborder="0"></iframe>
+    </div>
+    <div v-else-if="type === 'video'" class="media-preview-container q-mb-sm">
+      <video :src="src" controls></video>
+    </div>
     <audio v-else-if="type === 'audio'" :src="src" controls class="q-mb-sm"></audio>
   </div>
 </template>
@@ -43,4 +37,4 @@ const src = computed(() => {
 const type = computed(() => (src.value ? determineMediaType(src.value) : 'image'));
 </script>
 
-<style scoped></style>
+<style lang="scss" src="../css/media-preview.scss" scoped></style>

--- a/src/css/media-preview.scss
+++ b/src/css/media-preview.scss
@@ -1,0 +1,19 @@
+.media-preview-container {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+.media-preview-container iframe,
+.media-preview-container img,
+.media-preview-container video {
+  width: 100%;
+  height: 100%;
+}
+
+.media-preview-container img {
+  object-fit: cover;
+}


### PR DESCRIPTION
## Summary
- add fixed aspect ratio wrapper and scoped style for MediaPreview
- create new stylesheet `media-preview.scss`

## Testing
- `npm test` *(fails: InfoTooltip shows tooltip, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688bbdce5ee883308a1b6d468738444a