### PR TITLE
Show no-subscribers message

### DIFF
--- a/src/components/CreatorSubscribers.vue
+++ b/src/components/CreatorSubscribers.vue
@@ -43,6 +43,12 @@
           </q-badge>
         </q-td>
       </template>
+      <template #no-data>
+        <div class="full-width column items-center q-pa-md">
+          <div>No subscribers yet</div>
+          <q-btn flat color="primary" label="Find creators" to="/find-creators" class="q-mt-sm" />
+        </div>
+      </template>
     </q-table>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- Show a friendly "No subscribers yet" message in the creator subscribers table and link to the Find Creators page

## Testing
- `npm test` *(fails: 30 failed, 30 passed)*
- `npm run lint` *(fails: Invalid option '--ext')*


------
https://chatgpt.com/codex/tasks/task_e_6891a2dde7c48330bbdba9a6e5eb9480