### PR TITLE
feat: localize subscriber status

### DIFF
--- a/src/components/CreatorSubscribers.vue
+++ b/src/components/CreatorSubscribers.vue
@@ -217,7 +217,10 @@ const tierOptions = computed(() => {
   return Array.from(set).map((tierName) => ({ label: tierName, value: tierName }));
 });
 
-const statusOptions = ["active", "pending"];
+const statusOptions = computed(() => [
+  { label: t("CreatorSubscribers.status.active"), value: "active" },
+  { label: t("CreatorSubscribers.status.pending"), value: "pending" },
+]);
 
 const filteredSubscriptions = computed(() =>
   subscriptions.value.filter(

--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -1591,6 +1591,10 @@ export default {
       viewProfile: "View profile",
       sendMessage: "Send message",
     },
+    status: {
+      active: "نشط",
+      pending: "معلق",
+    },
     noData: "No subscribers yet",
     shareProfile: "Share your profile",
   },

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -1597,6 +1597,10 @@ export default {
       viewProfile: "View profile",
       sendMessage: "Send message",
     },
+    status: {
+      active: "Aktiv",
+      pending: "Ausstehend",
+    },
     noData: "No subscribers yet",
     shareProfile: "Share your profile",
   },

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -1601,6 +1601,10 @@ export default {
       viewProfile: "View profile",
       sendMessage: "Send message",
     },
+    status: {
+      active: "Ενεργό",
+      pending: "Σε εκκρεμότητα",
+    },
     noData: "No subscribers yet",
     shareProfile: "Share your profile",
   },

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1648,6 +1648,10 @@ export const messages = {
       viewProfile: "View profile",
       sendMessage: "Send message",
     },
+    status: {
+      active: "Active",
+      pending: "Pending",
+    },
     noData: "No subscribers yet",
     shareProfile: "Share your profile",
   },

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -1598,6 +1598,10 @@ export default {
       viewProfile: "View profile",
       sendMessage: "Send message",
     },
+    status: {
+      active: "Activo",
+      pending: "Pendiente",
+    },
     noData: "No subscribers yet",
     shareProfile: "Share your profile",
   },

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -1588,6 +1588,10 @@ export default {
       viewProfile: "View profile",
       sendMessage: "Send message",
     },
+    status: {
+      active: "Actif",
+      pending: "En attente",
+    },
     noData: "No subscribers yet",
     shareProfile: "Share your profile",
   },

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -1580,6 +1580,10 @@ export default {
       viewProfile: "View profile",
       sendMessage: "Send message",
     },
+    status: {
+      active: "Attivo",
+      pending: "In attesa",
+    },
     noData: "No subscribers yet",
     shareProfile: "Share your profile",
   },

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -1581,6 +1581,10 @@ export default {
       viewProfile: "View profile",
       sendMessage: "Send message",
     },
+    status: {
+      active: "アクティブ",
+      pending: "保留中",
+    },
     noData: "No subscribers yet",
     shareProfile: "Share your profile",
   },

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -1580,6 +1580,10 @@ export default {
       viewProfile: "View profile",
       sendMessage: "Send message",
     },
+    status: {
+      active: "Aktiv",
+      pending: "Väntande",
+    },
     noData: "No subscribers yet",
     shareProfile: "Share your profile",
   },

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -1578,6 +1578,10 @@ export default {
       viewProfile: "View profile",
       sendMessage: "Send message",
     },
+    status: {
+      active: "ใช้งาน",
+      pending: "รอดำเนินการ",
+    },
     noData: "No subscribers yet",
     shareProfile: "Share your profile",
   },

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -1583,6 +1583,10 @@ export default {
       viewProfile: "View profile",
       sendMessage: "Send message",
     },
+    status: {
+      active: "Aktif",
+      pending: "Beklemede",
+    },
     noData: "No subscribers yet",
     shareProfile: "Share your profile",
   },

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -1570,6 +1570,10 @@ export default {
       viewProfile: "View profile",
       sendMessage: "Send message",
     },
+    status: {
+      active: "活跃",
+      pending: "待处理",
+    },
     noData: "No subscribers yet",
     shareProfile: "Share your profile",
   },


### PR DESCRIPTION
## Summary
- localize subscriber status options
- add translation strings for subscriber status across locales

## Testing
- `npm test` *(fails: p2pk.generateKeypair is not a function, Insufficient balance, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6891eb5bacec8330bb099c9de7fafcf8