### PR TITLE
Replace sticky bar with footer

### DIFF
--- a/src/components/PublishBar.vue
+++ b/src/components/PublishBar.vue
@@ -1,6 +1,6 @@
 <template>
-  <q-page-sticky position="bottom" expand class="bg-grey-9">
-    <div class="q-pa-sm text-center">
+  <q-footer class="w-full bg-grey-3 dark:bg-grey-9 text-dark dark:text-white">
+    <q-toolbar class="justify-center">
       <q-btn
         color="primary"
         outline
@@ -10,8 +10,8 @@
       >
         {{ $t('creatorHub.publish') }}
       </q-btn>
-    </div>
-  </q-page-sticky>
+    </q-toolbar>
+  </q-footer>
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
## Summary
- use `<q-footer>` with toolbar layout for PublishBar
- keep button behavior but make it full width and theme-aware

## Testing
- `npm test` *(fails: InfoTooltip > shows tooltip on hover)*

------
https://chatgpt.com/codex/tasks/task_e_688c6ea82d2883309c05e3e2bd578b78