### PR TITLE
Fix TierItem prop warning

### DIFF
--- a/src/components/TierItem.vue
+++ b/src/components/TierItem.vue
@@ -11,7 +11,7 @@
 import TierCard from "./TierCard.vue";
 import type { Tier } from "stores/types";
 
-const props = defineProps<{ tierData: Tier; saved: boolean }>();
+const props = defineProps<{ tierData: Tier }>();
 const emit = defineEmits(["save", "delete", "update:tierData"]);
 </script>
 


### PR DESCRIPTION
## Summary
- remove the unused `saved` prop from `TierItem`

This eliminates runtime Vue warnings about a missing required prop.

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688c77f68e388330a4514a0e9bbc220c