### PR TITLE
Fix Navigation Map table row border binding

### DIFF
--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -251,7 +251,7 @@
                 <tr
                   v-for="(item, index) in navigationItems"
                   :key="item.menuItem"
-                  :class="{ 'border-b border-gray-800': index !== navigationItems.length - 1 }"
+                  :class="{ 'border-b border-gray-800': index !== navigationItems.value.length - 1 }"
                 >
                   <td class="p-4 font-semibold">{{ item.menuItem }}</td>
                   <td class="p-4">


### PR DESCRIPTION
## Summary
- ensure Navigation Map table only draws row borders between items by accessing `navigationItems.value.length`

## Testing
- `npm test` *(fails: ReferenceError: windowMixin is not defined, TypeError: useTokensStore is not a function)*
- `npm run lint` *(fails: Invalid option '--ext' - perhaps you meant '-c'?)*

------
https://chatgpt.com/codex/tasks/task_e_688e380deb1c8330a19dea13e5939a86