### PR TITLE
Add subscription date tracking and localized subscriber table

### DIFF
--- a/src/components/CreatorSubscribers.vue
+++ b/src/components/CreatorSubscribers.vue
@@ -105,13 +105,6 @@
                 {{ t("CreatorSubscribers.monthsTooltip") }}
               </q-tooltip>
             </div>
-            <div v-if="props.row.nextRenewal" class="text-caption">
-              {{
-                t("CreatorSubscribers.nextRenewal", {
-                  date: formatTs(props.row.nextRenewal),
-                })
-              }}
-            </div>
           </div>
         </q-td>
       </template>
@@ -206,17 +199,31 @@
                       <q-tooltip>
                         {{ t("CreatorSubscribers.monthsTooltip") }}
                       </q-tooltip>
-                      <div
-                        v-if="props.row.nextRenewal"
-                        class="text-caption"
-                      >
-                        {{
-                          t("CreatorSubscribers.nextRenewal", {
-                            date: formatTs(props.row.nextRenewal),
-                          })
-                        }}
-                      </div>
                     </div>
+                  </q-item-label>
+                </q-item-section>
+              </q-item>
+              <q-item>
+                <q-item-section>
+                  <q-item-label caption>
+                    {{ t("CreatorSubscribers.columns.start") }}
+                  </q-item-label>
+                  <q-item-label>
+                    {{ props.row.startDate ? formatTs(props.row.startDate) : "-" }}
+                  </q-item-label>
+                </q-item-section>
+              </q-item>
+              <q-item>
+                <q-item-section>
+                  <q-item-label caption>
+                    {{ t("CreatorSubscribers.columns.nextRenewal") }}
+                  </q-item-label>
+                  <q-item-label>
+                    {{
+                      props.row.nextRenewal
+                        ? formatTs(props.row.nextRenewal)
+                        : "-"
+                    }}
                   </q-item-label>
                 </q-item-section>
               </q-item>
@@ -310,7 +317,7 @@ import { useCreatorsStore } from "stores/creators";
 const store = useCreatorSubscriptionsStore();
 const { subscriptions, loading } = storeToRefs(store);
 
-const { t } = useI18n();
+const { t, d } = useI18n();
 const router = useRouter();
 const messenger = useMessengerStore();
 const $q = useQuasar();
@@ -346,6 +353,24 @@ const columns = computed(() => [
     field: "tierName",
     align: "left",
     sortable: true,
+  },
+  {
+    name: "start",
+    label: t("CreatorSubscribers.columns.start"),
+    field: "startDate",
+    align: "left",
+    sortable: true,
+    sort: (a, b) => (a ?? 0) - (b ?? 0),
+    format: (val) => (val ? formatTs(val) : "-"),
+  },
+  {
+    name: "nextRenewal",
+    label: t("CreatorSubscribers.columns.nextRenewal"),
+    field: "nextRenewal",
+    align: "left",
+    sortable: true,
+    sort: (a, b) => (a ?? 0) - (b ?? 0),
+    format: (val) => (val ? formatTs(val) : "-"),
   },
   {
     name: "months",
@@ -454,10 +479,7 @@ function pubkeyNpub(hex: string): string {
 }
 
 function formatTs(ts: number): string {
-  const d = new Date(ts * 1000);
-  return `${d.getFullYear()}-${("0" + (d.getMonth() + 1)).slice(-2)}-${(
-    "0" + d.getDate()
-  ).slice(-2)}`;
+  return d(new Date(ts * 1000), { dateStyle: "medium" });
 }
 
 function sendMessage(pk: string) {

--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -1583,6 +1583,8 @@ export default {
     columns: {
       subscriber: "Subscriber",
       tier: "Tier",
+      start: "Start",
+      nextRenewal: "Next renewal",
       months: "Months",
       status: "Status",
       actions: "Actions",

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -1589,6 +1589,8 @@ export default {
     columns: {
       subscriber: "Subscriber",
       tier: "Tier",
+      start: "Start",
+      nextRenewal: "Next renewal",
       months: "Months",
       status: "Status",
       actions: "Actions",

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -1593,6 +1593,8 @@ export default {
     columns: {
       subscriber: "Subscriber",
       tier: "Tier",
+      start: "Start",
+      nextRenewal: "Next renewal",
       months: "Months",
       status: "Status",
       actions: "Actions",

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1640,6 +1640,8 @@ export const messages = {
     columns: {
       subscriber: "Subscriber",
       tier: "Tier",
+      start: "Start",
+      nextRenewal: "Next renewal",
       months: "Months",
       status: "Status",
       actions: "Actions",

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -1590,6 +1590,8 @@ export default {
     columns: {
       subscriber: "Subscriber",
       tier: "Tier",
+      start: "Start",
+      nextRenewal: "Next renewal",
       months: "Months",
       status: "Status",
       actions: "Actions",

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -1580,6 +1580,8 @@ export default {
     columns: {
       subscriber: "Subscriber",
       tier: "Tier",
+      start: "Start",
+      nextRenewal: "Next renewal",
       months: "Months",
       status: "Status",
       actions: "Actions",

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -1572,6 +1572,8 @@ export default {
     columns: {
       subscriber: "Subscriber",
       tier: "Tier",
+      start: "Start",
+      nextRenewal: "Next renewal",
       months: "Months",
       status: "Status",
       actions: "Actions",

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -1573,6 +1573,8 @@ export default {
     columns: {
       subscriber: "Subscriber",
       tier: "Tier",
+      start: "Start",
+      nextRenewal: "Next renewal",
       months: "Months",
       status: "Status",
       actions: "Actions",

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -1572,6 +1572,8 @@ export default {
     columns: {
       subscriber: "Subscriber",
       tier: "Tier",
+      start: "Start",
+      nextRenewal: "Next renewal",
       months: "Months",
       status: "Status",
       actions: "Actions",

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -1570,6 +1570,8 @@ export default {
     columns: {
       subscriber: "Subscriber",
       tier: "Tier",
+      start: "Start",
+      nextRenewal: "Next renewal",
       months: "Months",
       status: "Status",
       actions: "Actions",

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -1575,6 +1575,8 @@ export default {
     columns: {
       subscriber: "Subscriber",
       tier: "Tier",
+      start: "Start",
+      nextRenewal: "Next renewal",
       months: "Months",
       status: "Status",
       actions: "Actions",

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -1562,6 +1562,8 @@ export default {
     columns: {
       subscriber: "Subscriber",
       tier: "Tier",
+      start: "Start",
+      nextRenewal: "Next renewal",
       months: "Months",
       status: "Status",
       actions: "Actions",

--- a/test/vitest/__tests__/subscriptions.spec.ts
+++ b/test/vitest/__tests__/subscriptions.spec.ts
@@ -235,8 +235,14 @@ describe("Nutzap subscriptions", () => {
     expect(subStore.subscriptions.length).toBe(2);
     expect(sub1?.receivedMonths).toBe(2);
     expect(sub1?.status).toBe("active");
+    expect(sub1?.startDate).toBe(0);
+    expect(sub1?.endDate).toBe(0);
+    expect(sub1?.nextRenewal).toBe(0 + 30 * 24 * 60 * 60);
     expect(sub2?.receivedMonths).toBe(1);
     expect(sub2?.status).toBe("pending");
+    expect(sub2?.startDate).toBe(0);
+    expect(sub2?.endDate).toBe(0);
+    expect(sub2?.nextRenewal).toBe(0 + 30 * 24 * 60 * 60);
   });
 
   it("redeems tokens when unlock time passed", async () => {


### PR DESCRIPTION
## Summary
- compute subscription start/end from token timestamps
- show localized Start and Next renewal columns in CreatorSubscribers table
- cover new fields in subscription tests

## Testing
- `npm test` *(fails: "Failed Suites 14" and other errors)*
- `npm run lint` *(fails: invalid option '--ext')*


------
https://chatgpt.com/codex/tasks/task_e_6892597f7a7c8330a2a02b3bbf621c93