### PR TITLE
style: enhance about page warnings

### DIFF
--- a/docs/about-fundstr.html
+++ b/docs/about-fundstr.html
@@ -1,462 +1,754 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>About Fundstr</title>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>About Fundstr</title>
 
-  <!-- TailwindCSS -->
-  <script src="https://cdn.tailwindcss.com"></script>
+    <!-- TailwindCSS -->
+    <script src="https://cdn.tailwindcss.com"></script>
 
-  <!-- Google Fonts -->
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+    <!-- Google Fonts -->
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap"
+      rel="stylesheet"
+    />
 
-  <style>
-    :root {
-      --color-accent: #22d3ee;
-      --color-accent-rgb: 34, 211, 238;
-    }
-    body {
-      font-family: 'Inter', sans-serif;
-      background-color: #0a0a0a;
-      background-image: radial-gradient(#1e293b 1px, transparent 1px);
-      background-size: 20px 20px;
-      color: #e2e8f0;
-    }
-    .gradient-text {
-      background: linear-gradient(to right, #a78bfa, #f472b6);
-      -webkit-background-clip: text;
-      color: transparent;
-    }
-    .accent-text {
-      color: var(--color-accent);
-    }
-    .interactive-card {
-      background-color: rgba(15, 23, 42, 0.5);
-      backdrop-filter: blur(4px);
-      border: 1px solid #1e293b;
-      border-radius: 0.5rem;
-      transition: all 0.3s ease;
-    }
-    .interactive-card:hover {
-      transform: translateY(-5px);
-      box-shadow: 0 0 25px rgba(var(--color-accent-rgb), 0.2);
-      border-color: rgba(var(--color-accent-rgb), 0.4);
-    }
-    .step-card {
-      position: relative;
-    }
-    .step-card::after {
-      content: '→';
-      position: absolute;
-      top: 50%;
-      right: -1.5rem;
-      transform: translateY(-50%);
-      font-size: 2rem;
-      color: currentColor;
-    }
-    .step-card:last-child::after {
-      content: '';
-    }
-    @media (max-width: 768px) {
+    <style>
+      :root {
+        --color-accent: #22d3ee;
+        --color-accent-rgb: 34, 211, 238;
+      }
+      body {
+        font-family: "Inter", sans-serif;
+        background-color: #0a0a0a;
+        background-image: radial-gradient(#1e293b 1px, transparent 1px);
+        background-size: 20px 20px;
+        color: #e2e8f0;
+      }
+      .gradient-text {
+        background: linear-gradient(to right, #a78bfa, #f472b6);
+        -webkit-background-clip: text;
+        color: transparent;
+      }
+      .accent-text {
+        color: var(--color-accent);
+      }
+      .interactive-card {
+        background-color: rgba(15, 23, 42, 0.5);
+        backdrop-filter: blur(4px);
+        border: 1px solid #1e293b;
+        border-radius: 0.5rem;
+        transition: all 0.3s ease;
+      }
+      .interactive-card:hover {
+        transform: translateY(-5px);
+        box-shadow: 0 0 25px rgba(var(--color-accent-rgb), 0.2);
+        border-color: rgba(var(--color-accent-rgb), 0.4);
+      }
+      .step-card {
+        position: relative;
+      }
       .step-card::after {
-        content: '↓';
-        top: auto;
-        bottom: -1.5rem;
-        left: 50%;
-        right: auto;
-        transform: translateX(-50%);
-        font-size: 1.5rem;
+        content: "→";
+        position: absolute;
+        top: 50%;
+        right: -1.5rem;
+        transform: translateY(-50%);
+        font-size: 2rem;
+        color: currentColor;
       }
-    }
-    .fade-in-section {
-      opacity: 0;
-      transform: translateY(20px);
-      transition: opacity 0.6s ease-out, transform 0.6s ease-out;
-    }
-    .fade-in-section.is-visible {
-      opacity: 1;
-      transform: none;
-    }
-    .alpha-warning {
-      background-color: rgba(120, 53, 15, 0.2);
-      border: 1px solid rgba(245, 158, 11, 0.3);
-      color: #fcd34d;
-      border-radius: 0.5rem;
-      padding: 1.5rem;
-      font-size: 1.25rem;
-      font-weight: 700;
-      box-shadow: 0 0 10px rgba(245, 158, 11, 0.5);
-    }
-    @media (min-width: 768px) {
-      .alpha-warning {
-        font-size: 1.5rem;
+      .step-card:last-child::after {
+        content: "";
       }
-    }
-  </style>
-</head>
-<body class="antialiased">
-  <!-- Header -->
-  <header class="text-center py-20 fade-in-section">
-    <h1 class="text-5xl md:text-7xl font-extrabold mb-6">
-      About <span class="gradient-text">Fundstr</span>
-    </h1>
-    <p class="max-w-2xl mx-auto text-lg md:text-xl mb-8">
-      A privacy-first Bitcoin wallet, social chat, and creator-monetisation hub built on the open-source Cashu ecash protocol and the decentralised Nostr network.
-    </p>
-    <div class="alpha-warning max-w-3xl mx-auto flex items-start gap-3 animate-pulse" role="alert">
-      <span class="text-3xl">⚠️</span>
-      <p>
-        Fundstr is experimental alpha software. Features may break or change, and loss of funds is possible. Use only small amounts you can afford to lose.
-      </p>
-    </div>
-  </header>
-
-  <!-- Vision -->
-  <section id="vision" class="max-w-3xl mx-auto px-4 py-20 fade-in-section">
-    <h2 class="text-4xl font-bold mb-6 gradient-text">Your Money, Your Network</h2>
-    <p>
-      We believe in a world where your financial life and social interactions are truly your own. Fundstr is an experiment in creating a parallel, peer-to-peer economy—free from corporate gatekeepers, surveillance, and unpredictable fees. It’s a gateway to a more sovereign way of connecting and transacting.
-    </p>
-  </section>
-
-  <!-- How Ecash Works -->
-  <section id="how-it-works" class="px-4 py-20 fade-in-section">
-    <h2 class="text-center text-4xl font-bold mb-10 gradient-text">How Ecash Works</h2>
-    <p class="text-center mb-12">The loop is simple: Bitcoin in → private e-cash out → social payments everywhere.</p>
-    <div class="grid grid-cols-1 md:grid-cols-3 items-center gap-6 max-w-5xl mx-auto">
-      <!-- Step 1 -->
-      <button type="button" data-modal="modal-step1" class="step-card interactive-card p-6 flex flex-col items-center focus:outline-none">
-        <svg class="w-12 h-12 mb-4 text-yellow-400" viewBox="0 0 24 24" fill="currentColor">
-          <path d="M23.112 13.506c.353-2.353-1.444-3.415-3.897-4.2l.797-3.194-1.948-.485-.776 3.111c-.511-.127-1.035-.246-1.555-.364l.784-3.144-1.948-.486-.797 3.194c-.422-.096-.84-.19-1.246-.29l-.001-.006-2.688-.669-.518 2.075s1.444.331 1.415.352c.79.197.933.716.909 1.13l-2.195 8.8c-.096.238-.34.596-.89.461.02.028-1.415-.353-1.415-.353l-.966 2.385 2.538.631c.472.119.934.241 1.392.357l-.806 3.245 1.948.486.797-3.194c.529.143 1.042.274 1.547.398l-.793 3.179 1.948.485.805-3.244c3.324.63 5.827.376 6.885-2.633.849-2.417-.042-3.814-1.794-4.728 1.277-.295 2.237-1.135 2.497-2.873zm-4.462 6.26c-.605 2.417-4.696 1.108-6.025.781l1.076-4.32c1.329.332 5.585.991 4.949 3.539zm.605-6.29c-.553 2.211-3.96 1.086-5.063.811l.974-3.906c1.102.275 4.67.79 4.09 3.095z"/>
-        </svg>
-        <h3 class="font-bold text-xl mb-2">Your Bitcoin</h3>
-        <p class="text-sm">From any wallet</p>
-      </button>
-
-      <!-- Step 2 -->
-      <button type="button" data-modal="modal-step2" class="step-card interactive-card p-6 flex flex-col items-center focus:outline-none">
-        <svg class="w-12 h-12 mb-4 text-indigo-400" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
-        </svg>
-        <h3 class="font-bold text-xl mb-2">The Mint</h3>
-        <p class="text-sm">Swaps for Ecash</p>
-      </button>
-
-      <!-- Step 3 -->
-      <button type="button" data-modal="modal-step3" class="step-card interactive-card p-6 flex flex-col items-center focus:outline-none">
-        <svg class="w-12 h-12 mb-4 text-pink-400" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-          <path stroke-linecap="round" stroke-linejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
-        </svg>
-        <h3 class="font-bold text-xl mb-2">Fundstr Wallet</h3>
-        <p class="text-sm">Private & ready to spend</p>
-      </button>
-    </div>
-
-    <!-- Modals -->
-    <div id="modal-step1" class="modal fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-75 hidden">
-      <div class="bg-slate-900 border border-slate-700 p-6 rounded max-w-sm mx-4 text-left">
-        <h3 class="text-xl font-bold mb-4">Your Bitcoin</h3>
-        <p>Start with sats from any wallet. For example, swap 100k sats for ecash to send privately.</p>
-        <button class="close-modal mt-6 px-4 py-2 bg-indigo-600 rounded text-white">Close</button>
-      </div>
-    </div>
-
-    <div id="modal-step2" class="modal fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-75 hidden">
-      <div class="bg-slate-900 border border-slate-700 p-6 rounded max-w-sm mx-4 text-left">
-        <h3 class="text-xl font-bold mb-4">The Mint</h3>
-        <p>The mint issues blind signed tokens in exchange for your bitcoin. Example: deposit 100k sats and receive ecash you can split and spend.</p>
-        <button class="close-modal mt-6 px-4 py-2 bg-indigo-600 rounded text-white">Close</button>
-      </div>
-    </div>
-
-    <div id="modal-step3" class="modal fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-75 hidden">
-      <div class="bg-slate-900 border border-slate-700 p-6 rounded max-w-sm mx-4 text-left">
-        <h3 class="text-xl font-bold mb-4">Fundstr Wallet</h3>
-        <p>Store and send ecash privately. For instance, forward tokens to a friend or redeem them back for bitcoin later.</p>
-        <button class="close-modal mt-6 px-4 py-2 bg-indigo-600 rounded text-white">Close</button>
-      </div>
-    </div>
-  </section>
-
-  <!-- Built for the Sovereign Individual -->
-  <section id="who-for" class="px-4 py-20 fade-in-section">
-    <h2 class="text-center text-4xl font-bold mb-12 gradient-text">Built for the Sovereign Individual</h2>
-    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 max-w-6xl mx-auto">
-      <!-- Card 1 -->
-      <div class="interactive-card p-6 text-center">
-        <div class="text-4xl mb-4">🎨</div>
-        <h3 class="font-bold text-xl mb-2">Content Creators</h3>
-        <p class="text-sm">Monetize your audience directly, free from de-platforming and high fees.</p>
-      </div>
-      <!-- Card 2 -->
-      <div class="interactive-card p-6 text-center">
-        <div class="text-4xl mb-4">🛡️</div>
-        <h3 class="font-bold text-xl mb-2">Privacy Advocates</h3>
-        <p class="text-sm">Transact with confidence that your financial life isn't being tracked.</p>
-      </div>
-      <!-- Card 3 -->
-      <div class="interactive-card p-6 text-center">
-        <div class="text-4xl mb-4">⛓️</div>
-        <h3 class="font-bold text-xl mb-2">Nostr Users</h3>
-        <p class="text-sm">Upgrade your zaps to be truly private and integrate payments seamlessly.</p>
-      </div>
-      <!-- Card 4 -->
-      <div class="interactive-card p-6 text-center">
-        <div class="text-4xl mb-4">🌍</div>
-        <h3 class="font-bold text-xl mb-2">Global Citizens</h3>
-        <p class="text-sm">Move value across borders instantly, without relying on traditional banking.</p>
-      </div>
-    </div>
-  </section>
-
-  <!-- Navigation Map -->
-  <section id="navigation-map" class="px-4 py-20 fade-in-section">
-    <h2 class="text-center text-4xl font-bold mb-6 gradient-text">Navigation Map</h2>
-    <p class="text-center mb-12">Every page explained from both the Creator and Fan perspectives.</p>
-    <!-- Desktop Table -->
-    <div class="hidden md:block interactive-card p-6 overflow-x-auto">
-      <table class="w-full text-left">
-        <thead>
-          <tr class="text-sm text-gray-400">
-            <th class="py-2 pr-4">🧭 Menu item</th>
-            <th class="py-2 pr-4">Fan / Subscriber perspective</th>
-            <th class="py-2">Creator perspective</th>
-          </tr>
-        </thead>
-        <tbody class="text-sm">
-          <tr class="border-t border-gray-700">
-            <td class="py-3 pr-4">Settings</td>
-            <td class="py-3 pr-4">Add / switch mints, choose display unit, set language & theme, import or back-up your 12-word seed, manage Nostr keys & relays.</td>
-            <td class="py-3">Same, plus Publishing settings: toggle automatic NIP-61 profile updates and set a default “Earnings” bucket.</td>
-          </tr>
-          <tr class="border-t border-gray-700">
-            <td class="py-3 pr-4">Find Creators</td>
-            <td class="py-3 pr-4">Search or browse Nostr-indexed profiles. View tier prices, previews and public posts. Hit Subscribe or Zap with a single tap.</td>
-            <td class="py-3">Your public storefront as seen by visitors. Great for a quick audit of how your profile appears worldwide.</td>
-          </tr>
-          <tr class="border-t border-gray-700">
-            <td class="py-3 pr-4">Creator Hub</td>
-            <td class="py-3 pr-4">— (hidden unless you toggle “Creator Mode”)</td>
-            <td class="py-3">Define or edit tiers (price, duration, perks), upload cover art, publish pay-walled posts, check revenue analytics and subscriber list.</td>
-          </tr>
-          <tr class="border-t border-gray-700">
-            <td class="py-3 pr-4">My Profile</td>
-            <td class="py-3 pr-4">Show off your avatar, npub link and optional NIP-05. Personal stats: total zaps sent & received, bucket balances.</td>
-            <td class="py-3">Same card plus Edit. Update bio, tags and the secondary P2PK key used by fans to send you locked tokens.</td>
-          </tr>
-          <tr class="border-t border-gray-700">
-            <td class="py-3 pr-4">Buckets</td>
-            <td class="py-3 pr-4">Drag-and-drop jars for budgeting (“Groceries”, “Fun money”, “Subs”). Move sats with zero fees.</td>
-            <td class="py-3">Create an “Income” bucket that auto-receives new tips; split out taxes or savings instantly.</td>
-          </tr>
-          <tr class="border-t border-gray-700">
-            <td class="py-3 pr-4">Subscriptions</td>
-            <td class="py-3 pr-4">See every active plan: tier name, next renewal, cumulative sats spent. Cancel or renew with one click.</td>
-            <td class="py-3">Quick list of paying supporters, tier breakdown, churn alerts and pending renewals.</td>
-          </tr>
-          <tr class="border-t border-gray-700">
-            <td class="py-3 pr-4">Chats</td>
-            <td class="py-3 pr-4">End-to-end encrypted DMs (Nostr kind 4). Attach images or Cashu tokens. Green flash means a payment is embedded and auto-redeemed on receipt.</td>
-            <td class="py-3">Same powerful chat plus a broadcast toggle to message all subs in a tier at once.</td>
-          </tr>
-          <tr class="border-t border-gray-700">
-            <td class="py-3 pr-4">Terms</td>
-            <td class="py-3 pr-4">Human-readable, plain-English licence & disclaimers.</td>
-            <td class="py-3">Identical — clarifies you keep full custody of funds.</td>
-          </tr>
-          <tr class="border-t border-gray-700">
-            <td class="py-3 pr-4">About</td>
-            <td class="py-3 pr-4">Learn everything in one scroll.</td>
-            <td class="py-3">Ditto; includes creator-specific FAQs below.</td>
-          </tr>
-          <tr class="border-t border-gray-700">
-            <td class="py-3 pr-4">External links</td>
-            <td class="py-3 pr-4">Cashu.space docs, GitHub, Twitter, Telegram, Donate.</td>
-            <td class="py-3">Identical — share with collaborators or fans.</td>
-          </tr>
-        </tbody>
-      </table>
-    </div>
-
-    <!-- Mobile Cards -->
-    <div class="md:hidden space-y-4">
-      <!-- Repeat each row as card -->
-      <div class="interactive-card p-4">
-        <h3 class="font-semibold text-lg mb-1">Settings</h3>
-        <p class="text-sm"><span class="font-medium">Fan / Subscriber perspective:</span> Add / switch mints, choose display unit, set language & theme, import or back-up your 12-word seed, manage Nostr keys & relays.</p>
-        <p class="text-sm mt-2"><span class="font-medium">Creator perspective:</span> Same, plus Publishing settings: toggle automatic NIP-61 profile updates and set a default “Earnings” bucket.</p>
-      </div>
-      <div class="interactive-card p-4">
-        <h3 class="font-semibold text-lg mb-1">Find Creators</h3>
-        <p class="text-sm"><span class="font-medium">Fan / Subscriber perspective:</span> Search or browse Nostr-indexed profiles. View tier prices, previews and public posts. Hit Subscribe or Zap with a single tap.</p>
-        <p class="text-sm mt-2"><span class="font-medium">Creator perspective:</span> Your public storefront as seen by visitors. Great for a quick audit of how your profile appears worldwide.</p>
-      </div>
-      <div class="interactive-card p-4">
-        <h3 class="font-semibold text-lg mb-1">Creator Hub</h3>
-        <p class="text-sm"><span class="font-medium">Fan / Subscriber perspective:</span> — (hidden unless you toggle “Creator Mode”)</p>
-        <p class="text-sm mt-2"><span class="font-medium">Creator perspective:</span> Define or edit tiers (price, duration, perks), upload cover art, publish pay-walled posts, check revenue analytics and subscriber list.</p>
-      </div>
-      <div class="interactive-card p-4">
-        <h3 class="font-semibold text-lg mb-1">My Profile</h3>
-        <p class="text-sm"><span class="font-medium">Fan / Subscriber perspective:</span> Show off your avatar, npub link and optional NIP-05. Personal stats: total zaps sent & received, bucket balances.</p>
-        <p class="text-sm mt-2"><span class="font-medium">Creator perspective:</span> Same card plus Edit. Update bio, tags and the secondary P2PK key used by fans to send you locked tokens.</p>
-      </div>
-      <div class="interactive-card p-4">
-        <h3 class="font-semibold text-lg mb-1">Buckets</h3>
-        <p class="text-sm"><span class="font-medium">Fan / Subscriber perspective:</span> Drag-and-drop jars for budgeting (“Groceries”, “Fun money”, “Subs”). Move sats with zero fees.</p>
-        <p class="text-sm mt-2"><span class="font-medium">Creator perspective:</span> Create an “Income” bucket that auto-receives new tips; split out taxes or savings instantly.</p>
-      </div>
-      <div class="interactive-card p-4">
-        <h3 class="font-semibold text-lg mb-1">Subscriptions</h3>
-        <p class="text-sm"><span class="font-medium">Fan / Subscriber perspective:</span> See every active plan: tier name, next renewal, cumulative sats spent. Cancel or renew with one click.</p>
-        <p class="text-sm mt-2"><span class="font-medium">Creator perspective:</span> Quick list of paying supporters, tier breakdown, churn alerts and pending renewals.</p>
-      </div>
-      <div class="interactive-card p-4">
-        <h3 class="font-semibold text-lg mb-1">Chats</h3>
-        <p class="text-sm"><span class="font-medium">Fan / Subscriber perspective:</span> End-to-end encrypted DMs (Nostr kind 4). Attach images or Cashu tokens. Green flash means a payment is embedded and auto-redeemed on receipt.</p>
-        <p class="text-sm mt-2"><span class="font-medium">Creator perspective:</span> Same powerful chat plus a broadcast toggle to message all subs in a tier at once.</p>
-      </div>
-      <div class="interactive-card p-4">
-        <h3 class="font-semibold text-lg mb-1">Terms</h3>
-        <p class="text-sm"><span class="font-medium">Fan / Subscriber perspective:</span> Human-readable, plain-English licence & disclaimers.</p>
-        <p class="text-sm mt-2"><span class="font-medium">Creator perspective:</span> Identical — clarifies you keep full custody of funds.</p>
-      </div>
-      <div class="interactive-card p-4">
-        <h3 class="font-semibold text-lg mb-1">About</h3>
-        <p class="text-sm"><span class="font-medium">Fan / Subscriber perspective:</span> Learn everything in one scroll.</p>
-        <p class="text-sm mt-2"><span class="font-medium">Creator perspective:</span> Ditto; includes creator-specific FAQs below.</p>
-      </div>
-      <div class="interactive-card p-4">
-        <h3 class="font-semibold text-lg mb-1">External links</h3>
-        <p class="text-sm"><span class="font-medium">Fan / Subscriber perspective:</span> Cashu.space docs, GitHub, Twitter, Telegram, Donate.</p>
-        <p class="text-sm mt-2"><span class="font-medium">Creator perspective:</span> Identical — share with collaborators or fans.</p>
-      </div>
-    </div>
-  </section>
-
-  <!-- Trust Through Transparency -->
-  <section id="trust" class="px-4 py-20 fade-in-section">
-    <h2 class="text-center text-4xl font-bold mb-12 gradient-text">Trust Through Transparency</h2>
-    <div class="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-5xl mx-auto">
-      <!-- Card 1 -->
-      <div class="interactive-card p-6">
-        <div class="text-4xl mb-4">🐙</div>
-        <h3 class="font-bold text-xl mb-2">Open Source & Verifiable</h3>
-        <p class="text-sm">Fundstr is built on open-source code. We invite you to inspect, verify, and contribute. Transparency is our core principle.</p>
-      </div>
-      <!-- Card 2 -->
-      <div class="interactive-card p-6">
-        <div class="text-4xl mb-4">🔑</div>
-        <h3 class="font-bold text-xl mb-2">You Hold the Keys</h3>
-        <p class="text-sm">You are the sole holder of your ecash tokens and Nostr identity. Mints act as custodians for the underlying Bitcoin, but only you can spend your ecash.</p>
-      </div>
-      <!-- Card 3 -->
-      <div class="interactive-card p-6">
-        <div class="text-4xl mb-4">🛡️✔️</div>
-        <h3 class="font-bold text-xl mb-2">Unbreakable Privacy</h3>
-        <p class="text-sm">Thanks to Chaumian blind signatures, mints cannot link your deposits to your withdrawals. Your spending habits remain completely private.</p>
-      </div>
-      <!-- Card 4 -->
-      <div class="interactive-card p-6">
-        <div class="text-4xl mb-4">🪙🪙</div>
-        <h3 class="font-bold text-xl mb-2">Mint Diversification</h3>
-        <p class="text-sm">Fundstr supports multiple mints, allowing you to diversify your holdings. Our audit tools will warn you (⚠️) of any unusual mint behavior.</p>
-      </div>
-    </div>
-  </section>
-
-  <!-- FAQ -->
-  <section id="faq" class="px-4 py-20 max-w-3xl mx-auto fade-in-section">
-    <h2 class="text-4xl font-bold mb-10 gradient-text">Frequently Asked Questions</h2>
-    <div class="space-y-6">
-      <details class="interactive-card p-4">
-        <summary class="font-semibold cursor-pointer">What if a fan stops paying?</summary>
-        <div class="mt-2 text-sm space-y-2">
-          <p><span class="font-medium">Creator view »</span> Their timelocked token never unlocks for you. Fundstr flags the user as “Expired” and hides future paid posts.</p>
-          <p><span class="font-medium">Fan view »</span> You simply don’t renew. No recurring pull, no surprise charges.</p>
-        </div>
-      </details>
-      <details class="interactive-card p-4">
-        <summary class="font-semibold cursor-pointer">Can I withdraw to a Lightning wallet?</summary>
-        <div class="mt-2 text-sm">
-          Yes. Go to Wallet → Send → Lightning Invoice, paste the invoice from any external wallet; Fundstr melts the tokens at the mint and pays it.
-        </div>
-      </details>
-      <details class="interactive-card p-4">
-        <summary class="font-semibold cursor-pointer">How private is this really?</summary>
-        <div class="mt-2 text-sm space-y-2">
-          <p>Mints see withdraw/redeem events but cannot correlate them.</p>
-          <p>Nostr chats are E2E encrypted; Nutzaps use P2PK so only the intended receiver can claim them.</p>
-          <p>Choose different mints or buckets to compartmentalise further.</p>
-        </div>
-      </details>
-    </div>
-  </section>
-
-  <!-- Community -->
-  <section class="px-4 py-20 fade-in-section">
-    <h2 class="text-center text-4xl font-bold mb-4 gradient-text">Join the Conversation</h2>
-    <p class="text-center max-w-2xl mx-auto mb-6">
-      Follow the project and its creator on Nostr to stay up-to-date and connect with the community.
-    </p>
-    <div class="flex justify-center space-x-6">
-      <a href="#" class="accent-text underline">Creator's Profile</a>
-      <a href="#" class="accent-text underline">Fundstr Project Page</a>
-    </div>
-  </section>
-
-  <!-- Quote -->
-  <section class="max-w-3xl mx-auto px-4 mb-20 fade-in-section">
-    <blockquote class="border-l-4 pl-4 border-[var(--color-accent)] italic">
-      Fundstr is powered by open-source code and an open community. Whether you’re a storyteller earning sats or a fan supporting work you love, we hope this guide helps you navigate every page with confidence — and makes your next payment feel as effortless as a like, comment, or retweet.
-    </blockquote>
-  </section>
-
-  <!-- CTA -->
-  <section id="cta" class="text-center px-4 py-20 fade-in-section">
-    <h2 class="text-4xl font-bold mb-4 gradient-text">Ready to Join the Movement?</h2>
-    <p class="mb-8">Install the PWA, explore the code, or help fund development.</p>
-    <div class="flex flex-col sm:flex-row justify-center gap-4">
-      <a href="#" class="px-8 py-3 rounded bg-indigo-600 text-white font-semibold">Install PWA</a>
-      <a href="#" class="px-8 py-3 rounded bg-gradient-to-r from-purple-500 to-pink-500 text-white font-semibold">Support Fundstr</a>
-    </div>
-  </section>
-
-  <!-- Fade-in script -->
-  <script>
-    const observer = new IntersectionObserver(entries => {
-      entries.forEach(entry => {
-        if (entry.isIntersecting) {
-          entry.target.classList.add('is-visible');
+      @media (max-width: 768px) {
+        .step-card::after {
+          content: "↓";
+          top: auto;
+          bottom: -1.5rem;
+          left: 50%;
+          right: auto;
+          transform: translateX(-50%);
+          font-size: 1.5rem;
         }
-      });
-    }, { threshold: 0.1 });
+      }
+      .fade-in-section {
+        opacity: 0;
+        transform: translateY(20px);
+        transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+      }
+      .fade-in-section.is-visible {
+        opacity: 1;
+        transform: none;
+      }
+    </style>
+  </head>
+  <body class="antialiased">
+    <!-- Header -->
+    <header class="text-center py-20 fade-in-section">
+      <h1 class="text-5xl md:text-7xl font-extrabold mb-6">
+        About <span class="gradient-text">Fundstr</span>
+      </h1>
+      <p class="max-w-2xl mx-auto text-lg md:text-xl mb-8">
+        A privacy-first Bitcoin wallet, social chat, and creator-monetisation
+        hub built on the open-source Cashu ecash protocol and the decentralised
+        Nostr network.
+      </p>
+      <div
+        class="alpha-warning max-w-3xl mx-auto flex items-center gap-4 bg-yellow-50 p-4 border-l-4 border-yellow-400 rounded text-yellow-800 animate-pulse"
+        role="alert"
+      >
+        <span class="text-5xl">⚠️</span>
+        <p>
+          Fundstr is experimental alpha software. Features may break or change,
+          and loss of funds is possible. Use only small amounts you can afford
+          to lose.
+        </p>
+      </div>
+    </header>
 
-    document.querySelectorAll('.fade-in-section').forEach(section => {
-      observer.observe(section);
-    });
+    <!-- Vision -->
+    <section id="vision" class="max-w-3xl mx-auto px-4 py-20 fade-in-section">
+      <h2 class="text-4xl font-bold mb-6 gradient-text">
+        Your Money, Your Network
+      </h2>
+      <p>
+        We believe in a world where your financial life and social interactions
+        are truly your own. Fundstr is an experiment in creating a parallel,
+        peer-to-peer economy—free from corporate gatekeepers, surveillance, and
+        unpredictable fees. It’s a gateway to a more sovereign way of connecting
+        and transacting.
+      </p>
+    </section>
 
-    // Modal interactions
-    document.querySelectorAll('[data-modal]').forEach(btn => {
-      btn.addEventListener('click', () => {
-        const modal = document.getElementById(btn.dataset.modal);
-        if (modal) modal.classList.remove('hidden');
-      });
-    });
+    <!-- How Ecash Works -->
+    <section id="how-it-works" class="px-4 py-20 fade-in-section">
+      <h2 class="text-center text-4xl font-bold mb-10 gradient-text">
+        How Ecash Works
+      </h2>
+      <p class="text-center mb-12">
+        The loop is simple: Bitcoin in → private e-cash out → social payments
+        everywhere.
+      </p>
+      <div
+        class="grid grid-cols-1 md:grid-cols-3 items-center gap-6 max-w-5xl mx-auto"
+      >
+        <!-- Step 1 -->
+        <button
+          type="button"
+          data-modal="modal-step1"
+          class="step-card interactive-card p-6 flex flex-col items-center focus:outline-none"
+        >
+          <svg
+            class="w-12 h-12 mb-4 text-yellow-400"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+          >
+            <path
+              d="M23.112 13.506c.353-2.353-1.444-3.415-3.897-4.2l.797-3.194-1.948-.485-.776 3.111c-.511-.127-1.035-.246-1.555-.364l.784-3.144-1.948-.486-.797 3.194c-.422-.096-.84-.19-1.246-.29l-.001-.006-2.688-.669-.518 2.075s1.444.331 1.415.352c.79.197.933.716.909 1.13l-2.195 8.8c-.096.238-.34.596-.89.461.02.028-1.415-.353-1.415-.353l-.966 2.385 2.538.631c.472.119.934.241 1.392.357l-.806 3.245 1.948.486.797-3.194c.529.143 1.042.274 1.547.398l-.793 3.179 1.948.485.805-3.244c3.324.63 5.827.376 6.885-2.633.849-2.417-.042-3.814-1.794-4.728 1.277-.295 2.237-1.135 2.497-2.873zm-4.462 6.26c-.605 2.417-4.696 1.108-6.025.781l1.076-4.32c1.329.332 5.585.991 4.949 3.539zm.605-6.29c-.553 2.211-3.96 1.086-5.063.811l.974-3.906c1.102.275 4.67.79 4.09 3.095z"
+            />
+          </svg>
+          <h3 class="font-bold text-xl mb-2">Your Bitcoin</h3>
+          <p class="text-sm">From any wallet</p>
+        </button>
 
-    document.querySelectorAll('.close-modal').forEach(btn => {
-      btn.addEventListener('click', () => {
-        btn.closest('.modal').classList.add('hidden');
-      });
-    });
+        <!-- Step 2 -->
+        <button
+          type="button"
+          data-modal="modal-step2"
+          class="step-card interactive-card p-6 flex flex-col items-center focus:outline-none"
+        >
+          <svg
+            class="w-12 h-12 mb-4 text-indigo-400"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"
+            />
+          </svg>
+          <h3 class="font-bold text-xl mb-2">The Mint</h3>
+          <p class="text-sm">Swaps for Ecash</p>
+        </button>
 
-    document.querySelectorAll('.modal').forEach(modal => {
-      modal.addEventListener('click', (e) => {
-        if (e.target === modal) modal.classList.add('hidden');
+        <!-- Step 3 -->
+        <button
+          type="button"
+          data-modal="modal-step3"
+          class="step-card interactive-card p-6 flex flex-col items-center focus:outline-none"
+        >
+          <svg
+            class="w-12 h-12 mb-4 text-pink-400"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+            />
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+            />
+          </svg>
+          <h3 class="font-bold text-xl mb-2">Fundstr Wallet</h3>
+          <p class="text-sm">Private & ready to spend</p>
+        </button>
+      </div>
+
+      <!-- Modals -->
+      <div
+        id="modal-step1"
+        class="modal fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-75 hidden"
+      >
+        <div
+          class="bg-slate-900 border border-slate-700 p-6 rounded max-w-sm mx-4 text-left"
+        >
+          <h3 class="text-xl font-bold mb-4">Your Bitcoin</h3>
+          <p>
+            Start with sats from any wallet. For example, swap 100k sats for
+            ecash to send privately.
+          </p>
+          <button
+            class="close-modal mt-6 px-4 py-2 bg-indigo-600 rounded text-white"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+
+      <div
+        id="modal-step2"
+        class="modal fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-75 hidden"
+      >
+        <div
+          class="bg-slate-900 border border-slate-700 p-6 rounded max-w-sm mx-4 text-left"
+        >
+          <h3 class="text-xl font-bold mb-4">The Mint</h3>
+          <p>
+            The mint issues blind signed tokens in exchange for your bitcoin.
+            Example: deposit 100k sats and receive ecash you can split and
+            spend.
+          </p>
+          <button
+            class="close-modal mt-6 px-4 py-2 bg-indigo-600 rounded text-white"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+
+      <div
+        id="modal-step3"
+        class="modal fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-75 hidden"
+      >
+        <div
+          class="bg-slate-900 border border-slate-700 p-6 rounded max-w-sm mx-4 text-left"
+        >
+          <h3 class="text-xl font-bold mb-4">Fundstr Wallet</h3>
+          <p>
+            Store and send ecash privately. For instance, forward tokens to a
+            friend or redeem them back for bitcoin later.
+          </p>
+          <button
+            class="close-modal mt-6 px-4 py-2 bg-indigo-600 rounded text-white"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </section>
+
+    <!-- Built for the Sovereign Individual -->
+    <section id="who-for" class="px-4 py-20 fade-in-section">
+      <h2 class="text-center text-4xl font-bold mb-12 gradient-text">
+        Built for the Sovereign Individual
+      </h2>
+      <div
+        class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 max-w-6xl mx-auto"
+      >
+        <!-- Card 1 -->
+        <div class="interactive-card p-6 text-center">
+          <div class="text-4xl mb-4">🎨</div>
+          <h3 class="font-bold text-xl mb-2">Content Creators</h3>
+          <p class="text-sm">
+            Monetize your audience directly, free from de-platforming and high
+            fees.
+          </p>
+        </div>
+        <!-- Card 2 -->
+        <div class="interactive-card p-6 text-center">
+          <div class="text-4xl mb-4">🛡️</div>
+          <h3 class="font-bold text-xl mb-2">Privacy Advocates</h3>
+          <p class="text-sm">
+            Transact with confidence that your financial life isn't being
+            tracked.
+          </p>
+        </div>
+        <!-- Card 3 -->
+        <div class="interactive-card p-6 text-center">
+          <div class="text-4xl mb-4">⛓️</div>
+          <h3 class="font-bold text-xl mb-2">Nostr Users</h3>
+          <p class="text-sm">
+            Upgrade your zaps to be truly private and integrate payments
+            seamlessly.
+          </p>
+        </div>
+        <!-- Card 4 -->
+        <div class="interactive-card p-6 text-center">
+          <div class="text-4xl mb-4">🌍</div>
+          <h3 class="font-bold text-xl mb-2">Global Citizens</h3>
+          <p class="text-sm">
+            Move value across borders instantly, without relying on traditional
+            banking.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Navigation Map -->
+    <section id="navigation-map" class="px-4 py-20 fade-in-section">
+      <h2 class="text-center text-4xl font-bold mb-6 gradient-text">
+        Navigation Map
+      </h2>
+      <p class="text-center mb-12">
+        Every page explained from both the Creator and Fan perspectives.
+      </p>
+      <!-- Desktop Table -->
+      <div class="hidden md:block interactive-card p-6 overflow-x-auto">
+        <table class="w-full text-left">
+          <thead>
+            <tr class="text-sm text-gray-400">
+              <th class="py-2 pr-4">🧭 Menu item</th>
+              <th class="py-2 pr-4">Fan / Subscriber perspective</th>
+              <th class="py-2">Creator perspective</th>
+            </tr>
+          </thead>
+          <tbody class="text-sm">
+            <tr class="border-t border-gray-700">
+              <td class="py-3 pr-4">Settings</td>
+              <td class="py-3 pr-4">
+                Add / switch mints, choose display unit, set language & theme,
+                import or back-up your 12-word seed, manage Nostr keys & relays.
+              </td>
+              <td class="py-3">
+                Same, plus Publishing settings: toggle automatic NIP-61 profile
+                updates and set a default “Earnings” bucket.
+              </td>
+            </tr>
+            <tr class="border-t border-gray-700">
+              <td class="py-3 pr-4">Find Creators</td>
+              <td class="py-3 pr-4">
+                Search or browse Nostr-indexed profiles. View tier prices,
+                previews and public posts. Hit Subscribe or Zap with a single
+                tap.
+              </td>
+              <td class="py-3">
+                Your public storefront as seen by visitors. Great for a quick
+                audit of how your profile appears worldwide.
+              </td>
+            </tr>
+            <tr class="border-t border-gray-700">
+              <td class="py-3 pr-4">Creator Hub</td>
+              <td class="py-3 pr-4">
+                — (hidden unless you toggle “Creator Mode”)
+              </td>
+              <td class="py-3">
+                Define or edit tiers (price, duration, perks), upload cover art,
+                publish pay-walled posts, check revenue analytics and subscriber
+                list.
+              </td>
+            </tr>
+            <tr class="border-t border-gray-700">
+              <td class="py-3 pr-4">My Profile</td>
+              <td class="py-3 pr-4">
+                Show off your avatar, npub link and optional NIP-05. Personal
+                stats: total zaps sent & received, bucket balances.
+              </td>
+              <td class="py-3">
+                Same card plus Edit. Update bio, tags and the secondary P2PK key
+                used by fans to send you locked tokens.
+              </td>
+            </tr>
+            <tr class="border-t border-gray-700">
+              <td class="py-3 pr-4">Buckets</td>
+              <td class="py-3 pr-4">
+                Drag-and-drop jars for budgeting (“Groceries”, “Fun money”,
+                “Subs”). Move sats with zero fees.
+              </td>
+              <td class="py-3">
+                Create an “Income” bucket that auto-receives new tips; split out
+                taxes or savings instantly.
+              </td>
+            </tr>
+            <tr class="border-t border-gray-700">
+              <td class="py-3 pr-4">Subscriptions</td>
+              <td class="py-3 pr-4">
+                See every active plan: tier name, next renewal, cumulative sats
+                spent. Cancel or renew with one click.
+              </td>
+              <td class="py-3">
+                Quick list of paying supporters, tier breakdown, churn alerts
+                and pending renewals.
+              </td>
+            </tr>
+            <tr class="border-t border-gray-700">
+              <td class="py-3 pr-4">Chats</td>
+              <td class="py-3 pr-4">
+                End-to-end encrypted DMs (Nostr kind 4). Attach images or Cashu
+                tokens. Green flash means a payment is embedded and
+                auto-redeemed on receipt.
+              </td>
+              <td class="py-3">
+                Same powerful chat plus a broadcast toggle to message all subs
+                in a tier at once.
+              </td>
+            </tr>
+            <tr class="border-t border-gray-700">
+              <td class="py-3 pr-4">Terms</td>
+              <td class="py-3 pr-4">
+                Human-readable, plain-English licence & disclaimers.
+              </td>
+              <td class="py-3">
+                Identical — clarifies you keep full custody of funds.
+              </td>
+            </tr>
+            <tr class="border-t border-gray-700">
+              <td class="py-3 pr-4">About</td>
+              <td class="py-3 pr-4">Learn everything in one scroll.</td>
+              <td class="py-3">Ditto; includes creator-specific FAQs below.</td>
+            </tr>
+            <tr class="border-t border-gray-700">
+              <td class="py-3 pr-4">External links</td>
+              <td class="py-3 pr-4">
+                Cashu.space docs, GitHub, Twitter, Telegram, Donate.
+              </td>
+              <td class="py-3">
+                Identical — share with collaborators or fans.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <!-- Mobile Cards -->
+      <div class="md:hidden space-y-4">
+        <!-- Repeat each row as card -->
+        <div class="interactive-card p-4">
+          <h3 class="font-semibold text-lg mb-1">Settings</h3>
+          <p class="text-sm">
+            <span class="font-medium">Fan / Subscriber perspective:</span> Add /
+            switch mints, choose display unit, set language & theme, import or
+            back-up your 12-word seed, manage Nostr keys & relays.
+          </p>
+          <p class="text-sm mt-2">
+            <span class="font-medium">Creator perspective:</span> Same, plus
+            Publishing settings: toggle automatic NIP-61 profile updates and set
+            a default “Earnings” bucket.
+          </p>
+        </div>
+        <div class="interactive-card p-4">
+          <h3 class="font-semibold text-lg mb-1">Find Creators</h3>
+          <p class="text-sm">
+            <span class="font-medium">Fan / Subscriber perspective:</span>
+            Search or browse Nostr-indexed profiles. View tier prices, previews
+            and public posts. Hit Subscribe or Zap with a single tap.
+          </p>
+          <p class="text-sm mt-2">
+            <span class="font-medium">Creator perspective:</span> Your public
+            storefront as seen by visitors. Great for a quick audit of how your
+            profile appears worldwide.
+          </p>
+        </div>
+        <div class="interactive-card p-4">
+          <h3 class="font-semibold text-lg mb-1">Creator Hub</h3>
+          <p class="text-sm">
+            <span class="font-medium">Fan / Subscriber perspective:</span> —
+            (hidden unless you toggle “Creator Mode”)
+          </p>
+          <p class="text-sm mt-2">
+            <span class="font-medium">Creator perspective:</span> Define or edit
+            tiers (price, duration, perks), upload cover art, publish pay-walled
+            posts, check revenue analytics and subscriber list.
+          </p>
+        </div>
+        <div class="interactive-card p-4">
+          <h3 class="font-semibold text-lg mb-1">My Profile</h3>
+          <p class="text-sm">
+            <span class="font-medium">Fan / Subscriber perspective:</span> Show
+            off your avatar, npub link and optional NIP-05. Personal stats:
+            total zaps sent & received, bucket balances.
+          </p>
+          <p class="text-sm mt-2">
+            <span class="font-medium">Creator perspective:</span> Same card plus
+            Edit. Update bio, tags and the secondary P2PK key used by fans to
+            send you locked tokens.
+          </p>
+        </div>
+        <div class="interactive-card p-4">
+          <h3 class="font-semibold text-lg mb-1">Buckets</h3>
+          <p class="text-sm">
+            <span class="font-medium">Fan / Subscriber perspective:</span>
+            Drag-and-drop jars for budgeting (“Groceries”, “Fun money”, “Subs”).
+            Move sats with zero fees.
+          </p>
+          <p class="text-sm mt-2">
+            <span class="font-medium">Creator perspective:</span> Create an
+            “Income” bucket that auto-receives new tips; split out taxes or
+            savings instantly.
+          </p>
+        </div>
+        <div class="interactive-card p-4">
+          <h3 class="font-semibold text-lg mb-1">Subscriptions</h3>
+          <p class="text-sm">
+            <span class="font-medium">Fan / Subscriber perspective:</span> See
+            every active plan: tier name, next renewal, cumulative sats spent.
+            Cancel or renew with one click.
+          </p>
+          <p class="text-sm mt-2">
+            <span class="font-medium">Creator perspective:</span> Quick list of
+            paying supporters, tier breakdown, churn alerts and pending
+            renewals.
+          </p>
+        </div>
+        <div class="interactive-card p-4">
+          <h3 class="font-semibold text-lg mb-1">Chats</h3>
+          <p class="text-sm">
+            <span class="font-medium">Fan / Subscriber perspective:</span>
+            End-to-end encrypted DMs (Nostr kind 4). Attach images or Cashu
+            tokens. Green flash means a payment is embedded and auto-redeemed on
+            receipt.
+          </p>
+          <p class="text-sm mt-2">
+            <span class="font-medium">Creator perspective:</span> Same powerful
+            chat plus a broadcast toggle to message all subs in a tier at once.
+          </p>
+        </div>
+        <div class="interactive-card p-4">
+          <h3 class="font-semibold text-lg mb-1">Terms</h3>
+          <p class="text-sm">
+            <span class="font-medium">Fan / Subscriber perspective:</span>
+            Human-readable, plain-English licence & disclaimers.
+          </p>
+          <p class="text-sm mt-2">
+            <span class="font-medium">Creator perspective:</span> Identical —
+            clarifies you keep full custody of funds.
+          </p>
+        </div>
+        <div class="interactive-card p-4">
+          <h3 class="font-semibold text-lg mb-1">About</h3>
+          <p class="text-sm">
+            <span class="font-medium">Fan / Subscriber perspective:</span> Learn
+            everything in one scroll.
+          </p>
+          <p class="text-sm mt-2">
+            <span class="font-medium">Creator perspective:</span> Ditto;
+            includes creator-specific FAQs below.
+          </p>
+        </div>
+        <div class="interactive-card p-4">
+          <h3 class="font-semibold text-lg mb-1">External links</h3>
+          <p class="text-sm">
+            <span class="font-medium">Fan / Subscriber perspective:</span>
+            Cashu.space docs, GitHub, Twitter, Telegram, Donate.
+          </p>
+          <p class="text-sm mt-2">
+            <span class="font-medium">Creator perspective:</span> Identical —
+            share with collaborators or fans.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Trust Through Transparency -->
+    <section id="trust" class="px-4 py-20 fade-in-section">
+      <h2 class="text-center text-4xl font-bold mb-12 gradient-text">
+        Trust Through Transparency
+      </h2>
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-5xl mx-auto">
+        <!-- Card 1 -->
+        <div class="interactive-card p-6">
+          <div class="text-4xl mb-4">🐙</div>
+          <h3 class="font-bold text-xl mb-2">Open Source & Verifiable</h3>
+          <p class="text-sm">
+            Fundstr is built on open-source code. We invite you to inspect,
+            verify, and contribute. Transparency is our core principle.
+          </p>
+        </div>
+        <!-- Card 2 -->
+        <div class="interactive-card p-6">
+          <div class="text-4xl mb-4">🔑</div>
+          <h3 class="font-bold text-xl mb-2">You Hold the Keys</h3>
+          <p class="text-sm">
+            You are the sole holder of your ecash tokens and Nostr identity.
+            Mints act as custodians for the underlying Bitcoin, but only you can
+            spend your ecash.
+          </p>
+        </div>
+        <!-- Card 3 -->
+        <div class="interactive-card p-6">
+          <div class="text-4xl mb-4">🛡️✔️</div>
+          <h3 class="font-bold text-xl mb-2">Unbreakable Privacy</h3>
+          <p class="text-sm">
+            Thanks to Chaumian blind signatures, mints cannot link your deposits
+            to your withdrawals. Your spending habits remain completely private.
+          </p>
+        </div>
+        <!-- Card 4 -->
+        <div class="interactive-card p-6">
+          <div class="text-4xl mb-4">🪙🪙</div>
+          <h3 class="font-bold text-xl mb-2">Mint Diversification</h3>
+          <p class="text-sm">
+            Fundstr supports multiple mints, allowing you to diversify your
+            holdings. Our audit tools will warn you (⚠️) of any unusual mint
+            behavior.
+          </p>
+        </div>
+      </div>
+    </section>
+
+    <!-- FAQ -->
+    <section id="faq" class="px-4 py-20 max-w-3xl mx-auto fade-in-section">
+      <h2 class="text-4xl font-bold mb-10 gradient-text">
+        Frequently Asked Questions
+      </h2>
+      <div class="space-y-6">
+        <details class="interactive-card p-4">
+          <summary class="font-semibold cursor-pointer">
+            What if a fan stops paying?
+          </summary>
+          <div class="mt-2 text-sm space-y-2">
+            <p>
+              <span class="font-medium">Creator view »</span> Their timelocked
+              token never unlocks for you. Fundstr flags the user as “Expired”
+              and hides future paid posts.
+            </p>
+            <p>
+              <span class="font-medium">Fan view »</span> You simply don’t
+              renew. No recurring pull, no surprise charges.
+            </p>
+          </div>
+        </details>
+        <details class="interactive-card p-4">
+          <summary class="font-semibold cursor-pointer">
+            Can I withdraw to a Lightning wallet?
+          </summary>
+          <div class="mt-2 text-sm">
+            Yes. Go to Wallet → Send → Lightning Invoice, paste the invoice from
+            any external wallet; Fundstr melts the tokens at the mint and pays
+            it.
+          </div>
+        </details>
+        <details class="interactive-card p-4">
+          <summary class="font-semibold cursor-pointer">
+            How private is this really?
+          </summary>
+          <div class="mt-2 text-sm space-y-2">
+            <p>Mints see withdraw/redeem events but cannot correlate them.</p>
+            <p>
+              Nostr chats are E2E encrypted; Nutzaps use P2PK so only the
+              intended receiver can claim them.
+            </p>
+            <p>
+              Choose different mints or buckets to compartmentalise further.
+            </p>
+          </div>
+        </details>
+      </div>
+    </section>
+
+    <!-- Community -->
+    <section class="px-4 py-20 fade-in-section">
+      <h2 class="text-center text-4xl font-bold mb-4 gradient-text">
+        Join the Conversation
+      </h2>
+      <p class="text-center max-w-2xl mx-auto mb-6">
+        Follow the project and its creator on Nostr to stay up-to-date and
+        connect with the community.
+      </p>
+      <div class="flex justify-center space-x-6">
+        <a href="#" class="accent-text underline">Creator's Profile</a>
+        <a href="#" class="accent-text underline">Fundstr Project Page</a>
+      </div>
+    </section>
+
+    <!-- Quote -->
+    <section class="max-w-3xl mx-auto px-4 mb-20 fade-in-section">
+      <blockquote class="border-l-4 pl-4 border-[var(--color-accent)] italic">
+        Fundstr is powered by open-source code and an open community. Whether
+        you’re a storyteller earning sats or a fan supporting work you love, we
+        hope this guide helps you navigate every page with confidence — and
+        makes your next payment feel as effortless as a like, comment, or
+        retweet.
+      </blockquote>
+    </section>
+
+    <!-- CTA -->
+    <section id="cta" class="text-center px-4 py-20 fade-in-section">
+      <h2 class="text-4xl font-bold mb-4 gradient-text">
+        Ready to Join the Movement?
+      </h2>
+      <p class="mb-8">
+        Install the PWA, explore the code, or help fund development.
+      </p>
+      <div class="flex flex-col sm:flex-row justify-center gap-4">
+        <a
+          href="#"
+          class="px-8 py-3 rounded bg-indigo-600 text-white font-semibold"
+          >Install PWA</a
+        >
+        <a
+          href="#"
+          class="px-8 py-3 rounded bg-gradient-to-r from-purple-500 to-pink-500 text-white font-semibold"
+          >Support Fundstr</a
+        >
+      </div>
+    </section>
+
+    <!-- Fade-in script -->
+    <script>
+      const observer = new IntersectionObserver(
+        (entries) => {
+          entries.forEach((entry) => {
+            if (entry.isIntersecting) {
+              entry.target.classList.add("is-visible");
+            }
+          });
+        },
+        { threshold: 0.1 }
+      );
+
+      document.querySelectorAll(".fade-in-section").forEach((section) => {
+        observer.observe(section);
       });
-    });
-  </script>
-</body>
+
+      // Modal interactions
+      document.querySelectorAll("[data-modal]").forEach((btn) => {
+        btn.addEventListener("click", () => {
+          const modal = document.getElementById(btn.dataset.modal);
+          if (modal) modal.classList.remove("hidden");
+        });
+      });
+
+      document.querySelectorAll(".close-modal").forEach((btn) => {
+        btn.addEventListener("click", () => {
+          btn.closest(".modal").classList.add("hidden");
+        });
+      });
+
+      document.querySelectorAll(".modal").forEach((modal) => {
+        modal.addEventListener("click", (e) => {
+          if (e.target === modal) modal.classList.add("hidden");
+        });
+      });
+    </script>
+  </body>
 </html>

--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -6,15 +6,19 @@
         About <span class="gradient-text">Fundstr</span>
       </h1>
       <p class="max-w-3xl mx-auto text-lg md:text-xl">
-        A privacy-first Bitcoin wallet, social chat, and creator-monetisation hub built on the open-source Cashu ecash protocol and the decentralised Nostr network.
+        A privacy-first Bitcoin wallet, social chat, and creator-monetisation
+        hub built on the open-source Cashu ecash protocol and the decentralised
+        Nostr network.
       </p>
       <div
-        class="alpha-warning mt-8 max-w-3xl mx-auto flex items-start gap-3 animate-pulse"
+        class="alpha-warning mt-8 max-w-3xl mx-auto flex items-center gap-4 bg-yellow-50 p-4 border-l-4 border-yellow-400 rounded text-yellow-800 animate-pulse"
         role="alert"
       >
-        <span class="text-3xl">⚠️</span>
+        <span class="text-5xl">⚠️</span>
         <p>
-          Fundstr is experimental alpha software. Features may break or change, and loss of funds is possible. Use only small amounts you can afford to lose.
+          Fundstr is experimental alpha software. Features may break or change,
+          and loss of funds is possible. Use only small amounts you can afford
+          to lose.
         </p>
       </div>
     </header>
@@ -26,7 +30,11 @@
           Your Money, Your Network
         </h2>
         <p class="text-lg md:text-xl">
-          We believe in a world where your financial life and social interactions are truly your own. Fundstr is an experiment in creating a parallel, peer-to-peer economy—free from corporate gatekeepers, surveillance, and unpredictable fees. It’s a gateway to a more sovereign way of connecting and transacting.
+          We believe in a world where your financial life and social
+          interactions are truly your own. Fundstr is an experiment in creating
+          a parallel, peer-to-peer economy—free from corporate gatekeepers,
+          surveillance, and unpredictable fees. It’s a gateway to a more
+          sovereign way of connecting and transacting.
         </p>
       </div>
     </section>
@@ -38,7 +46,8 @@
           How Ecash Works
         </h2>
         <p class="text-lg md:text-xl mb-12">
-          The loop is simple: Bitcoin in → private e-cash out → social payments everywhere.
+          The loop is simple: Bitcoin in → private e-cash out → social payments
+          everywhere.
         </p>
 
         <!-- Flow Grid -->
@@ -128,7 +137,8 @@
           <q-card>
             <q-card-section class="text-h6">Your Bitcoin</q-card-section>
             <q-card-section>
-              Start with sats from any wallet. For example, swap 100k sats for ecash to send privately.
+              Start with sats from any wallet. For example, swap 100k sats for
+              ecash to send privately.
             </q-card-section>
             <q-card-actions align="right">
               <q-btn flat label="Close" v-close-popup />
@@ -140,8 +150,9 @@
           <q-card>
             <q-card-section class="text-h6">The Mint</q-card-section>
             <q-card-section>
-              The mint issues blind signed tokens in exchange for your bitcoin. Example: deposit 100k sats and receive
-              ecash you can split and spend.
+              The mint issues blind signed tokens in exchange for your bitcoin.
+              Example: deposit 100k sats and receive ecash you can split and
+              spend.
             </q-card-section>
             <q-card-actions align="right">
               <q-btn flat label="Close" v-close-popup />
@@ -153,8 +164,8 @@
           <q-card>
             <q-card-section class="text-h6">Fundstr Wallet</q-card-section>
             <q-card-section>
-              Store and send ecash privately. For instance, forward tokens to a friend or redeem them back for bitcoin
-              later.
+              Store and send ecash privately. For instance, forward tokens to a
+              friend or redeem them back for bitcoin later.
             </q-card-section>
             <q-card-actions align="right">
               <q-btn flat label="Close" v-close-popup />
@@ -176,7 +187,8 @@
             <div class="text-4xl mb-4">🖌️</div>
             <h3 class="font-semibold text-xl mb-2">Content Creators</h3>
             <p class="text-sm">
-              Monetize your audience directly, free from de-platforming and high fees.
+              Monetize your audience directly, free from de-platforming and high
+              fees.
             </p>
           </div>
 
@@ -185,7 +197,8 @@
             <div class="text-4xl mb-4">🛡️</div>
             <h3 class="font-semibold text-xl mb-2">Privacy Advocates</h3>
             <p class="text-sm">
-              Transact with confidence that your financial life isn't being tracked.
+              Transact with confidence that your financial life isn't being
+              tracked.
             </p>
           </div>
 
@@ -194,7 +207,8 @@
             <div class="text-4xl mb-4">🔗</div>
             <h3 class="font-semibold text-xl mb-2">Nostr Users</h3>
             <p class="text-sm">
-              Upgrade your zaps to be truly private and integrate payments seamlessly.
+              Upgrade your zaps to be truly private and integrate payments
+              seamlessly.
             </p>
           </div>
 
@@ -203,7 +217,8 @@
             <div class="text-4xl mb-4">🌐</div>
             <h3 class="font-semibold text-xl mb-2">Global Citizens</h3>
             <p class="text-sm">
-              Move value across borders instantly, without relying on traditional banking.
+              Move value across borders instantly, without relying on
+              traditional banking.
             </p>
           </div>
         </div>
@@ -235,62 +250,81 @@
                 <tr class="border-b border-gray-800">
                   <td class="p-4 font-semibold">Settings</td>
                   <td class="p-4">
-                    Add / switch mints, choose display unit, set language & theme, import or back-up your 12-word seed, manage Nostr keys & relays.
+                    Add / switch mints, choose display unit, set language &
+                    theme, import or back-up your 12-word seed, manage Nostr
+                    keys & relays.
                   </td>
                   <td class="p-4">
-                    Same, plus Publishing settings: toggle automatic NIP-61 profile updates and set a default “Earnings” bucket.
+                    Same, plus Publishing settings: toggle automatic NIP-61
+                    profile updates and set a default “Earnings” bucket.
                   </td>
                 </tr>
                 <tr class="border-b border-gray-800">
                   <td class="p-4 font-semibold">Find Creators</td>
                   <td class="p-4">
-                    Search or browse Nostr-indexed profiles. View tier prices, previews and public posts. Hit Subscribe or Zap with a single tap.
+                    Search or browse Nostr-indexed profiles. View tier prices,
+                    previews and public posts. Hit Subscribe or Zap with a
+                    single tap.
                   </td>
                   <td class="p-4">
-                    Your public storefront as seen by visitors. Great for a quick audit of how your profile appears worldwide.
+                    Your public storefront as seen by visitors. Great for a
+                    quick audit of how your profile appears worldwide.
                   </td>
                 </tr>
                 <tr class="border-b border-gray-800">
                   <td class="p-4 font-semibold">Creator Hub</td>
-                  <td class="p-4">— (hidden unless you toggle “Creator Mode”)</td>
                   <td class="p-4">
-                    Define or edit tiers (price, duration, perks), upload cover art, publish pay-walled posts, check revenue analytics and subscriber list.
+                    — (hidden unless you toggle “Creator Mode”)
+                  </td>
+                  <td class="p-4">
+                    Define or edit tiers (price, duration, perks), upload cover
+                    art, publish pay-walled posts, check revenue analytics and
+                    subscriber list.
                   </td>
                 </tr>
                 <tr class="border-b border-gray-800">
                   <td class="p-4 font-semibold">My Profile</td>
                   <td class="p-4">
-                    Show off your avatar, npub link and optional NIP-05. Personal stats: total zaps sent & received, bucket balances.
+                    Show off your avatar, npub link and optional NIP-05.
+                    Personal stats: total zaps sent & received, bucket balances.
                   </td>
                   <td class="p-4">
-                    Same card plus Edit. Update bio, tags and the secondary P2PK key used by fans to send you locked tokens.
+                    Same card plus Edit. Update bio, tags and the secondary P2PK
+                    key used by fans to send you locked tokens.
                   </td>
                 </tr>
                 <tr class="border-b border-gray-800">
                   <td class="p-4 font-semibold">Buckets</td>
                   <td class="p-4">
-                    Drag-and-drop jars for budgeting (“Groceries”, “Fun money”, “Subs”). Move sats with zero fees.
+                    Drag-and-drop jars for budgeting (“Groceries”, “Fun money”,
+                    “Subs”). Move sats with zero fees.
                   </td>
                   <td class="p-4">
-                    Create an “Income” bucket that auto-receives new tips; split out taxes or savings instantly.
+                    Create an “Income” bucket that auto-receives new tips; split
+                    out taxes or savings instantly.
                   </td>
                 </tr>
                 <tr class="border-b border-gray-800">
                   <td class="p-4 font-semibold">Subscriptions</td>
                   <td class="p-4">
-                    See every active plan: tier name, next renewal, cumulative sats spent. Cancel or renew with one click.
+                    See every active plan: tier name, next renewal, cumulative
+                    sats spent. Cancel or renew with one click.
                   </td>
                   <td class="p-4">
-                    Quick list of paying supporters, tier breakdown, churn alerts and pending renewals.
+                    Quick list of paying supporters, tier breakdown, churn
+                    alerts and pending renewals.
                   </td>
                 </tr>
                 <tr class="border-b border-gray-800">
                   <td class="p-4 font-semibold">Chats</td>
                   <td class="p-4">
-                    End-to-end encrypted DMs (Nostr kind 4). Attach images or Cashu tokens. Green flash means a payment is embedded and auto-redeemed on receipt.
+                    End-to-end encrypted DMs (Nostr kind 4). Attach images or
+                    Cashu tokens. Green flash means a payment is embedded and
+                    auto-redeemed on receipt.
                   </td>
                   <td class="p-4">
-                    Same powerful chat plus a broadcast toggle to message all subs in a tier at once.
+                    Same powerful chat plus a broadcast toggle to message all
+                    subs in a tier at once.
                   </td>
                 </tr>
                 <tr class="border-b border-gray-800">
@@ -305,7 +339,9 @@
                 <tr class="border-b border-gray-800">
                   <td class="p-4 font-semibold">About</td>
                   <td class="p-4">Learn everything in one scroll.</td>
-                  <td class="p-4">Ditto; includes creator-specific FAQs below.</td>
+                  <td class="p-4">
+                    Ditto; includes creator-specific FAQs below.
+                  </td>
                 </tr>
                 <tr>
                   <td class="p-4 font-semibold">External links</td>
@@ -326,100 +362,130 @@
           <div class="interactive-card p-6">
             <h3 class="font-semibold text-lg mb-2">Settings</h3>
             <p class="text-sm mb-2">
-              <strong>Fan / Subscriber perspective:</strong> Add / switch mints, choose display unit, set language & theme, import or back-up your 12-word seed, manage Nostr keys & relays.
+              <strong>Fan / Subscriber perspective:</strong> Add / switch mints,
+              choose display unit, set language & theme, import or back-up your
+              12-word seed, manage Nostr keys & relays.
             </p>
             <p class="text-sm">
-              <strong>Creator perspective:</strong> Same, plus Publishing settings: toggle automatic NIP-61 profile updates and set a default “Earnings” bucket.
+              <strong>Creator perspective:</strong> Same, plus Publishing
+              settings: toggle automatic NIP-61 profile updates and set a
+              default “Earnings” bucket.
             </p>
           </div>
 
           <div class="interactive-card p-6">
             <h3 class="font-semibold text-lg mb-2">Find Creators</h3>
             <p class="text-sm mb-2">
-              <strong>Fan / Subscriber perspective:</strong> Search or browse Nostr-indexed profiles. View tier prices, previews and public posts. Hit Subscribe or Zap with a single tap.
+              <strong>Fan / Subscriber perspective:</strong> Search or browse
+              Nostr-indexed profiles. View tier prices, previews and public
+              posts. Hit Subscribe or Zap with a single tap.
             </p>
             <p class="text-sm">
-              <strong>Creator perspective:</strong> Your public storefront as seen by visitors. Great for a quick audit of how your profile appears worldwide.
+              <strong>Creator perspective:</strong> Your public storefront as
+              seen by visitors. Great for a quick audit of how your profile
+              appears worldwide.
             </p>
           </div>
 
           <div class="interactive-card p-6">
             <h3 class="font-semibold text-lg mb-2">Creator Hub</h3>
             <p class="text-sm mb-2">
-              <strong>Fan / Subscriber perspective:</strong> — (hidden unless you toggle “Creator Mode”)
+              <strong>Fan / Subscriber perspective:</strong> — (hidden unless
+              you toggle “Creator Mode”)
             </p>
             <p class="text-sm">
-              <strong>Creator perspective:</strong> Define or edit tiers (price, duration, perks), upload cover art, publish pay-walled posts, check revenue analytics and subscriber list.
+              <strong>Creator perspective:</strong> Define or edit tiers (price,
+              duration, perks), upload cover art, publish pay-walled posts,
+              check revenue analytics and subscriber list.
             </p>
           </div>
 
           <div class="interactive-card p-6">
             <h3 class="font-semibold text-lg mb-2">My Profile</h3>
             <p class="text-sm mb-2">
-              <strong>Fan / Subscriber perspective:</strong> Show off your avatar, npub link and optional NIP-05. Personal stats: total zaps sent & received, bucket balances.
+              <strong>Fan / Subscriber perspective:</strong> Show off your
+              avatar, npub link and optional NIP-05. Personal stats: total zaps
+              sent & received, bucket balances.
             </p>
             <p class="text-sm">
-              <strong>Creator perspective:</strong> Same card plus Edit. Update bio, tags and the secondary P2PK key used by fans to send you locked tokens.
+              <strong>Creator perspective:</strong> Same card plus Edit. Update
+              bio, tags and the secondary P2PK key used by fans to send you
+              locked tokens.
             </p>
           </div>
 
           <div class="interactive-card p-6">
             <h3 class="font-semibold text-lg mb-2">Buckets</h3>
             <p class="text-sm mb-2">
-              <strong>Fan / Subscriber perspective:</strong> Drag-and-drop jars for budgeting (“Groceries”, “Fun money”, “Subs”). Move sats with zero fees.
+              <strong>Fan / Subscriber perspective:</strong> Drag-and-drop jars
+              for budgeting (“Groceries”, “Fun money”, “Subs”). Move sats with
+              zero fees.
             </p>
             <p class="text-sm">
-              <strong>Creator perspective:</strong> Create an “Income” bucket that auto-receives new tips; split out taxes or savings instantly.
+              <strong>Creator perspective:</strong> Create an “Income” bucket
+              that auto-receives new tips; split out taxes or savings instantly.
             </p>
           </div>
 
           <div class="interactive-card p-6">
             <h3 class="font-semibold text-lg mb-2">Subscriptions</h3>
             <p class="text-sm mb-2">
-              <strong>Fan / Subscriber perspective:</strong> See every active plan: tier name, next renewal, cumulative sats spent. Cancel or renew with one click.
+              <strong>Fan / Subscriber perspective:</strong> See every active
+              plan: tier name, next renewal, cumulative sats spent. Cancel or
+              renew with one click.
             </p>
             <p class="text-sm">
-              <strong>Creator perspective:</strong> Quick list of paying supporters, tier breakdown, churn alerts and pending renewals.
+              <strong>Creator perspective:</strong> Quick list of paying
+              supporters, tier breakdown, churn alerts and pending renewals.
             </p>
           </div>
 
           <div class="interactive-card p-6">
             <h3 class="font-semibold text-lg mb-2">Chats</h3>
             <p class="text-sm mb-2">
-              <strong>Fan / Subscriber perspective:</strong> End-to-end encrypted DMs (Nostr kind 4). Attach images or Cashu tokens. Green flash means a payment is embedded and auto-redeemed on receipt.
+              <strong>Fan / Subscriber perspective:</strong> End-to-end
+              encrypted DMs (Nostr kind 4). Attach images or Cashu tokens. Green
+              flash means a payment is embedded and auto-redeemed on receipt.
             </p>
             <p class="text-sm">
-              <strong>Creator perspective:</strong> Same powerful chat plus a broadcast toggle to message all subs in a tier at once.
+              <strong>Creator perspective:</strong> Same powerful chat plus a
+              broadcast toggle to message all subs in a tier at once.
             </p>
           </div>
 
           <div class="interactive-card p-6">
             <h3 class="font-semibold text-lg mb-2">Terms</h3>
             <p class="text-sm mb-2">
-              <strong>Fan / Subscriber perspective:</strong> Human-readable, plain-English licence & disclaimers.
+              <strong>Fan / Subscriber perspective:</strong> Human-readable,
+              plain-English licence & disclaimers.
             </p>
             <p class="text-sm">
-              <strong>Creator perspective:</strong> Identical — clarifies you keep full custody of funds.
+              <strong>Creator perspective:</strong> Identical — clarifies you
+              keep full custody of funds.
             </p>
           </div>
 
           <div class="interactive-card p-6">
             <h3 class="font-semibold text-lg mb-2">About</h3>
             <p class="text-sm mb-2">
-              <strong>Fan / Subscriber perspective:</strong> Learn everything in one scroll.
+              <strong>Fan / Subscriber perspective:</strong> Learn everything in
+              one scroll.
             </p>
             <p class="text-sm">
-              <strong>Creator perspective:</strong> Ditto; includes creator-specific FAQs below.
+              <strong>Creator perspective:</strong> Ditto; includes
+              creator-specific FAQs below.
             </p>
           </div>
 
           <div class="interactive-card p-6">
             <h3 class="font-semibold text-lg mb-2">External links</h3>
             <p class="text-sm mb-2">
-              <strong>Fan / Subscriber perspective:</strong> Cashu.space docs, GitHub, Twitter, Telegram, Donate.
+              <strong>Fan / Subscriber perspective:</strong> Cashu.space docs,
+              GitHub, Twitter, Telegram, Donate.
             </p>
             <p class="text-sm">
-              <strong>Creator perspective:</strong> Identical — share with collaborators or fans.
+              <strong>Creator perspective:</strong> Identical — share with
+              collaborators or fans.
             </p>
           </div>
         </div>
@@ -438,7 +504,8 @@
             <div class="text-4xl mb-4">🐙</div>
             <h3 class="font-semibold text-xl mb-2">Open Source & Verifiable</h3>
             <p class="text-sm">
-              Fundstr is built on open-source code. We invite you to inspect, verify, and contribute. Transparency is our core principle.
+              Fundstr is built on open-source code. We invite you to inspect,
+              verify, and contribute. Transparency is our core principle.
             </p>
           </div>
 
@@ -447,7 +514,9 @@
             <div class="text-4xl mb-4">🔑</div>
             <h3 class="font-semibold text-xl mb-2">You Hold the Keys</h3>
             <p class="text-sm">
-              You are the sole holder of your ecash tokens and Nostr identity. Mints act as custodians for the underlying Bitcoin, but only you can spend your ecash.
+              You are the sole holder of your ecash tokens and Nostr identity.
+              Mints act as custodians for the underlying Bitcoin, but only you
+              can spend your ecash.
             </p>
           </div>
 
@@ -456,7 +525,9 @@
             <div class="text-4xl mb-4">🛡️</div>
             <h3 class="font-semibold text-xl mb-2">Unbreakable Privacy</h3>
             <p class="text-sm">
-              Thanks to Chaumian blind signatures, mints cannot link your deposits to your withdrawals. Your spending habits remain completely private.
+              Thanks to Chaumian blind signatures, mints cannot link your
+              deposits to your withdrawals. Your spending habits remain
+              completely private.
             </p>
           </div>
 
@@ -465,7 +536,9 @@
             <div class="text-4xl mb-4">🪙</div>
             <h3 class="font-semibold text-xl mb-2">Mint Diversification</h3>
             <p class="text-sm">
-              Fundstr supports multiple mints, allowing you to diversify your holdings. Our audit tools will warn you (⚠️) of any unusual mint behavior.
+              Fundstr supports multiple mints, allowing you to diversify your
+              holdings. Our audit tools will warn you (⚠️) of any unusual mint
+              behavior.
             </p>
           </div>
         </div>
@@ -475,7 +548,9 @@
     <!-- FAQ -->
     <section id="faq" class="py-16 px-4 fade-in-section">
       <div class="max-w-4xl mx-auto">
-        <h2 class="text-3xl md:text-5xl font-bold mb-12 text-center gradient-text">
+        <h2
+          class="text-3xl md:text-5xl font-bold mb-12 text-center gradient-text"
+        >
           Frequently Asked Questions
         </h2>
 
@@ -486,7 +561,10 @@
               What if a fan stops paying?
             </summary>
             <p class="mt-4 text-sm">
-              Creator view » Their timelocked token never unlocks for you. Fundstr flags the user as “Expired” and hides future paid posts. Fan view » You simply don’t renew. No recurring pull, no surprise charges.
+              Creator view » Their timelocked token never unlocks for you.
+              Fundstr flags the user as “Expired” and hides future paid posts.
+              Fan view » You simply don’t renew. No recurring pull, no surprise
+              charges.
             </p>
           </details>
 
@@ -496,7 +574,9 @@
               Can I withdraw to a Lightning wallet?
             </summary>
             <p class="mt-4 text-sm">
-              Yes. Go to Wallet → Send → Lightning Invoice, paste the invoice from any external wallet; Fundstr melts the tokens at the mint and pays it.
+              Yes. Go to Wallet → Send → Lightning Invoice, paste the invoice
+              from any external wallet; Fundstr melts the tokens at the mint and
+              pays it.
             </p>
           </details>
 
@@ -506,9 +586,16 @@
               How private is this really?
             </summary>
             <ul class="mt-4 text-sm list-disc pl-6 space-y-1">
-              <li>Mints see withdraw/redeem events but cannot correlate them.</li>
-              <li>Nostr chats are E2E encrypted; Nutzaps use P2PK so only the intended receiver can claim them.</li>
-              <li>Choose different mints or buckets to compartmentalise further.</li>
+              <li>
+                Mints see withdraw/redeem events but cannot correlate them.
+              </li>
+              <li>
+                Nostr chats are E2E encrypted; Nutzaps use P2PK so only the
+                intended receiver can claim them.
+              </li>
+              <li>
+                Choose different mints or buckets to compartmentalise further.
+              </li>
             </ul>
           </details>
         </div>
@@ -524,9 +611,12 @@
             Join the Conversation
           </h2>
           <p class="mb-6">
-            Follow the project and its creator on Nostr to stay up-to-date and connect with the community.
+            Follow the project and its creator on Nostr to stay up-to-date and
+            connect with the community.
           </p>
-          <div class="flex flex-col sm:flex-row justify-center gap-4 text-accent">
+          <div
+            class="flex flex-col sm:flex-row justify-center gap-4 text-accent"
+          >
             <a
               href="#"
               class="interactive-card px-6 py-3 flex items-center justify-center gap-2"
@@ -545,7 +635,11 @@
       <section class="py-16 fade-in-section">
         <div class="max-w-5xl mx-auto">
           <blockquote>
-            Fundstr is powered by open-source code and an open community. Whether you’re a storyteller earning sats or a fan supporting work you love, we hope this guide helps you navigate every page with confidence — and makes your next payment feel as effortless as a like, comment, or retweet.
+            Fundstr is powered by open-source code and an open community.
+            Whether you’re a storyteller earning sats or a fan supporting work
+            you love, we hope this guide helps you navigate every page with
+            confidence — and makes your next payment feel as effortless as a
+            like, comment, or retweet.
           </blockquote>
         </div>
       </section>
@@ -578,32 +672,32 @@
 </template>
 
 <script setup>
-import { onMounted, ref } from 'vue'
+import { onMounted, ref } from "vue";
 
-const dialogStep1 = ref(false)
-const dialogStep2 = ref(false)
-const dialogStep3 = ref(false)
+const dialogStep1 = ref(false);
+const dialogStep2 = ref(false);
+const dialogStep3 = ref(false);
 
 onMounted(() => {
   const observer = new IntersectionObserver((entries) => {
     entries.forEach((entry) => {
       if (entry.isIntersecting) {
-        entry.target.classList.add('is-visible')
+        entry.target.classList.add("is-visible");
       }
-    })
-  })
+    });
+  });
 
-  document.querySelectorAll('.fade-in-section').forEach((el) => {
-    observer.observe(el)
-  })
-})
+  document.querySelectorAll(".fade-in-section").forEach((el) => {
+    observer.observe(el);
+  });
+});
 </script>
 
 <style scoped>
 .about-page {
   --color-accent: #22d3ee;
   --color-accent-rgb: 34, 211, 238;
-  font-family: 'Inter', sans-serif;
+  font-family: "Inter", sans-serif;
   background-color: #0a0a0a;
   background-image: radial-gradient(#1e293b 1px, transparent 1px);
   background-size: 20px 20px;
@@ -640,7 +734,7 @@ onMounted(() => {
 }
 
 .step-card::after {
-  content: '→';
+  content: "→";
   position: absolute;
   top: 50%;
   right: -1.5rem;
@@ -650,12 +744,12 @@ onMounted(() => {
 }
 
 .step-card:last-child::after {
-  content: '';
+  content: "";
 }
 
 @media (max-width: 768px) {
   .step-card::after {
-    content: '↓';
+    content: "↓";
     top: auto;
     bottom: -1.5rem;
     left: 50%;
@@ -681,22 +775,4 @@ blockquote {
   padding-left: 1rem;
   font-style: italic;
 }
-
-.alpha-warning {
-  background-color: rgba(120, 53, 15, 0.2);
-  border: 1px solid rgba(245, 158, 11, 0.3);
-  color: #fcd34d;
-  border-radius: 0.5rem;
-  padding: 1.5rem;
-  font-size: 1.25rem;
-  font-weight: 700;
-  box-shadow: 0 0 10px rgba(245, 158, 11, 0.5);
-}
-
-@media (min-width: 768px) {
-  .alpha-warning {
-    font-size: 1.5rem;
-  }
-}
 </style>
-


### PR DESCRIPTION
## Summary
- style: center and highlight alpha warning on about page
- style: update docs version of about page warning layout

## Testing
- `npm test` *(fails: many failing suites)*
- `npm run lint` *(fails: invalid option '--ext')*


------
https://chatgpt.com/codex/tasks/task_e_688df3799e1483308ef0c6c17263947a