### PR TITLE
Add accessibility attributes to About page accordion

### DIFF
--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -292,6 +292,8 @@
                 class="accordion-header w-full flex items-center justify-between p-4"
                 type="button"
                 @click="toggleItem(index)"
+                :aria-expanded="openIndex === index"
+                :aria-controls="`accordion-content-${index}`"
               >
                 <div class="flex items-center gap-2">
                   <q-icon :name="item.icon" />
@@ -307,6 +309,7 @@
               </button>
               <div
                 class="accordion-content px-4 pb-4 text-sm"
+                :id="`accordion-content-${index}`"
                 :ref="(el) => (accordionRefs[index] = el as HTMLElement)"
               >
                 <div class="fan-content">
@@ -849,6 +852,11 @@ blockquote {
 
 #map-container.creator-mode {
   --mode-color: var(--creator-color);
+}
+
+.accordion-header:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
 }
 
 .accordion-content {


### PR DESCRIPTION
## Summary
- add `aria-expanded` and `aria-controls` to About page accordion headers
- give accordion content matching IDs and accent-colored focus outline

## Testing
- `npm test` *(fails: expected 2 to be 1, Cannot read properties of undefined, etc.)*
- `npm run lint` *(errors: Invalid option '--ext')*


------
https://chatgpt.com/codex/tasks/task_e_68907f52ae1083309f9a68a474fb541d