### PR TITLE
fix navigation items length access

### DIFF
--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -260,7 +260,7 @@
                 <tr
                   v-for="(item, index) in navigationItems"
                   :key="item.menuItem"
-                  :class="{ 'border-b border-gray-800': index !== navigationItems.value.length - 1 }"
+                  :class="{ 'border-b border-gray-800': index !== navigationItems.length - 1 }"
                 >
                   <td class="p-4 font-semibold">{{ item.menuItem }}</td>
                   <td class="p-4">


### PR DESCRIPTION
## Summary
- fix desktop table loop class binding to use navigationItems.length in AboutPage

## Testing
- `npm run build` *(fails: `Buffer` is not exported by __vite-browser-external)*
- `npm test` *(fails: multiple failing test suites)*

------
https://chatgpt.com/codex/tasks/task_e_688e3ecd1c1c833086e6979ac8176302