### PR TITLE
feat: use vpn_key icon for Nostr Login

### DIFF
--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -1497,7 +1497,7 @@ export default {
       nostrLoginTitle: "Nostr Login",
       nostrLogin: {
         description: "Authenticate using your Nostr keys.",
-        icon: "login",
+        icon: "vpn_key",
       },
     },
     navigation: {

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -1503,7 +1503,7 @@ export default {
       nostrLoginTitle: "Nostr Login",
       nostrLogin: {
         description: "Authenticate using your Nostr keys.",
-        icon: "login",
+        icon: "vpn_key",
       },
     },
     navigation: {

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -1507,7 +1507,7 @@ export default {
       nostrLoginTitle: "Nostr Login",
       nostrLogin: {
         description: "Authenticate using your Nostr keys.",
-        icon: "login",
+        icon: "vpn_key",
       },
     },
     navigation: {

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1765,7 +1765,7 @@ export const messages = {
       nostrLoginTitle: "Nostr Login",
       nostrLogin: {
         description: "Authenticate using your Nostr keys.",
-        icon: "login",
+        icon: "vpn_key",
       },
     },
     navigation: {

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -1504,7 +1504,7 @@ export default {
       nostrLoginTitle: "Nostr Login",
       nostrLogin: {
         description: "Authenticate using your Nostr keys.",
-        icon: "login",
+        icon: "vpn_key",
       },
     },
     navigation: {

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -1494,7 +1494,7 @@ export default {
       nostrLoginTitle: "Nostr Login",
       nostrLogin: {
         description: "Authenticate using your Nostr keys.",
-        icon: "login",
+        icon: "vpn_key",
       },
     },
     navigation: {

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -1486,7 +1486,7 @@ export default {
       nostrLoginTitle: "Nostr Login",
       nostrLogin: {
         description: "Authenticate using your Nostr keys.",
-        icon: "login",
+        icon: "vpn_key",
       },
     },
     navigation: {

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -1487,7 +1487,7 @@ export default {
       nostrLoginTitle: "Nostr Login",
       nostrLogin: {
         description: "Authenticate using your Nostr keys.",
-        icon: "login",
+        icon: "vpn_key",
       },
     },
     navigation: {

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -1486,7 +1486,7 @@ export default {
       nostrLoginTitle: "Nostr Login",
       nostrLogin: {
         description: "Authenticate using your Nostr keys.",
-        icon: "login",
+        icon: "vpn_key",
       },
     },
     navigation: {

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -1484,7 +1484,7 @@ export default {
       nostrLoginTitle: "Nostr Login",
       nostrLogin: {
         description: "Authenticate using your Nostr keys.",
-        icon: "login",
+        icon: "vpn_key",
       },
     },
     navigation: {

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -1489,7 +1489,7 @@ export default {
       nostrLoginTitle: "Nostr Login",
       nostrLogin: {
         description: "Authenticate using your Nostr keys.",
-        icon: "login",
+        icon: "vpn_key",
       },
     },
     navigation: {

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -1476,7 +1476,7 @@ export default {
       nostrLoginTitle: "Nostr Login",
       nostrLogin: {
         description: "Authenticate using your Nostr keys.",
-        icon: "login",
+        icon: "vpn_key",
       },
     },
     navigation: {


### PR DESCRIPTION
## Summary
- swap Nostr Login icon to `vpn_key` across locale translations
- ensure About page uses `vpn_key` icon for Nostr Login navigation entry

## Testing
- `npm test` *(fails: 30 failed, 30 passed)*
- `npm run lint` *(fails: Invalid option '--ext')*


------
https://chatgpt.com/codex/tasks/task_e_68909f32f0b48330b79adb4ae1a5f0d4