### PR TITLE
Make profile loading async

### DIFF
--- a/src/composables/useCreatorHub.ts
+++ b/src/composables/useCreatorHub.ts
@@ -67,13 +67,15 @@ export function useCreatorHub() {
 
   async function loginNip07() {
     await store.loginWithNip07();
-    await initPage();
+    // load cached data immediately and update in the background
+    initPage();
   }
 
   async function loginNsec() {
     if (!nsec.value) return;
     await store.loginWithNsec(nsec.value);
-    await initPage();
+    // don't block UI while profile/tiers are fetched
+    initPage();
   }
 
   function logout() {
@@ -192,8 +194,8 @@ export function useCreatorHub() {
     deleteDialog.value = false;
   }
 
-  onMounted(async () => {
-    if (store.loggedInNpub) await initPage();
+  onMounted(() => {
+    if (store.loggedInNpub) initPage();
   });
 
   return {


### PR DESCRIPTION
## Summary
- load creator profile cache immediately while fetching in background

## Testing
- `npm test` *(fails: 32 failed, 28 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688c7467d0188330ae9e27318069214f