### PR TITLE
fix: maintain accordion height after mode switch

### DIFF
--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -682,6 +682,10 @@ watch(mode, (val) => {
     mapContainer.value.classList.toggle('fan-mode', val === 'fan')
     mapContainer.value.classList.toggle('creator-mode', val === 'creator')
   }
+  if (openIndex.value !== -1 && accordionRefs.value[openIndex.value]) {
+    const el = accordionRefs.value[openIndex.value]
+    el.style.maxHeight = el.scrollHeight + 'px'
+  }
 })
 
 onMounted(() => {


### PR DESCRIPTION
## Summary
- ensure accordion adjusts its max-height when mode switches

## Testing
- `npm test` *(fails: ReferenceError windowMixin is not defined)*
- `npm run lint` *(fails: Invalid option '--ext')*

------
https://chatgpt.com/codex/tasks/task_e_68906f99fe6c8330ad9ba4a92773d4f9