### PR TITLE
fix: populate navigation map

### DIFF
--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -549,7 +549,8 @@ const dialogStep2 = ref(false)
 const dialogStep3 = ref(false)
 const viewMode = ref<'fan' | 'creator'>('fan')
 
-const navigationItems: NavigationItem[] = [
+// navigation items for the navigation map
+const navigationItems = ref<NavigationItem[]>([
   {
     menuItem: 'Settings',
     fanText:
@@ -613,7 +614,7 @@ const navigationItems: NavigationItem[] = [
     fanText: 'Cashu.space docs, GitHub, Twitter, Telegram, Donate.',
     creatorText: 'Identical — share with collaborators or fans.',
   },
-]
+])
 
 onMounted(() => {
   if ('IntersectionObserver' in window) {


### PR DESCRIPTION
## Summary
- ensure navigation map on about page renders menu descriptions

## Testing
- `npm test` *(fails: multiple failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_688f02452c0c83309f2a730a4f779ff0