### PR TITLE
Update media preview docs and link

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,13 @@ mint URLs to use.
 Creators can attach media links to each tier so supporters can preview what they’ll receive. Simply add trusted URLs (e.g. YouTube, IPFS, or other HTTPS resources) when defining your tiers in the Creator Hub. The app doesn’t host any files itself – it only stores the links you provide and renders previews from those sources. 
 
 You can also supply raw `<iframe>` snippets for custom embeds or include a `nostr:` link that references an event ID. If a `nostr:` link is provided, the preview displays the linked event’s content. These previews appear both on a creator’s profile and when browsing tiers from the **find creators** page.
+**Preview layout tips**
+
+- Previews are displayed inside a responsive container that aims for a 16:9 aspect ratio.
+- Images and videos are scaled to fit while maintaining their own ratio.
+- Content with very different dimensions may be letterboxed or cropped depending on the source embed.
+
+You can access this documentation from the Creator Hub: look for the "Learn more" link next to the Media Preview help icon when editing tiers.
 
 Example `kind:30000` event content:
 

--- a/src/components/AddTierDialog.vue
+++ b/src/components/AddTierDialog.vue
@@ -80,6 +80,12 @@
                 :text="$t('AddTierDialog.helper.media_preview')"
                 :close-label="$t('global.actions.close.label')"
               />
+              <a
+                href="https://github.com/cashu-community/cashu.me/blob/main/README.md#media-previews-for-tiers"
+                target="_blank"
+                class="text-primary text-caption q-ml-sm"
+                >Learn more</a
+              >
             </div>
             <q-btn flat dense icon="add" label="Add Media" @click="addMedia" />
           </div>


### PR DESCRIPTION
## Summary
- expand README's media preview section with aspect ratio tips
- link from the Creator Hub tier editor to the README documentation

## Testing
- `pnpm install`
- `pnpm run test:ci` *(fails: 32 failed, 28 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688bc3f587a08330810b18c82f328095