### PR TITLE
feat: show tier names for creator subscriptions

### DIFF
--- a/src/components/CreatorSubscribers.vue
+++ b/src/components/CreatorSubscribers.vue
@@ -20,6 +20,8 @@
         dense
         outlined
         clearable
+        emit-value
+        map-options
         :label="t('CreatorSubscribers.columns.tier')"
         class="col-3"
       />
@@ -177,7 +179,7 @@ const columns = computed(() => [
   {
     name: "tier",
     label: t("CreatorSubscribers.columns.tier"),
-    field: "tierId",
+    field: "tierName",
     align: "left",
     sortable: true,
   },
@@ -208,9 +210,11 @@ const columns = computed(() => [
 ]);
 
 const tierOptions = computed(() => {
-  const set = new Set<string>();
-  for (const sub of subscriptions.value) set.add(sub.tierId);
-  return Array.from(set);
+  const map = new Map<string, string>();
+  for (const sub of subscriptions.value) {
+    map.set(sub.tierId, sub.tierName);
+  }
+  return Array.from(map.entries()).map(([value, label]) => ({ label, value }));
 });
 
 const statusOptions = ["active", "pending"];

--- a/src/stores/creatorSubscriptions.ts
+++ b/src/stores/creatorSubscriptions.ts
@@ -7,6 +7,7 @@ export interface CreatorSubscription {
   subscriptionId: string;
   subscriberNpub: string;
   tierId: string;
+  tierName: string;
   totalMonths: number;
   receivedMonths: number;
   status: "pending" | "active";
@@ -35,6 +36,7 @@ export const useCreatorSubscriptionsStore = defineStore(
               subscriptionId: id,
               subscriberNpub: row.subscriberNpub || "",
               tierId: row.tierId,
+              tierName: row.tierName || "",
               totalMonths: row.totalMonths || 0,
               receivedMonths: 0,
               status: "pending",


### PR DESCRIPTION
## Summary
- add tierName to CreatorSubscription store entries
- display tier names and filter options in CreatorSubscribers table

## Testing
- `npm test` *(fails: Insufficient balance; p2pk.generateKeypair is not a function; 22 failed, 127 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6891ccee17fc8330a4ab53b203e6e38a