### PR TITLE
feat: add fan/creator overview on about page

### DIFF
--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -1,11 +1,82 @@
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref } from "vue";
 
-const viewMode = ref<'fan' | 'creator'>('fan')
+interface NavItem {
+  label: string;
+  fan: string;
+  creator: string;
+}
 
-defineExpose({ viewMode })
+const viewMode = ref<"fan" | "creator">("fan");
+
+const navItems: NavItem[] = [
+  {
+    label: "Wallet",
+    fan: "View your balance and recent activity.",
+    creator: "Track incoming support and withdraw funds.",
+  },
+  {
+    label: "Send",
+    fan: "Tip your favorite creators or friends.",
+    creator: "Pay collaborators or move funds.",
+  },
+  {
+    label: "Receive",
+    fan: "Collect ecash or lightning payments.",
+    creator: "Let fans support you directly.",
+  },
+  {
+    label: "Settings",
+    fan: "Customize the app to suit your needs.",
+    creator: "Manage creator tools and preferences.",
+  },
+];
+
+const toggleOptions = [
+  { label: "Fan", value: "fan" },
+  { label: "Creator", value: "creator" },
+];
+
+defineExpose({ viewMode });
 </script>
 
 <template>
-  <div />
+  <div class="about-container q-pa-md">
+    <div class="flex justify-center q-mb-md">
+      <q-btn-toggle
+        v-model="viewMode"
+        :options="toggleOptions"
+        color="primary"
+        toggle-color="primary"
+        text-color="white"
+        dense
+        class="about-toggle"
+      />
+    </div>
+
+    <q-markup-table flat bordered class="about-table">
+      <tbody>
+        <tr v-for="item in navItems" :key="item.label">
+          <td class="text-weight-medium">{{ item.label }}</td>
+          <td>{{ item[viewMode] }}</td>
+        </tr>
+      </tbody>
+    </q-markup-table>
+  </div>
 </template>
+
+<style scoped>
+.about-container {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.about-table td:first-child {
+  width: 30%;
+  white-space: nowrap;
+}
+
+.about-table td {
+  vertical-align: top;
+}
+</style>


### PR DESCRIPTION
## Summary
- add nav items with fan and creator descriptions to About page
- provide toggle to switch view between fan and creator perspectives
- present comparison table and basic styling for readability

## Testing
- `npm test` *(fails: [🍍]: "getActivePinia()" was called but there was no active Pinia)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e2ae9e4a4833099d38e69e4a3c64f