### PR TITLE
Expand About page navigation table

### DIFF
--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -11,24 +11,54 @@ const viewMode = ref<"fan" | "creator">("fan");
 
 const navItems: NavItem[] = [
   {
-    label: "Wallet",
-    fan: "View your balance and recent activity.",
-    creator: "Track incoming support and withdraw funds.",
-  },
-  {
-    label: "Send",
-    fan: "Tip your favorite creators or friends.",
-    creator: "Pay collaborators or move funds.",
-  },
-  {
-    label: "Receive",
-    fan: "Collect ecash or lightning payments.",
-    creator: "Let fans support you directly.",
-  },
-  {
     label: "Settings",
     fan: "Customize the app to suit your needs.",
     creator: "Manage creator tools and preferences.",
+  },
+  {
+    label: "Find Creators",
+    fan: "Discover new creators to support.",
+    creator: "Promote your profile to potential fans.",
+  },
+  {
+    label: "Creator Hub",
+    fan: "Explore tools designed for creators.",
+    creator: "Access your creator dashboard and resources.",
+  },
+  {
+    label: "My Profile",
+    fan: "View and edit your personal information.",
+    creator: "Manage your creator identity and bio.",
+  },
+  {
+    label: "Buckets",
+    fan: "Organize your funds into custom buckets.",
+    creator: "Track income streams with bucketed funds.",
+  },
+  {
+    label: "Subscriptions",
+    fan: "Manage the creators you're subscribed to.",
+    creator: "Control your subscriber tiers and benefits.",
+  },
+  {
+    label: "Chats",
+    fan: "Message creators directly.",
+    creator: "Interact with your supporters.",
+  },
+  {
+    label: "Terms",
+    fan: "Review the platform's terms of service.",
+    creator: "Review the platform's terms of service.",
+  },
+  {
+    label: "About",
+    fan: "Learn more about the project.",
+    creator: "Learn more about the project.",
+  },
+  {
+    label: "External links",
+    fan: "Visit official resources and documentation.",
+    creator: "Visit official resources and documentation.",
   },
 ];
 


### PR DESCRIPTION
## Summary
- replace About page navItems with Settings, Find Creators, Creator Hub, My Profile, Buckets, Subscriptions, Chats, Terms, About, and External links entries, each with fan and creator descriptions
- keep fan/creator toggle to show appropriate descriptions

## Testing
- `npm test` *(fails: [🍍]: "getActivePinia()" was called but there was no active Pinia)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e662bee1483309b0e1ff26b3ff291