### PR TITLE
Use two-column compact FAQ layout

### DIFF
--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -395,138 +395,138 @@
           Frequently Asked Questions
         </h2>
 
-        <div class="space-y-4">
-          <!-- Q1 -->
-          <details class="interactive-card p-6">
-            <summary class="cursor-pointer font-semibold text-lg">
-              What if a fan stops paying?
-            </summary>
-            <p class="mt-4 text-sm">
-              Creator view » Their timelocked token never unlocks for you. Fundstr flags the user as “Expired” and hides future paid posts. Fan view » You simply don’t renew. No recurring pull, no surprise charges.
-            </p>
-          </details>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <!-- Q1 -->
+            <details class="interactive-card p-4">
+              <summary class="cursor-pointer font-semibold text-lg">
+                What if a fan stops paying?
+              </summary>
+              <p class="mt-4 text-sm">
+                Creator view » Their timelocked token never unlocks for you. Fundstr flags the user as “Expired” and hides future paid posts. Fan view » You simply don’t renew. No recurring pull, no surprise charges.
+              </p>
+            </details>
 
           <!-- Q2 -->
-          <details class="interactive-card p-6">
-            <summary class="cursor-pointer font-semibold text-lg">
-              Can I withdraw to a Lightning wallet?
-            </summary>
-            <p class="mt-4 text-sm">
-              Yes. Go to Wallet → Send → Lightning Invoice, paste the invoice from any external wallet; Fundstr melts the tokens at the mint and pays it.
-            </p>
-          </details>
+            <details class="interactive-card p-4">
+              <summary class="cursor-pointer font-semibold text-lg">
+                Can I withdraw to a Lightning wallet?
+              </summary>
+              <p class="mt-4 text-sm">
+                Yes. Go to Wallet → Send → Lightning Invoice, paste the invoice from any external wallet; Fundstr melts the tokens at the mint and pays it.
+              </p>
+            </details>
 
           <!-- Q3 -->
-          <details class="interactive-card p-6">
-            <summary class="cursor-pointer font-semibold text-lg">
-              How private is this really?
-            </summary>
-            <ul class="mt-4 text-sm list-disc pl-6 space-y-1">
-              <li>Mints see withdraw/redeem events but cannot correlate them.</li>
+            <details class="interactive-card p-4">
+              <summary class="cursor-pointer font-semibold text-lg">
+                How private is this really?
+              </summary>
+              <ul class="mt-4 text-sm list-disc pl-6 space-y-1">
+                <li>Mints see withdraw/redeem events but cannot correlate them.</li>
               <li>Nostr chats are E2E encrypted; Nutzaps use P2PK so only the intended receiver can claim them.</li>
               <li>Choose different mints or buckets to compartmentalise further.</li>
             </ul>
           </details>
 
           <!-- Q4 -->
-          <details class="interactive-card p-6">
-            <summary class="cursor-pointer font-semibold text-lg">
-              What exactly is Cashu and how is it different from regular Bitcoin or Lightning wallets?
-            </summary>
-            <p class="mt-4 text-sm">
-              Cashu uses Chaumian e‑cash, allowing the mint to issue anonymized tokens. Unlike typical wallets, your transactions never appear on the blockchain, and the mint cannot link where your tokens are spent.
-            </p>
-          </details>
+            <details class="interactive-card p-4">
+              <summary class="cursor-pointer font-semibold text-lg">
+                What exactly is Cashu and how is it different from regular Bitcoin or Lightning wallets?
+              </summary>
+              <p class="mt-4 text-sm">
+                Cashu uses Chaumian e‑cash, allowing the mint to issue anonymized tokens. Unlike typical wallets, your transactions never appear on the blockchain, and the mint cannot link where your tokens are spent.
+              </p>
+            </details>
 
           <!-- Q5 -->
-          <details class="interactive-card p-6">
-            <summary class="cursor-pointer font-semibold text-lg">
-              Do I need to trust a mint, and what happens if a mint goes offline?
-            </summary>
-            <p class="mt-4 text-sm">
-              A mint is required to issue and redeem tokens. If it disappears, any tokens it issued become unusable. To reduce risk, you can hold small balances, spread funds across multiple mints, and withdraw or swap tokens when you suspect a mint might fail.
-            </p>
-          </details>
+            <details class="interactive-card p-4">
+              <summary class="cursor-pointer font-semibold text-lg">
+                Do I need to trust a mint, and what happens if a mint goes offline?
+              </summary>
+              <p class="mt-4 text-sm">
+                A mint is required to issue and redeem tokens. If it disappears, any tokens it issued become unusable. To reduce risk, you can hold small balances, spread funds across multiple mints, and withdraw or swap tokens when you suspect a mint might fail.
+              </p>
+            </details>
 
           <!-- Q6 -->
-          <details class="interactive-card p-6">
-            <summary class="cursor-pointer font-semibold text-lg">
-              How can I back up or restore my wallet?
-            </summary>
-            <p class="mt-4 text-sm">
-              During setup you can generate a BIP‑39 seed. Record it safely; if your device is lost, reinstall the app, enter the seed, and reconnect to your mints to restore unspent tokens. Without a seed or token export, lost devices mean lost funds.
-            </p>
-          </details>
+            <details class="interactive-card p-4">
+              <summary class="cursor-pointer font-semibold text-lg">
+                How can I back up or restore my wallet?
+              </summary>
+              <p class="mt-4 text-sm">
+                During setup you can generate a BIP‑39 seed. Record it safely; if your device is lost, reinstall the app, enter the seed, and reconnect to your mints to restore unspent tokens. Without a seed or token export, lost devices mean lost funds.
+              </p>
+            </details>
 
-          <!-- Q7 -->
-          <details class="interactive-card p-6">
-            <summary class="cursor-pointer font-semibold text-lg">
-              What are “Buckets” and why would I use them?
-            </summary>
-            <p class="mt-4 text-sm">
-              Buckets act like sub‑accounts. You can allocate tokens to categories (e.g., savings, subscriptions) and move funds between buckets instantly, which helps with budgeting or keeping project funds separate.
-            </p>
-          </details>
+            <!-- Q7 -->
+            <details class="interactive-card p-4">
+              <summary class="cursor-pointer font-semibold text-lg">
+                What are “Buckets” and why would I use them?
+              </summary>
+              <p class="mt-4 text-sm">
+                Buckets act like sub‑accounts. You can allocate tokens to categories (e.g., savings, subscriptions) and move funds between buckets instantly, which helps with budgeting or keeping project funds separate.
+              </p>
+            </details>
 
-          <!-- Q8 -->
-          <details class="interactive-card p-6">
-            <summary class="cursor-pointer font-semibold text-lg">
-              How does the Nostr integration work?
-            </summary>
-            <p class="mt-4 text-sm">
-              The app can generate or import a Nostr key pair, connect to relays, and send encrypted DMs. This enables token transfers and tipping directly through Nostr events without exposing invoices or addresses.
-            </p>
-          </details>
+            <!-- Q8 -->
+            <details class="interactive-card p-4">
+              <summary class="cursor-pointer font-semibold text-lg">
+                How does the Nostr integration work?
+              </summary>
+              <p class="mt-4 text-sm">
+                The app can generate or import a Nostr key pair, connect to relays, and send encrypted DMs. This enables token transfers and tipping directly through Nostr events without exposing invoices or addresses.
+              </p>
+            </details>
 
-          <!-- Q9 -->
-          <details class="interactive-card p-6">
-            <summary class="cursor-pointer font-semibold text-lg">
-              What are Nutzaps and how do I receive them?
-            </summary>
-            <p class="mt-4 text-sm">
-              Nutzaps let users send Cashu tokens as Nostr “zap” events. Publish your NIP‑61 profile (the app guides you), and others can tip you using ecash locked to your Nostr wallet key, keeping the payment private yet publicly verifiable.
-            </p>
-          </details>
+            <!-- Q9 -->
+            <details class="interactive-card p-4">
+              <summary class="cursor-pointer font-semibold text-lg">
+                What are Nutzaps and how do I receive them?
+              </summary>
+              <p class="mt-4 text-sm">
+                Nutzaps let users send Cashu tokens as Nostr “zap” events. Publish your NIP‑61 profile (the app guides you), and others can tip you using ecash locked to your Nostr wallet key, keeping the payment private yet publicly verifiable.
+              </p>
+            </details>
 
-          <!-- Q10 -->
-          <details class="interactive-card p-6">
-            <summary class="cursor-pointer font-semibold text-lg">
-              Can I connect the wallet to other Nostr‑enabled apps?
-            </summary>
-            <p class="mt-4 text-sm">
-              Yes. Nostr Wallet Connect (NWC) provides a QR code and secret key. Pair it with supported apps, and they can request payments or signatures through Nostr events that you approve inside the wallet.
-            </p>
-          </details>
+            <!-- Q10 -->
+            <details class="interactive-card p-4">
+              <summary class="cursor-pointer font-semibold text-lg">
+                Can I connect the wallet to other Nostr‑enabled apps?
+              </summary>
+              <p class="mt-4 text-sm">
+                Yes. Nostr Wallet Connect (NWC) provides a QR code and secret key. Pair it with supported apps, and they can request payments or signatures through Nostr events that you approve inside the wallet.
+              </p>
+            </details>
 
-          <!-- Q11 -->
-          <details class="interactive-card p-6">
-            <summary class="cursor-pointer font-semibold text-lg">
-              Are there any fees for using Cashu tokens?
-            </summary>
-            <p class="mt-4 text-sm">
-              Sending tokens between users is free. Fees may apply when minting or melting tokens via Lightning, depending on the mint’s policy and Lightning network costs. The app shows mint‑specific fees before you confirm a transaction.
-            </p>
-          </details>
+            <!-- Q11 -->
+            <details class="interactive-card p-4">
+              <summary class="cursor-pointer font-semibold text-lg">
+                Are there any fees for using Cashu tokens?
+              </summary>
+              <p class="mt-4 text-sm">
+                Sending tokens between users is free. Fees may apply when minting or melting tokens via Lightning, depending on the mint’s policy and Lightning network costs. The app shows mint‑specific fees before you confirm a transaction.
+              </p>
+            </details>
 
-          <!-- Q12 -->
-          <details class="interactive-card p-6">
-            <summary class="cursor-pointer font-semibold text-lg">
-              Does the app work offline?
-            </summary>
-            <p class="mt-4 text-sm">
-              You can view balances, buckets, and message history offline. Creating or redeeming tokens, chatting, and nutzap processing require an internet connection to reach the mint and Nostr relays.
-            </p>
-          </details>
+            <!-- Q12 -->
+            <details class="interactive-card p-4">
+              <summary class="cursor-pointer font-semibold text-lg">
+                Does the app work offline?
+              </summary>
+              <p class="mt-4 text-sm">
+                You can view balances, buckets, and message history offline. Creating or redeeming tokens, chatting, and nutzap processing require an internet connection to reach the mint and Nostr relays.
+              </p>
+            </details>
 
-          <!-- Q13 -->
-          <details class="interactive-card p-6">
-            <summary class="cursor-pointer font-semibold text-lg">
-              Is the code open source and can I run it myself?
-            </summary>
-            <p class="mt-4 text-sm">
-              Yes. The entire project is MIT‑licensed. You can review, fork, or self‑host the repository. Advanced users can also run their own mint and point the wallet at it for full control over issuance and redemption.
-            </p>
-          </details>
+            <!-- Q13 -->
+            <details class="interactive-card p-4">
+              <summary class="cursor-pointer font-semibold text-lg">
+                Is the code open source and can I run it myself?
+              </summary>
+              <p class="mt-4 text-sm">
+                Yes. The entire project is MIT‑licensed. You can review, fork, or self‑host the repository. Advanced users can also run their own mint and point the wallet at it for full control over issuance and redemption.
+              </p>
+            </details>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- use a responsive two-column grid for FAQ entries
- shrink FAQ card padding to make section more compact

## Testing
- `npm test` *(fails: 30 failed files, 48 failed tests, 1 error)*

------
https://chatgpt.com/codex/tasks/task_e_6890f36f6cc48330894f55d939653e0f