### PR TITLE
feat: show subscriber count

### DIFF
--- a/src/pages/CreatorSubscribersPage.vue
+++ b/src/pages/CreatorSubscribersPage.vue
@@ -10,12 +10,19 @@
         aria-label="Go back"
         class="q-mr-sm"
       />
-      <h5 class="q-my-none">My Subscribers</h5>
+      <h5 class="q-my-none">My Subscribers ({{ count }})</h5>
     </div>
     <CreatorSubscribers />
   </q-page>
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue';
+import { storeToRefs } from 'pinia';
 import CreatorSubscribers from 'components/CreatorSubscribers.vue';
+import { useCreatorSubscriptionsStore } from 'stores/creatorSubscriptions';
+
+const creatorSubscriptionsStore = useCreatorSubscriptionsStore();
+const { subscriptions } = storeToRefs(creatorSubscriptionsStore);
+const count = computed(() => subscriptions.value.length);
 </script>


### PR DESCRIPTION
## Summary
- display count of creator subscriptions in the page header
- compute subscriber count from creator subscription store

## Testing
- `npm test` (fails: p2pk.generateKeypair is not a function)
- `npm run lint` (fails: Invalid option '--ext')

------
https://chatgpt.com/codex/tasks/task_e_689226f242108330840c318136405839