### PR TITLE
localize subscriber status text

### DIFF
--- a/src/components/CreatorSubscribers.vue
+++ b/src/components/CreatorSubscribers.vue
@@ -93,7 +93,7 @@
           <q-badge
             :color="props.row.status === 'active' ? 'positive' : 'warning'"
           >
-            {{ props.row.status }}
+            {{ t('CreatorSubscribers.status.' + props.row.status) }}
           </q-badge>
         </q-td>
       </template>
@@ -193,7 +193,7 @@
                         props.row.status === 'active' ? 'positive' : 'warning'
                       "
                     >
-                      {{ props.row.status }}
+                      {{ t('CreatorSubscribers.status.' + props.row.status) }}
                     </q-badge>
                   </q-item-label>
                 </q-item-section>


### PR DESCRIPTION
## Summary
- localize subscriber status labels using i18n mappings

## Testing
- `npm test` *(fails: many failing tests)*
- `npm run lint` *(fails: Invalid option '--ext')*


------
https://chatgpt.com/codex/tasks/task_e_6891f62046248330a575b4b4afd6ead0