### PR TITLE
feat: add subscription renewal and alerts

### DIFF
--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1583,6 +1583,7 @@ export const messages = {
     discover: "Discover creators",
     view: "View",
     message: "Message",
+    renew: "Renew",
     extend: "Extend",
     export: "Export",
     export_csv: "Export CSV",
@@ -1591,6 +1592,8 @@ export const messages = {
     cancel_confirm_text: "Delete all future locked tokens?",
     extend_dialog_title: "Extend subscription",
     extend_dialog_text: "Number of additional months",
+    soon_unlock: "{ count } subscriptions unlocking within 7 days",
+    soon_badge: "Soon",
     filter: {
       status: "Filter by status",
       bucket: "Filter by bucket",


### PR DESCRIPTION
## Summary
- highlight subscriptions unlocking within 7 days with banner and badge
- allow renewing subscriptions directly from card and append intervals
- add translations for renewal and upcoming unlock warnings

## Testing
- `npm test` *(fails: ReferenceError and other test failures)*
- `npm run lint` *(fails: Invalid option '--ext')*

------
https://chatgpt.com/codex/tasks/task_e_6891be8e0b048330b61c6710521d6798