### PR TITLE
style: render site overview icons in white

### DIFF
--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -49,7 +49,7 @@
             <q-icon
               :name="$t(card.iconKey)"
               size="2.5rem"
-              class="text-accent mb-4"
+              class="text-white mb-4"
             />
             <p class="text-accent font-semibold">
               {{ $t(card.titleKey) }}


### PR DESCRIPTION
## Summary
- show site overview icons in white for both light and dark themes

## Testing
- `npm test` *(fails: multiple suites)*
- `npm run lint` *(fails: Invalid option '--ext' - perhaps you meant '-c'?)*

------
https://chatgpt.com/codex/tasks/task_e_6890ab6a091883308a237d7337db3e26