### PR TITLE
feat: label filter controls for clarity

### DIFF
--- a/src/pages/SubscriptionsOverview.vue
+++ b/src/pages/SubscriptionsOverview.vue
@@ -76,8 +76,8 @@
             flat
             dense
             icon="tune"
+            :label="$t('SubscriptionsOverview.actions.open_filters.label')"
             @click="showAdvancedFilters = true"
-            :aria-label="$t('SubscriptionsOverview.actions.open_filters.label')"
           />
         </q-toolbar>
       </q-form>
@@ -191,6 +191,9 @@
               icon="more_vert"
               :aria-label="$t('SubscriptionsOverview.actions.more_actions.label')"
             >
+              <q-tooltip>
+                {{ $t('SubscriptionsOverview.actions.more_actions.label') }}
+              </q-tooltip>
               <q-menu anchor="bottom right" self="top right">
                 <q-list dense style="min-width: 150px">
                   <q-item


### PR DESCRIPTION
## Summary
- add a "Filters" label to the advanced filter button
- clarify three-dot actions button with tooltip

## Testing
- `npm test` *(fails: Test Files 6 failed | 4 passed | 1 skipped; 22 failed tests)*
- `npm run lint` *(fails: Invalid option '--ext' - perhaps you meant '-c'?)*

------
https://chatgpt.com/codex/tasks/task_e_68910ea1bba4833083ae3ab82d63c579