### PR TITLE
feat: add site overview to about page

### DIFF
--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -1433,4 +1433,18 @@ export default {
       invalid_pubkey: "Invalid pubkey",
     },
   },
+  AboutPage: {
+    siteOverview: {
+      title: "Site Overview",
+      wallet: "Manage your ecash balance.",
+      findCreators: "Discover creators to support.",
+      creatorHub: "Set up and manage your creator profile.",
+      myProfile: "View and edit your profile.",
+      buckets: "Organize funds into buckets.",
+      subscriptions: "Manage your subscriptions.",
+      nostrMessengerTitle: "Nostr Messenger",
+      nostrMessenger: "Chat privately with Nostr.",
+      settings: "Configure the app.",
+    },
+  },
 };

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -1439,4 +1439,18 @@ export default {
       invalid_pubkey: "Invalid pubkey",
     },
   },
+  AboutPage: {
+    siteOverview: {
+      title: "Site Overview",
+      wallet: "Manage your ecash balance.",
+      findCreators: "Discover creators to support.",
+      creatorHub: "Set up and manage your creator profile.",
+      myProfile: "View and edit your profile.",
+      buckets: "Organize funds into buckets.",
+      subscriptions: "Manage your subscriptions.",
+      nostrMessengerTitle: "Nostr Messenger",
+      nostrMessenger: "Chat privately with Nostr.",
+      settings: "Configure the app.",
+    },
+  },
 };

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -1443,4 +1443,18 @@ export default {
       invalid_pubkey: "Invalid pubkey",
     },
   },
+  AboutPage: {
+    siteOverview: {
+      title: "Site Overview",
+      wallet: "Manage your ecash balance.",
+      findCreators: "Discover creators to support.",
+      creatorHub: "Set up and manage your creator profile.",
+      myProfile: "View and edit your profile.",
+      buckets: "Organize funds into buckets.",
+      subscriptions: "Manage your subscriptions.",
+      nostrMessengerTitle: "Nostr Messenger",
+      nostrMessenger: "Chat privately with Nostr.",
+      settings: "Configure the app.",
+    },
+  },
 };

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1701,6 +1701,20 @@ export const messages = {
     goal: "Monthly goal",
     description: "Description",
   },
+  AboutPage: {
+    siteOverview: {
+      title: "Site Overview",
+      wallet: "Manage your ecash balance.",
+      findCreators: "Discover creators to support.",
+      creatorHub: "Set up and manage your creator profile.",
+      myProfile: "View and edit your profile.",
+      buckets: "Organize funds into buckets.",
+      subscriptions: "Manage your subscriptions.",
+      nostrMessengerTitle: "Nostr Messenger",
+      nostrMessenger: "Chat privately with Nostr.",
+      settings: "Configure the app.",
+    },
+  },
 };
 
 export default {

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -1440,4 +1440,18 @@ export default {
       invalid_pubkey: "Invalid pubkey",
     },
   },
+  AboutPage: {
+    siteOverview: {
+      title: "Site Overview",
+      wallet: "Manage your ecash balance.",
+      findCreators: "Discover creators to support.",
+      creatorHub: "Set up and manage your creator profile.",
+      myProfile: "View and edit your profile.",
+      buckets: "Organize funds into buckets.",
+      subscriptions: "Manage your subscriptions.",
+      nostrMessengerTitle: "Nostr Messenger",
+      nostrMessenger: "Chat privately with Nostr.",
+      settings: "Configure the app.",
+    },
+  },
 };

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -1430,4 +1430,18 @@ export default {
       invalid_pubkey: "Invalid pubkey",
     },
   },
+  AboutPage: {
+    siteOverview: {
+      title: "Site Overview",
+      wallet: "Manage your ecash balance.",
+      findCreators: "Discover creators to support.",
+      creatorHub: "Set up and manage your creator profile.",
+      myProfile: "View and edit your profile.",
+      buckets: "Organize funds into buckets.",
+      subscriptions: "Manage your subscriptions.",
+      nostrMessengerTitle: "Nostr Messenger",
+      nostrMessenger: "Chat privately with Nostr.",
+      settings: "Configure the app.",
+    },
+  },
 };

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -1422,4 +1422,18 @@ export default {
       invalid_pubkey: "Invalid pubkey",
     },
   },
+  AboutPage: {
+    siteOverview: {
+      title: "Site Overview",
+      wallet: "Manage your ecash balance.",
+      findCreators: "Discover creators to support.",
+      creatorHub: "Set up and manage your creator profile.",
+      myProfile: "View and edit your profile.",
+      buckets: "Organize funds into buckets.",
+      subscriptions: "Manage your subscriptions.",
+      nostrMessengerTitle: "Nostr Messenger",
+      nostrMessenger: "Chat privately with Nostr.",
+      settings: "Configure the app.",
+    },
+  },
 };

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -1423,4 +1423,18 @@ export default {
       invalid_pubkey: "Invalid pubkey",
     },
   },
+  AboutPage: {
+    siteOverview: {
+      title: "Site Overview",
+      wallet: "Manage your ecash balance.",
+      findCreators: "Discover creators to support.",
+      creatorHub: "Set up and manage your creator profile.",
+      myProfile: "View and edit your profile.",
+      buckets: "Organize funds into buckets.",
+      subscriptions: "Manage your subscriptions.",
+      nostrMessengerTitle: "Nostr Messenger",
+      nostrMessenger: "Chat privately with Nostr.",
+      settings: "Configure the app.",
+    },
+  },
 };

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -1422,4 +1422,18 @@ export default {
       invalid_pubkey: "Invalid pubkey",
     },
   },
+  AboutPage: {
+    siteOverview: {
+      title: "Site Overview",
+      wallet: "Manage your ecash balance.",
+      findCreators: "Discover creators to support.",
+      creatorHub: "Set up and manage your creator profile.",
+      myProfile: "View and edit your profile.",
+      buckets: "Organize funds into buckets.",
+      subscriptions: "Manage your subscriptions.",
+      nostrMessengerTitle: "Nostr Messenger",
+      nostrMessenger: "Chat privately with Nostr.",
+      settings: "Configure the app.",
+    },
+  },
 };

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -1420,4 +1420,18 @@ export default {
       invalid_pubkey: "Invalid pubkey",
     },
   },
+  AboutPage: {
+    siteOverview: {
+      title: "Site Overview",
+      wallet: "Manage your ecash balance.",
+      findCreators: "Discover creators to support.",
+      creatorHub: "Set up and manage your creator profile.",
+      myProfile: "View and edit your profile.",
+      buckets: "Organize funds into buckets.",
+      subscriptions: "Manage your subscriptions.",
+      nostrMessengerTitle: "Nostr Messenger",
+      nostrMessenger: "Chat privately with Nostr.",
+      settings: "Configure the app.",
+    },
+  },
 };

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -1425,4 +1425,18 @@ export default {
       invalid_pubkey: "Invalid pubkey",
     },
   },
+  AboutPage: {
+    siteOverview: {
+      title: "Site Overview",
+      wallet: "Manage your ecash balance.",
+      findCreators: "Discover creators to support.",
+      creatorHub: "Set up and manage your creator profile.",
+      myProfile: "View and edit your profile.",
+      buckets: "Organize funds into buckets.",
+      subscriptions: "Manage your subscriptions.",
+      nostrMessengerTitle: "Nostr Messenger",
+      nostrMessenger: "Chat privately with Nostr.",
+      settings: "Configure the app.",
+    },
+  },
 };

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -1412,4 +1412,18 @@ export default {
       invalid_pubkey: "Invalid pubkey",
     },
   },
+  AboutPage: {
+    siteOverview: {
+      title: "Site Overview",
+      wallet: "Manage your ecash balance.",
+      findCreators: "Discover creators to support.",
+      creatorHub: "Set up and manage your creator profile.",
+      myProfile: "View and edit your profile.",
+      buckets: "Organize funds into buckets.",
+      subscriptions: "Manage your subscriptions.",
+      nostrMessengerTitle: "Nostr Messenger",
+      nostrMessenger: "Chat privately with Nostr.",
+      settings: "Configure the app.",
+    },
+  },
 };

--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -31,6 +31,65 @@
       </div>
     </section>
 
+    <!-- Site Overview -->
+    <section id="site-overview" class="py-16 px-4 fade-in-section">
+      <div class="max-w-4xl mx-auto text-center">
+        <h2 class="text-3xl md:text-5xl font-bold mb-6 gradient-text">
+          {{ $t('AboutPage.siteOverview.title') }}
+        </h2>
+        <ul class="text-lg md:text-xl space-y-4 text-left">
+          <li>
+            <router-link to="/wallet" class="text-accent font-semibold">
+              {{ $t('MainHeader.menu.wallet.title') }}
+            </router-link>
+            – {{ $t('AboutPage.siteOverview.wallet') }}
+          </li>
+          <li>
+            <router-link to="/find-creators" class="text-accent font-semibold">
+              {{ $t('MainHeader.menu.findCreators.title') }}
+            </router-link>
+            – {{ $t('AboutPage.siteOverview.findCreators') }}
+          </li>
+          <li>
+            <router-link to="/creator-hub" class="text-accent font-semibold">
+              {{ $t('MainHeader.menu.creatorHub.title') }}
+            </router-link>
+            – {{ $t('AboutPage.siteOverview.creatorHub') }}
+          </li>
+          <li>
+            <router-link to="/my-profile" class="text-accent font-semibold">
+              {{ $t('MainHeader.menu.myProfile.title') }}
+            </router-link>
+            – {{ $t('AboutPage.siteOverview.myProfile') }}
+          </li>
+          <li>
+            <router-link to="/buckets" class="text-accent font-semibold">
+              {{ $t('MainHeader.menu.buckets.title') }}
+            </router-link>
+            – {{ $t('AboutPage.siteOverview.buckets') }}
+          </li>
+          <li>
+            <router-link to="/subscriptions" class="text-accent font-semibold">
+              {{ $t('MainHeader.menu.subscriptions.title') }}
+            </router-link>
+            – {{ $t('AboutPage.siteOverview.subscriptions') }}
+          </li>
+          <li>
+            <router-link to="/nostr-messenger" class="text-accent font-semibold">
+              {{ $t('AboutPage.siteOverview.nostrMessengerTitle') }}
+            </router-link>
+            – {{ $t('AboutPage.siteOverview.nostrMessenger') }}
+          </li>
+          <li>
+            <router-link to="/settings" class="text-accent font-semibold">
+              {{ $t('MainHeader.menu.settings.title') }}
+            </router-link>
+            – {{ $t('AboutPage.siteOverview.settings') }}
+          </li>
+        </ul>
+      </div>
+    </section>
+
     <!-- How Ecash Works -->
     <section id="how-it-works" class="py-16 px-4 fade-in-section">
       <div class="max-w-5xl mx-auto text-center">


### PR DESCRIPTION
## Summary
- add "Site Overview" section linking to key routes on About page
- introduce i18n strings for new overview section across locales

## Testing
- `npm run lint` *(fails: Invalid option '--ext' - perhaps you meant '-c'?)*
- `npm test` *(fails: Duplicate key "creatorHub" in object literal)*

------
https://chatgpt.com/codex/tasks/task_e_688e5b49ae708330810a9dc67d064662