### PR TITLE
feat: allow sorting of actions column

### DIFF
--- a/src/components/CreatorSubscribers.vue
+++ b/src/components/CreatorSubscribers.vue
@@ -186,6 +186,7 @@ const columns = computed(() => [
     label: t("CreatorSubscribers.columns.actions"),
     field: "actions",
     align: "right",
+    sortable: true,
   },
 ]);
 


### PR DESCRIPTION
## Summary
- ensure all CreatorSubscribers table columns are sortable

## Testing
- `pnpm lint` *(fails: Invalid option '--ext' - perhaps you meant '-c'?)*
- `pnpm test` *(fails: 30 failed, 30 passed tests)*

------
https://chatgpt.com/codex/tasks/task_e_6891b9f4303083309721baf3addfb00f