### PR TITLE
Use translation keys for AboutPage site overview links

### DIFF
--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -101,6 +101,12 @@ export default {
   },
   MainHeader: {
     menu: {
+      wallet: { title: "@:FullscreenHeader.actions.back.label" },
+      nostrMessenger: { title: "@:AboutPage.siteOverview.nostrMessengerTitle" },
+      restore: { title: "@:AboutPage.siteOverview.restoreTitle" },
+      alreadyRunning: { title: "@:AboutPage.siteOverview.alreadyRunningTitle" },
+      welcome: { title: "@:AboutPage.siteOverview.welcomeTitle" },
+      nostrLogin: { title: "@:AboutPage.siteOverview.nostrLoginTitle" },
       settings: {
         title: "الإعدادات",
         settings: {

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -102,6 +102,12 @@ export default {
   },
   MainHeader: {
     menu: {
+      wallet: { title: "@:FullscreenHeader.actions.back.label" },
+      nostrMessenger: { title: "@:AboutPage.siteOverview.nostrMessengerTitle" },
+      restore: { title: "@:AboutPage.siteOverview.restoreTitle" },
+      alreadyRunning: { title: "@:AboutPage.siteOverview.alreadyRunningTitle" },
+      welcome: { title: "@:AboutPage.siteOverview.welcomeTitle" },
+      nostrLogin: { title: "@:AboutPage.siteOverview.nostrLoginTitle" },
       settings: {
         title: "Einstellungen",
         settings: {

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -102,6 +102,12 @@ export default {
   },
   MainHeader: {
     menu: {
+      wallet: { title: "@:FullscreenHeader.actions.back.label" },
+      nostrMessenger: { title: "@:AboutPage.siteOverview.nostrMessengerTitle" },
+      restore: { title: "@:AboutPage.siteOverview.restoreTitle" },
+      alreadyRunning: { title: "@:AboutPage.siteOverview.alreadyRunningTitle" },
+      welcome: { title: "@:AboutPage.siteOverview.welcomeTitle" },
+      nostrLogin: { title: "@:AboutPage.siteOverview.nostrLoginTitle" },
       settings: {
         title: "Ρυθμίσεις",
         settings: {

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -106,6 +106,12 @@ export const messages = {
   },
   MainHeader: {
     menu: {
+      wallet: { title: "@:FullscreenHeader.actions.back.label" },
+      nostrMessenger: { title: "@:AboutPage.siteOverview.nostrMessengerTitle" },
+      restore: { title: "@:AboutPage.siteOverview.restoreTitle" },
+      alreadyRunning: { title: "@:AboutPage.siteOverview.alreadyRunningTitle" },
+      welcome: { title: "@:AboutPage.siteOverview.welcomeTitle" },
+      nostrLogin: { title: "@:AboutPage.siteOverview.nostrLoginTitle" },
       settings: {
         title: "Settings",
         settings: {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -7,7 +7,12 @@
       "myProfile": { "title": "My Profile" },
       "buckets": { "title": "Buckets" },
       "subscriptions": { "title": "Subscriptions" },
+      "nostrMessenger": { "title": "@:AboutPage.siteOverview.nostrMessengerTitle" },
       "settings": { "title": "Settings" },
+      "restore": { "title": "@:AboutPage.siteOverview.restoreTitle" },
+      "alreadyRunning": { "title": "@:AboutPage.siteOverview.alreadyRunningTitle" },
+      "welcome": { "title": "@:AboutPage.siteOverview.welcomeTitle" },
+      "nostrLogin": { "title": "@:AboutPage.siteOverview.nostrLoginTitle" },
       "terms": { "title": "Terms" }
     }
   },

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -102,6 +102,12 @@ export default {
   },
   MainHeader: {
     menu: {
+      wallet: { title: "@:FullscreenHeader.actions.back.label" },
+      nostrMessenger: { title: "@:AboutPage.siteOverview.nostrMessengerTitle" },
+      restore: { title: "@:AboutPage.siteOverview.restoreTitle" },
+      alreadyRunning: { title: "@:AboutPage.siteOverview.alreadyRunningTitle" },
+      welcome: { title: "@:AboutPage.siteOverview.welcomeTitle" },
+      nostrLogin: { title: "@:AboutPage.siteOverview.nostrLoginTitle" },
       settings: {
         title: "Configuración",
         settings: {

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -102,6 +102,12 @@ export default {
   },
   MainHeader: {
     menu: {
+      wallet: { title: "@:FullscreenHeader.actions.back.label" },
+      nostrMessenger: { title: "@:AboutPage.siteOverview.nostrMessengerTitle" },
+      restore: { title: "@:AboutPage.siteOverview.restoreTitle" },
+      alreadyRunning: { title: "@:AboutPage.siteOverview.alreadyRunningTitle" },
+      welcome: { title: "@:AboutPage.siteOverview.welcomeTitle" },
+      nostrLogin: { title: "@:AboutPage.siteOverview.nostrLoginTitle" },
       settings: {
         title: "Paramètres",
         settings: {

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -102,6 +102,12 @@ export default {
   },
   MainHeader: {
     menu: {
+      wallet: { title: "@:FullscreenHeader.actions.back.label" },
+      nostrMessenger: { title: "@:AboutPage.siteOverview.nostrMessengerTitle" },
+      restore: { title: "@:AboutPage.siteOverview.restoreTitle" },
+      alreadyRunning: { title: "@:AboutPage.siteOverview.alreadyRunningTitle" },
+      welcome: { title: "@:AboutPage.siteOverview.welcomeTitle" },
+      nostrLogin: { title: "@:AboutPage.siteOverview.nostrLoginTitle" },
       settings: {
         title: "Impostazioni",
         settings: {

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -102,6 +102,12 @@ export default {
   },
   MainHeader: {
     menu: {
+      wallet: { title: "@:FullscreenHeader.actions.back.label" },
+      nostrMessenger: { title: "@:AboutPage.siteOverview.nostrMessengerTitle" },
+      restore: { title: "@:AboutPage.siteOverview.restoreTitle" },
+      alreadyRunning: { title: "@:AboutPage.siteOverview.alreadyRunningTitle" },
+      welcome: { title: "@:AboutPage.siteOverview.welcomeTitle" },
+      nostrLogin: { title: "@:AboutPage.siteOverview.nostrLoginTitle" },
       settings: {
         title: "設定",
         settings: {

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -101,6 +101,12 @@ export default {
   },
   MainHeader: {
     menu: {
+      wallet: { title: "@:FullscreenHeader.actions.back.label" },
+      nostrMessenger: { title: "@:AboutPage.siteOverview.nostrMessengerTitle" },
+      restore: { title: "@:AboutPage.siteOverview.restoreTitle" },
+      alreadyRunning: { title: "@:AboutPage.siteOverview.alreadyRunningTitle" },
+      welcome: { title: "@:AboutPage.siteOverview.welcomeTitle" },
+      nostrLogin: { title: "@:AboutPage.siteOverview.nostrLoginTitle" },
       settings: {
         title: "Inställningar",
         settings: {

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -102,6 +102,12 @@ export default {
   },
   MainHeader: {
     menu: {
+      wallet: { title: "@:FullscreenHeader.actions.back.label" },
+      nostrMessenger: { title: "@:AboutPage.siteOverview.nostrMessengerTitle" },
+      restore: { title: "@:AboutPage.siteOverview.restoreTitle" },
+      alreadyRunning: { title: "@:AboutPage.siteOverview.alreadyRunningTitle" },
+      welcome: { title: "@:AboutPage.siteOverview.welcomeTitle" },
+      nostrLogin: { title: "@:AboutPage.siteOverview.nostrLoginTitle" },
       settings: {
         title: "การตั้งค่า",
         settings: {

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -102,6 +102,12 @@ export default {
   },
   MainHeader: {
     menu: {
+      wallet: { title: "@:FullscreenHeader.actions.back.label" },
+      nostrMessenger: { title: "@:AboutPage.siteOverview.nostrMessengerTitle" },
+      restore: { title: "@:AboutPage.siteOverview.restoreTitle" },
+      alreadyRunning: { title: "@:AboutPage.siteOverview.alreadyRunningTitle" },
+      welcome: { title: "@:AboutPage.siteOverview.welcomeTitle" },
+      nostrLogin: { title: "@:AboutPage.siteOverview.nostrLoginTitle" },
       settings: {
         title: "Ayarlar",
         settings: {

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -101,6 +101,12 @@ export default {
   },
   MainHeader: {
     menu: {
+      wallet: { title: "@:FullscreenHeader.actions.back.label" },
+      nostrMessenger: { title: "@:AboutPage.siteOverview.nostrMessengerTitle" },
+      restore: { title: "@:AboutPage.siteOverview.restoreTitle" },
+      alreadyRunning: { title: "@:AboutPage.siteOverview.alreadyRunningTitle" },
+      welcome: { title: "@:AboutPage.siteOverview.welcomeTitle" },
+      nostrLogin: { title: "@:AboutPage.siteOverview.nostrLoginTitle" },
       settings: {
         title: "设置",
         settings: {

--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -76,7 +76,7 @@
           </li>
           <li>
             <router-link to="/nostr-messenger" class="text-accent font-semibold">
-              {{ $t('AboutPage.siteOverview.nostrMessengerTitle') }}
+              {{ $t('MainHeader.menu.nostrMessenger.title') }}
             </router-link>
             – {{ $t('AboutPage.siteOverview.nostrMessenger') }}
           </li>
@@ -88,19 +88,19 @@
           </li>
           <li>
             <router-link to="/restore" class="text-accent font-semibold">
-              {{ $t('AboutPage.siteOverview.restoreTitle') }}
+              {{ $t('MainHeader.menu.restore.title') }}
             </router-link>
             – {{ $t('AboutPage.siteOverview.restore') }}
           </li>
           <li>
             <router-link to="/already-running" class="text-accent font-semibold">
-              {{ $t('AboutPage.siteOverview.alreadyRunningTitle') }}
+              {{ $t('MainHeader.menu.alreadyRunning.title') }}
             </router-link>
             – {{ $t('AboutPage.siteOverview.alreadyRunning') }}
           </li>
           <li>
             <router-link to="/welcome" class="text-accent font-semibold">
-              {{ $t('AboutPage.siteOverview.welcomeTitle') }}
+              {{ $t('MainHeader.menu.welcome.title') }}
             </router-link>
             – {{ $t('AboutPage.siteOverview.welcome') }}
           </li>
@@ -112,7 +112,7 @@
           </li>
           <li>
             <router-link to="/nostr-login" class="text-accent font-semibold">
-              {{ $t('AboutPage.siteOverview.nostrLoginTitle') }}
+              {{ $t('MainHeader.menu.nostrLogin.title') }}
             </router-link>
             – {{ $t('AboutPage.siteOverview.nostrLogin') }}
           </li>


### PR DESCRIPTION
## Summary
- localize About page site overview links using MainHeader menu titles
- add translation entries for new menu items across locales

## Testing
- `npm test` *(fails: There was an error when mocking a module)*
- `npm run lint` *(fails: Invalid option '--ext')*

------
https://chatgpt.com/codex/tasks/task_e_688f10fe7eac83309a169763492c062f