### PR TITLE
feat: add creator profile link

### DIFF
--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -544,7 +544,9 @@
           </p>
           <div class="flex flex-col sm:flex-row justify-center gap-4 text-accent">
             <a
-              href="#"
+              href="https://primal.net/KalonAxiarch"
+              target="_blank"
+              rel="noopener noreferrer"
               class="interactive-card px-6 py-3 flex items-center justify-center gap-2"
               >👤 Creator's Profile</a
             >


### PR DESCRIPTION
## Summary
- add external link to creator profile on About page

## Testing
- `npm test` (fails: 30 failed, 30 passed)
- `npm run lint` (fails: Invalid option '--ext')

------
https://chatgpt.com/codex/tasks/task_e_6890fadf541c833089adcc94b196cfd4