### PR TITLE
fix: use array for about page navigation items

### DIFF
--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -460,7 +460,7 @@ const dialogStep2 = ref(false)
 const dialogStep3 = ref(false)
 const viewMode = ref<'fan' | 'creator'>('fan')
 
-const navigationItems = ref<NavigationItem[]>([
+const navigationItems: NavigationItem[] = [
   {
     menuItem: 'Settings',
     fanText:
@@ -524,7 +524,7 @@ const navigationItems = ref<NavigationItem[]>([
     fanText: 'Cashu.space docs, GitHub, Twitter, Telegram, Donate.',
     creatorText: 'Identical — share with collaborators or fans.',
   },
-])
+]
 
 onMounted(() => {
   const observer = new IntersectionObserver((entries) => {


### PR DESCRIPTION
## Summary
- use plain array for `navigationItems` on about page
- maintain view mode toggle to switch fan/creator descriptions

## Testing
- `pnpm lint` *(fails: Invalid option '--ext' - perhaps you meant '-c'?)*
- `pnpm test` *(fails: multiple failing suites)*

------
https://chatgpt.com/codex/tasks/task_e_688e4755a2748330a3aaf20793f05ba3