### PR TITLE
docs: update alpha warning message

### DIFF
--- a/docs/about-fundstr.html
+++ b/docs/about-fundstr.html
@@ -64,7 +64,7 @@
       A privacy-first Bitcoin wallet, social chat, and creator-monetisation hub built on the open-source Cashu ecash protocol and the decentralised Nostr network.
     </p>
     <div class="max-w-3xl mx-auto bg-amber-900/20 border border-amber-500/30 text-amber-300 px-4 py-3 rounded">
-      ⚠️ Please note: Fundstr is currently in an alpha stage. While functional, it is experimental software. Use with caution and do not store large amounts of funds.
+      ⚠️ Fundstr is experimental alpha software. Features may break or change, and loss of funds is possible. Use only small amounts you can afford to lose.
     </div>
   </header>
 

--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -11,7 +11,7 @@
       <div class="mt-8 p-4 border rounded bg-amber-900/20 border-amber-500/30 max-w-3xl mx-auto flex items-start gap-2 text-amber-300">
         <span class="text-2xl">⚠️</span>
         <p>
-          Please note: Fundstr is currently in an alpha stage. While functional, it is experimental software. Use with caution and do not store large amounts of funds.
+          Fundstr is experimental alpha software. Features may break or change, and loss of funds is possible. Use only small amounts you can afford to lose.
         </p>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- clarify alpha software warning on About page
- update about page HTML in docs

## Testing
- `npm test` *(fails: Error: [vitest] There was an error when mocking a module... etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688deb6182d08330b24e86ddaa3ba6b8