### PR TITLE
feat: add intersection observer fallback

### DIFF
--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -527,17 +527,23 @@ const navigationItems: NavigationItem[] = [
 ]
 
 onMounted(() => {
-  const observer = new IntersectionObserver((entries) => {
-    entries.forEach((entry) => {
-      if (entry.isIntersecting) {
-        entry.target.classList.add('is-visible')
-      }
+  if ('IntersectionObserver' in window) {
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('is-visible')
+        }
+      })
     })
-  })
 
-  document.querySelectorAll('.fade-in-section').forEach((el) => {
-    observer.observe(el)
-  })
+    document.querySelectorAll('.fade-in-section').forEach((el) => {
+      observer.observe(el)
+    })
+  } else {
+    document
+      .querySelectorAll('.fade-in-section')
+      .forEach((el) => el.classList.add('is-visible'))
+  }
 })
 </script>
 


### PR DESCRIPTION
## Summary
- add feature detection for IntersectionObserver on About page
- ensure sections show if observer unsupported

## Testing
- `npm test` (fails: 7 test files failed, 24 tests failed)
- `npm run lint` (fails: Invalid option '--ext')

------
https://chatgpt.com/codex/tasks/task_e_688e4dd175808330a000e725c941b3c2