### PR TITLE
Fix failing unit tests

### DIFF
--- a/test/vitest/__tests__/bucketCardMenu.spec.ts
+++ b/test/vitest/__tests__/bucketCardMenu.spec.ts
@@ -22,14 +22,14 @@ describe('BucketCard menu actions', () => {
     });
 
     await wrapper.find('[data-test="bucket-menu-btn"]').trigger('click');
-    await wrapper.find('[data-test="view"]').trigger('click');
+    await wrapper.find('[data-test="manage"]').trigger('click');
     await wrapper.find('[data-test="edit"]').trigger('click');
     await wrapper.find('[data-test="archive"]').trigger('click');
     await wrapper.find('[data-test="delete"]').trigger('click');
 
     const events = wrapper.emitted('menu-action');
     expect(events).toHaveLength(4);
-    expect(events?.[0][0].action).toBe('view');
+    expect(events?.[0][0].action).toBe('manage');
     expect(events?.[1][0].action).toBe('edit');
     expect(events?.[2][0].action).toBe('archive');
     expect(events?.[3][0].action).toBe('delete');


### PR DESCRIPTION
## Summary
- fix menu action test to use `manage`
- reset stores and DB before bucket tests and update expectations

## Testing
- `pnpm exec vitest run test/vitest/__tests__/bucketCardMenu.spec.ts`
- `pnpm exec vitest run test/vitest/__tests__/buckets.spec.ts`
- `pnpm test` *(fails: p2pk.spec.ts and others)*

------
https://chatgpt.com/codex/tasks/task_e_688ceaadd6f08330a236f61dd0cd3fee