### PR TITLE
Add progress bar for subscription months

### DIFF
--- a/src/components/CreatorSubscribers.vue
+++ b/src/components/CreatorSubscribers.vue
@@ -65,7 +65,24 @@
       </template>
       <template #body-cell-months="props">
         <q-td :props="props">
-          {{ props.row.receivedMonths }} / {{ props.row.totalMonths }}
+          <div class="row items-center no-wrap">
+            <q-linear-progress
+              :value="
+                props.row.totalMonths
+                  ? props.row.receivedMonths / props.row.totalMonths
+                  : 0
+              "
+              color="primary"
+              style="width: 100px"
+            >
+              <q-tooltip>
+                {{ props.row.receivedMonths }} / {{ props.row.totalMonths }}
+              </q-tooltip>
+            </q-linear-progress>
+            <div class="q-ml-sm text-caption">
+              {{ props.row.receivedMonths }} / {{ props.row.totalMonths }}
+            </div>
+          </div>
         </q-td>
       </template>
       <template #body-cell-status="props">
@@ -88,7 +105,7 @@
                   :to="`/creator/${pubkeyNpub(props.row.subscriberNpub)}`"
                 >
                   <q-item-section>
-                    {{ t('CreatorSubscribers.actions.viewProfile') }}
+                    {{ t("CreatorSubscribers.actions.viewProfile") }}
                   </q-item-section>
                 </q-item>
                 <q-item
@@ -97,7 +114,7 @@
                   @click="sendMessage(props.row.subscriberNpub)"
                 >
                   <q-item-section>
-                    {{ t('CreatorSubscribers.actions.sendMessage') }}
+                    {{ t("CreatorSubscribers.actions.sendMessage") }}
                   </q-item-section>
                 </q-item>
               </q-list>


### PR DESCRIPTION
## Summary
- replace subscriber months text with linear progress and tooltip

## Testing
- `npm test` *(fails: module mocking errors etc.)*
- `npm run lint` *(fails: Invalid option '--ext')*
- `npx eslint .` *(fails: module is not defined in ES module scope)*

------
https://chatgpt.com/codex/tasks/task_e_6891bbfe6d5483308a02c0d36ddb3888