### PR TITLE
Fix tier name handling for subscriptions

### DIFF
--- a/src/components/CreatorSubscribers.vue
+++ b/src/components/CreatorSubscribers.vue
@@ -283,6 +283,7 @@ import { useMessengerStore } from "stores/messenger";
 import { useQuasar } from "quasar";
 import profileCache from "src/js/profile-cache";
 import SubscriberProfileDialog from "./SubscriberProfileDialog.vue";
+import { useCreatorsStore } from "stores/creators";
 
 const store = useCreatorSubscriptionsStore();
 const { subscriptions, loading } = storeToRefs(store);
@@ -291,6 +292,7 @@ const { t } = useI18n();
 const router = useRouter();
 const messenger = useMessengerStore();
 const $q = useQuasar();
+const creators = useCreatorsStore();
 const isSmallScreen = computed(() => $q.screen.lt.md);
 
 const showFilters = ref(!isSmallScreen.value);
@@ -409,7 +411,12 @@ async function updateProfiles() {
   }
 }
 
-onMounted(updateProfiles);
+onMounted(() => {
+  updateProfiles();
+  if (!creators.tiersMap[nostr.pubkey]) {
+    creators.fetchTierDefinitions(nostr.pubkey);
+  }
+});
 watch(subscriptions, updateProfiles);
 
 watch([filter, tierFilter, statusFilter, showFilters], () => {

--- a/src/pages/SubscriptionsOverview.vue
+++ b/src/pages/SubscriptionsOverview.vue
@@ -751,6 +751,7 @@ function extendSubscription(pubkey: string) {
         newTokens.map((t: any, idx: number) => ({
           ...t,
           tierId: sub.tierId,
+          ...(sub.tierName ? { tierName: sub.tierName } : {}),
           subscriptionId: sub.id,
           monthIndex: sub.intervals.length + idx + 1,
           totalMonths,

--- a/src/stores/creatorSubscriptions.ts
+++ b/src/stores/creatorSubscriptions.ts
@@ -2,6 +2,7 @@ import { defineStore } from "pinia";
 import { cashuDb } from "./dexie";
 import { liveQuery } from "dexie";
 import { ref } from "vue";
+import { useCreatorsStore } from "./creators";
 
 export interface CreatorSubscription {
   subscriptionId: string;
@@ -18,6 +19,7 @@ export const useCreatorSubscriptionsStore = defineStore(
   () => {
     const subscriptions = ref<CreatorSubscription[]>([]);
     const loading = ref(true);
+    const creatorsStore = useCreatorsStore();
 
     liveQuery(() =>
       cashuDb.lockedTokens
@@ -36,7 +38,12 @@ export const useCreatorSubscriptionsStore = defineStore(
               subscriptionId: id,
               subscriberNpub: row.subscriberNpub || "",
               tierId: row.tierId,
-              tierName: row.tierName || "",
+              tierName:
+                row.tierName ||
+                creatorsStore.tiersMap[row.creatorNpub || ""]?.find(
+                  (t) => t.id === row.tierId,
+                )?.name ||
+                "",
               totalMonths: row.totalMonths || 0,
               receivedMonths: 0,
               status: "pending",

--- a/src/stores/dexie.ts
+++ b/src/stores/dexie.ts
@@ -72,6 +72,7 @@ export interface LockedToken {
   creatorNpub?: string;
   creatorP2PK?: string;
   tierId: string;
+  tierName?: string;
   intervalKey: string;
   unlockTs: number;
   status: "pending" | "unlockable" | "claimed" | "expired";

--- a/src/stores/messenger.ts
+++ b/src/stores/messenger.ts
@@ -21,6 +21,7 @@ import { cashuDb, type LockedToken } from "./dexie";
 import { DEFAULT_BUCKET_ID } from "./buckets";
 import token from "src/js/token";
 import { subscriptionPayload } from "src/utils/receipt-utils";
+import { useCreatorsStore } from "./creators";
 
 function parseSubscriptionPaymentPayload(
   obj: any
@@ -485,14 +486,21 @@ export const useMessengerStore = defineStore("messenger", {
             htlc_secret: sub.htlc_secret,
           };
           const unlockTs = sub.unlock_time ?? payload.unlockTime ?? 0;
+          const creatorsStore = useCreatorsStore();
+          const myPubkey = useNostrStore().pubkey;
+          const tierName =
+            creatorsStore.tiersMap[myPubkey || ""]?.find(
+              (t) => t.id === payload.tier_id,
+            )?.name;
           const entry: LockedToken = {
             id: uuidv4(),
             tokenString: sub.token,
             amount,
             owner: "creator",
-            creatorNpub: useNostrStore().pubkey,
+            creatorNpub: myPubkey,
             subscriberNpub: event.pubkey,
             tierId: payload.tier_id ?? "",
+            ...(tierName ? { tierName } : {}),
             intervalKey: payload.subscription_id ?? "",
             unlockTs,
             autoRedeem: true,

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -56,6 +56,7 @@ import { v4 as uuidv4 } from "uuid";
 import { useRouter } from "vue-router";
 import { useP2PKStore } from "./p2pk";
 import { watch } from "vue";
+import { useCreatorsStore } from "./creators";
 
 const STORAGE_SECRET = "cashu_ndk_storage_key";
 let cachedKey: CryptoKey | null = null;
@@ -1420,6 +1421,11 @@ export const useNostrStore = defineStore("nostr", {
             ? token.getProofs(decoded).reduce((s, p) => s + p.amount, 0)
             : 0;
           const unlockTs = payload.unlock_time ?? payload.unlockTime ?? 0;
+          const creatorsStore = useCreatorsStore();
+          const tierName =
+            creatorsStore.tiersMap[this.pubkey || ""]?.find(
+              (t) => t.id === payload.tier_id,
+            )?.name;
           const entry: LockedToken = {
             id: uuidv4(),
             tokenString: payload.token,
@@ -1428,6 +1434,7 @@ export const useNostrStore = defineStore("nostr", {
             creatorNpub: this.pubkey,
             subscriberNpub: sender,
             tierId: payload.tier_id ?? "",
+            ...(tierName ? { tierName } : {}),
             intervalKey: payload.subscription_id ?? "",
             unlockTs,
             autoRedeem: true,

--- a/src/stores/nutzap.ts
+++ b/src/stores/nutzap.ts
@@ -158,6 +158,7 @@ export const useNutzapStore = defineStore("nutzap", {
           creatorNpub: creator.pubkey,
           subscriberNpub: ev.pubkey,
           tierId: "nutzap",
+          tierName: "Nutzap",
           intervalKey: ev.id,
           unlockTs,
           status:
@@ -270,6 +271,7 @@ export const useNutzapStore = defineStore("nutzap", {
           creatorNpub: creator.nostrPubkey,
           autoRedeem: false,
           tierId,
+          ...(tierName ? { tierName } : {}),
           intervalKey: String(i + 1),
           unlockTs: unlockDate,
           status:
@@ -426,6 +428,7 @@ export const useNutzapStore = defineStore("nutzap", {
             monthIndex: i + 1,
             totalMonths: months,
             label: "Subscription payment",
+            tierName: "Nutzap",
           };
           lockedTokens.push(entry);
 
@@ -440,6 +443,7 @@ export const useNutzapStore = defineStore("nutzap", {
         await subStore.addSubscription({
           creatorNpub: npub,
           tierId: "nutzap",
+          tierName: "Nutzap",
           creatorP2PK: creatorP2pk,
           mintUrl: mints.activeMintUrl,
         amountPerInterval: amount,


### PR DESCRIPTION
## Summary
- derive missing subscription tier names from creators store
- persist tier names when creating subscription tokens and records
- load creator tier definitions so subscriber list shows names

## Testing
- `npm run test:ci` *(fails: walletStore.t is not a function, useNostrStore(...).resolvePubkey is not a function)*
- `npm run lint` *(fails: Invalid option '--ext')*


------
https://chatgpt.com/codex/tasks/task_e_68924625ae8c8330aa941e4e0d8956ba