### PR TITLE
fix navigation map section

### DIFF
--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -549,7 +549,7 @@ const dialogStep2 = ref(false)
 const dialogStep3 = ref(false)
 const viewMode = ref<'fan' | 'creator'>('fan')
 
-const navigationItems = ref<NavigationItem[]>([
+const navigationItems: NavigationItem[] = [
   {
     menuItem: 'Settings',
     fanText:
@@ -613,7 +613,7 @@ const navigationItems = ref<NavigationItem[]>([
     fanText: 'Cashu.space docs, GitHub, Twitter, Telegram, Donate.',
     creatorText: 'Identical — share with collaborators or fans.',
   },
-])
+]
 
 onMounted(() => {
   if ('IntersectionObserver' in window) {


### PR DESCRIPTION
## Summary
- fix navigation map to show fan and creator descriptions

## Testing
- `npm test` *(fails: Failed Suites 14)*
- `npm run lint` *(fails: Invalid option '--ext')*

------
https://chatgpt.com/codex/tasks/task_e_688e6b8064288330b81e21453f8cbbfb