### PR TITLE
Use nextTick after mode switch in AboutPage

### DIFF
--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -483,7 +483,7 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, onUnmounted, ref, watch } from 'vue'
+import { onMounted, onUnmounted, ref, watch, nextTick } from 'vue'
 
 interface NavigationItem {
   menuItem: string
@@ -686,11 +686,12 @@ watch(openIndex, (newIndex, oldIndex) => {
   updateOpenItemHeight()
 })
 
-watch(mode, (val) => {
+watch(mode, async (val) => {
   if (mapContainer.value) {
     mapContainer.value.classList.toggle('fan-mode', val === 'fan')
     mapContainer.value.classList.toggle('creator-mode', val === 'creator')
   }
+  await nextTick()
   updateOpenItemHeight()
 })
 


### PR DESCRIPTION
## Summary
- import `nextTick` and await DOM updates before adjusting accordion heights when mode changes

## Testing
- `npm run test:ci` *(fails: Invalid mnemonic, Cannot set properties of undefined (setting 'value'))*

------
https://chatgpt.com/codex/tasks/task_e_6890848d0ce08330a1212bf93d8b7972