### PR TITLE
feat: expand about page site overview grid

### DIFF
--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -38,7 +38,7 @@
           {{ $t('AboutPage.siteOverview.title') }}
         </h2>
         <div
-          class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 text-left"
+          class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-6 text-left"
         >
           <router-link
             v-for="card in siteOverviewCards"


### PR DESCRIPTION
## Summary
- allow more columns for Site Overview cards on wider screens

## Testing
- `pnpm run lint` *(fails: Invalid option '--ext')*
- `pnpm run test` *(fails: Failed Suites 14)*

------
https://chatgpt.com/codex/tasks/task_e_6890a7ba9ef483308ae7dcaacbb56860