### PR TITLE
Add timeout handling to profile publishing

### DIFF
--- a/src/composables/useCreatorHub.ts
+++ b/src/composables/useCreatorHub.ts
@@ -120,12 +120,18 @@ export function useCreatorHub() {
   async function publishFullProfile() {
     publishing.value = true;
     try {
-      await publishDiscoveryProfile({
-        profile: profile.value,
-        p2pkPub: profilePub.value,
-        mints: profileMints.value,
-        relays: profileRelays.value,
-      });
+      const timeoutMs = 10000;
+      await Promise.race([
+        publishDiscoveryProfile({
+          profile: profile.value,
+          p2pkPub: profilePub.value,
+          mints: profileMints.value,
+          relays: profileRelays.value,
+        }),
+        new Promise((_, reject) =>
+          setTimeout(() => reject(new PublishTimeoutError()), timeoutMs)
+        ),
+      ]);
       notifySuccess('Profile updated');
       profileStore.markClean();
     } catch (e: any) {


### PR DESCRIPTION
## Summary
- handle network timeouts when publishing creator profile

## Testing
- `pnpm run test:ci` *(fails: Test Files 32 failed | 28 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688c7285f4608330bed10f56a3e1b669