### PR TITLE
Align About page icons with header icons

### DIFF
--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -1448,11 +1448,11 @@ export default {
       },
       findCreators: {
         description: "اكتشف المبدعين لدعمهم.",
-        icon: "search",
+        icon: "img:icons/find-creators.svg",
       },
       creatorHub: {
         description: "إعداد وإدارة ملف المبدع الخاص بك.",
-        icon: "hub",
+        icon: "img:icons/creator-hub.svg",
       },
       myProfile: {
         description: "عرض وتحرير ملفك الشخصي.",
@@ -1460,11 +1460,11 @@ export default {
       },
       buckets: {
         description: "تنظيم الأموال في حاويات.",
-        icon: "inbox",
+        icon: "inventory_2",
       },
       subscriptions: {
         description: "إدارة اشتراكاتك.",
-        icon: "subscriptions",
+        icon: "auto_awesome_motion",
       },
       nostrMessengerTitle: "Nostr Messenger",
       nostrMessenger: {

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -1454,11 +1454,11 @@ export default {
       },
       findCreators: {
         description: "Entdecken Sie Creator zur Unterstützung.",
-        icon: "search",
+        icon: "img:icons/find-creators.svg",
       },
       creatorHub: {
         description: "Richten Sie Ihr Creator-Profil ein und verwalten Sie es.",
-        icon: "hub",
+        icon: "img:icons/creator-hub.svg",
       },
       myProfile: {
         description: "Sehen und bearbeiten Sie Ihr Profil.",
@@ -1466,11 +1466,11 @@ export default {
       },
       buckets: {
         description: "Organisieren Sie Mittel in Buckets.",
-        icon: "inbox",
+        icon: "inventory_2",
       },
       subscriptions: {
         description: "Verwalten Sie Ihre Abonnements.",
-        icon: "subscriptions",
+        icon: "auto_awesome_motion",
       },
       nostrMessengerTitle: "Nostr Messenger",
       nostrMessenger: {

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -1458,11 +1458,11 @@ export default {
       },
       findCreators: {
         description: "Ανακαλύψτε δημιουργούς για υποστήριξη.",
-        icon: "search",
+        icon: "img:icons/find-creators.svg",
       },
       creatorHub: {
         description: "Ρυθμίστε και διαχειριστείτε το προφίλ δημιουργού σας.",
-        icon: "hub",
+        icon: "img:icons/creator-hub.svg",
       },
       myProfile: {
         description: "Προβάλετε και επεξεργαστείτε το προφίλ σας.",
@@ -1470,11 +1470,11 @@ export default {
       },
       buckets: {
         description: "Οργανώστε κεφάλαια σε κάδους.",
-        icon: "inbox",
+        icon: "inventory_2",
       },
       subscriptions: {
         description: "Διαχειριστείτε τις συνδρομές σας.",
-        icon: "subscriptions",
+        icon: "auto_awesome_motion",
       },
       nostrMessengerTitle: "Nostr Messenger",
       nostrMessenger: {

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1716,11 +1716,11 @@ export const messages = {
       },
       findCreators: {
         description: "Discover creators to support.",
-        icon: "search",
+        icon: "img:icons/find-creators.svg",
       },
       creatorHub: {
         description: "Set up and manage your creator profile.",
-        icon: "hub",
+        icon: "img:icons/creator-hub.svg",
       },
       myProfile: {
         description: "View and edit your profile.",
@@ -1728,11 +1728,11 @@ export const messages = {
       },
       buckets: {
         description: "Organize funds into buckets.",
-        icon: "inbox",
+        icon: "inventory_2",
       },
       subscriptions: {
         description: "Manage your subscriptions.",
-        icon: "subscriptions",
+        icon: "auto_awesome_motion",
       },
       nostrMessengerTitle: "Nostr Messenger",
       nostrMessenger: {

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -1455,11 +1455,11 @@ export default {
       },
       findCreators: {
         description: "Descubre creadores a los que apoyar.",
-        icon: "search",
+        icon: "img:icons/find-creators.svg",
       },
       creatorHub: {
         description: "Configura y gestiona tu perfil de creador.",
-        icon: "hub",
+        icon: "img:icons/creator-hub.svg",
       },
       myProfile: {
         description: "Visualiza y edita tu perfil.",
@@ -1467,11 +1467,11 @@ export default {
       },
       buckets: {
         description: "Organiza fondos en cubos.",
-        icon: "inbox",
+        icon: "inventory_2",
       },
       subscriptions: {
         description: "Administra tus suscripciones.",
-        icon: "subscriptions",
+        icon: "auto_awesome_motion",
       },
       nostrMessengerTitle: "Nostr Messenger",
       nostrMessenger: {

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -1445,11 +1445,11 @@ export default {
       },
       findCreators: {
         description: "Découvrez des créateurs à soutenir.",
-        icon: "search",
+        icon: "img:icons/find-creators.svg",
       },
       creatorHub: {
         description: "Configurez et gérez votre profil créateur.",
-        icon: "hub",
+        icon: "img:icons/creator-hub.svg",
       },
       myProfile: {
         description: "Affichez et modifiez votre profil.",
@@ -1457,11 +1457,11 @@ export default {
       },
       buckets: {
         description: "Organisez les fonds en catégories.",
-        icon: "inbox",
+        icon: "inventory_2",
       },
       subscriptions: {
         description: "Gérez vos abonnements.",
-        icon: "subscriptions",
+        icon: "auto_awesome_motion",
       },
       nostrMessengerTitle: "Nostr Messenger",
       nostrMessenger: {

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -1437,11 +1437,11 @@ export default {
       },
       findCreators: {
         description: "Scopri i creatori da supportare.",
-        icon: "search",
+        icon: "img:icons/find-creators.svg",
       },
       creatorHub: {
         description: "Imposta e gestisci il tuo profilo creatore.",
-        icon: "hub",
+        icon: "img:icons/creator-hub.svg",
       },
       myProfile: {
         description: "Visualizza e modifica il tuo profilo.",
@@ -1449,11 +1449,11 @@ export default {
       },
       buckets: {
         description: "Organizza i fondi in secchi.",
-        icon: "inbox",
+        icon: "inventory_2",
       },
       subscriptions: {
         description: "Gestisci i tuoi abbonamenti.",
-        icon: "subscriptions",
+        icon: "auto_awesome_motion",
       },
       nostrMessengerTitle: "Nostr Messenger",
       nostrMessenger: {

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -1438,11 +1438,11 @@ export default {
       },
       findCreators: {
         description: "支援するクリエイターを見つけましょう。",
-        icon: "search",
+        icon: "img:icons/find-creators.svg",
       },
       creatorHub: {
         description: "クリエイタープロフィールを設定して管理します。",
-        icon: "hub",
+        icon: "img:icons/creator-hub.svg",
       },
       myProfile: {
         description: "プロフィールを表示して編集します。",
@@ -1450,11 +1450,11 @@ export default {
       },
       buckets: {
         description: "資金をバケットに整理します。",
-        icon: "inbox",
+        icon: "inventory_2",
       },
       subscriptions: {
         description: "サブスクリプションを管理します。",
-        icon: "subscriptions",
+        icon: "auto_awesome_motion",
       },
       nostrMessengerTitle: "Nostr Messenger",
       nostrMessenger: {

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -1437,11 +1437,11 @@ export default {
       },
       findCreators: {
         description: "Upptäck skapare att stödja.",
-        icon: "search",
+        icon: "img:icons/find-creators.svg",
       },
       creatorHub: {
         description: "Ställ in och hantera din skapareprofil.",
-        icon: "hub",
+        icon: "img:icons/creator-hub.svg",
       },
       myProfile: {
         description: "Visa och redigera din profil.",
@@ -1449,11 +1449,11 @@ export default {
       },
       buckets: {
         description: "Organisera medel i hinkar.",
-        icon: "inbox",
+        icon: "inventory_2",
       },
       subscriptions: {
         description: "Hantera dina prenumerationer.",
-        icon: "subscriptions",
+        icon: "auto_awesome_motion",
       },
       nostrMessengerTitle: "Nostr Messenger",
       nostrMessenger: {

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -1435,11 +1435,11 @@ export default {
       },
       findCreators: {
         description: "ค้นพบผู้สร้างเพื่อสนับสนุน",
-        icon: "search",
+        icon: "img:icons/find-creators.svg",
       },
       creatorHub: {
         description: "ตั้งค่าและจัดการโปรไฟล์ผู้สร้างของคุณ",
-        icon: "hub",
+        icon: "img:icons/creator-hub.svg",
       },
       myProfile: {
         description: "ดูและแก้ไขโปรไฟล์ของคุณ",
@@ -1447,11 +1447,11 @@ export default {
       },
       buckets: {
         description: "จัดระเบียบเงินทุนเป็นถัง",
-        icon: "inbox",
+        icon: "inventory_2",
       },
       subscriptions: {
         description: "จัดการการสมัครสมาชิกของคุณ",
-        icon: "subscriptions",
+        icon: "auto_awesome_motion",
       },
       nostrMessengerTitle: "Nostr Messenger",
       nostrMessenger: {

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -1440,11 +1440,11 @@ export default {
       },
       findCreators: {
         description: "Destekleyecek yaratıcılar keşfedin.",
-        icon: "search",
+        icon: "img:icons/find-creators.svg",
       },
       creatorHub: {
         description: "Yaratıcı profilinizi kurun ve yönetin.",
-        icon: "hub",
+        icon: "img:icons/creator-hub.svg",
       },
       myProfile: {
         description: "Profilinizi görüntüleyin ve düzenleyin.",
@@ -1452,11 +1452,11 @@ export default {
       },
       buckets: {
         description: "Fonları kovalar halinde düzenleyin.",
-        icon: "inbox",
+        icon: "inventory_2",
       },
       subscriptions: {
         description: "Aboneliklerinizi yönetin.",
-        icon: "subscriptions",
+        icon: "auto_awesome_motion",
       },
       nostrMessengerTitle: "Nostr Messenger",
       nostrMessenger: {

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -1427,11 +1427,11 @@ export default {
       },
       findCreators: {
         description: "发现可以支持的创作者。",
-        icon: "search",
+        icon: "img:icons/find-creators.svg",
       },
       creatorHub: {
         description: "设置并管理您的创作者资料。",
-        icon: "hub",
+        icon: "img:icons/creator-hub.svg",
       },
       myProfile: {
         description: "查看并编辑您的个人资料。",
@@ -1439,11 +1439,11 @@ export default {
       },
       buckets: {
         description: "将资金组织成类别。",
-        icon: "inbox",
+        icon: "inventory_2",
       },
       subscriptions: {
         description: "管理您的订阅。",
-        icon: "subscriptions",
+        icon: "auto_awesome_motion",
       },
       nostrMessengerTitle: "Nostr Messenger",
       nostrMessenger: {

--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -571,13 +571,13 @@ const navigationItems = computed<NavigationItem[]>(() => [
   },
   {
     menuItem: t('MainHeader.menu.findCreators.title'),
-    icon: 'search',
+    icon: 'img:icons/find-creators.svg',
     fanText: t('AboutPage.navigation.items.findCreators.fan'),
     creatorText: t('AboutPage.navigation.items.findCreators.creator'),
   },
   {
     menuItem: t('MainHeader.menu.creatorHub.title'),
-    icon: 'hub',
+    icon: 'img:icons/creator-hub.svg',
     fanText: t('AboutPage.navigation.items.creatorHub.fan'),
     creatorText: t('AboutPage.navigation.items.creatorHub.creator'),
   },
@@ -589,13 +589,13 @@ const navigationItems = computed<NavigationItem[]>(() => [
   },
   {
     menuItem: t('MainHeader.menu.buckets.title'),
-    icon: 'inbox',
+    icon: 'inventory_2',
     fanText: t('AboutPage.navigation.items.buckets.fan'),
     creatorText: t('AboutPage.navigation.items.buckets.creator'),
   },
   {
     menuItem: t('MainHeader.menu.subscriptions.title'),
-    icon: 'subscriptions',
+    icon: 'auto_awesome_motion',
     fanText: t('AboutPage.navigation.items.subscriptions.fan'),
     creatorText: t('AboutPage.navigation.items.subscriptions.creator'),
   },


### PR DESCRIPTION
## Summary
- Use header icon names for Find Creators, Creator Hub, Buckets, and Subscriptions links in About page navigation
- Sync About page site overview icons across all locale files with new icon names

## Testing
- `npm test` *(fails: Failed Suites 14 etc.)*
- `npm run lint` *(fails: Invalid option '--ext')*

------
https://chatgpt.com/codex/tasks/task_e_68909798019083309df60b1dd55c5308