### PR TITLE
feat: add creator subscribers list

### DIFF
--- a/src/components/CreatorSubscribers.vue
+++ b/src/components/CreatorSubscribers.vue
@@ -1,0 +1,77 @@
+<template>
+  <div>
+    <div class="row q-mb-md">
+      <q-input
+        v-model="filter"
+        dense
+        outlined
+        debounce="300"
+        clearable
+        placeholder="Filter"
+        class="col"
+      >
+        <template #prepend>
+          <q-icon name="search" />
+        </template>
+      </q-input>
+    </div>
+    <q-table
+      flat
+      bordered
+      row-key="subscriptionId"
+      :rows="subscriptions"
+      :columns="columns"
+      :filter="filter"
+      :pagination="pagination"
+      :loading="loading"
+      :rows-per-page-options="[5, 10, 20]"
+    >
+      <template #body-cell-subscriber="props">
+        <q-td :props="props">
+          {{ shortenString(pubkeyNpub(props.row.subscriberNpub), 15, 6) }}
+        </q-td>
+      </template>
+      <template #body-cell-months="props">
+        <q-td :props="props">
+          {{ props.row.receivedMonths }} / {{ props.row.totalMonths }}
+        </q-td>
+      </template>
+      <template #body-cell-status="props">
+        <q-td :props="props">
+          <q-badge :color="props.row.status === 'active' ? 'positive' : 'warning'">
+            {{ props.row.status }}
+          </q-badge>
+        </q-td>
+      </template>
+    </q-table>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { storeToRefs } from 'pinia';
+import { nip19 } from 'nostr-tools';
+import { useCreatorSubscriptionsStore } from 'stores/creatorSubscriptions';
+import { shortenString } from 'src/js/string-utils';
+
+const store = useCreatorSubscriptionsStore();
+const { subscriptions, loading } = storeToRefs(store);
+
+const filter = ref('');
+const pagination = ref({ page: 1, rowsPerPage: 5 });
+
+const columns = [
+  { name: 'subscriber', label: 'Subscriber', field: 'subscriberNpub', align: 'left' },
+  { name: 'tier', label: 'Tier', field: 'tierId', align: 'left' },
+  { name: 'months', label: 'Months', field: 'receivedMonths', align: 'center' },
+  { name: 'status', label: 'Status', field: 'status', align: 'left' }
+];
+
+function pubkeyNpub(hex: string): string {
+  try {
+    return nip19.npubEncode(hex);
+  } catch {
+    return hex;
+  }
+}
+</script>

--- a/src/pages/CreatorHubPage.vue
+++ b/src/pages/CreatorHubPage.vue
@@ -17,7 +17,18 @@
       <div v-else>
         <div class="text-center q-mb-md">
           Logged in as <span class="text-primary">{{ npub }}</span>
-          <q-btn flat dense color="primary" class="q-ml-sm" @click="logout">Logout</q-btn>
+          <q-btn
+            flat
+            dense
+            color="primary"
+            class="q-ml-sm"
+            to="/creator-subscribers"
+          >
+            Subscribers
+          </q-btn>
+          <q-btn flat dense color="primary" class="q-ml-sm" @click="logout"
+            >Logout</q-btn
+          >
         </div>
 <q-splitter v-if="!isMobile" v-model="splitterModel">
   <template #before>

--- a/src/pages/CreatorSubscribersPage.vue
+++ b/src/pages/CreatorSubscribersPage.vue
@@ -1,0 +1,10 @@
+<template>
+  <q-page class="q-pa-md">
+    <h5 class="q-mt-none q-mb-md">My Subscribers</h5>
+    <CreatorSubscribers />
+  </q-page>
+</template>
+
+<script setup lang="ts">
+import CreatorSubscribers from 'components/CreatorSubscribers.vue';
+</script>

--- a/src/pages/SubscriptionsOverview.vue
+++ b/src/pages/SubscriptionsOverview.vue
@@ -1,6 +1,11 @@
 <template>
   <div class="q-pa-md">
-    <h5 class="q-my-none q-mb-md">{{ $t("SubscriptionsOverview.title") }}</h5>
+    <div class="row items-center justify-between q-mb-md">
+      <h5 class="q-my-none">{{ $t("SubscriptionsOverview.title") }}</h5>
+      <q-btn flat color="primary" to="/creator-subscribers">
+        My Subscribers
+      </q-btn>
+    </div>
     <q-card flat bordered class="q-mb-md">
       <q-card-section class="row items-center">
         <div class="col-12 col-sm-6">

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -30,6 +30,13 @@ const routes = [
     ],
   },
   {
+    path: "/creator-subscribers",
+    component: () => import("layouts/FullscreenLayout.vue"),
+    children: [
+      { path: "", component: () => import("src/pages/CreatorSubscribersPage.vue") },
+    ],
+  },
+  {
     path: "/my-profile",
     component: () => import("layouts/FullscreenLayout.vue"),
     children: [

--- a/src/stores/creatorSubscriptions.ts
+++ b/src/stores/creatorSubscriptions.ts
@@ -16,6 +16,7 @@ export const useCreatorSubscriptionsStore = defineStore(
   "creatorSubscriptions",
   () => {
     const subscriptions = ref<CreatorSubscription[]>([]);
+    const loading = ref(true);
 
     liveQuery(() =>
       cashuDb.lockedTokens
@@ -47,10 +48,14 @@ export const useCreatorSubscriptionsStore = defineStore(
           return s;
         });
         subscriptions.value = arr;
+        loading.value = false;
       },
-      error: (err) => console.error(err),
+      error: (err) => {
+        console.error(err);
+        loading.value = false;
+      },
     });
 
-    return { subscriptions };
+    return { subscriptions, loading };
   }
 );


### PR DESCRIPTION
## Summary
- add loading state to creator subscriptions store
- list subscribers with filter and pagination
- expose subscribers page and navigation

## Testing
- `pnpm lint` *(fails: Invalid option '--ext')*
- `pnpm test` *(fails: Test Files 30 failed | 30 passed (60))*

------
https://chatgpt.com/codex/tasks/task_e_68910ba079e48330a2f404b551a2d1cb