### PR TITLE
feat: add base English translations

### DIFF
--- a/src/boot/i18n.js
+++ b/src/boot/i18n.js
@@ -2,16 +2,16 @@ import { boot } from "quasar/wrappers";
 import { createI18n } from "vue-i18n";
 import { loadMessages } from "src/i18n";
 
-// Get stored locale from localStorage or fallback to browser language or en-US
+// Get stored locale from localStorage or fallback to browser language or en
 let storedLocale =
-  localStorage.getItem("cashu.language") || navigator.language || "en-US";
+  localStorage.getItem("cashu.language") || navigator.language || "en";
 
-// Map generic English locale to en-US since no "en" folder exists
-if (storedLocale === "en") {
-  storedLocale = "en-US";
-}
-const messages = { "en-US": await loadMessages("en-US") };
-if (storedLocale !== "en-US") {
+const messages = {
+  en: await loadMessages("en"),
+  "en-US": await loadMessages("en-US"),
+};
+
+if (!["en", "en-US"].includes(storedLocale)) {
   messages[storedLocale] = await loadMessages(storedLocale);
 }
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,0 +1,37 @@
+{
+  "MainHeader": {
+    "menu": {
+      "wallet": { "title": "Wallet" },
+      "findCreators": { "title": "Find Creators" },
+      "creatorHub": { "title": "Creator Hub" },
+      "myProfile": { "title": "My Profile" },
+      "buckets": { "title": "Buckets" },
+      "subscriptions": { "title": "Subscriptions" },
+      "settings": { "title": "Settings" },
+      "terms": { "title": "Terms" }
+    }
+  },
+  "AboutPage": {
+    "siteOverview": {
+      "title": "Site Overview",
+      "wallet": "A private, secure ecash wallet to manage your funds.",
+      "findCreators": "Discover and support your favorite creators on the Nostr network.",
+      "creatorHub": "Manage your tiers, posts, and subscribers.",
+      "myProfile": "View and edit your public profile.",
+      "buckets": "Organize your sats into different spending buckets.",
+      "subscriptions": "Manage your subscriptions to creators.",
+      "nostrMessengerTitle": "Nostr Messenger",
+      "nostrMessenger": "Chat privately with end‑to‑end encrypted messages.",
+      "settings": "Configure your wallet, mints, and Nostr settings.",
+      "restoreTitle": "Restore",
+      "restore": "Restore your wallet from your seed phrase.",
+      "alreadyRunningTitle": "Already Running",
+      "alreadyRunning": "Handles cases where the app is open in another tab.",
+      "welcomeTitle": "Welcome",
+      "welcome": "The initial welcome and setup screen.",
+      "terms": "Read the terms of service.",
+      "nostrLoginTitle": "Nostr Login",
+      "nostrLogin": "Login using your Nostr credentials."
+    }
+  }
+}

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,6 +1,12 @@
 const messageModules = import.meta.glob<{ default: any }>("./*/index.ts");
+const jsonModules = import.meta.glob<{ default: any }>("./*.json");
 
 export async function loadMessages(locale: string) {
+  const jsonLoader = jsonModules[`./${locale}.json`];
+  if (jsonLoader) {
+    return (await jsonLoader()).default;
+  }
+
   const loader = messageModules[`./${locale}/index.ts`];
   if (!loader) {
     throw new Error(`Locale messages not found: ${locale}`);


### PR DESCRIPTION
## Summary
- add English translations for main header and about page
- load JSON locale files and register base `en` locale in i18n boot

## Testing
- `npm test` *(fails: TypeError: p2pk.generateKeypair is not a function, etc.)*
- `npm run lint` *(fails: Invalid option '--ext')*


------
https://chatgpt.com/codex/tasks/task_e_688f0d09e3c08330b12485b87a61c06a