### PR TITLE
Remove Save Draft button

### DIFF
--- a/src/components/PublishBar.vue
+++ b/src/components/PublishBar.vue
@@ -3,15 +3,6 @@
     <div class="q-pa-sm text-center">
       <q-btn
         color="primary"
-        class="q-mr-sm"
-        :loading="publishing"
-        :disable="publishing"
-        @click="emit('save')"
-      >
-        {{ $t('creatorHub.saveDraft') }}
-      </q-btn>
-      <q-btn
-        color="primary"
         outline
         :loading="publishing"
         :disable="publishing"
@@ -25,5 +16,5 @@
 
 <script setup lang="ts">
 const { publishing } = defineProps<{ publishing: boolean }>();
-const emit = defineEmits(['publish', 'save']);
+const emit = defineEmits(['publish']);
 </script>

--- a/src/composables/useCreatorHub.ts
+++ b/src/composables/useCreatorHub.ts
@@ -139,9 +139,6 @@ export function useCreatorHub() {
     }
   }
 
-  async function saveProfile() {
-    await publishFullProfile();
-  }
 
   function addTier() {
     currentTier.value = {
@@ -214,7 +211,6 @@ export function useCreatorHub() {
     logout,
     initPage,
     publishFullProfile,
-    saveProfile,
     addTier,
     editTier,
     confirmDelete,

--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -41,7 +41,6 @@ export default {
       },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
       swap: {
@@ -749,7 +748,6 @@ export default {
     },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
     swap: {
@@ -771,7 +769,6 @@ export default {
       actions: {
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
         swap: {
@@ -969,7 +966,6 @@ export default {
       },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
       swap: {
@@ -979,7 +975,6 @@ export default {
       },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
       cancel_swap: {
@@ -988,7 +983,6 @@ export default {
       },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
       confirm_swap: {
@@ -1385,7 +1379,6 @@ export default {
   },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
     endpointsHeader: "Endpoints",
   },

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -41,7 +41,6 @@ export default {
       },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
       swap: {
@@ -754,7 +753,6 @@ export default {
     },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
     swap: {
@@ -776,7 +774,6 @@ export default {
       actions: {
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
         swap: {
@@ -975,7 +972,6 @@ export default {
       },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
       swap: {
@@ -985,7 +981,6 @@ export default {
       },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
       cancel_swap: {
@@ -994,7 +989,6 @@ export default {
       },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
       confirm_swap: {
@@ -1391,7 +1385,6 @@ export default {
   },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
     endpointsHeader: "Endpoints",
   },

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -41,7 +41,6 @@ export default {
       },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
       swap: {
@@ -757,7 +756,6 @@ export default {
     },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
     swap: {
@@ -779,7 +777,6 @@ export default {
       actions: {
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
         swap: {
@@ -978,7 +975,6 @@ export default {
       },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
       swap: {
@@ -988,7 +984,6 @@ export default {
       },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
       cancel_swap: {
@@ -997,7 +992,6 @@ export default {
       },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
       confirm_swap: {
@@ -1395,7 +1389,6 @@ export default {
   },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
     endpointsHeader: "Endpoints",
   },

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1675,7 +1675,6 @@ export const messages = {
   },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
     endpointsHeader: "Endpoints",
   },

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -41,7 +41,6 @@ export default {
       },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
       swap: {
@@ -755,7 +754,6 @@ export default {
     },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
     swap: {
@@ -777,7 +775,6 @@ export default {
       actions: {
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
         swap: {
@@ -976,7 +973,6 @@ export default {
       },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
       swap: {
@@ -986,7 +982,6 @@ export default {
       },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
       cancel_swap: {
@@ -995,7 +990,6 @@ export default {
       },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
       confirm_swap: {
@@ -1392,7 +1386,6 @@ export default {
   },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
     endpointsHeader: "Endpoints",
   },

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -41,7 +41,6 @@ export default {
       },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
       swap: {
@@ -753,7 +752,6 @@ export default {
     },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
     swap: {
@@ -775,7 +773,6 @@ export default {
       actions: {
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
         swap: {
@@ -974,7 +971,6 @@ export default {
       },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
       swap: {
@@ -984,7 +980,6 @@ export default {
       },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
       cancel_swap: {
@@ -993,7 +988,6 @@ export default {
       },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
       confirm_swap: {
@@ -1382,7 +1376,6 @@ export default {
   },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
     endpointsHeader: "Endpoints",
   },

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -41,7 +41,6 @@ export default {
       },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
       swap: {
@@ -748,7 +747,6 @@ export default {
     },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
     swap: {
@@ -770,7 +768,6 @@ export default {
       actions: {
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
         swap: {
@@ -968,7 +965,6 @@ export default {
       },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
       swap: {
@@ -978,7 +974,6 @@ export default {
       },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
       cancel_swap: {
@@ -987,7 +982,6 @@ export default {
       },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
       confirm_swap: {
@@ -1374,7 +1368,6 @@ export default {
   },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
     endpointsHeader: "Endpoints",
   },

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -41,7 +41,6 @@ export default {
       },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
       swap: {
@@ -746,7 +745,6 @@ export default {
     },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
     swap: {
@@ -768,7 +766,6 @@ export default {
       actions: {
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
         swap: {
@@ -967,7 +964,6 @@ export default {
       },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
       swap: {
@@ -977,7 +973,6 @@ export default {
       },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
       cancel_swap: {
@@ -986,7 +981,6 @@ export default {
       },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
       confirm_swap: {
@@ -1375,7 +1369,6 @@ export default {
   },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
     endpointsHeader: "Endpoints",
   },

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -41,7 +41,6 @@ export default {
       },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
       swap: {
@@ -747,7 +746,6 @@ export default {
     },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
     swap: {
@@ -769,7 +767,6 @@ export default {
       actions: {
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
         swap: {
@@ -968,7 +965,6 @@ export default {
       },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
       swap: {
@@ -978,7 +974,6 @@ export default {
       },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
       cancel_swap: {
@@ -987,7 +982,6 @@ export default {
       },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
       confirm_swap: {
@@ -1374,7 +1368,6 @@ export default {
   },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
     endpointsHeader: "Endpoints",
   },

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -41,7 +41,6 @@ export default {
       },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
       swap: {
@@ -745,7 +744,6 @@ export default {
     },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
     swap: {
@@ -767,7 +765,6 @@ export default {
       actions: {
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
         swap: {
@@ -965,7 +962,6 @@ export default {
       },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
       swap: {
@@ -975,7 +971,6 @@ export default {
       },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
       cancel_swap: {
@@ -984,7 +979,6 @@ export default {
       },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
       confirm_swap: {
@@ -1372,7 +1366,6 @@ export default {
   },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
     endpointsHeader: "Endpoints",
   },

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -41,7 +41,6 @@ export default {
       },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
       swap: {
@@ -749,7 +748,6 @@ export default {
     },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
     swap: {
@@ -771,7 +769,6 @@ export default {
       actions: {
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
         swap: {
@@ -970,7 +967,6 @@ export default {
       },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
       swap: {
@@ -980,7 +976,6 @@ export default {
       },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
       cancel_swap: {
@@ -989,7 +984,6 @@ export default {
       },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
       confirm_swap: {
@@ -1377,7 +1371,6 @@ export default {
   },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
     endpointsHeader: "Endpoints",
   },

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -41,7 +41,6 @@ export default {
       },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
       swap: {
@@ -738,7 +737,6 @@ export default {
     },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
     swap: {
@@ -760,7 +758,6 @@ export default {
       actions: {
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
         swap: {
@@ -958,7 +955,6 @@ export default {
       },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
       swap: {
@@ -968,7 +964,6 @@ export default {
       },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
       cancel_swap: {
@@ -977,7 +972,6 @@ export default {
       },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
   },
       confirm_swap: {
@@ -1364,7 +1358,6 @@ export default {
   },
   creatorHub: {
     publish: "Publish Profile",
-    saveDraft: "Save Draft",
     profileHeader: "Profile details",
     endpointsHeader: "Endpoints",
   },

--- a/src/pages/CreatorHubPage.vue
+++ b/src/pages/CreatorHubPage.vue
@@ -88,7 +88,6 @@
   v-if="loggedIn"
   :publishing="publishing"
   @publish="publishFullProfile"
-  @save="saveProfile"
 />
 </q-card>
   </q-page>
@@ -122,7 +121,6 @@ const {
   loginNsec,
   logout,
   publishFullProfile,
-  saveProfile,
   addTier,
   editTier,
   confirmDelete,

--- a/test/vitest/__tests__/creatorHub-layout.spec.ts
+++ b/test/vitest/__tests__/creatorHub-layout.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { shallowMount } from '@vue/test-utils';
+import { shallowMount, mount } from '@vue/test-utils';
 import * as quasar from 'quasar';
 
 vi.spyOn(quasar, 'useQuasar').mockReturnValue({ screen: { lt: { md: false } } });
@@ -85,11 +85,17 @@ vi.mock('nostr-tools', () => ({
 }));
 
 import CreatorHubPage from '../../../src/pages/CreatorHubPage.vue';
+import PublishBar from '../../../src/components/PublishBar.vue';
 
 describe('CreatorHubPage layout', () => {
   it('renders two section cards and PublishBar on desktop', () => {
     const wrapper = shallowMount(CreatorHubPage);
     expect(wrapper.find('publish-bar-stub').exists()).toBe(true);
+  });
+
+  it('PublishBar shows only publish button', () => {
+    const wrapper = mount(PublishBar, { props: { publishing: false } });
+    expect(wrapper.findAll('button')).toHaveLength(1);
   });
 });
 


### PR DESCRIPTION
## Summary
- remove Save Draft button from `PublishBar`
- drop `saveProfile` emit and composable export
- update `CreatorHubPage` usage of `PublishBar`
- purge `creatorHub.saveDraft` from i18n messages
- update Creator Hub layout test for new publish bar

## Testing
- `pnpm test` *(fails: Tests failed. See above for more details)*

------
https://chatgpt.com/codex/tasks/task_e_688bc8d6aa5883309ddb92831c0de1e1