### PR TITLE
feat: label subscription icons

### DIFF
--- a/src/components/SubscriptionDetailDialog.vue
+++ b/src/components/SubscriptionDetailDialog.vue
@@ -24,7 +24,13 @@
                 :color="t.redeemed ? 'positive' : 'grey'"
                 class="q-mr-sm"
               />
-              <q-btn flat dense icon="content_copy" @click="copy(t.token)" />
+              <q-btn
+                flat
+                dense
+                icon="content_copy"
+                @click="copy(t.token)"
+                :aria-label="$t('global.actions.copy.label')"
+              />
             </q-item-section>
           </q-item>
         </q-list>

--- a/src/components/SubscriptionReceipt.vue
+++ b/src/components/SubscriptionReceipt.vue
@@ -38,6 +38,11 @@
                   :icon="expanded[r.id] ? 'expand_less' : 'expand_more'"
                   class="q-ml-xs"
                   @click.stop="toggle(r.id)"
+                  :aria-label="
+                    expanded[r.id]
+                      ? $t('SubscriptionReceipt.actions.collapse_token.label')
+                      : $t('SubscriptionReceipt.actions.expand_token.label')
+                  "
                 />
               </div>
               <q-slide-transition>

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1111,6 +1111,8 @@ export const messages = {
       save: {
         label: "@:global.actions.save.label",
       },
+      expand_token: { label: "Expand token" },
+      collapse_token: { label: "Collapse token" },
     },
   },
   NumericKeyboard: {
@@ -1607,6 +1609,8 @@ export const messages = {
     pending_retry: "Queued { count } payments for resend",
     actions: {
       retry_now: { label: "Retry now" },
+      open_filters: { label: "Open filters" },
+      more_actions: { label: "More actions" },
     },
   },
   LockedTokensTable: {

--- a/src/pages/SubscriptionsOverview.vue
+++ b/src/pages/SubscriptionsOverview.vue
@@ -67,7 +67,13 @@
             :options="sortOptions"
             :placeholder="$t('SubscriptionsOverview.sort_by')"
           />
-          <q-btn flat dense icon="tune" @click="showAdvancedFilters = true" />
+          <q-btn
+            flat
+            dense
+            icon="tune"
+            @click="showAdvancedFilters = true"
+            :aria-label="$t('SubscriptionsOverview.actions.open_filters.label')"
+          />
         </q-toolbar>
       </q-form>
       <div v-if="isLoading" class="subscription-grid">
@@ -173,7 +179,13 @@
                 {{ $t('SubscriptionsOverview.message') }}
               </q-btn>
             </div>
-            <q-btn flat round dense icon="more_vert">
+            <q-btn
+              flat
+              round
+              dense
+              icon="more_vert"
+              :aria-label="$t('SubscriptionsOverview.actions.more_actions.label')"
+            >
               <q-menu anchor="bottom right" self="top right">
                 <q-list dense style="min-width: 150px">
                   <q-item


### PR DESCRIPTION
## Summary
- add localized aria labels to subscription overview filter and menu buttons
- label copy and expand actions in subscription dialogs
- extend English translations for new labels

## Testing
- `npm test` (fails: Failed Suites 14)
- `npm run lint` (fails: Invalid option '--ext')

------
https://chatgpt.com/codex/tasks/task_e_6891078e6ed883308832c5931f4f8b5b