### PR TITLE
Replace view toggle on About page with explicit buttons

### DIFF
--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -221,13 +221,22 @@
         </p>
 
         <!-- Perspective Toggle -->
-        <div class="mb-8 flex justify-center">
-          <q-btn-toggle
-            v-model="viewMode"
-            :options="[
-              { label: 'Fan', value: 'fan' },
-              { label: 'Creator', value: 'creator' }
-            ]"
+        <div class="mb-8 flex justify-center gap-4">
+          <q-btn
+            rounded
+            unelevated
+            color="primary"
+            label="Fan / Subscriber"
+            :outline="viewMode !== 'fan'"
+            @click="viewMode = 'fan'"
+          />
+          <q-btn
+            rounded
+            unelevated
+            color="primary"
+            label="Creator"
+            :outline="viewMode !== 'creator'"
+            @click="viewMode = 'creator'"
           />
         </div>
 


### PR DESCRIPTION
## Summary
- replace q-btn-toggle with two explicit buttons for "Fan / Subscriber" and "Creator" on About page
- highlight active perspective and update view accordingly

## Testing
- `npm test` *(fails: 30 failed, 30 passed)*
- `npx eslint src/pages/AboutPage.vue` *(fails: ReferenceError: module is not defined in ES module scope)*


------
https://chatgpt.com/codex/tasks/task_e_688e3a2d6c508330a296b50f75fcec0b