### PR TITLE
feat: replace video placeholder with demo carousel

### DIFF
--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -1349,7 +1349,6 @@ export default {
   AboutPage: {
     title: "About Fundstr",
     alpha_notice: "Fundstr is in Alpha/Beta – use at your own risk.",
-    video_placeholder: "Video coming soon",
     license_section:
       "Fundstr is open-source under the <a href='https://github.com/cashubtc/cashu.me/blob/master/LICENSE.md' target='_blank'>MIT License</a>. Contribute or read the code on <a href='https://github.com/cashubtc/cashu.me' target='_blank'>GitHub</a>.",
     cross_platform:

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -1355,7 +1355,6 @@ export default {
   AboutPage: {
     title: "About Fundstr",
     alpha_notice: "Fundstr is in Alpha/Beta – use at your own risk.",
-    video_placeholder: "Video coming soon",
     license_section:
       "Fundstr is open-source under the <a href='https://github.com/cashubtc/cashu.me/blob/master/LICENSE.md' target='_blank'>MIT License</a>. Contribute or read the code on <a href='https://github.com/cashubtc/cashu.me' target='_blank'>GitHub</a>.",
     cross_platform:

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -1359,7 +1359,6 @@ export default {
   AboutPage: {
     title: "About Fundstr",
     alpha_notice: "Fundstr is in Alpha/Beta – use at your own risk.",
-    video_placeholder: "Video coming soon",
     license_section:
       "Fundstr is open-source under the <a href='https://github.com/cashubtc/cashu.me/blob/master/LICENSE.md' target='_blank'>MIT License</a>. Contribute or read the code on <a href='https://github.com/cashubtc/cashu.me' target='_blank'>GitHub</a>.",
     cross_platform:

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1632,7 +1632,6 @@ export const messages = {
   AboutPage: {
     title: "About Fundstr",
     alpha_notice: "Fundstr is in Alpha/Beta – use at your own risk.",
-    video_placeholder: "Video coming soon",
     license_section:
       "Fundstr is open-source under the <a href='https://github.com/cashubtc/cashu.me/blob/master/LICENSE.md' target='_blank'>MIT License</a>. Contribute or read the code on <a href='https://github.com/cashubtc/cashu.me' target='_blank'>GitHub</a>.",
     cross_platform:

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -1356,7 +1356,6 @@ export default {
   AboutPage: {
     title: "About Fundstr",
     alpha_notice: "Fundstr is in Alpha/Beta – use at your own risk.",
-    video_placeholder: "Video coming soon",
     license_section:
       "Fundstr is open-source under the <a href='https://github.com/cashubtc/cashu.me/blob/master/LICENSE.md' target='_blank'>MIT License</a>. Contribute or read the code on <a href='https://github.com/cashubtc/cashu.me' target='_blank'>GitHub</a>.",
     cross_platform:

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -1346,7 +1346,6 @@ export default {
   AboutPage: {
     title: "About Fundstr",
     alpha_notice: "Fundstr is in Alpha/Beta – use at your own risk.",
-    video_placeholder: "Video coming soon",
     license_section:
       "Fundstr is open-source under the <a href='https://github.com/cashubtc/cashu.me/blob/master/LICENSE.md' target='_blank'>MIT License</a>. Contribute or read the code on <a href='https://github.com/cashubtc/cashu.me' target='_blank'>GitHub</a>.",
     cross_platform:

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -1338,7 +1338,6 @@ export default {
   AboutPage: {
     title: "About Fundstr",
     alpha_notice: "Fundstr is in Alpha/Beta – use at your own risk.",
-    video_placeholder: "Video coming soon",
     license_section:
       "Fundstr is open-source under the <a href='https://github.com/cashubtc/cashu.me/blob/master/LICENSE.md' target='_blank'>MIT License</a>. Contribute or read the code on <a href='https://github.com/cashubtc/cashu.me' target='_blank'>GitHub</a>.",
     cross_platform:

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -1339,7 +1339,6 @@ export default {
   AboutPage: {
     title: "About Fundstr",
     alpha_notice: "Fundstr is in Alpha/Beta – use at your own risk.",
-    video_placeholder: "Video coming soon",
     license_section:
       "Fundstr is open-source under the <a href='https://github.com/cashubtc/cashu.me/blob/master/LICENSE.md' target='_blank'>MIT License</a>. Contribute or read the code on <a href='https://github.com/cashubtc/cashu.me' target='_blank'>GitHub</a>.",
     cross_platform:

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -1338,7 +1338,6 @@ export default {
   AboutPage: {
     title: "About Fundstr",
     alpha_notice: "Fundstr is in Alpha/Beta – use at your own risk.",
-    video_placeholder: "Video coming soon",
     license_section:
       "Fundstr is open-source under the <a href='https://github.com/cashubtc/cashu.me/blob/master/LICENSE.md' target='_blank'>MIT License</a>. Contribute or read the code on <a href='https://github.com/cashubtc/cashu.me' target='_blank'>GitHub</a>.",
     cross_platform:

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -1336,7 +1336,6 @@ export default {
   AboutPage: {
     title: "About Fundstr",
     alpha_notice: "Fundstr is in Alpha/Beta – use at your own risk.",
-    video_placeholder: "Video coming soon",
     license_section:
       "Fundstr is open-source under the <a href='https://github.com/cashubtc/cashu.me/blob/master/LICENSE.md' target='_blank'>MIT License</a>. Contribute or read the code on <a href='https://github.com/cashubtc/cashu.me' target='_blank'>GitHub</a>.",
     cross_platform:

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -1341,7 +1341,6 @@ export default {
   AboutPage: {
     title: "About Fundstr",
     alpha_notice: "Fundstr is in Alpha/Beta – use at your own risk.",
-    video_placeholder: "Video coming soon",
     license_section:
       "Fundstr is open-source under the <a href='https://github.com/cashubtc/cashu.me/blob/master/LICENSE.md' target='_blank'>MIT License</a>. Contribute or read the code on <a href='https://github.com/cashubtc/cashu.me' target='_blank'>GitHub</a>.",
     cross_platform:

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -1328,7 +1328,6 @@ export default {
   AboutPage: {
     title: "About Fundstr",
     alpha_notice: "Fundstr is in Alpha/Beta – use at your own risk.",
-    video_placeholder: "Video coming soon",
     license_section:
       "Fundstr is open-source under the <a href='https://github.com/cashubtc/cashu.me/blob/master/LICENSE.md' target='_blank'>MIT License</a>. Contribute or read the code on <a href='https://github.com/cashubtc/cashu.me' target='_blank'>GitHub</a>.",
     cross_platform:

--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -74,8 +74,23 @@
               you’re here to follow, tip and chat.
             </li>
           </ul>
-          <div class="video-placeholder q-my-xl flex flex-center">
-            {{ $t("AboutPage.video_placeholder") }}
+          <div class="q-my-xl">
+            <q-carousel
+              v-model="carouselSlide"
+              swipeable
+              animated
+              arrows
+              navigation
+              infinite
+              height="200px"
+            >
+              <q-carousel-slide
+                v-for="(src, idx) in demoScreens"
+                :key="idx"
+                :name="idx"
+                :img-src="src"
+              />
+            </q-carousel>
           </div>
           <hr />
           <h3 id="section-1">1 How Fundstr works in one minute</h3>
@@ -404,6 +419,14 @@ const sections = [
 
 const creatorView = ref(false);
 
+const carouselSlide = ref(0);
+
+const demoScreens = [
+  "https://placehold.co/600x400?text=Demo+1",
+  "https://placehold.co/600x400?text=Demo+2",
+  "https://placehold.co/600x400?text=Demo+3",
+];
+
 const menuItems = [
   {
     title: "Settings",
@@ -494,14 +517,6 @@ onUnmounted(() => {
 </script>
 
 <style scoped>
-.video-placeholder {
-  height: 200px;
-  border: 1px dashed #ccc;
-  border-radius: 8px;
-  color: #ccc;
-  width: 100%;
-}
-
 .about-inline-icon {
   width: 24px;
   height: 24px;


### PR DESCRIPTION
## Summary
- replace About page video placeholder with demo carousel using q-carousel
- remove unused `video_placeholder` i18n key from translations

## Testing
- `npm run test:ci 2>&1 | tail -n 20`
- `npm run lint` *(fails: Invalid option '--ext')*


------
https://chatgpt.com/codex/tasks/task_e_688db0c2848883308a523375a8f1d042