### PR TITLE
Improve creator publishing UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,10 @@ Fundstr is currently in Alpha/Beta.
 
 1. Go to the **Creator Hub** section.
 2. Set up your profile and link your npub.
-3. Define support tiers and benefits.
-4. Share your Fundstr profile with your audience.
-5. Communicate with supporters through Nostr DMs.
+3. Make sure a Nostr signer (NIP-07 extension or nsec key) is connected and at least one relay is configured.
+4. Define support tiers and benefits.
+5. Share your Fundstr profile with your audience.
+6. Communicate with supporters through Nostr DMs.
 
 ### DM-per-Token Subscriptions
 

--- a/src/composables/useCreatorHub.ts
+++ b/src/composables/useCreatorHub.ts
@@ -124,6 +124,14 @@ export function useCreatorHub() {
       notifyError('Pay-to-public-key pubkey is required');
       return;
     }
+
+    await nostr.initSignerIfNotSet();
+
+    if (!nostr.signer) {
+      notifyError('Please connect a Nostr signer (NIP-07 or nsec)');
+      return;
+    }
+
     if (!profileRelays.value.length) {
       notifyError('Please configure at least one Nostr relay');
       return;
@@ -148,7 +156,10 @@ export function useCreatorHub() {
       if (e instanceof PublishTimeoutError) {
         notifyError('Publishing timed out');
       } else {
-        notifyError(e?.message || 'Failed to publish profile');
+        let msg = e?.message || 'Failed to publish profile';
+        if (!nostr.signer) msg += ' (missing signer)';
+        if (!profileRelays.value.length) msg += ' (no relays)';
+        notifyError(msg);
       }
     } finally {
       publishing.value = false;

--- a/src/layouts/FullscreenLayout.vue
+++ b/src/layouts/FullscreenLayout.vue
@@ -7,18 +7,30 @@
     <q-page-container>
       <router-view />
     </q-page-container>
+    <PublishBar
+      v-if="loggedIn"
+      :publishing="publishing"
+      @publish="publishFullProfile"
+    />
   </q-layout>
 </template>
 
 <script>
 import { defineComponent } from "vue";
 import MainHeader from "components/MainHeader.vue";
+import PublishBar from "components/PublishBar.vue";
+import { useCreatorHub } from "src/composables/useCreatorHub";
 
 export default defineComponent({
   name: "FullscreenLayout",
   mixins: [windowMixin],
   components: {
     MainHeader,
+    PublishBar,
+  },
+  setup() {
+    const { loggedIn, publishFullProfile, publishing } = useCreatorHub();
+    return { loggedIn, publishFullProfile, publishing };
   },
 });
 </script>

--- a/src/pages/CreatorHubPage.vue
+++ b/src/pages/CreatorHubPage.vue
@@ -84,11 +84,6 @@
 <DeleteModal v-model="deleteDialog" @confirm="performDelete" />
 <AddTierDialog v-model="showTierDialog" :tier="currentTier" @save="refreshTiers" />
 </div>
-  <PublishBar
-    v-if="loggedIn"
-    :publishing="publishing"
-    @publish="publishFullProfile"
-  />
 </q-card>
   </q-page>
 </template>
@@ -102,7 +97,6 @@ import TierItem from 'components/TierItem.vue';
 import AddTierDialog from 'components/AddTierDialog.vue';
 import DeleteModal from 'components/DeleteModal.vue';
 import ThemeToggle from 'components/ThemeToggle.vue';
-import PublishBar from 'components/PublishBar.vue';
 
 const {
   nsec,
@@ -115,7 +109,6 @@ const {
   deleteId,
   showTierDialog,
   currentTier,
-  publishing,
   npub,
   loginNip07,
   loginNsec,

--- a/test/vitest/__tests__/creatorHub-layout.spec.ts
+++ b/test/vitest/__tests__/creatorHub-layout.spec.ts
@@ -85,10 +85,13 @@ vi.mock('nostr-tools', () => ({
 }));
 
 import CreatorHubPage from '../../../src/pages/CreatorHubPage.vue';
+import FullscreenLayout from '../../../src/layouts/FullscreenLayout.vue';
 
 describe('CreatorHubPage layout', () => {
-  it('renders two section cards and PublishBar on desktop', () => {
-    const wrapper = shallowMount(CreatorHubPage);
+  it('renders PublishBar when logged in', () => {
+    const wrapper = shallowMount(FullscreenLayout, {
+      global: { stubs: { 'router-view': CreatorHubPage } },
+    });
     expect(wrapper.find('publish-bar-stub').exists()).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- clarify need for signer and relay in Creator Hub docs
- initialize signer before publishing discovery profile
- show detailed publish errors
- keep PublishBar in FullscreenLayout
- remove duplicate PublishBar from CreatorHubPage
- update layout test

## Testing
- `pnpm run test:ci` *(fails: 52 failed tests)*

------
https://chatgpt.com/codex/tasks/task_e_688c862e44b48330a2a9f6c6571f38e4