### PR TITLE
feat: add actions menu to creator subscribers

### DIFF
--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -1585,6 +1585,11 @@ export default {
       tier: "Tier",
       months: "Months",
       status: "Status",
+      actions: "Actions",
+    },
+    actions: {
+      viewProfile: "View profile",
+      sendMessage: "Send message",
     },
     noData: "No subscribers yet",
     findCreators: "Find creators",

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -1591,6 +1591,11 @@ export default {
       tier: "Tier",
       months: "Months",
       status: "Status",
+      actions: "Actions",
+    },
+    actions: {
+      viewProfile: "View profile",
+      sendMessage: "Send message",
     },
     noData: "No subscribers yet",
     findCreators: "Find creators",

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -1595,6 +1595,11 @@ export default {
       tier: "Tier",
       months: "Months",
       status: "Status",
+      actions: "Actions",
+    },
+    actions: {
+      viewProfile: "View profile",
+      sendMessage: "Send message",
     },
     noData: "No subscribers yet",
     findCreators: "Find creators",

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1639,6 +1639,11 @@ export const messages = {
       tier: "Tier",
       months: "Months",
       status: "Status",
+      actions: "Actions",
+    },
+    actions: {
+      viewProfile: "View profile",
+      sendMessage: "Send message",
     },
     noData: "No subscribers yet",
     findCreators: "Find creators",

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -1592,6 +1592,11 @@ export default {
       tier: "Tier",
       months: "Months",
       status: "Status",
+      actions: "Actions",
+    },
+    actions: {
+      viewProfile: "View profile",
+      sendMessage: "Send message",
     },
     noData: "No subscribers yet",
     findCreators: "Find creators",

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -1582,6 +1582,11 @@ export default {
       tier: "Tier",
       months: "Months",
       status: "Status",
+      actions: "Actions",
+    },
+    actions: {
+      viewProfile: "View profile",
+      sendMessage: "Send message",
     },
     noData: "No subscribers yet",
     findCreators: "Find creators",

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -1574,6 +1574,11 @@ export default {
       tier: "Tier",
       months: "Months",
       status: "Status",
+      actions: "Actions",
+    },
+    actions: {
+      viewProfile: "View profile",
+      sendMessage: "Send message",
     },
     noData: "No subscribers yet",
     findCreators: "Find creators",

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -1575,6 +1575,11 @@ export default {
       tier: "Tier",
       months: "Months",
       status: "Status",
+      actions: "Actions",
+    },
+    actions: {
+      viewProfile: "View profile",
+      sendMessage: "Send message",
     },
     noData: "No subscribers yet",
     findCreators: "Find creators",

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -1574,6 +1574,11 @@ export default {
       tier: "Tier",
       months: "Months",
       status: "Status",
+      actions: "Actions",
+    },
+    actions: {
+      viewProfile: "View profile",
+      sendMessage: "Send message",
     },
     noData: "No subscribers yet",
     findCreators: "Find creators",

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -1572,6 +1572,11 @@ export default {
       tier: "Tier",
       months: "Months",
       status: "Status",
+      actions: "Actions",
+    },
+    actions: {
+      viewProfile: "View profile",
+      sendMessage: "Send message",
     },
     noData: "No subscribers yet",
     findCreators: "Find creators",

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -1577,6 +1577,11 @@ export default {
       tier: "Tier",
       months: "Months",
       status: "Status",
+      actions: "Actions",
+    },
+    actions: {
+      viewProfile: "View profile",
+      sendMessage: "Send message",
     },
     noData: "No subscribers yet",
     findCreators: "Find creators",

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -1564,6 +1564,11 @@ export default {
       tier: "Tier",
       months: "Months",
       status: "Status",
+      actions: "Actions",
+    },
+    actions: {
+      viewProfile: "View profile",
+      sendMessage: "Send message",
     },
     noData: "No subscribers yet",
     findCreators: "Find creators",


### PR DESCRIPTION
## Summary
- add actions column to creator subscribers table
- include menu for viewing profile and sending messages
- localize new actions column and menu labels

## Testing
- `npm run lint` (fails: Invalid option '--ext')
- `npx eslint .` (fails: ReferenceError: module is not defined in ES module scope)
- `npm test` (fails: 30 failed)


------
https://chatgpt.com/codex/tasks/task_e_6891b5730e7c8330a44957d3ceedb6da