### PR TITLE
feat: add about navigation items

### DIFF
--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -1504,6 +1504,10 @@ export default {
       fanPerspective: "Fan perspective",
       creatorPerspective: "Creator perspective",
       items: {
+        wallet: {
+          fan: "Check balance, send and receive ecash.",
+          creator: "Same wallet view—shows supporter payments.",
+        },
         settings: {
           fan: "Add / switch mints, choose display unit, set language & theme, import or back-up your 12-word seed, manage Nostr keys & relays.",
           creator: "Same, plus Publishing settings: toggle automatic NIP-61 profile updates and set a default “Earnings” bucket.",
@@ -1532,6 +1536,18 @@ export default {
           fan: "End-to-end encrypted DMs (Nostr kind 4). Attach images or Cashu tokens. Green flash means a payment is embedded and auto-redeemed on receipt.",
           creator: "Same powerful chat plus a broadcast toggle to message all subs in a tier at once.",
         },
+        restore: {
+          fan: "Recover your wallet from a 12-word seed.",
+          creator: "Same recovery flow for creator profiles.",
+        },
+        alreadyRunning: {
+          fan: "Warns when Fundstr is open in another tab.",
+          creator: "Same warning to avoid conflicting sessions.",
+        },
+        welcome: {
+          fan: "Quick guide for new users.",
+          creator: "Same introduction including creator tips.",
+        },
         terms: {
           fan: "Human-readable, plain-English licence & disclaimers.",
           creator: "Identical — clarifies you keep full custody of funds.",
@@ -1543,6 +1559,10 @@ export default {
         externalLinks: {
           fan: "Cashu.space docs, GitHub, Twitter, Telegram, Donate.",
           creator: "Identical — share with collaborators or fans.",
+        },
+        nostrLogin: {
+          fan: "Sign in using your Nostr keys.",
+          creator: "Same login method required for posting.",
         },
       },
     },

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -1510,6 +1510,10 @@ export default {
       fanPerspective: "Fan perspective",
       creatorPerspective: "Creator perspective",
       items: {
+        wallet: {
+          fan: "Check balance, send and receive ecash.",
+          creator: "Same wallet view—shows supporter payments.",
+        },
         settings: {
           fan: "Add / switch mints, choose display unit, set language & theme, import or back-up your 12-word seed, manage Nostr keys & relays.",
           creator: "Same, plus Publishing settings: toggle automatic NIP-61 profile updates and set a default “Earnings” bucket.",
@@ -1538,6 +1542,18 @@ export default {
           fan: "End-to-end encrypted DMs (Nostr kind 4). Attach images or Cashu tokens. Green flash means a payment is embedded and auto-redeemed on receipt.",
           creator: "Same powerful chat plus a broadcast toggle to message all subs in a tier at once.",
         },
+        restore: {
+          fan: "Recover your wallet from a 12-word seed.",
+          creator: "Same recovery flow for creator profiles.",
+        },
+        alreadyRunning: {
+          fan: "Warns when Fundstr is open in another tab.",
+          creator: "Same warning to avoid conflicting sessions.",
+        },
+        welcome: {
+          fan: "Quick guide for new users.",
+          creator: "Same introduction including creator tips.",
+        },
         terms: {
           fan: "Human-readable, plain-English licence & disclaimers.",
           creator: "Identical — clarifies you keep full custody of funds.",
@@ -1549,6 +1565,10 @@ export default {
         externalLinks: {
           fan: "Cashu.space docs, GitHub, Twitter, Telegram, Donate.",
           creator: "Identical — share with collaborators or fans.",
+        },
+        nostrLogin: {
+          fan: "Sign in using your Nostr keys.",
+          creator: "Same login method required for posting.",
         },
       },
     },

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -1514,6 +1514,10 @@ export default {
       fanPerspective: "Fan perspective",
       creatorPerspective: "Creator perspective",
       items: {
+        wallet: {
+          fan: "Check balance, send and receive ecash.",
+          creator: "Same wallet view—shows supporter payments.",
+        },
         settings: {
           fan: "Add / switch mints, choose display unit, set language & theme, import or back-up your 12-word seed, manage Nostr keys & relays.",
           creator: "Same, plus Publishing settings: toggle automatic NIP-61 profile updates and set a default “Earnings” bucket.",
@@ -1542,6 +1546,18 @@ export default {
           fan: "End-to-end encrypted DMs (Nostr kind 4). Attach images or Cashu tokens. Green flash means a payment is embedded and auto-redeemed on receipt.",
           creator: "Same powerful chat plus a broadcast toggle to message all subs in a tier at once.",
         },
+        restore: {
+          fan: "Recover your wallet from a 12-word seed.",
+          creator: "Same recovery flow for creator profiles.",
+        },
+        alreadyRunning: {
+          fan: "Warns when Fundstr is open in another tab.",
+          creator: "Same warning to avoid conflicting sessions.",
+        },
+        welcome: {
+          fan: "Quick guide for new users.",
+          creator: "Same introduction including creator tips.",
+        },
         terms: {
           fan: "Human-readable, plain-English licence & disclaimers.",
           creator: "Identical — clarifies you keep full custody of funds.",
@@ -1553,6 +1569,10 @@ export default {
         externalLinks: {
           fan: "Cashu.space docs, GitHub, Twitter, Telegram, Donate.",
           creator: "Identical — share with collaborators or fans.",
+        },
+        nostrLogin: {
+          fan: "Sign in using your Nostr keys.",
+          creator: "Same login method required for posting.",
         },
       },
     },

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1772,6 +1772,10 @@ export const messages = {
       fanPerspective: "Fan perspective",
       creatorPerspective: "Creator perspective",
       items: {
+        wallet: {
+          fan: "Check balance, send and receive ecash.",
+          creator: "Same wallet view—shows supporter payments.",
+        },
         settings: {
           fan: "Add / switch mints, choose display unit, set language & theme, import or back-up your 12-word seed, manage Nostr keys & relays.",
           creator: "Same, plus Publishing settings: toggle automatic NIP-61 profile updates and set a default “Earnings” bucket.",
@@ -1800,6 +1804,18 @@ export const messages = {
           fan: "End-to-end encrypted DMs (Nostr kind 4). Attach images or Cashu tokens. Green flash means a payment is embedded and auto-redeemed on receipt.",
           creator: "Same powerful chat plus a broadcast toggle to message all subs in a tier at once.",
         },
+        restore: {
+          fan: "Recover your wallet from a 12-word seed.",
+          creator: "Same recovery flow for creator profiles.",
+        },
+        alreadyRunning: {
+          fan: "Warns when Fundstr is open in another tab.",
+          creator: "Same warning to avoid conflicting sessions.",
+        },
+        welcome: {
+          fan: "Quick guide for new users.",
+          creator: "Same introduction including creator tips.",
+        },
         terms: {
           fan: "Human-readable, plain-English licence & disclaimers.",
           creator: "Identical — clarifies you keep full custody of funds.",
@@ -1811,6 +1827,10 @@ export const messages = {
         externalLinks: {
           fan: "Cashu.space docs, GitHub, Twitter, Telegram, Donate.",
           creator: "Identical — share with collaborators or fans.",
+        },
+        nostrLogin: {
+          fan: "Sign in using your Nostr keys.",
+          creator: "Same login method required for posting.",
         },
       },
     },

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -1511,6 +1511,10 @@ export default {
       fanPerspective: "Fan perspective",
       creatorPerspective: "Creator perspective",
       items: {
+        wallet: {
+          fan: "Check balance, send and receive ecash.",
+          creator: "Same wallet view—shows supporter payments.",
+        },
         settings: {
           fan: "Add / switch mints, choose display unit, set language & theme, import or back-up your 12-word seed, manage Nostr keys & relays.",
           creator: "Same, plus Publishing settings: toggle automatic NIP-61 profile updates and set a default “Earnings” bucket.",
@@ -1539,6 +1543,18 @@ export default {
           fan: "End-to-end encrypted DMs (Nostr kind 4). Attach images or Cashu tokens. Green flash means a payment is embedded and auto-redeemed on receipt.",
           creator: "Same powerful chat plus a broadcast toggle to message all subs in a tier at once.",
         },
+        restore: {
+          fan: "Recover your wallet from a 12-word seed.",
+          creator: "Same recovery flow for creator profiles.",
+        },
+        alreadyRunning: {
+          fan: "Warns when Fundstr is open in another tab.",
+          creator: "Same warning to avoid conflicting sessions.",
+        },
+        welcome: {
+          fan: "Quick guide for new users.",
+          creator: "Same introduction including creator tips.",
+        },
         terms: {
           fan: "Human-readable, plain-English licence & disclaimers.",
           creator: "Identical — clarifies you keep full custody of funds.",
@@ -1550,6 +1566,10 @@ export default {
         externalLinks: {
           fan: "Cashu.space docs, GitHub, Twitter, Telegram, Donate.",
           creator: "Identical — share with collaborators or fans.",
+        },
+        nostrLogin: {
+          fan: "Sign in using your Nostr keys.",
+          creator: "Same login method required for posting.",
         },
       },
     },

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -1501,6 +1501,10 @@ export default {
       fanPerspective: "Fan perspective",
       creatorPerspective: "Creator perspective",
       items: {
+        wallet: {
+          fan: "Check balance, send and receive ecash.",
+          creator: "Same wallet view—shows supporter payments.",
+        },
         settings: {
           fan: "Add / switch mints, choose display unit, set language & theme, import or back-up your 12-word seed, manage Nostr keys & relays.",
           creator: "Same, plus Publishing settings: toggle automatic NIP-61 profile updates and set a default “Earnings” bucket.",
@@ -1529,6 +1533,18 @@ export default {
           fan: "End-to-end encrypted DMs (Nostr kind 4). Attach images or Cashu tokens. Green flash means a payment is embedded and auto-redeemed on receipt.",
           creator: "Same powerful chat plus a broadcast toggle to message all subs in a tier at once.",
         },
+        restore: {
+          fan: "Recover your wallet from a 12-word seed.",
+          creator: "Same recovery flow for creator profiles.",
+        },
+        alreadyRunning: {
+          fan: "Warns when Fundstr is open in another tab.",
+          creator: "Same warning to avoid conflicting sessions.",
+        },
+        welcome: {
+          fan: "Quick guide for new users.",
+          creator: "Same introduction including creator tips.",
+        },
         terms: {
           fan: "Human-readable, plain-English licence & disclaimers.",
           creator: "Identical — clarifies you keep full custody of funds.",
@@ -1540,6 +1556,10 @@ export default {
         externalLinks: {
           fan: "Cashu.space docs, GitHub, Twitter, Telegram, Donate.",
           creator: "Identical — share with collaborators or fans.",
+        },
+        nostrLogin: {
+          fan: "Sign in using your Nostr keys.",
+          creator: "Same login method required for posting.",
         },
       },
     },

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -1493,6 +1493,10 @@ export default {
       fanPerspective: "Fan perspective",
       creatorPerspective: "Creator perspective",
       items: {
+        wallet: {
+          fan: "Check balance, send and receive ecash.",
+          creator: "Same wallet view—shows supporter payments.",
+        },
         settings: {
           fan: "Add / switch mints, choose display unit, set language & theme, import or back-up your 12-word seed, manage Nostr keys & relays.",
           creator: "Same, plus Publishing settings: toggle automatic NIP-61 profile updates and set a default “Earnings” bucket.",
@@ -1521,6 +1525,18 @@ export default {
           fan: "End-to-end encrypted DMs (Nostr kind 4). Attach images or Cashu tokens. Green flash means a payment is embedded and auto-redeemed on receipt.",
           creator: "Same powerful chat plus a broadcast toggle to message all subs in a tier at once.",
         },
+        restore: {
+          fan: "Recover your wallet from a 12-word seed.",
+          creator: "Same recovery flow for creator profiles.",
+        },
+        alreadyRunning: {
+          fan: "Warns when Fundstr is open in another tab.",
+          creator: "Same warning to avoid conflicting sessions.",
+        },
+        welcome: {
+          fan: "Quick guide for new users.",
+          creator: "Same introduction including creator tips.",
+        },
         terms: {
           fan: "Human-readable, plain-English licence & disclaimers.",
           creator: "Identical — clarifies you keep full custody of funds.",
@@ -1532,6 +1548,10 @@ export default {
         externalLinks: {
           fan: "Cashu.space docs, GitHub, Twitter, Telegram, Donate.",
           creator: "Identical — share with collaborators or fans.",
+        },
+        nostrLogin: {
+          fan: "Sign in using your Nostr keys.",
+          creator: "Same login method required for posting.",
         },
       },
     },

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -1494,6 +1494,10 @@ export default {
       fanPerspective: "Fan perspective",
       creatorPerspective: "Creator perspective",
       items: {
+        wallet: {
+          fan: "Check balance, send and receive ecash.",
+          creator: "Same wallet view—shows supporter payments.",
+        },
         settings: {
           fan: "Add / switch mints, choose display unit, set language & theme, import or back-up your 12-word seed, manage Nostr keys & relays.",
           creator: "Same, plus Publishing settings: toggle automatic NIP-61 profile updates and set a default “Earnings” bucket.",
@@ -1522,6 +1526,18 @@ export default {
           fan: "End-to-end encrypted DMs (Nostr kind 4). Attach images or Cashu tokens. Green flash means a payment is embedded and auto-redeemed on receipt.",
           creator: "Same powerful chat plus a broadcast toggle to message all subs in a tier at once.",
         },
+        restore: {
+          fan: "Recover your wallet from a 12-word seed.",
+          creator: "Same recovery flow for creator profiles.",
+        },
+        alreadyRunning: {
+          fan: "Warns when Fundstr is open in another tab.",
+          creator: "Same warning to avoid conflicting sessions.",
+        },
+        welcome: {
+          fan: "Quick guide for new users.",
+          creator: "Same introduction including creator tips.",
+        },
         terms: {
           fan: "Human-readable, plain-English licence & disclaimers.",
           creator: "Identical — clarifies you keep full custody of funds.",
@@ -1533,6 +1549,10 @@ export default {
         externalLinks: {
           fan: "Cashu.space docs, GitHub, Twitter, Telegram, Donate.",
           creator: "Identical — share with collaborators or fans.",
+        },
+        nostrLogin: {
+          fan: "Sign in using your Nostr keys.",
+          creator: "Same login method required for posting.",
         },
       },
     },

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -1493,6 +1493,10 @@ export default {
       fanPerspective: "Fan perspective",
       creatorPerspective: "Creator perspective",
       items: {
+        wallet: {
+          fan: "Check balance, send and receive ecash.",
+          creator: "Same wallet view—shows supporter payments.",
+        },
         settings: {
           fan: "Add / switch mints, choose display unit, set language & theme, import or back-up your 12-word seed, manage Nostr keys & relays.",
           creator: "Same, plus Publishing settings: toggle automatic NIP-61 profile updates and set a default “Earnings” bucket.",
@@ -1521,6 +1525,18 @@ export default {
           fan: "End-to-end encrypted DMs (Nostr kind 4). Attach images or Cashu tokens. Green flash means a payment is embedded and auto-redeemed on receipt.",
           creator: "Same powerful chat plus a broadcast toggle to message all subs in a tier at once.",
         },
+        restore: {
+          fan: "Recover your wallet from a 12-word seed.",
+          creator: "Same recovery flow for creator profiles.",
+        },
+        alreadyRunning: {
+          fan: "Warns when Fundstr is open in another tab.",
+          creator: "Same warning to avoid conflicting sessions.",
+        },
+        welcome: {
+          fan: "Quick guide for new users.",
+          creator: "Same introduction including creator tips.",
+        },
         terms: {
           fan: "Human-readable, plain-English licence & disclaimers.",
           creator: "Identical — clarifies you keep full custody of funds.",
@@ -1532,6 +1548,10 @@ export default {
         externalLinks: {
           fan: "Cashu.space docs, GitHub, Twitter, Telegram, Donate.",
           creator: "Identical — share with collaborators or fans.",
+        },
+        nostrLogin: {
+          fan: "Sign in using your Nostr keys.",
+          creator: "Same login method required for posting.",
         },
       },
     },

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -1491,6 +1491,10 @@ export default {
       fanPerspective: "Fan perspective",
       creatorPerspective: "Creator perspective",
       items: {
+        wallet: {
+          fan: "Check balance, send and receive ecash.",
+          creator: "Same wallet view—shows supporter payments.",
+        },
         settings: {
           fan: "Add / switch mints, choose display unit, set language & theme, import or back-up your 12-word seed, manage Nostr keys & relays.",
           creator: "Same, plus Publishing settings: toggle automatic NIP-61 profile updates and set a default “Earnings” bucket.",
@@ -1519,6 +1523,18 @@ export default {
           fan: "End-to-end encrypted DMs (Nostr kind 4). Attach images or Cashu tokens. Green flash means a payment is embedded and auto-redeemed on receipt.",
           creator: "Same powerful chat plus a broadcast toggle to message all subs in a tier at once.",
         },
+        restore: {
+          fan: "Recover your wallet from a 12-word seed.",
+          creator: "Same recovery flow for creator profiles.",
+        },
+        alreadyRunning: {
+          fan: "Warns when Fundstr is open in another tab.",
+          creator: "Same warning to avoid conflicting sessions.",
+        },
+        welcome: {
+          fan: "Quick guide for new users.",
+          creator: "Same introduction including creator tips.",
+        },
         terms: {
           fan: "Human-readable, plain-English licence & disclaimers.",
           creator: "Identical — clarifies you keep full custody of funds.",
@@ -1530,6 +1546,10 @@ export default {
         externalLinks: {
           fan: "Cashu.space docs, GitHub, Twitter, Telegram, Donate.",
           creator: "Identical — share with collaborators or fans.",
+        },
+        nostrLogin: {
+          fan: "Sign in using your Nostr keys.",
+          creator: "Same login method required for posting.",
         },
       },
     },

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -1496,6 +1496,10 @@ export default {
       fanPerspective: "Fan perspective",
       creatorPerspective: "Creator perspective",
       items: {
+        wallet: {
+          fan: "Check balance, send and receive ecash.",
+          creator: "Same wallet view—shows supporter payments.",
+        },
         settings: {
           fan: "Add / switch mints, choose display unit, set language & theme, import or back-up your 12-word seed, manage Nostr keys & relays.",
           creator: "Same, plus Publishing settings: toggle automatic NIP-61 profile updates and set a default “Earnings” bucket.",
@@ -1524,6 +1528,18 @@ export default {
           fan: "End-to-end encrypted DMs (Nostr kind 4). Attach images or Cashu tokens. Green flash means a payment is embedded and auto-redeemed on receipt.",
           creator: "Same powerful chat plus a broadcast toggle to message all subs in a tier at once.",
         },
+        restore: {
+          fan: "Recover your wallet from a 12-word seed.",
+          creator: "Same recovery flow for creator profiles.",
+        },
+        alreadyRunning: {
+          fan: "Warns when Fundstr is open in another tab.",
+          creator: "Same warning to avoid conflicting sessions.",
+        },
+        welcome: {
+          fan: "Quick guide for new users.",
+          creator: "Same introduction including creator tips.",
+        },
         terms: {
           fan: "Human-readable, plain-English licence & disclaimers.",
           creator: "Identical — clarifies you keep full custody of funds.",
@@ -1535,6 +1551,10 @@ export default {
         externalLinks: {
           fan: "Cashu.space docs, GitHub, Twitter, Telegram, Donate.",
           creator: "Identical — share with collaborators or fans.",
+        },
+        nostrLogin: {
+          fan: "Sign in using your Nostr keys.",
+          creator: "Same login method required for posting.",
         },
       },
     },

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -1483,6 +1483,10 @@ export default {
       fanPerspective: "Fan perspective",
       creatorPerspective: "Creator perspective",
       items: {
+        wallet: {
+          fan: "Check balance, send and receive ecash.",
+          creator: "Same wallet view—shows supporter payments.",
+        },
         settings: {
           fan: "Add / switch mints, choose display unit, set language & theme, import or back-up your 12-word seed, manage Nostr keys & relays.",
           creator: "Same, plus Publishing settings: toggle automatic NIP-61 profile updates and set a default “Earnings” bucket.",
@@ -1511,6 +1515,18 @@ export default {
           fan: "End-to-end encrypted DMs (Nostr kind 4). Attach images or Cashu tokens. Green flash means a payment is embedded and auto-redeemed on receipt.",
           creator: "Same powerful chat plus a broadcast toggle to message all subs in a tier at once.",
         },
+        restore: {
+          fan: "Recover your wallet from a 12-word seed.",
+          creator: "Same recovery flow for creator profiles.",
+        },
+        alreadyRunning: {
+          fan: "Warns when Fundstr is open in another tab.",
+          creator: "Same warning to avoid conflicting sessions.",
+        },
+        welcome: {
+          fan: "Quick guide for new users.",
+          creator: "Same introduction including creator tips.",
+        },
         terms: {
           fan: "Human-readable, plain-English licence & disclaimers.",
           creator: "Identical — clarifies you keep full custody of funds.",
@@ -1522,6 +1538,10 @@ export default {
         externalLinks: {
           fan: "Cashu.space docs, GitHub, Twitter, Telegram, Donate.",
           creator: "Identical — share with collaborators or fans.",
+        },
+        nostrLogin: {
+          fan: "Sign in using your Nostr keys.",
+          creator: "Same login method required for posting.",
         },
       },
     },

--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -564,6 +564,12 @@ const siteOverviewCards: SiteOverviewCard[] = [
 // navigation items for the navigation map
 const navigationItems = computed<NavigationItem[]>(() => [
   {
+    menuItem: t('MainHeader.menu.wallet.title'),
+    icon: 'account_balance_wallet',
+    fanText: t('AboutPage.navigation.items.wallet.fan'),
+    creatorText: t('AboutPage.navigation.items.wallet.creator'),
+  },
+  {
     menuItem: t('MainHeader.menu.settings.title'),
     icon: 'settings',
     fanText: t('AboutPage.navigation.items.settings.fan'),
@@ -606,6 +612,24 @@ const navigationItems = computed<NavigationItem[]>(() => [
     creatorText: t('AboutPage.navigation.items.chats.creator'),
   },
   {
+    menuItem: t('MainHeader.menu.restore.title'),
+    icon: 'settings_backup_restore',
+    fanText: t('AboutPage.navigation.items.restore.fan'),
+    creatorText: t('AboutPage.navigation.items.restore.creator'),
+  },
+  {
+    menuItem: t('MainHeader.menu.alreadyRunning.title'),
+    icon: 'warning',
+    fanText: t('AboutPage.navigation.items.alreadyRunning.fan'),
+    creatorText: t('AboutPage.navigation.items.alreadyRunning.creator'),
+  },
+  {
+    menuItem: t('MainHeader.menu.welcome.title'),
+    icon: 'info',
+    fanText: t('AboutPage.navigation.items.welcome.fan'),
+    creatorText: t('AboutPage.navigation.items.welcome.creator'),
+  },
+  {
     menuItem: t('MainHeader.menu.terms.title'),
     icon: 'gavel',
     fanText: t('AboutPage.navigation.items.terms.fan'),
@@ -622,6 +646,12 @@ const navigationItems = computed<NavigationItem[]>(() => [
     icon: 'link',
     fanText: t('AboutPage.navigation.items.externalLinks.fan'),
     creatorText: t('AboutPage.navigation.items.externalLinks.creator'),
+  },
+  {
+    menuItem: t('MainHeader.menu.nostrLogin.title'),
+    icon: 'vpn_key',
+    fanText: t('AboutPage.navigation.items.nostrLogin.fan'),
+    creatorText: t('AboutPage.navigation.items.nostrLogin.creator'),
   },
 ])
 


### PR DESCRIPTION
## Summary
- extend About page navigation with wallet, restore, already running, welcome, and Nostr Login links
- add translation strings for new navigation links across all locales

## Testing
- `npm test` *(fails: Failed Suites 14)*
- `npm run lint` *(fails: Invalid option '--ext')*


------
https://chatgpt.com/codex/tasks/task_e_68909b49d5108330b2babf6797fb979d