### PR TITLE
Fix PublishBar visibility

### DIFF
--- a/src/layouts/FullscreenLayout.vue
+++ b/src/layouts/FullscreenLayout.vue
@@ -8,7 +8,7 @@
       <router-view />
     </q-page-container>
     <PublishBar
-      v-if="loggedIn"
+      v-if="loggedIn && showPublishBar"
       :publishing="publishing"
       @publish="publishFullProfile"
     />
@@ -16,7 +16,8 @@
 </template>
 
 <script>
-import { defineComponent } from "vue";
+import { defineComponent, computed } from "vue";
+import { useRoute } from "vue-router";
 import MainHeader from "components/MainHeader.vue";
 import PublishBar from "components/PublishBar.vue";
 import { useCreatorHub } from "src/composables/useCreatorHub";
@@ -30,7 +31,9 @@ export default defineComponent({
   },
   setup() {
     const { loggedIn, publishFullProfile, publishing } = useCreatorHub();
-    return { loggedIn, publishFullProfile, publishing };
+    const route = useRoute();
+    const showPublishBar = computed(() => route.path === "/creator-hub");
+    return { loggedIn, publishFullProfile, publishing, showPublishBar };
   },
 });
 </script>

--- a/test/vitest/__tests__/creatorHub-layout.spec.ts
+++ b/test/vitest/__tests__/creatorHub-layout.spec.ts
@@ -88,11 +88,22 @@ import CreatorHubPage from '../../../src/pages/CreatorHubPage.vue';
 import FullscreenLayout from '../../../src/layouts/FullscreenLayout.vue';
 
 describe('CreatorHubPage layout', () => {
-  it('renders PublishBar when logged in', () => {
+  it('renders PublishBar only on creator hub page', () => {
     const wrapper = shallowMount(FullscreenLayout, {
-      global: { stubs: { 'router-view': CreatorHubPage } },
+      global: {
+        stubs: { 'router-view': CreatorHubPage },
+        mocks: { $route: { path: '/creator-hub' } },
+      },
     });
     expect(wrapper.find('publish-bar-stub').exists()).toBe(true);
+
+    const wrapperOther = shallowMount(FullscreenLayout, {
+      global: {
+        stubs: { 'router-view': CreatorHubPage },
+        mocks: { $route: { path: '/wallet' } },
+      },
+    });
+    expect(wrapperOther.find('publish-bar-stub').exists()).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
- show PublishBar only on the Creator Hub page
- update layout tests to confirm PublishBar visibility is route-based

## Testing
- `npm test` *(fails: Cannot access 'MockNDKEvent' before initialization)*

------
https://chatgpt.com/codex/tasks/task_e_688ce919882c8330a5e59addc3623758