### PR TITLE
feat: translate sidebar about link

### DIFF
--- a/src/components/Sidebar.vue
+++ b/src/components/Sidebar.vue
@@ -43,9 +43,12 @@
 
 <script setup lang="ts">
 import { ref } from "vue";
+import { useI18n } from "vue-i18n";
 
 const opened = ref(true);
 const mini = ref(false);
+
+const { t } = useI18n();
 
 const navLinks = [
   { to: "/wallet", label: "Wallet", icon: "account_balance_wallet" },
@@ -59,8 +62,8 @@ const accountLinks = [
 ];
 
 const docLinks = [
-  { to: "/terms", label: "Terms", icon: "gavel" },
-  { to: "/about", label: "About", icon: "info" },
+  { to: "/terms", label: t("MainHeader.menu.terms.terms.title"), icon: "gavel" },
+  { to: "/about", label: t("MainHeader.menu.about.about.title"), icon: "info" },
 ];
 </script>
 


### PR DESCRIPTION
## Summary
- use i18n translation for Terms and About links in sidebar

## Testing
- `npm run build` *(fails: Duplicate key "creatorHub" and Buffer export)*
- `npm run dev` then `curl -k https://localhost:8080/about -I`
- `npm test` *(fails: multiple failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_688de4b3b1cc8330b63ce855862acf09