### PR TITLE
Replace Find creators CTA with share profile

### DIFF
--- a/src/components/CreatorSubscribers.vue
+++ b/src/components/CreatorSubscribers.vue
@@ -130,8 +130,8 @@
           <q-btn
             flat
             color="primary"
-            :label="t('CreatorSubscribers.findCreators')"
-            to="/find-creators"
+            :label="t('CreatorSubscribers.shareProfile')"
+            to="/my-profile"
             class="q-mt-sm"
           />
         </div>

--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -1592,6 +1592,6 @@ export default {
       sendMessage: "Send message",
     },
     noData: "No subscribers yet",
-    findCreators: "Find creators",
+    shareProfile: "Share your profile",
   },
 };

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -1598,6 +1598,6 @@ export default {
       sendMessage: "Send message",
     },
     noData: "No subscribers yet",
-    findCreators: "Find creators",
+    shareProfile: "Share your profile",
   },
 };

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -1602,6 +1602,6 @@ export default {
       sendMessage: "Send message",
     },
     noData: "No subscribers yet",
-    findCreators: "Find creators",
+    shareProfile: "Share your profile",
   },
 };

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1649,7 +1649,7 @@ export const messages = {
       sendMessage: "Send message",
     },
     noData: "No subscribers yet",
-    findCreators: "Find creators",
+    shareProfile: "Share your profile",
   },
   restore: {
     mnemonic_error_text: "Please enter a mnemonic",

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -1599,6 +1599,6 @@ export default {
       sendMessage: "Send message",
     },
     noData: "No subscribers yet",
-    findCreators: "Find creators",
+    shareProfile: "Share your profile",
   },
 };

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -1589,6 +1589,6 @@ export default {
       sendMessage: "Send message",
     },
     noData: "No subscribers yet",
-    findCreators: "Find creators",
+    shareProfile: "Share your profile",
   },
 };

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -1581,6 +1581,6 @@ export default {
       sendMessage: "Send message",
     },
     noData: "No subscribers yet",
-    findCreators: "Find creators",
+    shareProfile: "Share your profile",
   },
 };

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -1582,6 +1582,6 @@ export default {
       sendMessage: "Send message",
     },
     noData: "No subscribers yet",
-    findCreators: "Find creators",
+    shareProfile: "Share your profile",
   },
 };

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -1581,6 +1581,6 @@ export default {
       sendMessage: "Send message",
     },
     noData: "No subscribers yet",
-    findCreators: "Find creators",
+    shareProfile: "Share your profile",
   },
 };

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -1579,6 +1579,6 @@ export default {
       sendMessage: "Send message",
     },
     noData: "No subscribers yet",
-    findCreators: "Find creators",
+    shareProfile: "Share your profile",
   },
 };

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -1584,6 +1584,6 @@ export default {
       sendMessage: "Send message",
     },
     noData: "No subscribers yet",
-    findCreators: "Find creators",
+    shareProfile: "Share your profile",
   },
 };

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -1571,6 +1571,6 @@ export default {
       sendMessage: "Send message",
     },
     noData: "No subscribers yet",
-    findCreators: "Find creators",
+    shareProfile: "Share your profile",
   },
 };


### PR DESCRIPTION
## Summary
- Update CreatorSubscribers CTA to "Share your profile"
- Add shareProfile translation key across locales

## Testing
- `npm test` (fails: 30 failed, 30 passed)
- `npm run lint` (fails: Invalid option '--ext')


------
https://chatgpt.com/codex/tasks/task_e_6891e1cf5d7c83309e344922b6ede30e