### PR TITLE
Localize CreatorSubscribers empty state

### DIFF
--- a/src/components/CreatorSubscribers.vue
+++ b/src/components/CreatorSubscribers.vue
@@ -52,15 +52,23 @@
       </template>
       <template #body-cell-status="props">
         <q-td :props="props">
-          <q-badge :color="props.row.status === 'active' ? 'positive' : 'warning'">
+          <q-badge
+            :color="props.row.status === 'active' ? 'positive' : 'warning'"
+          >
             {{ props.row.status }}
           </q-badge>
         </q-td>
       </template>
       <template #no-data>
         <div class="full-width column items-center q-pa-md">
-          <div>No subscribers yet</div>
-          <q-btn flat color="primary" label="Find creators" to="/find-creators" class="q-mt-sm" />
+          <div>{{ t("CreatorSubscribers.noData") }}</div>
+          <q-btn
+            flat
+            color="primary"
+            :label="t('CreatorSubscribers.findCreators')"
+            to="/find-creators"
+            class="q-mt-sm"
+          />
         </div>
       </template>
     </q-table>
@@ -68,57 +76,57 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, watch } from 'vue';
-import { storeToRefs } from 'pinia';
-import { nip19 } from 'nostr-tools';
-import { useCreatorSubscriptionsStore } from 'stores/creatorSubscriptions';
-import { shortenString } from 'src/js/string-utils';
-import { useI18n } from 'vue-i18n';
-import { useNostrStore } from 'stores/nostr';
+import { ref, computed, onMounted, watch } from "vue";
+import { storeToRefs } from "pinia";
+import { nip19 } from "nostr-tools";
+import { useCreatorSubscriptionsStore } from "stores/creatorSubscriptions";
+import { shortenString } from "src/js/string-utils";
+import { useI18n } from "vue-i18n";
+import { useNostrStore } from "stores/nostr";
 
 const store = useCreatorSubscriptionsStore();
 const { subscriptions, loading } = storeToRefs(store);
 
 const { t } = useI18n();
 
-const filter = ref('');
+const filter = ref("");
 const pagination = ref({
   page: 1,
   rowsPerPage: 5,
-  sortBy: 'subscriber',
+  sortBy: "subscriber",
   descending: false,
 });
 
 const columns = computed(() => [
   {
-    name: 'subscriber',
-    label: t('CreatorSubscribers.columns.subscriber'),
-    field: 'subscriberNpub',
-    align: 'left',
+    name: "subscriber",
+    label: t("CreatorSubscribers.columns.subscriber"),
+    field: "subscriberNpub",
+    align: "left",
     sortable: true,
   },
   {
-    name: 'tier',
-    label: t('CreatorSubscribers.columns.tier'),
-    field: 'tierId',
-    align: 'left',
+    name: "tier",
+    label: t("CreatorSubscribers.columns.tier"),
+    field: "tierId",
+    align: "left",
     sortable: true,
   },
   {
-    name: 'months',
-    label: t('CreatorSubscribers.columns.months'),
-    field: 'receivedMonths',
-    align: 'center',
+    name: "months",
+    label: t("CreatorSubscribers.columns.months"),
+    field: "receivedMonths",
+    align: "center",
     sortable: true,
     sort: (a, b, rowA, rowB) =>
       rowA.receivedMonths / rowA.totalMonths -
       rowB.receivedMonths / rowB.totalMonths,
   },
   {
-    name: 'status',
-    label: t('CreatorSubscribers.columns.status'),
-    field: 'status',
-    align: 'left',
+    name: "status",
+    label: t("CreatorSubscribers.columns.status"),
+    field: "status",
+    align: "left",
     sortable: true,
   },
 ]);

--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -39,10 +39,10 @@ export default {
       send: {
         label: "إرسال",
       },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+      creatorHub: {
+        publish: "Publish Profile",
+        profileHeader: "Profile details",
+      },
       swap: {
         label: "تبديل",
       },
@@ -756,10 +756,10 @@ export default {
         },
       },
     },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+    creatorHub: {
+      publish: "Publish Profile",
+      profileHeader: "Profile details",
+    },
     swap: {
       title: "تبديل",
       overline: "تبديل بين عدة Mints",
@@ -777,10 +777,10 @@ export default {
         },
       },
       actions: {
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+        creatorHub: {
+          publish: "Publish Profile",
+          profileHeader: "Profile details",
+        },
         swap: {
           label: "@:global.actions.swap.label",
           in_progress: "@:MintSettings.swap.actions.swap.label",
@@ -974,27 +974,27 @@ export default {
         label_known_mint: "@:ReceiveTokenDialog.actions.receive.label",
         label_adding_mint: "إضافة mint…",
       },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+      creatorHub: {
+        publish: "Publish Profile",
+        profileHeader: "Profile details",
+      },
       swap: {
         label: "@:global.actions.swap.label",
         tooltip_text: "التبديل إلى mint موثوق به",
         caption: "تبديل { value }",
       },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+      creatorHub: {
+        publish: "Publish Profile",
+        profileHeader: "Profile details",
+      },
       cancel_swap: {
         label: "@:global.actions.cancel.label",
         tooltip_text: "إلغاء التبديل",
       },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+      creatorHub: {
+        publish: "Publish Profile",
+        profileHeader: "Profile details",
+      },
       confirm_swap: {
         label: "@:ReceiveTokenDialog.actions.swap.label",
         tooltip_text: "@:ReceiveTokenDialog.actions.swap.tooltip_text",
@@ -1514,31 +1514,38 @@ export default {
         },
         settings: {
           fan: "Add / switch mints, choose display unit, set language & theme, import or back-up your 12-word seed, manage Nostr keys & relays.",
-          creator: "Same, plus Publishing settings: toggle automatic NIP-61 profile updates and set a default “Earnings” bucket.",
+          creator:
+            "Same, plus Publishing settings: toggle automatic NIP-61 profile updates and set a default “Earnings” bucket.",
         },
         findCreators: {
           fan: "Search or browse Nostr-indexed profiles. View tier prices, previews and public posts. Hit Subscribe or Zap with a single tap.",
-          creator: "Your public storefront as seen by visitors. Great for a quick audit of how your profile appears worldwide.",
+          creator:
+            "Your public storefront as seen by visitors. Great for a quick audit of how your profile appears worldwide.",
         },
         creatorHub: {
           fan: "— (hidden unless you toggle “Creator Mode”)",
-          creator: "Define or edit tiers (price, duration, perks), upload cover art, publish pay-walled posts, check revenue analytics and subscriber list.",
+          creator:
+            "Define or edit tiers (price, duration, perks), upload cover art, publish pay-walled posts, check revenue analytics and subscriber list.",
         },
         myProfile: {
           fan: "Show off your avatar, npub link and optional NIP-05. Personal stats: total zaps sent & received, bucket balances.",
-          creator: "Same card plus Edit. Update bio, tags and the secondary P2PK key used by fans to send you locked tokens.",
+          creator:
+            "Same card plus Edit. Update bio, tags and the secondary P2PK key used by fans to send you locked tokens.",
         },
         buckets: {
           fan: "Drag-and-drop jars for budgeting (“Groceries”, “Fun money”, “Subs”). Move sats with zero fees.",
-          creator: "Create an “Income” bucket that auto-receives new tips; split out taxes or savings instantly.",
+          creator:
+            "Create an “Income” bucket that auto-receives new tips; split out taxes or savings instantly.",
         },
         subscriptions: {
           fan: "See every active plan: tier name, next renewal, cumulative sats spent. Cancel or renew with one click.",
-          creator: "Quick list of paying supporters, tier breakdown, churn alerts and pending renewals.",
+          creator:
+            "Quick list of paying supporters, tier breakdown, churn alerts and pending renewals.",
         },
         chats: {
           fan: "End-to-end encrypted DMs (Nostr kind 4). Attach images or Cashu tokens. Green flash means a payment is embedded and auto-redeemed on receipt.",
-          creator: "Same powerful chat plus a broadcast toggle to message all subs in a tier at once.",
+          creator:
+            "Same powerful chat plus a broadcast toggle to message all subs in a tier at once.",
         },
         restore: {
           fan: "Recover your wallet from a 12-word seed.",
@@ -1579,5 +1586,7 @@ export default {
       months: "Months",
       status: "Status",
     },
+    noData: "No subscribers yet",
+    findCreators: "Find creators",
   },
 };

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -39,10 +39,10 @@ export default {
       send: {
         label: "Senden",
       },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+      creatorHub: {
+        publish: "Publish Profile",
+        profileHeader: "Profile details",
+      },
       swap: {
         label: "Tauschen",
       },
@@ -761,10 +761,10 @@ export default {
         },
       },
     },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+    creatorHub: {
+      publish: "Publish Profile",
+      profileHeader: "Profile details",
+    },
     swap: {
       title: "Tauschen",
       overline: "Multimint-Swaps",
@@ -782,10 +782,10 @@ export default {
         },
       },
       actions: {
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+        creatorHub: {
+          publish: "Publish Profile",
+          profileHeader: "Profile details",
+        },
         swap: {
           label: "@:global.actions.swap.label",
           in_progress: "@:MintSettings.swap.actions.swap.label",
@@ -980,27 +980,27 @@ export default {
         label_known_mint: "@:ReceiveTokenDialog.actions.receive.label",
         label_adding_mint: "Mint wird hinzugefügt…",
       },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+      creatorHub: {
+        publish: "Publish Profile",
+        profileHeader: "Profile details",
+      },
       swap: {
         label: "@:global.actions.swap.label",
         tooltip_text: "Zu einer vertrauenswürdigen Mint tauschen",
         caption: "Tauschen { value }",
       },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+      creatorHub: {
+        publish: "Publish Profile",
+        profileHeader: "Profile details",
+      },
       cancel_swap: {
         label: "@:global.actions.cancel.label",
         tooltip_text: "Swap abbrechen",
       },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+      creatorHub: {
+        publish: "Publish Profile",
+        profileHeader: "Profile details",
+      },
       confirm_swap: {
         label: "@:ReceiveTokenDialog.actions.swap.label",
         tooltip_text: "@:ReceiveTokenDialog.actions.swap.tooltip_text",
@@ -1520,31 +1520,38 @@ export default {
         },
         settings: {
           fan: "Add / switch mints, choose display unit, set language & theme, import or back-up your 12-word seed, manage Nostr keys & relays.",
-          creator: "Same, plus Publishing settings: toggle automatic NIP-61 profile updates and set a default “Earnings” bucket.",
+          creator:
+            "Same, plus Publishing settings: toggle automatic NIP-61 profile updates and set a default “Earnings” bucket.",
         },
         findCreators: {
           fan: "Search or browse Nostr-indexed profiles. View tier prices, previews and public posts. Hit Subscribe or Zap with a single tap.",
-          creator: "Your public storefront as seen by visitors. Great for a quick audit of how your profile appears worldwide.",
+          creator:
+            "Your public storefront as seen by visitors. Great for a quick audit of how your profile appears worldwide.",
         },
         creatorHub: {
           fan: "— (hidden unless you toggle “Creator Mode”)",
-          creator: "Define or edit tiers (price, duration, perks), upload cover art, publish pay-walled posts, check revenue analytics and subscriber list.",
+          creator:
+            "Define or edit tiers (price, duration, perks), upload cover art, publish pay-walled posts, check revenue analytics and subscriber list.",
         },
         myProfile: {
           fan: "Show off your avatar, npub link and optional NIP-05. Personal stats: total zaps sent & received, bucket balances.",
-          creator: "Same card plus Edit. Update bio, tags and the secondary P2PK key used by fans to send you locked tokens.",
+          creator:
+            "Same card plus Edit. Update bio, tags and the secondary P2PK key used by fans to send you locked tokens.",
         },
         buckets: {
           fan: "Drag-and-drop jars for budgeting (“Groceries”, “Fun money”, “Subs”). Move sats with zero fees.",
-          creator: "Create an “Income” bucket that auto-receives new tips; split out taxes or savings instantly.",
+          creator:
+            "Create an “Income” bucket that auto-receives new tips; split out taxes or savings instantly.",
         },
         subscriptions: {
           fan: "See every active plan: tier name, next renewal, cumulative sats spent. Cancel or renew with one click.",
-          creator: "Quick list of paying supporters, tier breakdown, churn alerts and pending renewals.",
+          creator:
+            "Quick list of paying supporters, tier breakdown, churn alerts and pending renewals.",
         },
         chats: {
           fan: "End-to-end encrypted DMs (Nostr kind 4). Attach images or Cashu tokens. Green flash means a payment is embedded and auto-redeemed on receipt.",
-          creator: "Same powerful chat plus a broadcast toggle to message all subs in a tier at once.",
+          creator:
+            "Same powerful chat plus a broadcast toggle to message all subs in a tier at once.",
         },
         restore: {
           fan: "Recover your wallet from a 12-word seed.",
@@ -1585,5 +1592,7 @@ export default {
       months: "Months",
       status: "Status",
     },
+    noData: "No subscribers yet",
+    findCreators: "Find creators",
   },
 };

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -39,10 +39,10 @@ export default {
       send: {
         label: "Αποστολή",
       },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+      creatorHub: {
+        publish: "Publish Profile",
+        profileHeader: "Profile details",
+      },
       swap: {
         label: "Ανταλλαγή",
       },
@@ -764,10 +764,10 @@ export default {
         },
       },
     },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+    creatorHub: {
+      publish: "Publish Profile",
+      profileHeader: "Profile details",
+    },
     swap: {
       title: "Ανταλλαγή",
       overline: "Ανταλλαγές Multimint",
@@ -785,10 +785,10 @@ export default {
         },
       },
       actions: {
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+        creatorHub: {
+          publish: "Publish Profile",
+          profileHeader: "Profile details",
+        },
         swap: {
           label: "@:global.actions.swap.label",
           in_progress: "@:MintSettings.swap.actions.swap.label",
@@ -983,27 +983,27 @@ export default {
         label_known_mint: "@:ReceiveTokenDialog.actions.receive.label",
         label_adding_mint: "Προσθήκη mint…",
       },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+      creatorHub: {
+        publish: "Publish Profile",
+        profileHeader: "Profile details",
+      },
       swap: {
         label: "@:global.actions.swap.label",
         tooltip_text: "Ανταλλαγή σε αξιόπιστο mint",
         caption: "Ανταλλαγή { value }",
       },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+      creatorHub: {
+        publish: "Publish Profile",
+        profileHeader: "Profile details",
+      },
       cancel_swap: {
         label: "@:global.actions.cancel.label",
         tooltip_text: "Ακύρωση ανταλλαγής",
       },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+      creatorHub: {
+        publish: "Publish Profile",
+        profileHeader: "Profile details",
+      },
       confirm_swap: {
         label: "@:ReceiveTokenDialog.actions.swap.label",
         tooltip_text: "@:ReceiveTokenDialog.actions.swap.tooltip_text",
@@ -1524,31 +1524,38 @@ export default {
         },
         settings: {
           fan: "Add / switch mints, choose display unit, set language & theme, import or back-up your 12-word seed, manage Nostr keys & relays.",
-          creator: "Same, plus Publishing settings: toggle automatic NIP-61 profile updates and set a default “Earnings” bucket.",
+          creator:
+            "Same, plus Publishing settings: toggle automatic NIP-61 profile updates and set a default “Earnings” bucket.",
         },
         findCreators: {
           fan: "Search or browse Nostr-indexed profiles. View tier prices, previews and public posts. Hit Subscribe or Zap with a single tap.",
-          creator: "Your public storefront as seen by visitors. Great for a quick audit of how your profile appears worldwide.",
+          creator:
+            "Your public storefront as seen by visitors. Great for a quick audit of how your profile appears worldwide.",
         },
         creatorHub: {
           fan: "— (hidden unless you toggle “Creator Mode”)",
-          creator: "Define or edit tiers (price, duration, perks), upload cover art, publish pay-walled posts, check revenue analytics and subscriber list.",
+          creator:
+            "Define or edit tiers (price, duration, perks), upload cover art, publish pay-walled posts, check revenue analytics and subscriber list.",
         },
         myProfile: {
           fan: "Show off your avatar, npub link and optional NIP-05. Personal stats: total zaps sent & received, bucket balances.",
-          creator: "Same card plus Edit. Update bio, tags and the secondary P2PK key used by fans to send you locked tokens.",
+          creator:
+            "Same card plus Edit. Update bio, tags and the secondary P2PK key used by fans to send you locked tokens.",
         },
         buckets: {
           fan: "Drag-and-drop jars for budgeting (“Groceries”, “Fun money”, “Subs”). Move sats with zero fees.",
-          creator: "Create an “Income” bucket that auto-receives new tips; split out taxes or savings instantly.",
+          creator:
+            "Create an “Income” bucket that auto-receives new tips; split out taxes or savings instantly.",
         },
         subscriptions: {
           fan: "See every active plan: tier name, next renewal, cumulative sats spent. Cancel or renew with one click.",
-          creator: "Quick list of paying supporters, tier breakdown, churn alerts and pending renewals.",
+          creator:
+            "Quick list of paying supporters, tier breakdown, churn alerts and pending renewals.",
         },
         chats: {
           fan: "End-to-end encrypted DMs (Nostr kind 4). Attach images or Cashu tokens. Green flash means a payment is embedded and auto-redeemed on receipt.",
-          creator: "Same powerful chat plus a broadcast toggle to message all subs in a tier at once.",
+          creator:
+            "Same powerful chat plus a broadcast toggle to message all subs in a tier at once.",
         },
         restore: {
           fan: "Recover your wallet from a 12-word seed.",
@@ -1589,5 +1596,7 @@ export default {
       months: "Months",
       status: "Status",
     },
+    noData: "No subscribers yet",
+    findCreators: "Find creators",
   },
 };

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1640,6 +1640,8 @@ export const messages = {
       months: "Months",
       status: "Status",
     },
+    noData: "No subscribers yet",
+    findCreators: "Find creators",
   },
   restore: {
     mnemonic_error_text: "Please enter a mnemonic",
@@ -1795,31 +1797,38 @@ export const messages = {
         },
         settings: {
           fan: "Add / switch mints, choose display unit, set language & theme, import or back-up your 12-word seed, manage Nostr keys & relays.",
-          creator: "Same, plus Publishing settings: toggle automatic NIP-61 profile updates and set a default “Earnings” bucket.",
+          creator:
+            "Same, plus Publishing settings: toggle automatic NIP-61 profile updates and set a default “Earnings” bucket.",
         },
         findCreators: {
           fan: "Search or browse Nostr-indexed profiles. View tier prices, previews and public posts. Hit Subscribe or Zap with a single tap.",
-          creator: "Your public storefront as seen by visitors. Great for a quick audit of how your profile appears worldwide.",
+          creator:
+            "Your public storefront as seen by visitors. Great for a quick audit of how your profile appears worldwide.",
         },
         creatorHub: {
           fan: "— (hidden unless you toggle “Creator Mode”)",
-          creator: "Define or edit tiers (price, duration, perks), upload cover art, publish pay-walled posts, check revenue analytics and subscriber list.",
+          creator:
+            "Define or edit tiers (price, duration, perks), upload cover art, publish pay-walled posts, check revenue analytics and subscriber list.",
         },
         myProfile: {
           fan: "Show off your avatar, npub link and optional NIP-05. Personal stats: total zaps sent & received, bucket balances.",
-          creator: "Same card plus Edit. Update bio, tags and the secondary P2PK key used by fans to send you locked tokens.",
+          creator:
+            "Same card plus Edit. Update bio, tags and the secondary P2PK key used by fans to send you locked tokens.",
         },
         buckets: {
           fan: "Drag-and-drop jars for budgeting (“Groceries”, “Fun money”, “Subs”). Move sats with zero fees.",
-          creator: "Create an “Income” bucket that auto-receives new tips; split out taxes or savings instantly.",
+          creator:
+            "Create an “Income” bucket that auto-receives new tips; split out taxes or savings instantly.",
         },
         subscriptions: {
           fan: "See every active plan: tier name, next renewal, cumulative sats spent. Cancel or renew with one click.",
-          creator: "Quick list of paying supporters, tier breakdown, churn alerts and pending renewals.",
+          creator:
+            "Quick list of paying supporters, tier breakdown, churn alerts and pending renewals.",
         },
         chats: {
           fan: "End-to-end encrypted DMs (Nostr kind 4). Attach images or Cashu tokens. Green flash means a payment is embedded and auto-redeemed on receipt.",
-          creator: "Same powerful chat plus a broadcast toggle to message all subs in a tier at once.",
+          creator:
+            "Same powerful chat plus a broadcast toggle to message all subs in a tier at once.",
         },
         restore: {
           fan: "Recover your wallet from a 12-word seed.",

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -39,10 +39,10 @@ export default {
       send: {
         label: "Enviar",
       },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+      creatorHub: {
+        publish: "Publish Profile",
+        profileHeader: "Profile details",
+      },
       swap: {
         label: "Intercambiar",
       },
@@ -762,10 +762,10 @@ export default {
         },
       },
     },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+    creatorHub: {
+      publish: "Publish Profile",
+      profileHeader: "Profile details",
+    },
     swap: {
       title: "Intercambiar",
       overline: "Intercambios Multimint",
@@ -783,10 +783,10 @@ export default {
         },
       },
       actions: {
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+        creatorHub: {
+          publish: "Publish Profile",
+          profileHeader: "Profile details",
+        },
         swap: {
           label: "@:global.actions.swap.label",
           in_progress: "@:MintSettings.swap.actions.swap.label",
@@ -981,27 +981,27 @@ export default {
         label_known_mint: "@:ReceiveTokenDialog.actions.receive.label",
         label_adding_mint: "Añadiendo mint…",
       },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+      creatorHub: {
+        publish: "Publish Profile",
+        profileHeader: "Profile details",
+      },
       swap: {
         label: "@:global.actions.swap.label",
         tooltip_text: "Intercambiar a un mint de confianza",
         caption: "Intercambiar { value }",
       },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+      creatorHub: {
+        publish: "Publish Profile",
+        profileHeader: "Profile details",
+      },
       cancel_swap: {
         label: "@:global.actions.cancel.label",
         tooltip_text: "Cancelar intercambio",
       },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+      creatorHub: {
+        publish: "Publish Profile",
+        profileHeader: "Profile details",
+      },
       confirm_swap: {
         label: "@:ReceiveTokenDialog.actions.swap.label",
         tooltip_text: "@:ReceiveTokenDialog.actions.swap.tooltip_text",
@@ -1521,31 +1521,38 @@ export default {
         },
         settings: {
           fan: "Add / switch mints, choose display unit, set language & theme, import or back-up your 12-word seed, manage Nostr keys & relays.",
-          creator: "Same, plus Publishing settings: toggle automatic NIP-61 profile updates and set a default “Earnings” bucket.",
+          creator:
+            "Same, plus Publishing settings: toggle automatic NIP-61 profile updates and set a default “Earnings” bucket.",
         },
         findCreators: {
           fan: "Search or browse Nostr-indexed profiles. View tier prices, previews and public posts. Hit Subscribe or Zap with a single tap.",
-          creator: "Your public storefront as seen by visitors. Great for a quick audit of how your profile appears worldwide.",
+          creator:
+            "Your public storefront as seen by visitors. Great for a quick audit of how your profile appears worldwide.",
         },
         creatorHub: {
           fan: "— (hidden unless you toggle “Creator Mode”)",
-          creator: "Define or edit tiers (price, duration, perks), upload cover art, publish pay-walled posts, check revenue analytics and subscriber list.",
+          creator:
+            "Define or edit tiers (price, duration, perks), upload cover art, publish pay-walled posts, check revenue analytics and subscriber list.",
         },
         myProfile: {
           fan: "Show off your avatar, npub link and optional NIP-05. Personal stats: total zaps sent & received, bucket balances.",
-          creator: "Same card plus Edit. Update bio, tags and the secondary P2PK key used by fans to send you locked tokens.",
+          creator:
+            "Same card plus Edit. Update bio, tags and the secondary P2PK key used by fans to send you locked tokens.",
         },
         buckets: {
           fan: "Drag-and-drop jars for budgeting (“Groceries”, “Fun money”, “Subs”). Move sats with zero fees.",
-          creator: "Create an “Income” bucket that auto-receives new tips; split out taxes or savings instantly.",
+          creator:
+            "Create an “Income” bucket that auto-receives new tips; split out taxes or savings instantly.",
         },
         subscriptions: {
           fan: "See every active plan: tier name, next renewal, cumulative sats spent. Cancel or renew with one click.",
-          creator: "Quick list of paying supporters, tier breakdown, churn alerts and pending renewals.",
+          creator:
+            "Quick list of paying supporters, tier breakdown, churn alerts and pending renewals.",
         },
         chats: {
           fan: "End-to-end encrypted DMs (Nostr kind 4). Attach images or Cashu tokens. Green flash means a payment is embedded and auto-redeemed on receipt.",
-          creator: "Same powerful chat plus a broadcast toggle to message all subs in a tier at once.",
+          creator:
+            "Same powerful chat plus a broadcast toggle to message all subs in a tier at once.",
         },
         restore: {
           fan: "Recover your wallet from a 12-word seed.",
@@ -1586,5 +1593,7 @@ export default {
       months: "Months",
       status: "Status",
     },
+    noData: "No subscribers yet",
+    findCreators: "Find creators",
   },
 };

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -39,10 +39,10 @@ export default {
       send: {
         label: "Envoyer",
       },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+      creatorHub: {
+        publish: "Publish Profile",
+        profileHeader: "Profile details",
+      },
       swap: {
         label: "Échanger",
       },
@@ -760,10 +760,10 @@ export default {
         },
       },
     },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+    creatorHub: {
+      publish: "Publish Profile",
+      profileHeader: "Profile details",
+    },
     swap: {
       title: "Échanger",
       overline: "Échanges Multi-mints",
@@ -781,10 +781,10 @@ export default {
         },
       },
       actions: {
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+        creatorHub: {
+          publish: "Publish Profile",
+          profileHeader: "Profile details",
+        },
         swap: {
           label: "@:global.actions.swap.label",
           in_progress: "@:MintSettings.swap.actions.swap.label",
@@ -979,27 +979,27 @@ export default {
         label_known_mint: "@:ReceiveTokenDialog.actions.receive.label",
         label_adding_mint: "Ajout de la mint…",
       },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+      creatorHub: {
+        publish: "Publish Profile",
+        profileHeader: "Profile details",
+      },
       swap: {
         label: "@:global.actions.swap.label",
         tooltip_text: "Échanger vers une mint de confiance",
         caption: "Échanger { value }",
       },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+      creatorHub: {
+        publish: "Publish Profile",
+        profileHeader: "Profile details",
+      },
       cancel_swap: {
         label: "@:global.actions.cancel.label",
         tooltip_text: "Annuler l'échange",
       },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+      creatorHub: {
+        publish: "Publish Profile",
+        profileHeader: "Profile details",
+      },
       confirm_swap: {
         label: "@:ReceiveTokenDialog.actions.swap.label",
         tooltip_text: "@:ReceiveTokenDialog.actions.swap.tooltip_text",
@@ -1511,31 +1511,38 @@ export default {
         },
         settings: {
           fan: "Add / switch mints, choose display unit, set language & theme, import or back-up your 12-word seed, manage Nostr keys & relays.",
-          creator: "Same, plus Publishing settings: toggle automatic NIP-61 profile updates and set a default “Earnings” bucket.",
+          creator:
+            "Same, plus Publishing settings: toggle automatic NIP-61 profile updates and set a default “Earnings” bucket.",
         },
         findCreators: {
           fan: "Search or browse Nostr-indexed profiles. View tier prices, previews and public posts. Hit Subscribe or Zap with a single tap.",
-          creator: "Your public storefront as seen by visitors. Great for a quick audit of how your profile appears worldwide.",
+          creator:
+            "Your public storefront as seen by visitors. Great for a quick audit of how your profile appears worldwide.",
         },
         creatorHub: {
           fan: "— (hidden unless you toggle “Creator Mode”)",
-          creator: "Define or edit tiers (price, duration, perks), upload cover art, publish pay-walled posts, check revenue analytics and subscriber list.",
+          creator:
+            "Define or edit tiers (price, duration, perks), upload cover art, publish pay-walled posts, check revenue analytics and subscriber list.",
         },
         myProfile: {
           fan: "Show off your avatar, npub link and optional NIP-05. Personal stats: total zaps sent & received, bucket balances.",
-          creator: "Same card plus Edit. Update bio, tags and the secondary P2PK key used by fans to send you locked tokens.",
+          creator:
+            "Same card plus Edit. Update bio, tags and the secondary P2PK key used by fans to send you locked tokens.",
         },
         buckets: {
           fan: "Drag-and-drop jars for budgeting (“Groceries”, “Fun money”, “Subs”). Move sats with zero fees.",
-          creator: "Create an “Income” bucket that auto-receives new tips; split out taxes or savings instantly.",
+          creator:
+            "Create an “Income” bucket that auto-receives new tips; split out taxes or savings instantly.",
         },
         subscriptions: {
           fan: "See every active plan: tier name, next renewal, cumulative sats spent. Cancel or renew with one click.",
-          creator: "Quick list of paying supporters, tier breakdown, churn alerts and pending renewals.",
+          creator:
+            "Quick list of paying supporters, tier breakdown, churn alerts and pending renewals.",
         },
         chats: {
           fan: "End-to-end encrypted DMs (Nostr kind 4). Attach images or Cashu tokens. Green flash means a payment is embedded and auto-redeemed on receipt.",
-          creator: "Same powerful chat plus a broadcast toggle to message all subs in a tier at once.",
+          creator:
+            "Same powerful chat plus a broadcast toggle to message all subs in a tier at once.",
         },
         restore: {
           fan: "Recover your wallet from a 12-word seed.",
@@ -1576,5 +1583,7 @@ export default {
       months: "Months",
       status: "Status",
     },
+    noData: "No subscribers yet",
+    findCreators: "Find creators",
   },
 };

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -39,10 +39,10 @@ export default {
       send: {
         label: "Invia",
       },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+      creatorHub: {
+        publish: "Publish Profile",
+        profileHeader: "Profile details",
+      },
       swap: {
         label: "Scambia",
       },
@@ -755,10 +755,10 @@ export default {
         },
       },
     },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+    creatorHub: {
+      publish: "Publish Profile",
+      profileHeader: "Profile details",
+    },
     swap: {
       title: "Scambia",
       overline: "Scambi Multimint",
@@ -776,10 +776,10 @@ export default {
         },
       },
       actions: {
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+        creatorHub: {
+          publish: "Publish Profile",
+          profileHeader: "Profile details",
+        },
         swap: {
           label: "@:global.actions.swap.label",
           in_progress: "@:MintSettings.swap.actions.swap.label",
@@ -973,27 +973,27 @@ export default {
         label_known_mint: "@:ReceiveTokenDialog.actions.receive.label",
         label_adding_mint: "Aggiunta mint…",
       },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+      creatorHub: {
+        publish: "Publish Profile",
+        profileHeader: "Profile details",
+      },
       swap: {
         label: "@:global.actions.swap.label",
         tooltip_text: "Scambia verso un mint fidato",
         caption: "Scambia { value }",
       },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+      creatorHub: {
+        publish: "Publish Profile",
+        profileHeader: "Profile details",
+      },
       cancel_swap: {
         label: "@:global.actions.cancel.label",
         tooltip_text: "Annulla scambio",
       },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+      creatorHub: {
+        publish: "Publish Profile",
+        profileHeader: "Profile details",
+      },
       confirm_swap: {
         label: "@:ReceiveTokenDialog.actions.swap.label",
         tooltip_text: "@:ReceiveTokenDialog.actions.swap.tooltip_text",
@@ -1503,31 +1503,38 @@ export default {
         },
         settings: {
           fan: "Add / switch mints, choose display unit, set language & theme, import or back-up your 12-word seed, manage Nostr keys & relays.",
-          creator: "Same, plus Publishing settings: toggle automatic NIP-61 profile updates and set a default “Earnings” bucket.",
+          creator:
+            "Same, plus Publishing settings: toggle automatic NIP-61 profile updates and set a default “Earnings” bucket.",
         },
         findCreators: {
           fan: "Search or browse Nostr-indexed profiles. View tier prices, previews and public posts. Hit Subscribe or Zap with a single tap.",
-          creator: "Your public storefront as seen by visitors. Great for a quick audit of how your profile appears worldwide.",
+          creator:
+            "Your public storefront as seen by visitors. Great for a quick audit of how your profile appears worldwide.",
         },
         creatorHub: {
           fan: "— (hidden unless you toggle “Creator Mode”)",
-          creator: "Define or edit tiers (price, duration, perks), upload cover art, publish pay-walled posts, check revenue analytics and subscriber list.",
+          creator:
+            "Define or edit tiers (price, duration, perks), upload cover art, publish pay-walled posts, check revenue analytics and subscriber list.",
         },
         myProfile: {
           fan: "Show off your avatar, npub link and optional NIP-05. Personal stats: total zaps sent & received, bucket balances.",
-          creator: "Same card plus Edit. Update bio, tags and the secondary P2PK key used by fans to send you locked tokens.",
+          creator:
+            "Same card plus Edit. Update bio, tags and the secondary P2PK key used by fans to send you locked tokens.",
         },
         buckets: {
           fan: "Drag-and-drop jars for budgeting (“Groceries”, “Fun money”, “Subs”). Move sats with zero fees.",
-          creator: "Create an “Income” bucket that auto-receives new tips; split out taxes or savings instantly.",
+          creator:
+            "Create an “Income” bucket that auto-receives new tips; split out taxes or savings instantly.",
         },
         subscriptions: {
           fan: "See every active plan: tier name, next renewal, cumulative sats spent. Cancel or renew with one click.",
-          creator: "Quick list of paying supporters, tier breakdown, churn alerts and pending renewals.",
+          creator:
+            "Quick list of paying supporters, tier breakdown, churn alerts and pending renewals.",
         },
         chats: {
           fan: "End-to-end encrypted DMs (Nostr kind 4). Attach images or Cashu tokens. Green flash means a payment is embedded and auto-redeemed on receipt.",
-          creator: "Same powerful chat plus a broadcast toggle to message all subs in a tier at once.",
+          creator:
+            "Same powerful chat plus a broadcast toggle to message all subs in a tier at once.",
         },
         restore: {
           fan: "Recover your wallet from a 12-word seed.",
@@ -1568,5 +1575,7 @@ export default {
       months: "Months",
       status: "Status",
     },
+    noData: "No subscribers yet",
+    findCreators: "Find creators",
   },
 };

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -39,10 +39,10 @@ export default {
       send: {
         label: "送る",
       },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+      creatorHub: {
+        publish: "Publish Profile",
+        profileHeader: "Profile details",
+      },
       swap: {
         label: "スワップ",
       },
@@ -753,10 +753,10 @@ export default {
         },
       },
     },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+    creatorHub: {
+      publish: "Publish Profile",
+      profileHeader: "Profile details",
+    },
     swap: {
       title: "スワップ",
       overline: "マルチミントスワップ",
@@ -774,10 +774,10 @@ export default {
         },
       },
       actions: {
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+        creatorHub: {
+          publish: "Publish Profile",
+          profileHeader: "Profile details",
+        },
         swap: {
           label: "@:global.actions.swap.label",
           in_progress: "@:MintSettings.swap.actions.swap.label",
@@ -972,27 +972,27 @@ export default {
         label_known_mint: "@:ReceiveTokenDialog.actions.receive.label",
         label_adding_mint: "ミント追加中…",
       },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+      creatorHub: {
+        publish: "Publish Profile",
+        profileHeader: "Profile details",
+      },
       swap: {
         label: "@:global.actions.swap.label",
         tooltip_text: "信頼できるミントにスワップ",
         caption: "{ value }をスワップ",
       },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+      creatorHub: {
+        publish: "Publish Profile",
+        profileHeader: "Profile details",
+      },
       cancel_swap: {
         label: "@:global.actions.cancel.label",
         tooltip_text: "スワップをキャンセル",
       },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+      creatorHub: {
+        publish: "Publish Profile",
+        profileHeader: "Profile details",
+      },
       confirm_swap: {
         label: "@:ReceiveTokenDialog.actions.swap.label",
         tooltip_text: "@:ReceiveTokenDialog.actions.swap.tooltip_text",
@@ -1504,31 +1504,38 @@ export default {
         },
         settings: {
           fan: "Add / switch mints, choose display unit, set language & theme, import or back-up your 12-word seed, manage Nostr keys & relays.",
-          creator: "Same, plus Publishing settings: toggle automatic NIP-61 profile updates and set a default “Earnings” bucket.",
+          creator:
+            "Same, plus Publishing settings: toggle automatic NIP-61 profile updates and set a default “Earnings” bucket.",
         },
         findCreators: {
           fan: "Search or browse Nostr-indexed profiles. View tier prices, previews and public posts. Hit Subscribe or Zap with a single tap.",
-          creator: "Your public storefront as seen by visitors. Great for a quick audit of how your profile appears worldwide.",
+          creator:
+            "Your public storefront as seen by visitors. Great for a quick audit of how your profile appears worldwide.",
         },
         creatorHub: {
           fan: "— (hidden unless you toggle “Creator Mode”)",
-          creator: "Define or edit tiers (price, duration, perks), upload cover art, publish pay-walled posts, check revenue analytics and subscriber list.",
+          creator:
+            "Define or edit tiers (price, duration, perks), upload cover art, publish pay-walled posts, check revenue analytics and subscriber list.",
         },
         myProfile: {
           fan: "Show off your avatar, npub link and optional NIP-05. Personal stats: total zaps sent & received, bucket balances.",
-          creator: "Same card plus Edit. Update bio, tags and the secondary P2PK key used by fans to send you locked tokens.",
+          creator:
+            "Same card plus Edit. Update bio, tags and the secondary P2PK key used by fans to send you locked tokens.",
         },
         buckets: {
           fan: "Drag-and-drop jars for budgeting (“Groceries”, “Fun money”, “Subs”). Move sats with zero fees.",
-          creator: "Create an “Income” bucket that auto-receives new tips; split out taxes or savings instantly.",
+          creator:
+            "Create an “Income” bucket that auto-receives new tips; split out taxes or savings instantly.",
         },
         subscriptions: {
           fan: "See every active plan: tier name, next renewal, cumulative sats spent. Cancel or renew with one click.",
-          creator: "Quick list of paying supporters, tier breakdown, churn alerts and pending renewals.",
+          creator:
+            "Quick list of paying supporters, tier breakdown, churn alerts and pending renewals.",
         },
         chats: {
           fan: "End-to-end encrypted DMs (Nostr kind 4). Attach images or Cashu tokens. Green flash means a payment is embedded and auto-redeemed on receipt.",
-          creator: "Same powerful chat plus a broadcast toggle to message all subs in a tier at once.",
+          creator:
+            "Same powerful chat plus a broadcast toggle to message all subs in a tier at once.",
         },
         restore: {
           fan: "Recover your wallet from a 12-word seed.",
@@ -1569,5 +1576,7 @@ export default {
       months: "Months",
       status: "Status",
     },
+    noData: "No subscribers yet",
+    findCreators: "Find creators",
   },
 };

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -39,10 +39,10 @@ export default {
       send: {
         label: "Skicka",
       },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+      creatorHub: {
+        publish: "Publish Profile",
+        profileHeader: "Profile details",
+      },
       swap: {
         label: "Byt",
       },
@@ -754,10 +754,10 @@ export default {
         },
       },
     },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+    creatorHub: {
+      publish: "Publish Profile",
+      profileHeader: "Profile details",
+    },
     swap: {
       title: "Byt",
       overline: "Multimint-byten",
@@ -775,10 +775,10 @@ export default {
         },
       },
       actions: {
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+        creatorHub: {
+          publish: "Publish Profile",
+          profileHeader: "Profile details",
+        },
         swap: {
           label: "@:global.actions.swap.label",
           in_progress: "@:MintSettings.swap.actions.swap.label",
@@ -973,27 +973,27 @@ export default {
         label_known_mint: "@:ReceiveTokenDialog.actions.receive.label",
         label_adding_mint: "Lägger till mint…",
       },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+      creatorHub: {
+        publish: "Publish Profile",
+        profileHeader: "Profile details",
+      },
       swap: {
         label: "@:global.actions.swap.label",
         tooltip_text: "Byt till en betrodd mint",
         caption: "Byt { value }",
       },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+      creatorHub: {
+        publish: "Publish Profile",
+        profileHeader: "Profile details",
+      },
       cancel_swap: {
         label: "@:global.actions.cancel.label",
         tooltip_text: "Avbryt byte",
       },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+      creatorHub: {
+        publish: "Publish Profile",
+        profileHeader: "Profile details",
+      },
       confirm_swap: {
         label: "@:ReceiveTokenDialog.actions.swap.label",
         tooltip_text: "@:ReceiveTokenDialog.actions.swap.tooltip_text",
@@ -1503,31 +1503,38 @@ export default {
         },
         settings: {
           fan: "Add / switch mints, choose display unit, set language & theme, import or back-up your 12-word seed, manage Nostr keys & relays.",
-          creator: "Same, plus Publishing settings: toggle automatic NIP-61 profile updates and set a default “Earnings” bucket.",
+          creator:
+            "Same, plus Publishing settings: toggle automatic NIP-61 profile updates and set a default “Earnings” bucket.",
         },
         findCreators: {
           fan: "Search or browse Nostr-indexed profiles. View tier prices, previews and public posts. Hit Subscribe or Zap with a single tap.",
-          creator: "Your public storefront as seen by visitors. Great for a quick audit of how your profile appears worldwide.",
+          creator:
+            "Your public storefront as seen by visitors. Great for a quick audit of how your profile appears worldwide.",
         },
         creatorHub: {
           fan: "— (hidden unless you toggle “Creator Mode”)",
-          creator: "Define or edit tiers (price, duration, perks), upload cover art, publish pay-walled posts, check revenue analytics and subscriber list.",
+          creator:
+            "Define or edit tiers (price, duration, perks), upload cover art, publish pay-walled posts, check revenue analytics and subscriber list.",
         },
         myProfile: {
           fan: "Show off your avatar, npub link and optional NIP-05. Personal stats: total zaps sent & received, bucket balances.",
-          creator: "Same card plus Edit. Update bio, tags and the secondary P2PK key used by fans to send you locked tokens.",
+          creator:
+            "Same card plus Edit. Update bio, tags and the secondary P2PK key used by fans to send you locked tokens.",
         },
         buckets: {
           fan: "Drag-and-drop jars for budgeting (“Groceries”, “Fun money”, “Subs”). Move sats with zero fees.",
-          creator: "Create an “Income” bucket that auto-receives new tips; split out taxes or savings instantly.",
+          creator:
+            "Create an “Income” bucket that auto-receives new tips; split out taxes or savings instantly.",
         },
         subscriptions: {
           fan: "See every active plan: tier name, next renewal, cumulative sats spent. Cancel or renew with one click.",
-          creator: "Quick list of paying supporters, tier breakdown, churn alerts and pending renewals.",
+          creator:
+            "Quick list of paying supporters, tier breakdown, churn alerts and pending renewals.",
         },
         chats: {
           fan: "End-to-end encrypted DMs (Nostr kind 4). Attach images or Cashu tokens. Green flash means a payment is embedded and auto-redeemed on receipt.",
-          creator: "Same powerful chat plus a broadcast toggle to message all subs in a tier at once.",
+          creator:
+            "Same powerful chat plus a broadcast toggle to message all subs in a tier at once.",
         },
         restore: {
           fan: "Recover your wallet from a 12-word seed.",
@@ -1568,5 +1575,7 @@ export default {
       months: "Months",
       status: "Status",
     },
+    noData: "No subscribers yet",
+    findCreators: "Find creators",
   },
 };

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -39,10 +39,10 @@ export default {
       send: {
         label: "ส่ง",
       },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+      creatorHub: {
+        publish: "Publish Profile",
+        profileHeader: "Profile details",
+      },
       swap: {
         label: "แลกเปลี่ยน",
       },
@@ -752,10 +752,10 @@ export default {
         },
       },
     },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+    creatorHub: {
+      publish: "Publish Profile",
+      profileHeader: "Profile details",
+    },
     swap: {
       title: "แลกเปลี่ยน",
       overline: "การแลกเปลี่ยนระหว่าง Mints",
@@ -773,10 +773,10 @@ export default {
         },
       },
       actions: {
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+        creatorHub: {
+          publish: "Publish Profile",
+          profileHeader: "Profile details",
+        },
         swap: {
           label: "@:global.actions.swap.label",
           in_progress: "@:MintSettings.swap.actions.swap.label",
@@ -970,27 +970,27 @@ export default {
         label_known_mint: "@:ReceiveTokenDialog.actions.receive.label",
         label_adding_mint: "กำลังเพิ่ม Mint…",
       },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+      creatorHub: {
+        publish: "Publish Profile",
+        profileHeader: "Profile details",
+      },
       swap: {
         label: "@:global.actions.swap.label",
         tooltip_text: "แลกเปลี่ยนไปยัง Mint ที่เชื่อถือได้",
         caption: "แลกเปลี่ยน { value }",
       },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+      creatorHub: {
+        publish: "Publish Profile",
+        profileHeader: "Profile details",
+      },
       cancel_swap: {
         label: "@:global.actions.cancel.label",
         tooltip_text: "ยกเลิกการแลกเปลี่ยน",
       },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+      creatorHub: {
+        publish: "Publish Profile",
+        profileHeader: "Profile details",
+      },
       confirm_swap: {
         label: "@:ReceiveTokenDialog.actions.swap.label",
         tooltip_text: "@:ReceiveTokenDialog.actions.swap.tooltip_text",
@@ -1501,31 +1501,38 @@ export default {
         },
         settings: {
           fan: "Add / switch mints, choose display unit, set language & theme, import or back-up your 12-word seed, manage Nostr keys & relays.",
-          creator: "Same, plus Publishing settings: toggle automatic NIP-61 profile updates and set a default “Earnings” bucket.",
+          creator:
+            "Same, plus Publishing settings: toggle automatic NIP-61 profile updates and set a default “Earnings” bucket.",
         },
         findCreators: {
           fan: "Search or browse Nostr-indexed profiles. View tier prices, previews and public posts. Hit Subscribe or Zap with a single tap.",
-          creator: "Your public storefront as seen by visitors. Great for a quick audit of how your profile appears worldwide.",
+          creator:
+            "Your public storefront as seen by visitors. Great for a quick audit of how your profile appears worldwide.",
         },
         creatorHub: {
           fan: "— (hidden unless you toggle “Creator Mode”)",
-          creator: "Define or edit tiers (price, duration, perks), upload cover art, publish pay-walled posts, check revenue analytics and subscriber list.",
+          creator:
+            "Define or edit tiers (price, duration, perks), upload cover art, publish pay-walled posts, check revenue analytics and subscriber list.",
         },
         myProfile: {
           fan: "Show off your avatar, npub link and optional NIP-05. Personal stats: total zaps sent & received, bucket balances.",
-          creator: "Same card plus Edit. Update bio, tags and the secondary P2PK key used by fans to send you locked tokens.",
+          creator:
+            "Same card plus Edit. Update bio, tags and the secondary P2PK key used by fans to send you locked tokens.",
         },
         buckets: {
           fan: "Drag-and-drop jars for budgeting (“Groceries”, “Fun money”, “Subs”). Move sats with zero fees.",
-          creator: "Create an “Income” bucket that auto-receives new tips; split out taxes or savings instantly.",
+          creator:
+            "Create an “Income” bucket that auto-receives new tips; split out taxes or savings instantly.",
         },
         subscriptions: {
           fan: "See every active plan: tier name, next renewal, cumulative sats spent. Cancel or renew with one click.",
-          creator: "Quick list of paying supporters, tier breakdown, churn alerts and pending renewals.",
+          creator:
+            "Quick list of paying supporters, tier breakdown, churn alerts and pending renewals.",
         },
         chats: {
           fan: "End-to-end encrypted DMs (Nostr kind 4). Attach images or Cashu tokens. Green flash means a payment is embedded and auto-redeemed on receipt.",
-          creator: "Same powerful chat plus a broadcast toggle to message all subs in a tier at once.",
+          creator:
+            "Same powerful chat plus a broadcast toggle to message all subs in a tier at once.",
         },
         restore: {
           fan: "Recover your wallet from a 12-word seed.",
@@ -1566,5 +1573,7 @@ export default {
       months: "Months",
       status: "Status",
     },
+    noData: "No subscribers yet",
+    findCreators: "Find creators",
   },
 };

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -39,10 +39,10 @@ export default {
       send: {
         label: "Gönder",
       },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+      creatorHub: {
+        publish: "Publish Profile",
+        profileHeader: "Profile details",
+      },
       swap: {
         label: "Değiştir",
       },
@@ -756,10 +756,10 @@ export default {
         },
       },
     },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+    creatorHub: {
+      publish: "Publish Profile",
+      profileHeader: "Profile details",
+    },
     swap: {
       title: "Değiştir",
       overline: "Çoklu Nane Takasları",
@@ -777,10 +777,10 @@ export default {
         },
       },
       actions: {
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+        creatorHub: {
+          publish: "Publish Profile",
+          profileHeader: "Profile details",
+        },
         swap: {
           label: "@:global.actions.swap.label",
           in_progress: "@:MintSettings.swap.actions.swap.label",
@@ -975,27 +975,27 @@ export default {
         label_known_mint: "@:ReceiveTokenDialog.actions.receive.label",
         label_adding_mint: "Nane ekleniyor…",
       },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+      creatorHub: {
+        publish: "Publish Profile",
+        profileHeader: "Profile details",
+      },
       swap: {
         label: "@:global.actions.swap.label",
         tooltip_text: "Güvenilen bir nane'ye takas et",
         caption: "{ value } takas et",
       },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+      creatorHub: {
+        publish: "Publish Profile",
+        profileHeader: "Profile details",
+      },
       cancel_swap: {
         label: "@:global.actions.cancel.label",
         tooltip_text: "Takası iptal et",
       },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+      creatorHub: {
+        publish: "Publish Profile",
+        profileHeader: "Profile details",
+      },
       confirm_swap: {
         label: "@:ReceiveTokenDialog.actions.swap.label",
         tooltip_text: "@:ReceiveTokenDialog.actions.swap.tooltip_text",
@@ -1506,31 +1506,38 @@ export default {
         },
         settings: {
           fan: "Add / switch mints, choose display unit, set language & theme, import or back-up your 12-word seed, manage Nostr keys & relays.",
-          creator: "Same, plus Publishing settings: toggle automatic NIP-61 profile updates and set a default “Earnings” bucket.",
+          creator:
+            "Same, plus Publishing settings: toggle automatic NIP-61 profile updates and set a default “Earnings” bucket.",
         },
         findCreators: {
           fan: "Search or browse Nostr-indexed profiles. View tier prices, previews and public posts. Hit Subscribe or Zap with a single tap.",
-          creator: "Your public storefront as seen by visitors. Great for a quick audit of how your profile appears worldwide.",
+          creator:
+            "Your public storefront as seen by visitors. Great for a quick audit of how your profile appears worldwide.",
         },
         creatorHub: {
           fan: "— (hidden unless you toggle “Creator Mode”)",
-          creator: "Define or edit tiers (price, duration, perks), upload cover art, publish pay-walled posts, check revenue analytics and subscriber list.",
+          creator:
+            "Define or edit tiers (price, duration, perks), upload cover art, publish pay-walled posts, check revenue analytics and subscriber list.",
         },
         myProfile: {
           fan: "Show off your avatar, npub link and optional NIP-05. Personal stats: total zaps sent & received, bucket balances.",
-          creator: "Same card plus Edit. Update bio, tags and the secondary P2PK key used by fans to send you locked tokens.",
+          creator:
+            "Same card plus Edit. Update bio, tags and the secondary P2PK key used by fans to send you locked tokens.",
         },
         buckets: {
           fan: "Drag-and-drop jars for budgeting (“Groceries”, “Fun money”, “Subs”). Move sats with zero fees.",
-          creator: "Create an “Income” bucket that auto-receives new tips; split out taxes or savings instantly.",
+          creator:
+            "Create an “Income” bucket that auto-receives new tips; split out taxes or savings instantly.",
         },
         subscriptions: {
           fan: "See every active plan: tier name, next renewal, cumulative sats spent. Cancel or renew with one click.",
-          creator: "Quick list of paying supporters, tier breakdown, churn alerts and pending renewals.",
+          creator:
+            "Quick list of paying supporters, tier breakdown, churn alerts and pending renewals.",
         },
         chats: {
           fan: "End-to-end encrypted DMs (Nostr kind 4). Attach images or Cashu tokens. Green flash means a payment is embedded and auto-redeemed on receipt.",
-          creator: "Same powerful chat plus a broadcast toggle to message all subs in a tier at once.",
+          creator:
+            "Same powerful chat plus a broadcast toggle to message all subs in a tier at once.",
         },
         restore: {
           fan: "Recover your wallet from a 12-word seed.",
@@ -1571,5 +1578,7 @@ export default {
       months: "Months",
       status: "Status",
     },
+    noData: "No subscribers yet",
+    findCreators: "Find creators",
   },
 };

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -39,10 +39,10 @@ export default {
       send: {
         label: "发送",
       },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+      creatorHub: {
+        publish: "Publish Profile",
+        profileHeader: "Profile details",
+      },
       swap: {
         label: "兑换",
       },
@@ -745,10 +745,10 @@ export default {
         },
       },
     },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+    creatorHub: {
+      publish: "Publish Profile",
+      profileHeader: "Profile details",
+    },
     swap: {
       title: "兑换",
       overline: "多 Mint 兑换",
@@ -766,10 +766,10 @@ export default {
         },
       },
       actions: {
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+        creatorHub: {
+          publish: "Publish Profile",
+          profileHeader: "Profile details",
+        },
         swap: {
           label: "@:global.actions.swap.label",
           in_progress: "@:MintSettings.swap.actions.swap.label",
@@ -963,27 +963,27 @@ export default {
         label_known_mint: "@:ReceiveTokenDialog.actions.receive.label",
         label_adding_mint: "正在添加 Mint…",
       },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+      creatorHub: {
+        publish: "Publish Profile",
+        profileHeader: "Profile details",
+      },
       swap: {
         label: "@:global.actions.swap.label",
         tooltip_text: "兑换到信任的 Mint",
         caption: "兑换 { value }",
       },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+      creatorHub: {
+        publish: "Publish Profile",
+        profileHeader: "Profile details",
+      },
       cancel_swap: {
         label: "@:global.actions.cancel.label",
         tooltip_text: "取消兑换",
       },
-  creatorHub: {
-    publish: "Publish Profile",
-    profileHeader: "Profile details",
-  },
+      creatorHub: {
+        publish: "Publish Profile",
+        profileHeader: "Profile details",
+      },
       confirm_swap: {
         label: "@:ReceiveTokenDialog.actions.swap.label",
         tooltip_text: "@:ReceiveTokenDialog.actions.swap.tooltip_text",
@@ -1493,31 +1493,38 @@ export default {
         },
         settings: {
           fan: "Add / switch mints, choose display unit, set language & theme, import or back-up your 12-word seed, manage Nostr keys & relays.",
-          creator: "Same, plus Publishing settings: toggle automatic NIP-61 profile updates and set a default “Earnings” bucket.",
+          creator:
+            "Same, plus Publishing settings: toggle automatic NIP-61 profile updates and set a default “Earnings” bucket.",
         },
         findCreators: {
           fan: "Search or browse Nostr-indexed profiles. View tier prices, previews and public posts. Hit Subscribe or Zap with a single tap.",
-          creator: "Your public storefront as seen by visitors. Great for a quick audit of how your profile appears worldwide.",
+          creator:
+            "Your public storefront as seen by visitors. Great for a quick audit of how your profile appears worldwide.",
         },
         creatorHub: {
           fan: "— (hidden unless you toggle “Creator Mode”)",
-          creator: "Define or edit tiers (price, duration, perks), upload cover art, publish pay-walled posts, check revenue analytics and subscriber list.",
+          creator:
+            "Define or edit tiers (price, duration, perks), upload cover art, publish pay-walled posts, check revenue analytics and subscriber list.",
         },
         myProfile: {
           fan: "Show off your avatar, npub link and optional NIP-05. Personal stats: total zaps sent & received, bucket balances.",
-          creator: "Same card plus Edit. Update bio, tags and the secondary P2PK key used by fans to send you locked tokens.",
+          creator:
+            "Same card plus Edit. Update bio, tags and the secondary P2PK key used by fans to send you locked tokens.",
         },
         buckets: {
           fan: "Drag-and-drop jars for budgeting (“Groceries”, “Fun money”, “Subs”). Move sats with zero fees.",
-          creator: "Create an “Income” bucket that auto-receives new tips; split out taxes or savings instantly.",
+          creator:
+            "Create an “Income” bucket that auto-receives new tips; split out taxes or savings instantly.",
         },
         subscriptions: {
           fan: "See every active plan: tier name, next renewal, cumulative sats spent. Cancel or renew with one click.",
-          creator: "Quick list of paying supporters, tier breakdown, churn alerts and pending renewals.",
+          creator:
+            "Quick list of paying supporters, tier breakdown, churn alerts and pending renewals.",
         },
         chats: {
           fan: "End-to-end encrypted DMs (Nostr kind 4). Attach images or Cashu tokens. Green flash means a payment is embedded and auto-redeemed on receipt.",
-          creator: "Same powerful chat plus a broadcast toggle to message all subs in a tier at once.",
+          creator:
+            "Same powerful chat plus a broadcast toggle to message all subs in a tier at once.",
         },
         restore: {
           fan: "Recover your wallet from a 12-word seed.",
@@ -1558,5 +1565,7 @@ export default {
       months: "Months",
       status: "Status",
     },
+    noData: "No subscribers yet",
+    findCreators: "Find creators",
   },
 };


### PR DESCRIPTION
## Summary
- localize CreatorSubscribers no-data message
- add `noData` and `findCreators` translations to all locales

## Testing
- `npm test` *(fails: Test Files 30 failed | 30 passed)*
- `npm run lint` *(fails: Invalid option '--ext' - perhaps you meant '-c'?)*
- `npm run checkformat` *(fails: Code style issues found in 160 files. Forgot to run Prettier?)*

------
https://chatgpt.com/codex/tasks/task_e_6891af1dbcb0833085377b4681cdd6db