### PR TITLE
Increase publishing timeout

### DIFF
--- a/src/composables/useCreatorHub.ts
+++ b/src/composables/useCreatorHub.ts
@@ -122,7 +122,7 @@ export function useCreatorHub() {
   async function publishFullProfile() {
     publishing.value = true;
     try {
-      const timeoutMs = 10000;
+      const timeoutMs = 30000;
       await Promise.race([
         publishDiscoveryProfile({
           profile: profile.value,

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -132,7 +132,7 @@ export class PublishTimeoutError extends Error {
 export async function publishWithTimeout(
   ev: NDKEvent,
   relays?: NDKRelaySet,
-  timeoutMs = 10000
+  timeoutMs = 30000
 ): Promise<void> {
   return Promise.race([
     ev.publish(relays),


### PR DESCRIPTION
## Summary
- allow more time for full profile publishing
- increase default timeout for nostr publishing

## Testing
- `npm run test:ci` *(fails: 32 failed, 28 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688c7c43237c8330b7ab933c48b942c5