### PR TITLE
Add Fundstr link with translations

### DIFF
--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -326,6 +326,12 @@ export default defineComponent({
 
     const essentialLinks = [
       {
+        title: t("MainHeader.menu.links.fundstrCreator.title"),
+        caption: t("MainHeader.menu.links.fundstrCreator.caption"),
+        icon: "web",
+        link: "https://primal.net/KalonAxiarch",
+      },
+      {
         title: t("MainHeader.menu.links.cashuSpace.title"),
         caption: t("MainHeader.menu.links.cashuSpace.caption"),
         icon: "web",

--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -127,6 +127,10 @@ export default {
       },
       links: {
         title: "روابط",
+        fundstrCreator: {
+          title: "منشئ Fundstr",
+          caption: "primal.net/KalonAxiarch",
+        },
         cashuSpace: {
           title: "Cashu.space",
           caption: "cashu.space",

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -128,6 +128,10 @@ export default {
       },
       links: {
         title: "Links",
+        fundstrCreator: {
+          title: "Ersteller von Fundstr",
+          caption: "primal.net/KalonAxiarch",
+        },
         cashuSpace: {
           title: "Cashu.space",
           caption: "cashu.space",

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -128,6 +128,10 @@ export default {
       },
       links: {
         title: "Σύνδεσμοι",
+        fundstrCreator: {
+          title: "Δημιουργός του Fundstr",
+          caption: "primal.net/KalonAxiarch",
+        },
         cashuSpace: {
           title: "Cashu.space",
           caption: "cashu.space",

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -164,6 +164,10 @@ export const messages = {
       },
       links: {
         title: "Links",
+        fundstrCreator: {
+          title: "Fundstr's Creator",
+          caption: "primal.net/KalonAxiarch",
+        },
         cashuSpace: {
           title: "Cashu.space",
           caption: "cashu.space",

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -128,6 +128,10 @@ export default {
       },
       links: {
         title: "Enlaces",
+        fundstrCreator: {
+          title: "Creador de Fundstr",
+          caption: "primal.net/KalonAxiarch",
+        },
         cashuSpace: {
           title: "Cashu.space",
           caption: "cashu.space",

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -128,6 +128,10 @@ export default {
       },
       links: {
         title: "Liens",
+        fundstrCreator: {
+          title: "Créateur de Fundstr",
+          caption: "primal.net/KalonAxiarch",
+        },
         cashuSpace: {
           title: "Cashu.space",
           caption: "cashu.space",

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -128,6 +128,10 @@ export default {
       },
       links: {
         title: "Link",
+        fundstrCreator: {
+          title: "Creatore di Fundstr",
+          caption: "primal.net/KalonAxiarch",
+        },
         cashuSpace: {
           title: "Cashu.space",
           caption: "cashu.space",

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -128,6 +128,10 @@ export default {
       },
       links: {
         title: "リンク集",
+        fundstrCreator: {
+          title: "Fundstr の作成者",
+          caption: "primal.net/KalonAxiarch",
+        },
         cashuSpace: {
           title: "Cashu.space",
           caption: "cashu.space",

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -127,6 +127,10 @@ export default {
       },
       links: {
         title: "Länkar",
+        fundstrCreator: {
+          title: "Skaparen av Fundstr",
+          caption: "primal.net/KalonAxiarch",
+        },
         cashuSpace: {
           title: "Cashu.space",
           caption: "cashu.space",

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -128,6 +128,10 @@ export default {
       },
       links: {
         title: "ลิงก์",
+        fundstrCreator: {
+          title: "ผู้สร้าง Fundstr",
+          caption: "primal.net/KalonAxiarch",
+        },
         cashuSpace: {
           title: "Cashu.space",
           caption: "cashu.space",

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -128,6 +128,10 @@ export default {
       },
       links: {
         title: "Bağlantılar",
+        fundstrCreator: {
+          title: "Fundstr'nin Kurucusu",
+          caption: "primal.net/KalonAxiarch",
+        },
         cashuSpace: {
           title: "Cashu.space",
           caption: "cashu.space",

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -127,6 +127,10 @@ export default {
       },
       links: {
         title: "链接",
+        fundstrCreator: {
+          title: "Fundstr 的创建者",
+          caption: "primal.net/KalonAxiarch",
+        },
         cashuSpace: {
           title: "Cashu.space",
           caption: "cashu.space",


### PR DESCRIPTION
## Summary
- add Fundstr's Creator link to sidebar
- translate new link across all locales

## Testing
- `npm run lint` *(fails: Invalid option '--ext')*
- `npm test` *(fails: multiple suites)*

------
https://chatgpt.com/codex/tasks/task_e_68910b957cd483308afc9eb3fbbde0a6