### PR TITLE
refactor responsive cards

### DIFF
--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -1,5 +1,6 @@
 <template>
   <q-page
+    class="about-page-content"
     :class="[
       $q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark',
       'q-pa-md',
@@ -517,6 +518,10 @@ onUnmounted(() => {
 </script>
 
 <style scoped>
+.about-page-content {
+  overflow-x: hidden;
+}
+
 .about-inline-icon {
   width: 24px;
   height: 24px;
@@ -525,9 +530,23 @@ onUnmounted(() => {
 .about-toc ul {
   list-style: none;
   padding-left: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.about-toc li {
+  flex: 1 1 100%;
+}
+
+@media (min-width: 600px) {
+  .about-toc li {
+    flex: 0 0 auto;
+  }
 }
 
 .about-toc a {
   text-decoration: none;
+  word-break: break-word;
 }
 </style>

--- a/src/pages/SubscriptionsOverview.vue
+++ b/src/pages/SubscriptionsOverview.vue
@@ -1,16 +1,18 @@
 <template>
   <div class="q-pa-md">
     <h5 class="q-my-none q-mb-md">{{ $t("SubscriptionsOverview.title") }}</h5>
-    <div class="row items-center q-mb-md">
-      <div class="col">
-        {{ $t("SubscriptionsOverview.summary.monthly") }}:
-        {{ formatCurrency(monthlyTotal) }}
-      </div>
-      <div class="col text-right">
-        {{ $t("SubscriptionsOverview.summary.total") }}:
-        {{ formatCurrency(totalLocked) }}
-      </div>
-    </div>
+    <q-card flat bordered class="q-mb-md">
+      <q-card-section class="row items-center">
+        <div class="col-12 col-sm-6">
+          {{ $t("SubscriptionsOverview.summary.monthly") }}:
+          {{ formatCurrency(monthlyTotal) }}
+        </div>
+        <div class="col-12 col-sm-6 text-left text-sm-right">
+          {{ $t("SubscriptionsOverview.summary.total") }}:
+          {{ formatCurrency(totalLocked) }}
+        </div>
+      </q-card-section>
+    </q-card>
     <q-banner v-if="sendQueue.length" dense class="q-mb-md bg-orange-2">
       {{
         $t("SubscriptionsOverview.pending_retry", { count: sendQueue.length })


### PR DESCRIPTION
## Summary
- wrap subscriptions summary in responsive card for better stacking on small screens
- prevent horizontal overflow on About page with new flex-wrapped TOC and hidden x-axis overflow

## Testing
- `npm test` *(fails: ReferenceError, etc.)*
- `npm run lint` *(fails: Invalid option '--ext')*


------
https://chatgpt.com/codex/tasks/task_e_688db77215c48330b9b940aeb5eb0de5