### PR TITLE
refactor: add typing for AboutPage navigation map

### DIFF
--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -437,15 +437,21 @@
   </div>
 </template>
 
-<script setup>
+<script setup lang="ts">
 import { onMounted, ref } from 'vue'
+
+interface NavigationItem {
+  menuItem: string
+  fanText: string
+  creatorText: string
+}
 
 const dialogStep1 = ref(false)
 const dialogStep2 = ref(false)
 const dialogStep3 = ref(false)
 const viewMode = ref<'fan' | 'creator'>('fan')
 
-const navigationItems = ref([
+const navigationItems = ref<NavigationItem[]>([
   {
     menuItem: 'Settings',
     fanText:


### PR DESCRIPTION
## Summary
- migrate AboutPage.vue to use `<script setup lang="ts">`
- add `NavigationItem` interface and type navigation items

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*
- `npm test` *(fails: 22 failed, 136 passed)*

------
https://chatgpt.com/codex/tasks/task_e_688e35b9d9348330b109c897b55863d2