### PR TITLE
feat: add icons to about page

### DIFF
--- a/src/assets/about/privacy.svg
+++ b/src/assets/about/privacy.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="5" y="10" width="14" height="10" rx="2" stroke="currentColor" stroke-width="2"/>
+  <path d="M7 10V7a5 5 0 0110 0v3" stroke="currentColor" stroke-width="2"/>
+</svg>

--- a/src/assets/about/star.svg
+++ b/src/assets/about/star.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+  <path d="M12 2l3 7h7l-5.5 4.5L18 21l-6-4-6 4 1.5-7.5L2 9h7z"/>
+</svg>

--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -1358,6 +1358,11 @@ export default {
       "Advanced users can override default Nostr relays or set a custom search backend via local storage keys.",
     security_summary:
       "Fundstr is non-custodial. Lost seeds or tokens cannot be recovered, so back up your 12-word seed and Nostr keys securely.",
+    icons: {
+      privacy_alt: "Privacy icon",
+      star_alt: "Star icon",
+      warning: "Warning",
+    },
     sections: {
       intro: {
         title: "Introduction",

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -1364,6 +1364,11 @@ export default {
       "Advanced users can override default Nostr relays or set a custom search backend via local storage keys.",
     security_summary:
       "Fundstr is non-custodial. Lost seeds or tokens cannot be recovered, so back up your 12-word seed and Nostr keys securely.",
+    icons: {
+      privacy_alt: "Privacy icon",
+      star_alt: "Star icon",
+      warning: "Warning",
+    },
     sections: {
       intro: {
         title: "Introduction",

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -1368,6 +1368,11 @@ export default {
       "Advanced users can override default Nostr relays or set a custom search backend via local storage keys.",
     security_summary:
       "Fundstr is non-custodial. Lost seeds or tokens cannot be recovered, so back up your 12-word seed and Nostr keys securely.",
+    icons: {
+      privacy_alt: "Privacy icon",
+      star_alt: "Star icon",
+      warning: "Warning",
+    },
     sections: {
       intro: {
         title: "Introduction",

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1641,6 +1641,11 @@ export const messages = {
       "Advanced users can override default Nostr relays or set a custom search backend via local storage keys.",
     security_summary:
       "Fundstr is non-custodial. Lost seeds or tokens cannot be recovered, so back up your 12-word seed and Nostr keys securely.",
+    icons: {
+      privacy_alt: "Privacy icon",
+      star_alt: "Star icon",
+      warning: "Warning",
+    },
     sections: {
       intro: {
         title: "Introduction",

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -1365,6 +1365,11 @@ export default {
       "Advanced users can override default Nostr relays or set a custom search backend via local storage keys.",
     security_summary:
       "Fundstr is non-custodial. Lost seeds or tokens cannot be recovered, so back up your 12-word seed and Nostr keys securely.",
+    icons: {
+      privacy_alt: "Privacy icon",
+      star_alt: "Star icon",
+      warning: "Warning",
+    },
     sections: {
       intro: {
         title: "Introduction",

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -1355,6 +1355,11 @@ export default {
       "Advanced users can override default Nostr relays or set a custom search backend via local storage keys.",
     security_summary:
       "Fundstr is non-custodial. Lost seeds or tokens cannot be recovered, so back up your 12-word seed and Nostr keys securely.",
+    icons: {
+      privacy_alt: "Privacy icon",
+      star_alt: "Star icon",
+      warning: "Warning",
+    },
     sections: {
       intro: {
         title: "Introduction",

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -1347,6 +1347,11 @@ export default {
       "Advanced users can override default Nostr relays or set a custom search backend via local storage keys.",
     security_summary:
       "Fundstr is non-custodial. Lost seeds or tokens cannot be recovered, so back up your 12-word seed and Nostr keys securely.",
+    icons: {
+      privacy_alt: "Privacy icon",
+      star_alt: "Star icon",
+      warning: "Warning",
+    },
     sections: {
       intro: {
         title: "Introduction",

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -1348,6 +1348,11 @@ export default {
       "Advanced users can override default Nostr relays or set a custom search backend via local storage keys.",
     security_summary:
       "Fundstr is non-custodial. Lost seeds or tokens cannot be recovered, so back up your 12-word seed and Nostr keys securely.",
+    icons: {
+      privacy_alt: "Privacy icon",
+      star_alt: "Star icon",
+      warning: "Warning",
+    },
     sections: {
       intro: {
         title: "Introduction",

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -1347,6 +1347,11 @@ export default {
       "Advanced users can override default Nostr relays or set a custom search backend via local storage keys.",
     security_summary:
       "Fundstr is non-custodial. Lost seeds or tokens cannot be recovered, so back up your 12-word seed and Nostr keys securely.",
+    icons: {
+      privacy_alt: "Privacy icon",
+      star_alt: "Star icon",
+      warning: "Warning",
+    },
     sections: {
       intro: {
         title: "Introduction",

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -1345,6 +1345,11 @@ export default {
       "Advanced users can override default Nostr relays or set a custom search backend via local storage keys.",
     security_summary:
       "Fundstr is non-custodial. Lost seeds or tokens cannot be recovered, so back up your 12-word seed and Nostr keys securely.",
+    icons: {
+      privacy_alt: "Privacy icon",
+      star_alt: "Star icon",
+      warning: "Warning",
+    },
     sections: {
       intro: {
         title: "Introduction",

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -1350,6 +1350,11 @@ export default {
       "Advanced users can override default Nostr relays or set a custom search backend via local storage keys.",
     security_summary:
       "Fundstr is non-custodial. Lost seeds or tokens cannot be recovered, so back up your 12-word seed and Nostr keys securely.",
+    icons: {
+      privacy_alt: "Privacy icon",
+      star_alt: "Star icon",
+      warning: "Warning",
+    },
     sections: {
       intro: {
         title: "Introduction",

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -1337,6 +1337,11 @@ export default {
       "Advanced users can override default Nostr relays or set a custom search backend via local storage keys.",
     security_summary:
       "Fundstr is non-custodial. Lost seeds or tokens cannot be recovered, so back up your 12-word seed and Nostr keys securely.",
+    icons: {
+      privacy_alt: "Privacy icon",
+      star_alt: "Star icon",
+      warning: "Warning",
+    },
     sections: {
       intro: {
         title: "Introduction",

--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -9,15 +9,24 @@
         default-opened
       >
         <div class="q-mt-md">
-          <p>
-            Fundstr is a
-            <strong>privacy-first Bitcoin wallet, social chat and creator-monetisation hub</strong>
-            built on the open-source Cashu ecash protocol and the decentralised Nostr network. Everything you see in the
-            sidebar is a doorway to a feature that either <strong>helps creators earn</strong> or
-            <strong>lets fans support &amp; interact</strong> — all with instant, low-fee Bitcoin-denominated e-cash.
+          <p class="flex items-center">
+            <img :src="PrivacyIcon" :alt="$t('AboutPage.icons.privacy_alt')" class="about-inline-icon q-mr-sm" />
+            <span>
+              Fundstr is a
+              <strong>privacy-first Bitcoin wallet, social chat and creator-monetisation hub</strong>
+              built on the open-source Cashu ecash protocol and the decentralised Nostr network. Everything you see in the
+              sidebar is a doorway to a feature that either <strong>helps creators earn</strong> or
+              <strong>lets fans support &amp; interact</strong> — all with instant, low-fee Bitcoin-denominated e-cash.
+            </span>
           </p>
-          <p class="q-mt-sm">{{ $t('AboutPage.cross_platform') }}</p>
-          <p class="text-negative"><strong>{{ $t('AboutPage.alpha_notice') }}</strong></p>
+          <p class="q-mt-sm flex items-center">
+            <img :src="StarIcon" :alt="$t('AboutPage.icons.star_alt')" class="about-inline-icon q-mr-sm" />
+            {{ $t('AboutPage.cross_platform') }}
+          </p>
+          <p class="text-negative flex items-center">
+            <q-icon name="warning" class="q-mr-xs" :aria-label="$t('AboutPage.icons.warning')" />
+            <strong>{{ $t('AboutPage.alpha_notice') }}</strong>
+          </p>
           <p>Below you’ll find a <strong>page-by-page guide</strong> written in two parallel voices:</p>
           <ul>
             <li><strong>“Creator view”</strong> – what each screen means when you make money on Fundstr.</li>
@@ -294,7 +303,10 @@
   </q-page>
 </template>
 
-<script setup></script>
+<script setup>
+import PrivacyIcon from 'src/assets/about/privacy.svg';
+import StarIcon from 'src/assets/about/star.svg';
+</script>
 
 <style scoped>
 .video-placeholder {
@@ -303,5 +315,10 @@
   border-radius: 8px;
   color: #ccc;
   width: 100%;
+}
+
+.about-inline-icon {
+  width: 24px;
+  height: 24px;
 }
 </style>


### PR DESCRIPTION
## Summary
- add privacy/star icons to about page and show warning icon
- localize alt text and aria labels for new visuals

## Testing
- `npm test` *(fails: cannot access 'MockNDKEvent' before initialization and other errors)*
- `npm run lint` *(fails: Invalid option '--ext')*


------
https://chatgpt.com/codex/tasks/task_e_688da71e21e48330bb5dcb6f5273dae5