### PR TITLE
feat: add about cards

### DIFF
--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -1442,24 +1442,63 @@ export default {
   AboutPage: {
     siteOverview: {
       title: "نظرة عامة على الموقع",
-      wallet: "إدارة رصيد ecash الخاص بك.",
-      findCreators: "اكتشف المبدعين لدعمهم.",
-      creatorHub: "إعداد وإدارة ملف المبدع الخاص بك.",
-      myProfile: "عرض وتحرير ملفك الشخصي.",
-      buckets: "تنظيم الأموال في حاويات.",
-      subscriptions: "إدارة اشتراكاتك.",
+      wallet: {
+        description: "إدارة رصيد ecash الخاص بك.",
+        icon: "account_balance_wallet",
+      },
+      findCreators: {
+        description: "اكتشف المبدعين لدعمهم.",
+        icon: "search",
+      },
+      creatorHub: {
+        description: "إعداد وإدارة ملف المبدع الخاص بك.",
+        icon: "hub",
+      },
+      myProfile: {
+        description: "عرض وتحرير ملفك الشخصي.",
+        icon: "person",
+      },
+      buckets: {
+        description: "تنظيم الأموال في حاويات.",
+        icon: "inbox",
+      },
+      subscriptions: {
+        description: "إدارة اشتراكاتك.",
+        icon: "subscriptions",
+      },
       nostrMessengerTitle: "Nostr Messenger",
-      nostrMessenger: "الدردشة بشكل خاص عبر Nostr.",
-      settings: "تكوين التطبيق.",
+      nostrMessenger: {
+        description: "الدردشة بشكل خاص عبر Nostr.",
+        icon: "chat",
+      },
+      settings: {
+        description: "تكوين التطبيق.",
+        icon: "settings",
+      },
       restoreTitle: "Restore",
-      restore: "Recover your wallet from a backup.",
+      restore: {
+        description: "Recover your wallet from a backup.",
+        icon: "settings_backup_restore",
+      },
       alreadyRunningTitle: "Already Running",
-      alreadyRunning: "Warning when another session is active.",
+      alreadyRunning: {
+        description: "Warning when another session is active.",
+        icon: "warning",
+      },
       welcomeTitle: "Welcome",
-      welcome: "Introductory guide to Fundstr.",
-      terms: "Review the terms of service.",
+      welcome: {
+        description: "Introductory guide to Fundstr.",
+        icon: "info",
+      },
+      terms: {
+        description: "Review the terms of service.",
+        icon: "gavel",
+      },
       nostrLoginTitle: "Nostr Login",
-      nostrLogin: "Authenticate using your Nostr keys.",
+      nostrLogin: {
+        description: "Authenticate using your Nostr keys.",
+        icon: "login",
+      },
     },
   },
 };

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -1448,24 +1448,63 @@ export default {
   AboutPage: {
     siteOverview: {
       title: "Website-Übersicht",
-      wallet: "Verwalten Sie Ihr Ecash-Guthaben.",
-      findCreators: "Entdecken Sie Creator zur Unterstützung.",
-      creatorHub: "Richten Sie Ihr Creator-Profil ein und verwalten Sie es.",
-      myProfile: "Sehen und bearbeiten Sie Ihr Profil.",
-      buckets: "Organisieren Sie Mittel in Buckets.",
-      subscriptions: "Verwalten Sie Ihre Abonnements.",
+      wallet: {
+        description: "Verwalten Sie Ihr Ecash-Guthaben.",
+        icon: "account_balance_wallet",
+      },
+      findCreators: {
+        description: "Entdecken Sie Creator zur Unterstützung.",
+        icon: "search",
+      },
+      creatorHub: {
+        description: "Richten Sie Ihr Creator-Profil ein und verwalten Sie es.",
+        icon: "hub",
+      },
+      myProfile: {
+        description: "Sehen und bearbeiten Sie Ihr Profil.",
+        icon: "person",
+      },
+      buckets: {
+        description: "Organisieren Sie Mittel in Buckets.",
+        icon: "inbox",
+      },
+      subscriptions: {
+        description: "Verwalten Sie Ihre Abonnements.",
+        icon: "subscriptions",
+      },
       nostrMessengerTitle: "Nostr Messenger",
-      nostrMessenger: "Chatten Sie privat mit Nostr.",
-      settings: "Konfigurieren Sie die App.",
+      nostrMessenger: {
+        description: "Chatten Sie privat mit Nostr.",
+        icon: "chat",
+      },
+      settings: {
+        description: "Konfigurieren Sie die App.",
+        icon: "settings",
+      },
       restoreTitle: "Restore",
-      restore: "Recover your wallet from a backup.",
+      restore: {
+        description: "Recover your wallet from a backup.",
+        icon: "settings_backup_restore",
+      },
       alreadyRunningTitle: "Already Running",
-      alreadyRunning: "Warning when another session is active.",
+      alreadyRunning: {
+        description: "Warning when another session is active.",
+        icon: "warning",
+      },
       welcomeTitle: "Welcome",
-      welcome: "Introductory guide to Fundstr.",
-      terms: "Review the terms of service.",
+      welcome: {
+        description: "Introductory guide to Fundstr.",
+        icon: "info",
+      },
+      terms: {
+        description: "Review the terms of service.",
+        icon: "gavel",
+      },
       nostrLoginTitle: "Nostr Login",
-      nostrLogin: "Authenticate using your Nostr keys.",
+      nostrLogin: {
+        description: "Authenticate using your Nostr keys.",
+        icon: "login",
+      },
     },
   },
 };

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -1452,24 +1452,63 @@ export default {
   AboutPage: {
     siteOverview: {
       title: "Επισκόπηση ιστότοπου",
-      wallet: "Διαχειριστείτε το υπόλοιπο ecash σας.",
-      findCreators: "Ανακαλύψτε δημιουργούς για υποστήριξη.",
-      creatorHub: "Ρυθμίστε και διαχειριστείτε το προφίλ δημιουργού σας.",
-      myProfile: "Προβάλετε και επεξεργαστείτε το προφίλ σας.",
-      buckets: "Οργανώστε κεφάλαια σε κάδους.",
-      subscriptions: "Διαχειριστείτε τις συνδρομές σας.",
+      wallet: {
+        description: "Διαχειριστείτε το υπόλοιπο ecash σας.",
+        icon: "account_balance_wallet",
+      },
+      findCreators: {
+        description: "Ανακαλύψτε δημιουργούς για υποστήριξη.",
+        icon: "search",
+      },
+      creatorHub: {
+        description: "Ρυθμίστε και διαχειριστείτε το προφίλ δημιουργού σας.",
+        icon: "hub",
+      },
+      myProfile: {
+        description: "Προβάλετε και επεξεργαστείτε το προφίλ σας.",
+        icon: "person",
+      },
+      buckets: {
+        description: "Οργανώστε κεφάλαια σε κάδους.",
+        icon: "inbox",
+      },
+      subscriptions: {
+        description: "Διαχειριστείτε τις συνδρομές σας.",
+        icon: "subscriptions",
+      },
       nostrMessengerTitle: "Nostr Messenger",
-      nostrMessenger: "Συνομιλήστε ιδιωτικά με το Nostr.",
-      settings: "Διαμορφώστε την εφαρμογή.",
+      nostrMessenger: {
+        description: "Συνομιλήστε ιδιωτικά με το Nostr.",
+        icon: "chat",
+      },
+      settings: {
+        description: "Διαμορφώστε την εφαρμογή.",
+        icon: "settings",
+      },
       restoreTitle: "Restore",
-      restore: "Recover your wallet from a backup.",
+      restore: {
+        description: "Recover your wallet from a backup.",
+        icon: "settings_backup_restore",
+      },
       alreadyRunningTitle: "Already Running",
-      alreadyRunning: "Warning when another session is active.",
+      alreadyRunning: {
+        description: "Warning when another session is active.",
+        icon: "warning",
+      },
       welcomeTitle: "Welcome",
-      welcome: "Introductory guide to Fundstr.",
-      terms: "Review the terms of service.",
+      welcome: {
+        description: "Introductory guide to Fundstr.",
+        icon: "info",
+      },
+      terms: {
+        description: "Review the terms of service.",
+        icon: "gavel",
+      },
       nostrLoginTitle: "Nostr Login",
-      nostrLogin: "Authenticate using your Nostr keys.",
+      nostrLogin: {
+        description: "Authenticate using your Nostr keys.",
+        icon: "login",
+      },
     },
   },
 };

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1710,24 +1710,63 @@ export const messages = {
   AboutPage: {
     siteOverview: {
       title: "Site Overview",
-      wallet: "Manage your ecash balance.",
-      findCreators: "Discover creators to support.",
-      creatorHub: "Set up and manage your creator profile.",
-      myProfile: "View and edit your profile.",
-      buckets: "Organize funds into buckets.",
-      subscriptions: "Manage your subscriptions.",
+      wallet: {
+        description: "Manage your ecash balance.",
+        icon: "account_balance_wallet",
+      },
+      findCreators: {
+        description: "Discover creators to support.",
+        icon: "search",
+      },
+      creatorHub: {
+        description: "Set up and manage your creator profile.",
+        icon: "hub",
+      },
+      myProfile: {
+        description: "View and edit your profile.",
+        icon: "person",
+      },
+      buckets: {
+        description: "Organize funds into buckets.",
+        icon: "inbox",
+      },
+      subscriptions: {
+        description: "Manage your subscriptions.",
+        icon: "subscriptions",
+      },
       nostrMessengerTitle: "Nostr Messenger",
-      nostrMessenger: "Chat privately with Nostr.",
-      settings: "Configure the app.",
+      nostrMessenger: {
+        description: "Chat privately with Nostr.",
+        icon: "chat",
+      },
+      settings: {
+        description: "Configure the app.",
+        icon: "settings",
+      },
       restoreTitle: "Restore",
-      restore: "Recover your wallet from a backup.",
+      restore: {
+        description: "Recover your wallet from a backup.",
+        icon: "settings_backup_restore",
+      },
       alreadyRunningTitle: "Already Running",
-      alreadyRunning: "Warning when another session is active.",
+      alreadyRunning: {
+        description: "Warning when another session is active.",
+        icon: "warning",
+      },
       welcomeTitle: "Welcome",
-      welcome: "Introductory guide to Fundstr.",
-      terms: "Review the terms of service.",
+      welcome: {
+        description: "Introductory guide to Fundstr.",
+        icon: "info",
+      },
+      terms: {
+        description: "Review the terms of service.",
+        icon: "gavel",
+      },
       nostrLoginTitle: "Nostr Login",
-      nostrLogin: "Authenticate using your Nostr keys.",
+      nostrLogin: {
+        description: "Authenticate using your Nostr keys.",
+        icon: "login",
+      },
     },
   },
 };

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -1449,24 +1449,63 @@ export default {
   AboutPage: {
     siteOverview: {
       title: "Descripción general del sitio",
-      wallet: "Administra tu saldo de ecash.",
-      findCreators: "Descubre creadores a los que apoyar.",
-      creatorHub: "Configura y gestiona tu perfil de creador.",
-      myProfile: "Visualiza y edita tu perfil.",
-      buckets: "Organiza fondos en cubos.",
-      subscriptions: "Administra tus suscripciones.",
+      wallet: {
+        description: "Administra tu saldo de ecash.",
+        icon: "account_balance_wallet",
+      },
+      findCreators: {
+        description: "Descubre creadores a los que apoyar.",
+        icon: "search",
+      },
+      creatorHub: {
+        description: "Configura y gestiona tu perfil de creador.",
+        icon: "hub",
+      },
+      myProfile: {
+        description: "Visualiza y edita tu perfil.",
+        icon: "person",
+      },
+      buckets: {
+        description: "Organiza fondos en cubos.",
+        icon: "inbox",
+      },
+      subscriptions: {
+        description: "Administra tus suscripciones.",
+        icon: "subscriptions",
+      },
       nostrMessengerTitle: "Nostr Messenger",
-      nostrMessenger: "Chatea en privado con Nostr.",
-      settings: "Configura la aplicación.",
+      nostrMessenger: {
+        description: "Chatea en privado con Nostr.",
+        icon: "chat",
+      },
+      settings: {
+        description: "Configura la aplicación.",
+        icon: "settings",
+      },
       restoreTitle: "Restore",
-      restore: "Recover your wallet from a backup.",
+      restore: {
+        description: "Recover your wallet from a backup.",
+        icon: "settings_backup_restore",
+      },
       alreadyRunningTitle: "Already Running",
-      alreadyRunning: "Warning when another session is active.",
+      alreadyRunning: {
+        description: "Warning when another session is active.",
+        icon: "warning",
+      },
       welcomeTitle: "Welcome",
-      welcome: "Introductory guide to Fundstr.",
-      terms: "Review the terms of service.",
+      welcome: {
+        description: "Introductory guide to Fundstr.",
+        icon: "info",
+      },
+      terms: {
+        description: "Review the terms of service.",
+        icon: "gavel",
+      },
       nostrLoginTitle: "Nostr Login",
-      nostrLogin: "Authenticate using your Nostr keys.",
+      nostrLogin: {
+        description: "Authenticate using your Nostr keys.",
+        icon: "login",
+      },
     },
   },
 };

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -1439,24 +1439,63 @@ export default {
   AboutPage: {
     siteOverview: {
       title: "Aperçu du site",
-      wallet: "Gérez votre solde ecash.",
-      findCreators: "Découvrez des créateurs à soutenir.",
-      creatorHub: "Configurez et gérez votre profil créateur.",
-      myProfile: "Affichez et modifiez votre profil.",
-      buckets: "Organisez les fonds en catégories.",
-      subscriptions: "Gérez vos abonnements.",
+      wallet: {
+        description: "Gérez votre solde ecash.",
+        icon: "account_balance_wallet",
+      },
+      findCreators: {
+        description: "Découvrez des créateurs à soutenir.",
+        icon: "search",
+      },
+      creatorHub: {
+        description: "Configurez et gérez votre profil créateur.",
+        icon: "hub",
+      },
+      myProfile: {
+        description: "Affichez et modifiez votre profil.",
+        icon: "person",
+      },
+      buckets: {
+        description: "Organisez les fonds en catégories.",
+        icon: "inbox",
+      },
+      subscriptions: {
+        description: "Gérez vos abonnements.",
+        icon: "subscriptions",
+      },
       nostrMessengerTitle: "Nostr Messenger",
-      nostrMessenger: "Discutez en privé avec Nostr.",
-      settings: "Configurez l'application.",
+      nostrMessenger: {
+        description: "Discutez en privé avec Nostr.",
+        icon: "chat",
+      },
+      settings: {
+        description: "Configurez l'application.",
+        icon: "settings",
+      },
       restoreTitle: "Restore",
-      restore: "Recover your wallet from a backup.",
+      restore: {
+        description: "Recover your wallet from a backup.",
+        icon: "settings_backup_restore",
+      },
       alreadyRunningTitle: "Already Running",
-      alreadyRunning: "Warning when another session is active.",
+      alreadyRunning: {
+        description: "Warning when another session is active.",
+        icon: "warning",
+      },
       welcomeTitle: "Welcome",
-      welcome: "Introductory guide to Fundstr.",
-      terms: "Review the terms of service.",
+      welcome: {
+        description: "Introductory guide to Fundstr.",
+        icon: "info",
+      },
+      terms: {
+        description: "Review the terms of service.",
+        icon: "gavel",
+      },
       nostrLoginTitle: "Nostr Login",
-      nostrLogin: "Authenticate using your Nostr keys.",
+      nostrLogin: {
+        description: "Authenticate using your Nostr keys.",
+        icon: "login",
+      },
     },
   },
 };

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -1431,24 +1431,63 @@ export default {
   AboutPage: {
     siteOverview: {
       title: "Panoramica del sito",
-      wallet: "Gestisci il tuo saldo ecash.",
-      findCreators: "Scopri i creatori da supportare.",
-      creatorHub: "Imposta e gestisci il tuo profilo creatore.",
-      myProfile: "Visualizza e modifica il tuo profilo.",
-      buckets: "Organizza i fondi in secchi.",
-      subscriptions: "Gestisci i tuoi abbonamenti.",
+      wallet: {
+        description: "Gestisci il tuo saldo ecash.",
+        icon: "account_balance_wallet",
+      },
+      findCreators: {
+        description: "Scopri i creatori da supportare.",
+        icon: "search",
+      },
+      creatorHub: {
+        description: "Imposta e gestisci il tuo profilo creatore.",
+        icon: "hub",
+      },
+      myProfile: {
+        description: "Visualizza e modifica il tuo profilo.",
+        icon: "person",
+      },
+      buckets: {
+        description: "Organizza i fondi in secchi.",
+        icon: "inbox",
+      },
+      subscriptions: {
+        description: "Gestisci i tuoi abbonamenti.",
+        icon: "subscriptions",
+      },
       nostrMessengerTitle: "Nostr Messenger",
-      nostrMessenger: "Chatta in privato con Nostr.",
-      settings: "Configura l'app.",
+      nostrMessenger: {
+        description: "Chatta in privato con Nostr.",
+        icon: "chat",
+      },
+      settings: {
+        description: "Configura l'app.",
+        icon: "settings",
+      },
       restoreTitle: "Restore",
-      restore: "Recover your wallet from a backup.",
+      restore: {
+        description: "Recover your wallet from a backup.",
+        icon: "settings_backup_restore",
+      },
       alreadyRunningTitle: "Already Running",
-      alreadyRunning: "Warning when another session is active.",
+      alreadyRunning: {
+        description: "Warning when another session is active.",
+        icon: "warning",
+      },
       welcomeTitle: "Welcome",
-      welcome: "Introductory guide to Fundstr.",
-      terms: "Review the terms of service.",
+      welcome: {
+        description: "Introductory guide to Fundstr.",
+        icon: "info",
+      },
+      terms: {
+        description: "Review the terms of service.",
+        icon: "gavel",
+      },
       nostrLoginTitle: "Nostr Login",
-      nostrLogin: "Authenticate using your Nostr keys.",
+      nostrLogin: {
+        description: "Authenticate using your Nostr keys.",
+        icon: "login",
+      },
     },
   },
 };

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -1432,24 +1432,63 @@ export default {
   AboutPage: {
     siteOverview: {
       title: "サイトの概要",
-      wallet: "ecashの残高を管理します。",
-      findCreators: "支援するクリエイターを見つけましょう。",
-      creatorHub: "クリエイタープロフィールを設定して管理します。",
-      myProfile: "プロフィールを表示して編集します。",
-      buckets: "資金をバケットに整理します。",
-      subscriptions: "サブスクリプションを管理します。",
+      wallet: {
+        description: "ecashの残高を管理します。",
+        icon: "account_balance_wallet",
+      },
+      findCreators: {
+        description: "支援するクリエイターを見つけましょう。",
+        icon: "search",
+      },
+      creatorHub: {
+        description: "クリエイタープロフィールを設定して管理します。",
+        icon: "hub",
+      },
+      myProfile: {
+        description: "プロフィールを表示して編集します。",
+        icon: "person",
+      },
+      buckets: {
+        description: "資金をバケットに整理します。",
+        icon: "inbox",
+      },
+      subscriptions: {
+        description: "サブスクリプションを管理します。",
+        icon: "subscriptions",
+      },
       nostrMessengerTitle: "Nostr Messenger",
-      nostrMessenger: "Nostrとプライベートにチャットします。",
-      settings: "アプリを設定します。",
+      nostrMessenger: {
+        description: "Nostrとプライベートにチャットします。",
+        icon: "chat",
+      },
+      settings: {
+        description: "アプリを設定します。",
+        icon: "settings",
+      },
       restoreTitle: "Restore",
-      restore: "Recover your wallet from a backup.",
+      restore: {
+        description: "Recover your wallet from a backup.",
+        icon: "settings_backup_restore",
+      },
       alreadyRunningTitle: "Already Running",
-      alreadyRunning: "Warning when another session is active.",
+      alreadyRunning: {
+        description: "Warning when another session is active.",
+        icon: "warning",
+      },
       welcomeTitle: "Welcome",
-      welcome: "Introductory guide to Fundstr.",
-      terms: "Review the terms of service.",
+      welcome: {
+        description: "Introductory guide to Fundstr.",
+        icon: "info",
+      },
+      terms: {
+        description: "Review the terms of service.",
+        icon: "gavel",
+      },
       nostrLoginTitle: "Nostr Login",
-      nostrLogin: "Authenticate using your Nostr keys.",
+      nostrLogin: {
+        description: "Authenticate using your Nostr keys.",
+        icon: "login",
+      },
     },
   },
 };

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -1431,24 +1431,63 @@ export default {
   AboutPage: {
     siteOverview: {
       title: "Webbplatsöversikt",
-      wallet: "Hantera ditt ecash-saldo.",
-      findCreators: "Upptäck skapare att stödja.",
-      creatorHub: "Ställ in och hantera din skapareprofil.",
-      myProfile: "Visa och redigera din profil.",
-      buckets: "Organisera medel i hinkar.",
-      subscriptions: "Hantera dina prenumerationer.",
+      wallet: {
+        description: "Hantera ditt ecash-saldo.",
+        icon: "account_balance_wallet",
+      },
+      findCreators: {
+        description: "Upptäck skapare att stödja.",
+        icon: "search",
+      },
+      creatorHub: {
+        description: "Ställ in och hantera din skapareprofil.",
+        icon: "hub",
+      },
+      myProfile: {
+        description: "Visa och redigera din profil.",
+        icon: "person",
+      },
+      buckets: {
+        description: "Organisera medel i hinkar.",
+        icon: "inbox",
+      },
+      subscriptions: {
+        description: "Hantera dina prenumerationer.",
+        icon: "subscriptions",
+      },
       nostrMessengerTitle: "Nostr Messenger",
-      nostrMessenger: "Chatta privat med Nostr.",
-      settings: "Konfigurera appen.",
+      nostrMessenger: {
+        description: "Chatta privat med Nostr.",
+        icon: "chat",
+      },
+      settings: {
+        description: "Konfigurera appen.",
+        icon: "settings",
+      },
       restoreTitle: "Restore",
-      restore: "Recover your wallet from a backup.",
+      restore: {
+        description: "Recover your wallet from a backup.",
+        icon: "settings_backup_restore",
+      },
       alreadyRunningTitle: "Already Running",
-      alreadyRunning: "Warning when another session is active.",
+      alreadyRunning: {
+        description: "Warning when another session is active.",
+        icon: "warning",
+      },
       welcomeTitle: "Welcome",
-      welcome: "Introductory guide to Fundstr.",
-      terms: "Review the terms of service.",
+      welcome: {
+        description: "Introductory guide to Fundstr.",
+        icon: "info",
+      },
+      terms: {
+        description: "Review the terms of service.",
+        icon: "gavel",
+      },
       nostrLoginTitle: "Nostr Login",
-      nostrLogin: "Authenticate using your Nostr keys.",
+      nostrLogin: {
+        description: "Authenticate using your Nostr keys.",
+        icon: "login",
+      },
     },
   },
 };

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -1429,24 +1429,63 @@ export default {
   AboutPage: {
     siteOverview: {
       title: "ภาพรวมไซต์",
-      wallet: "จัดการยอดคงเหลือ ecash ของคุณ",
-      findCreators: "ค้นพบผู้สร้างเพื่อสนับสนุน",
-      creatorHub: "ตั้งค่าและจัดการโปรไฟล์ผู้สร้างของคุณ",
-      myProfile: "ดูและแก้ไขโปรไฟล์ของคุณ",
-      buckets: "จัดระเบียบเงินทุนเป็นถัง",
-      subscriptions: "จัดการการสมัครสมาชิกของคุณ",
+      wallet: {
+        description: "จัดการยอดคงเหลือ ecash ของคุณ",
+        icon: "account_balance_wallet",
+      },
+      findCreators: {
+        description: "ค้นพบผู้สร้างเพื่อสนับสนุน",
+        icon: "search",
+      },
+      creatorHub: {
+        description: "ตั้งค่าและจัดการโปรไฟล์ผู้สร้างของคุณ",
+        icon: "hub",
+      },
+      myProfile: {
+        description: "ดูและแก้ไขโปรไฟล์ของคุณ",
+        icon: "person",
+      },
+      buckets: {
+        description: "จัดระเบียบเงินทุนเป็นถัง",
+        icon: "inbox",
+      },
+      subscriptions: {
+        description: "จัดการการสมัครสมาชิกของคุณ",
+        icon: "subscriptions",
+      },
       nostrMessengerTitle: "Nostr Messenger",
-      nostrMessenger: "แชทแบบส่วนตัวกับ Nostr",
-      settings: "กำหนดค่าแอป",
+      nostrMessenger: {
+        description: "แชทแบบส่วนตัวกับ Nostr",
+        icon: "chat",
+      },
+      settings: {
+        description: "กำหนดค่าแอป",
+        icon: "settings",
+      },
       restoreTitle: "Restore",
-      restore: "Recover your wallet from a backup.",
+      restore: {
+        description: "Recover your wallet from a backup.",
+        icon: "settings_backup_restore",
+      },
       alreadyRunningTitle: "Already Running",
-      alreadyRunning: "Warning when another session is active.",
+      alreadyRunning: {
+        description: "Warning when another session is active.",
+        icon: "warning",
+      },
       welcomeTitle: "Welcome",
-      welcome: "Introductory guide to Fundstr.",
-      terms: "Review the terms of service.",
+      welcome: {
+        description: "Introductory guide to Fundstr.",
+        icon: "info",
+      },
+      terms: {
+        description: "Review the terms of service.",
+        icon: "gavel",
+      },
       nostrLoginTitle: "Nostr Login",
-      nostrLogin: "Authenticate using your Nostr keys.",
+      nostrLogin: {
+        description: "Authenticate using your Nostr keys.",
+        icon: "login",
+      },
     },
   },
 };

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -1434,24 +1434,63 @@ export default {
   AboutPage: {
     siteOverview: {
       title: "Siteye Genel Bakış",
-      wallet: "Ecash bakiyenizi yönetin.",
-      findCreators: "Destekleyecek yaratıcılar keşfedin.",
-      creatorHub: "Yaratıcı profilinizi kurun ve yönetin.",
-      myProfile: "Profilinizi görüntüleyin ve düzenleyin.",
-      buckets: "Fonları kovalar halinde düzenleyin.",
-      subscriptions: "Aboneliklerinizi yönetin.",
+      wallet: {
+        description: "Ecash bakiyenizi yönetin.",
+        icon: "account_balance_wallet",
+      },
+      findCreators: {
+        description: "Destekleyecek yaratıcılar keşfedin.",
+        icon: "search",
+      },
+      creatorHub: {
+        description: "Yaratıcı profilinizi kurun ve yönetin.",
+        icon: "hub",
+      },
+      myProfile: {
+        description: "Profilinizi görüntüleyin ve düzenleyin.",
+        icon: "person",
+      },
+      buckets: {
+        description: "Fonları kovalar halinde düzenleyin.",
+        icon: "inbox",
+      },
+      subscriptions: {
+        description: "Aboneliklerinizi yönetin.",
+        icon: "subscriptions",
+      },
       nostrMessengerTitle: "Nostr Messenger",
-      nostrMessenger: "Nostr ile özel olarak sohbet edin.",
-      settings: "Uygulamayı yapılandırın.",
+      nostrMessenger: {
+        description: "Nostr ile özel olarak sohbet edin.",
+        icon: "chat",
+      },
+      settings: {
+        description: "Uygulamayı yapılandırın.",
+        icon: "settings",
+      },
       restoreTitle: "Restore",
-      restore: "Recover your wallet from a backup.",
+      restore: {
+        description: "Recover your wallet from a backup.",
+        icon: "settings_backup_restore",
+      },
       alreadyRunningTitle: "Already Running",
-      alreadyRunning: "Warning when another session is active.",
+      alreadyRunning: {
+        description: "Warning when another session is active.",
+        icon: "warning",
+      },
       welcomeTitle: "Welcome",
-      welcome: "Introductory guide to Fundstr.",
-      terms: "Review the terms of service.",
+      welcome: {
+        description: "Introductory guide to Fundstr.",
+        icon: "info",
+      },
+      terms: {
+        description: "Review the terms of service.",
+        icon: "gavel",
+      },
       nostrLoginTitle: "Nostr Login",
-      nostrLogin: "Authenticate using your Nostr keys.",
+      nostrLogin: {
+        description: "Authenticate using your Nostr keys.",
+        icon: "login",
+      },
     },
   },
 };

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -1421,24 +1421,63 @@ export default {
   AboutPage: {
     siteOverview: {
       title: "站点概述",
-      wallet: "管理您的Ecash余额。",
-      findCreators: "发现可以支持的创作者。",
-      creatorHub: "设置并管理您的创作者资料。",
-      myProfile: "查看并编辑您的个人资料。",
-      buckets: "将资金组织成类别。",
-      subscriptions: "管理您的订阅。",
+      wallet: {
+        description: "管理您的Ecash余额。",
+        icon: "account_balance_wallet",
+      },
+      findCreators: {
+        description: "发现可以支持的创作者。",
+        icon: "search",
+      },
+      creatorHub: {
+        description: "设置并管理您的创作者资料。",
+        icon: "hub",
+      },
+      myProfile: {
+        description: "查看并编辑您的个人资料。",
+        icon: "person",
+      },
+      buckets: {
+        description: "将资金组织成类别。",
+        icon: "inbox",
+      },
+      subscriptions: {
+        description: "管理您的订阅。",
+        icon: "subscriptions",
+      },
       nostrMessengerTitle: "Nostr Messenger",
-      nostrMessenger: "与 Nostr 私下聊天。",
-      settings: "配置应用程序。",
+      nostrMessenger: {
+        description: "与 Nostr 私下聊天。",
+        icon: "chat",
+      },
+      settings: {
+        description: "配置应用程序。",
+        icon: "settings",
+      },
       restoreTitle: "Restore",
-      restore: "Recover your wallet from a backup.",
+      restore: {
+        description: "Recover your wallet from a backup.",
+        icon: "settings_backup_restore",
+      },
       alreadyRunningTitle: "Already Running",
-      alreadyRunning: "Warning when another session is active.",
+      alreadyRunning: {
+        description: "Warning when another session is active.",
+        icon: "warning",
+      },
       welcomeTitle: "Welcome",
-      welcome: "Introductory guide to Fundstr.",
-      terms: "Review the terms of service.",
+      welcome: {
+        description: "Introductory guide to Fundstr.",
+        icon: "info",
+      },
+      terms: {
+        description: "Review the terms of service.",
+        icon: "gavel",
+      },
       nostrLoginTitle: "Nostr Login",
-      nostrLogin: "Authenticate using your Nostr keys.",
+      nostrLogin: {
+        description: "Authenticate using your Nostr keys.",
+        icon: "login",
+      },
     },
   },
 };

--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -37,86 +37,27 @@
         <h2 class="text-3xl md:text-5xl font-bold mb-6 gradient-text">
           {{ $t('AboutPage.siteOverview.title') }}
         </h2>
-        <ul class="text-lg md:text-xl space-y-4 text-left">
-          <li>
-            <router-link to="/wallet" class="text-accent font-semibold">
-              {{ $t('MainHeader.menu.wallet.title') }}
+        <div
+          class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 text-left"
+        >
+          <div
+            v-for="card in siteOverviewCards"
+            :key="card.route"
+            class="interactive-card p-6 flex flex-col"
+          >
+            <q-icon
+              :name="$t(card.iconKey)"
+              size="2.5rem"
+              class="text-accent mb-4"
+            />
+            <router-link :to="card.route" class="text-accent font-semibold">
+              {{ $t(card.titleKey) }}
             </router-link>
-            – {{ $t('AboutPage.siteOverview.wallet') }}
-          </li>
-          <li>
-            <router-link to="/find-creators" class="text-accent font-semibold">
-              {{ $t('MainHeader.menu.findCreators.title') }}
-            </router-link>
-            – {{ $t('AboutPage.siteOverview.findCreators') }}
-          </li>
-          <li>
-            <router-link to="/creator-hub" class="text-accent font-semibold">
-              {{ $t('MainHeader.menu.creatorHub.title') }}
-            </router-link>
-            – {{ $t('AboutPage.siteOverview.creatorHub') }}
-          </li>
-          <li>
-            <router-link to="/my-profile" class="text-accent font-semibold">
-              {{ $t('MainHeader.menu.myProfile.title') }}
-            </router-link>
-            – {{ $t('AboutPage.siteOverview.myProfile') }}
-          </li>
-          <li>
-            <router-link to="/buckets" class="text-accent font-semibold">
-              {{ $t('MainHeader.menu.buckets.title') }}
-            </router-link>
-            – {{ $t('AboutPage.siteOverview.buckets') }}
-          </li>
-          <li>
-            <router-link to="/subscriptions" class="text-accent font-semibold">
-              {{ $t('MainHeader.menu.subscriptions.title') }}
-            </router-link>
-            – {{ $t('AboutPage.siteOverview.subscriptions') }}
-          </li>
-          <li>
-            <router-link to="/nostr-messenger" class="text-accent font-semibold">
-              {{ $t('MainHeader.menu.nostrMessenger.title') }}
-            </router-link>
-            – {{ $t('AboutPage.siteOverview.nostrMessenger') }}
-          </li>
-          <li>
-            <router-link to="/settings" class="text-accent font-semibold">
-              {{ $t('MainHeader.menu.settings.title') }}
-            </router-link>
-            – {{ $t('AboutPage.siteOverview.settings') }}
-          </li>
-          <li>
-            <router-link to="/restore" class="text-accent font-semibold">
-              {{ $t('MainHeader.menu.restore.title') }}
-            </router-link>
-            – {{ $t('AboutPage.siteOverview.restore') }}
-          </li>
-          <li>
-            <router-link to="/already-running" class="text-accent font-semibold">
-              {{ $t('MainHeader.menu.alreadyRunning.title') }}
-            </router-link>
-            – {{ $t('AboutPage.siteOverview.alreadyRunning') }}
-          </li>
-          <li>
-            <router-link to="/welcome" class="text-accent font-semibold">
-              {{ $t('MainHeader.menu.welcome.title') }}
-            </router-link>
-            – {{ $t('AboutPage.siteOverview.welcome') }}
-          </li>
-          <li>
-            <router-link to="/terms" class="text-accent font-semibold">
-              {{ $t('MainHeader.menu.terms.title') }}
-            </router-link>
-            – {{ $t('AboutPage.siteOverview.terms') }}
-          </li>
-          <li>
-            <router-link to="/nostr-login" class="text-accent font-semibold">
-              {{ $t('MainHeader.menu.nostrLogin.title') }}
-            </router-link>
-            – {{ $t('AboutPage.siteOverview.nostrLogin') }}
-          </li>
-        </ul>
+            <p class="text-sm mt-2">
+              {{ $t(card.descriptionKey) }}
+            </p>
+          </div>
+        </div>
       </div>
     </section>
 
@@ -548,6 +489,94 @@ const dialogStep1 = ref(false)
 const dialogStep2 = ref(false)
 const dialogStep3 = ref(false)
 const viewMode = ref<'fan' | 'creator'>('fan')
+
+interface SiteOverviewCard {
+  route: string
+  titleKey: string
+  descriptionKey: string
+  iconKey: string
+}
+
+const siteOverviewCards: SiteOverviewCard[] = [
+  {
+    route: '/wallet',
+    titleKey: 'MainHeader.menu.wallet.title',
+    descriptionKey: 'AboutPage.siteOverview.wallet.description',
+    iconKey: 'AboutPage.siteOverview.wallet.icon',
+  },
+  {
+    route: '/find-creators',
+    titleKey: 'MainHeader.menu.findCreators.title',
+    descriptionKey: 'AboutPage.siteOverview.findCreators.description',
+    iconKey: 'AboutPage.siteOverview.findCreators.icon',
+  },
+  {
+    route: '/creator-hub',
+    titleKey: 'MainHeader.menu.creatorHub.title',
+    descriptionKey: 'AboutPage.siteOverview.creatorHub.description',
+    iconKey: 'AboutPage.siteOverview.creatorHub.icon',
+  },
+  {
+    route: '/my-profile',
+    titleKey: 'MainHeader.menu.myProfile.title',
+    descriptionKey: 'AboutPage.siteOverview.myProfile.description',
+    iconKey: 'AboutPage.siteOverview.myProfile.icon',
+  },
+  {
+    route: '/buckets',
+    titleKey: 'MainHeader.menu.buckets.title',
+    descriptionKey: 'AboutPage.siteOverview.buckets.description',
+    iconKey: 'AboutPage.siteOverview.buckets.icon',
+  },
+  {
+    route: '/subscriptions',
+    titleKey: 'MainHeader.menu.subscriptions.title',
+    descriptionKey: 'AboutPage.siteOverview.subscriptions.description',
+    iconKey: 'AboutPage.siteOverview.subscriptions.icon',
+  },
+  {
+    route: '/nostr-messenger',
+    titleKey: 'MainHeader.menu.nostrMessenger.title',
+    descriptionKey: 'AboutPage.siteOverview.nostrMessenger.description',
+    iconKey: 'AboutPage.siteOverview.nostrMessenger.icon',
+  },
+  {
+    route: '/settings',
+    titleKey: 'MainHeader.menu.settings.title',
+    descriptionKey: 'AboutPage.siteOverview.settings.description',
+    iconKey: 'AboutPage.siteOverview.settings.icon',
+  },
+  {
+    route: '/restore',
+    titleKey: 'MainHeader.menu.restore.title',
+    descriptionKey: 'AboutPage.siteOverview.restore.description',
+    iconKey: 'AboutPage.siteOverview.restore.icon',
+  },
+  {
+    route: '/already-running',
+    titleKey: 'MainHeader.menu.alreadyRunning.title',
+    descriptionKey: 'AboutPage.siteOverview.alreadyRunning.description',
+    iconKey: 'AboutPage.siteOverview.alreadyRunning.icon',
+  },
+  {
+    route: '/welcome',
+    titleKey: 'MainHeader.menu.welcome.title',
+    descriptionKey: 'AboutPage.siteOverview.welcome.description',
+    iconKey: 'AboutPage.siteOverview.welcome.icon',
+  },
+  {
+    route: '/terms',
+    titleKey: 'MainHeader.menu.terms.title',
+    descriptionKey: 'AboutPage.siteOverview.terms.description',
+    iconKey: 'AboutPage.siteOverview.terms.icon',
+  },
+  {
+    route: '/nostr-login',
+    titleKey: 'MainHeader.menu.nostrLogin.title',
+    descriptionKey: 'AboutPage.siteOverview.nostrLogin.description',
+    iconKey: 'AboutPage.siteOverview.nostrLogin.icon',
+  },
+]
 
 // navigation items for the navigation map
 const navigationItems = ref<NavigationItem[]>([


### PR DESCRIPTION
## Summary
- replace About page list with responsive card grid
- add icon metadata to site overview i18n entries across locales

## Testing
- `npm test` (fails: multiple failing suites)
- `npm run lint` (fails: Invalid option '--ext')
- `npm run types` (fails: Cannot find name 'ExtendableEvent')

------
https://chatgpt.com/codex/tasks/task_e_688f293b8a84833086fe8c4b32b52fe3