### PR TITLE
feat: enhance about page navigation

### DIFF
--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -105,6 +105,16 @@
           }}</q-item-label>
         </q-item-section>
       </q-item>
+      <q-item-label header>About</q-item-label>
+      <q-item clickable to="/about">
+        <q-item-section avatar>
+          <q-icon name="info" />
+        </q-item-section>
+        <q-item-section>
+          <q-item-label>About</q-item-label>
+          <q-item-label caption>About this wallet</q-item-label>
+        </q-item-section>
+      </q-item>
       <q-item-label header>{{
         $t("MainHeader.menu.links.title")
       }}</q-item-label>

--- a/src/components/NavCard.vue
+++ b/src/components/NavCard.vue
@@ -1,0 +1,46 @@
+<template>
+  <q-card
+    class="nav-card q-pa-sm"
+    :to="to"
+    :href="href"
+    :target="href ? '_blank' : void 0"
+    clickable
+    bordered
+  >
+    <q-card-section class="row items-center no-wrap">
+      <slot name="icon">
+        <q-icon :name="icon" size="md" class="q-mr-sm" />
+      </slot>
+      <div class="text-h6">{{ label }}</div>
+    </q-card-section>
+    <q-card-section>
+      <slot>
+        {{ viewMode === 'fan' ? fan : creator }}
+      </slot>
+    </q-card-section>
+  </q-card>
+</template>
+
+<script setup lang="ts">
+interface Props {
+  icon: string;
+  label: string;
+  fan: string;
+  creator: string;
+  to?: string;
+  href?: string;
+  viewMode: 'fan' | 'creator';
+}
+
+const props = defineProps<Props>();
+</script>
+
+<style scoped>
+.nav-card {
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+.nav-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+}
+</style>

--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -1,64 +1,88 @@
 <script setup lang="ts">
 import { ref } from "vue";
+import NavCard from "components/NavCard.vue";
 
 interface NavItem {
+  icon: string;
   label: string;
   fan: string;
   creator: string;
+  to?: string;
+  href?: string;
 }
 
 const viewMode = ref<"fan" | "creator">("fan");
 
 const navItems: NavItem[] = [
   {
+    icon: "settings",
     label: "Settings",
     fan: "Customize the app to suit your needs.",
     creator: "Manage creator tools and preferences.",
+    to: "/settings",
   },
   {
+    icon: "search",
     label: "Find Creators",
     fan: "Discover new creators to support.",
     creator: "Promote your profile to potential fans.",
+    to: "/find-creators",
   },
   {
+    icon: "dashboard",
     label: "Creator Hub",
     fan: "Explore tools designed for creators.",
     creator: "Access your creator dashboard and resources.",
+    to: "/creator-hub",
   },
   {
+    icon: "person",
     label: "My Profile",
     fan: "View and edit your personal information.",
     creator: "Manage your creator identity and bio.",
+    to: "/profile",
   },
   {
+    icon: "inbox",
     label: "Buckets",
     fan: "Organize your funds into custom buckets.",
     creator: "Track income streams with bucketed funds.",
+    to: "/buckets",
   },
   {
+    icon: "subscriptions",
     label: "Subscriptions",
     fan: "Manage the creators you're subscribed to.",
     creator: "Control your subscriber tiers and benefits.",
+    to: "/subscriptions",
   },
   {
+    icon: "chat",
     label: "Chats",
     fan: "Message creators directly.",
     creator: "Interact with your supporters.",
+    to: "/chats",
   },
   {
+    icon: "gavel",
     label: "Terms",
     fan: "Review the platform's terms of service.",
     creator: "Review the platform's terms of service.",
+    to: "/terms",
   },
   {
+    icon: "info",
     label: "About",
     fan: "Learn more about the project.",
     creator: "Learn more about the project.",
+    to: "/about",
   },
   {
+    icon: "link",
     label: "External links",
     fan: "Visit official resources and documentation.",
     creator: "Visit official resources and documentation.",
+    href: "https://cashu.space",
   },
 ];
 
@@ -84,29 +108,27 @@ defineExpose({ viewMode });
       />
     </div>
 
-    <q-markup-table flat bordered class="about-table">
-      <tbody>
-        <tr v-for="item in navItems" :key="item.label">
-          <td class="text-weight-medium">{{ item.label }}</td>
-          <td>{{ item[viewMode] }}</td>
-        </tr>
-      </tbody>
-    </q-markup-table>
+    <div class="row q-col-gutter-md about-grid">
+      <div
+        v-for="item in navItems"
+        :key="item.label"
+        class="col-12 col-sm-6 col-md-4"
+      >
+        <NavCard v-bind="item" :view-mode="viewMode" />
+      </div>
+    </div>
   </div>
 </template>
 
 <style scoped>
+
 .about-container {
-  max-width: 600px;
+  max-width: 900px;
   margin: 0 auto;
 }
 
-.about-table td:first-child {
-  width: 30%;
-  white-space: nowrap;
-}
-
-.about-table td {
-  vertical-align: top;
+.about-grid {
+  max-width: 900px;
+  margin: 0 auto;
 }
 </style>

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -37,6 +37,11 @@ const routes = [
       { path: "", component: () => import("src/pages/TermsPage.vue") },
     ],
   },
+  {
+    path: "/about",
+    component: () => import("layouts/FullscreenLayout.vue"),
+    children: [{ path: "", component: () => import("src/pages/AboutPage.vue") }],
+  },
 
   // Always leave this as last one,
   // but you can also remove it


### PR DESCRIPTION
## Summary
- add reusable NavCard component with hover styles
- build responsive card grid for About page and wire up icons/links
- expose About page via router and header menu

## Testing
- `npm test` *(fails: getActivePinia() was called but there was no active Pinia)*

------
https://chatgpt.com/codex/tasks/task_e_68905de6a9748330ab4570e4c47e3db5