### PR TITLE
fix: remove extraneous exports from AboutPage

### DIFF
--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -443,9 +443,9 @@ import { onMounted, ref } from 'vue'
 const dialogStep1 = ref(false)
 const dialogStep2 = ref(false)
 const dialogStep3 = ref(false)
-export const viewMode = ref<'fan' | 'creator'>('fan')
+const viewMode = ref<'fan' | 'creator'>('fan')
 
-export const navigationItems = ref([
+const navigationItems = ref([
   {
     menuItem: 'Settings',
     fanText:


### PR DESCRIPTION
## Summary
- remove `export` from `viewMode` and `navigationItems` in AboutPage's `<script setup>`

## Testing
- `pnpm run dev`
- `pnpm lint` *(fails: Invalid option '--ext')*
- `pnpm test` *(fails: multiple failing suites)*

------
https://chatgpt.com/codex/tasks/task_e_688e3219b4cc83308bc0d79c7b9a825a