### PR TITLE
feat: add labels to subscription filter selects

### DIFF
--- a/src/pages/SubscriptionsOverview.vue
+++ b/src/pages/SubscriptionsOverview.vue
@@ -79,7 +79,7 @@
                   value: 'expired',
                 },
               ]"
-              :placeholder="$t('SubscriptionsOverview.filter.status')"
+              :label="$t('SubscriptionsOverview.filter.status')"
             />
             <q-select
               v-model="sortBy"
@@ -87,7 +87,7 @@
               emit-value
               map-options
               :options="sortOptions"
-              :placeholder="$t('SubscriptionsOverview.sort_by')"
+              :label="$t('SubscriptionsOverview.sort_by')"
             />
             <q-select
               v-model="bucketFilter"
@@ -101,7 +101,7 @@
                   value: b.name,
                 }))
               "
-              :placeholder="$t('SubscriptionsOverview.filter.bucket')"
+              :label="$t('SubscriptionsOverview.filter.bucket')"
             />
             <q-select
               v-model="frequencyFilter"
@@ -113,7 +113,7 @@
                 { label: 'monthly', value: 'monthly' },
                 { label: 'weekly', value: 'weekly' },
               ]"
-              :placeholder="$t('SubscriptionsOverview.filter.frequency')"
+              :label="$t('SubscriptionsOverview.filter.frequency')"
             />
           </div>
         </q-slide-transition>


### PR DESCRIPTION
## Summary
- add i18n label props to status, sort, bucket and frequency filters

## Testing
- `npm test` (fails: Test Files 30 failed | 30 passed (60))
- `npm run lint` (fails: Invalid option '--ext')

------
https://chatgpt.com/codex/tasks/task_e_6891d1c207008330ac308050f27f5693