### PR TITLE
Make AboutPage site overview cards fully clickable

### DIFF
--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -40,23 +40,24 @@
         <div
           class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 text-left"
         >
-          <div
+          <router-link
             v-for="card in siteOverviewCards"
             :key="card.route"
-            class="interactive-card p-6 flex flex-col"
+            :to="card.route"
+            class="interactive-card p-6 flex flex-col cursor-pointer"
           >
             <q-icon
               :name="$t(card.iconKey)"
               size="2.5rem"
               class="text-accent mb-4"
             />
-            <router-link :to="card.route" class="text-accent font-semibold">
+            <p class="text-accent font-semibold">
               {{ $t(card.titleKey) }}
-            </router-link>
+            </p>
             <p class="text-sm mt-2">
               {{ $t(card.descriptionKey) }}
             </p>
-          </div>
+          </router-link>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- Wrap About page site overview cards in `router-link`
- Display card titles as plain text and add cursor pointer styling

## Testing
- `pnpm run lint` *(fails: Invalid option '--ext')*
- `pnpm run test` *(fails: see output)*

------
https://chatgpt.com/codex/tasks/task_e_6890a500c00083309217f574f3ccacc0