### PR TITLE
feat: highlight alpha warning

### DIFF
--- a/docs/about-fundstr.html
+++ b/docs/about-fundstr.html
@@ -52,6 +52,21 @@
       opacity: 1;
       transform: none;
     }
+    .alpha-warning {
+      background-color: rgba(120, 53, 15, 0.2);
+      border: 1px solid rgba(245, 158, 11, 0.3);
+      color: #fcd34d;
+      border-radius: 0.5rem;
+      padding: 1.5rem;
+      font-size: 1.25rem;
+      font-weight: 700;
+      box-shadow: 0 0 10px rgba(245, 158, 11, 0.5);
+    }
+    @media (min-width: 768px) {
+      .alpha-warning {
+        font-size: 1.5rem;
+      }
+    }
   </style>
 </head>
 <body class="antialiased">
@@ -63,8 +78,11 @@
     <p class="max-w-2xl mx-auto text-lg md:text-xl mb-8">
       A privacy-first Bitcoin wallet, social chat, and creator-monetisation hub built on the open-source Cashu ecash protocol and the decentralised Nostr network.
     </p>
-    <div class="max-w-3xl mx-auto bg-amber-900/20 border border-amber-500/30 text-amber-300 px-4 py-3 rounded">
-      ⚠️ Fundstr is experimental alpha software. Features may break or change, and loss of funds is possible. Use only small amounts you can afford to lose.
+    <div class="alpha-warning max-w-3xl mx-auto flex items-start gap-3 animate-pulse" role="alert">
+      <span class="text-3xl">⚠️</span>
+      <p>
+        Fundstr is experimental alpha software. Features may break or change, and loss of funds is possible. Use only small amounts you can afford to lose.
+      </p>
     </div>
   </header>
 

--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -8,8 +8,11 @@
       <p class="max-w-3xl mx-auto text-lg md:text-xl">
         A privacy-first Bitcoin wallet, social chat, and creator-monetisation hub built on the open-source Cashu ecash protocol and the decentralised Nostr network.
       </p>
-      <div class="mt-8 p-4 border rounded bg-amber-900/20 border-amber-500/30 max-w-3xl mx-auto flex items-start gap-2 text-amber-300">
-        <span class="text-2xl">⚠️</span>
+      <div
+        class="alpha-warning mt-8 max-w-3xl mx-auto flex items-start gap-3 animate-pulse"
+        role="alert"
+      >
+        <span class="text-3xl">⚠️</span>
         <p>
           Fundstr is experimental alpha software. Features may break or change, and loss of funds is possible. Use only small amounts you can afford to lose.
         </p>
@@ -592,6 +595,23 @@ blockquote {
   border-left: 4px solid var(--color-accent);
   padding-left: 1rem;
   font-style: italic;
+}
+
+.alpha-warning {
+  background-color: rgba(120, 53, 15, 0.2);
+  border: 1px solid rgba(245, 158, 11, 0.3);
+  color: #fcd34d;
+  border-radius: 0.5rem;
+  padding: 1.5rem;
+  font-size: 1.25rem;
+  font-weight: 700;
+  box-shadow: 0 0 10px rgba(245, 158, 11, 0.5);
+}
+
+@media (min-width: 768px) {
+  .alpha-warning {
+    font-size: 1.5rem;
+  }
 }
 </style>
 


### PR DESCRIPTION
## Summary
- emphasize alpha software warning with larger, bold text and pulsing glow
- reuse `alpha-warning` styles across About page and static docs

## Testing
- `npm test` *(fails: Failed Suites 14, ReferenceError: windowMixin is not defined, and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_688dee21e9f88330827ad8c95cb5e3dc