### PR TITLE
feat: add subscriber summary panel

### DIFF
--- a/src/components/CreatorSubscribers.vue
+++ b/src/components/CreatorSubscribers.vue
@@ -117,6 +117,34 @@
         </div>
       </q-slide-transition>
     </div>
+    <div class="row q-col-gutter-md q-mb-md">
+      <div class="col-12 col-sm-4">
+        <q-card flat bordered class="q-pa-sm text-center">
+          <div class="text-h6">{{ totalActiveSubscribers }}</div>
+          <div class="text-caption">
+            {{ t('CreatorSubscribers.summary.activeSubscribers') }}
+          </div>
+        </q-card>
+      </div>
+      <div class="col-12 col-sm-4">
+        <q-card flat bordered class="q-pa-sm text-center">
+          <div class="text-h6">{{ totalReceivedMonths }}</div>
+          <div class="text-caption">
+            {{ t('CreatorSubscribers.summary.receivedMonths') }}
+          </div>
+        </q-card>
+      </div>
+      <div class="col-12 col-sm-4">
+        <q-card flat bordered class="q-pa-sm text-center">
+          <div class="text-h6">
+            {{ formatCurrency(totalRevenue) }}
+          </div>
+          <div class="text-caption">
+            {{ t('CreatorSubscribers.summary.revenue') }}
+          </div>
+        </q-card>
+      </div>
+    </div>
     <q-table
       flat
       bordered
@@ -393,6 +421,8 @@ import { useQuasar } from "quasar";
 import profileCache from "src/js/profile-cache";
 import SubscriberProfileDialog from "./SubscriberProfileDialog.vue";
 import { useCreatorsStore } from "stores/creators";
+import { useUiStore } from "stores/ui";
+import { useMintsStore } from "stores/mints";
 
 const store = useCreatorSubscriptionsStore();
 const { subscriptions, loading } = storeToRefs(store);
@@ -402,6 +432,9 @@ const router = useRouter();
 const messenger = useMessengerStore();
 const $q = useQuasar();
 const creators = useCreatorsStore();
+const ui = useUiStore();
+const mints = useMintsStore();
+const { activeUnit } = storeToRefs(mints);
 const isSmallScreen = computed(() => $q.screen.lt.md);
 
 const showFilters = ref(!isSmallScreen.value);
@@ -527,6 +560,19 @@ const filteredSubscriptions = computed(() =>
     );
   })
 );
+
+const totalActiveSubscribers = computed(
+  () => filteredSubscriptions.value.filter((s) => s.status === "active").length
+);
+const totalReceivedMonths = computed(() =>
+  filteredSubscriptions.value.reduce((sum, s) => sum + s.receivedMonths, 0)
+);
+const totalRevenue = computed(() =>
+  filteredSubscriptions.value.reduce((sum, s) => sum + (s.totalAmount || 0), 0)
+);
+function formatCurrency(amount: number) {
+  return ui.formatCurrency(amount, activeUnit.value);
+}
 
 const profiles = ref<Record<string, any>>({});
 const nostr = useNostrStore();

--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -1606,6 +1606,11 @@ export default {
       active: "نشط",
       pending: "معلق",
     },
+    summary: {
+      activeSubscribers: "Active subscribers",
+      receivedMonths: "Received months",
+      revenue: "Revenue",
+    },
     monthsText: "{received} of {total} months",
     monthsTooltip: "Months received vs months purchased",
     startTooltip: "Filter by subscription start date",

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -1612,6 +1612,11 @@ export default {
       active: "Aktiv",
       pending: "Ausstehend",
     },
+    summary: {
+      activeSubscribers: "Active subscribers",
+      receivedMonths: "Received months",
+      revenue: "Revenue",
+    },
     monthsText: "{received} of {total} months",
     monthsTooltip: "Months received vs months purchased",
     startTooltip: "Filter by subscription start date",

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -1616,6 +1616,11 @@ export default {
       active: "Ενεργό",
       pending: "Σε εκκρεμότητα",
     },
+    summary: {
+      activeSubscribers: "Active subscribers",
+      receivedMonths: "Received months",
+      revenue: "Revenue",
+    },
     monthsText: "{received} of {total} months",
     monthsTooltip: "Months received vs months purchased",
     startTooltip: "Filter by subscription start date",

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1663,6 +1663,11 @@ export const messages = {
       active: "Active",
       pending: "Pending",
     },
+    summary: {
+      activeSubscribers: "Active subscribers",
+      receivedMonths: "Received months",
+      revenue: "Revenue",
+    },
     monthsText: "{received} of {total} months",
     monthsTooltip: "Months received vs months purchased",
     startTooltip: "Filter by subscription start date",

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -1613,6 +1613,11 @@ export default {
       active: "Activo",
       pending: "Pendiente",
     },
+    summary: {
+      activeSubscribers: "Active subscribers",
+      receivedMonths: "Received months",
+      revenue: "Revenue",
+    },
     monthsText: "{received} of {total} months",
     monthsTooltip: "Months received vs months purchased",
     startTooltip: "Filter by subscription start date",

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -1603,6 +1603,11 @@ export default {
       active: "Actif",
       pending: "En attente",
     },
+    summary: {
+      activeSubscribers: "Active subscribers",
+      receivedMonths: "Received months",
+      revenue: "Revenue",
+    },
     monthsText: "{received} of {total} months",
     monthsTooltip: "Months received vs months purchased",
     startTooltip: "Filter by subscription start date",

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -1595,6 +1595,11 @@ export default {
       active: "Attivo",
       pending: "In attesa",
     },
+    summary: {
+      activeSubscribers: "Active subscribers",
+      receivedMonths: "Received months",
+      revenue: "Revenue",
+    },
     monthsText: "{received} of {total} months",
     monthsTooltip: "Months received vs months purchased",
     startTooltip: "Filter by subscription start date",

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -1596,6 +1596,11 @@ export default {
       active: "アクティブ",
       pending: "保留中",
     },
+    summary: {
+      activeSubscribers: "Active subscribers",
+      receivedMonths: "Received months",
+      revenue: "Revenue",
+    },
     monthsText: "{received} of {total} months",
     monthsTooltip: "Months received vs months purchased",
     startTooltip: "Filter by subscription start date",

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -1595,6 +1595,11 @@ export default {
       active: "Aktiv",
       pending: "Väntande",
     },
+    summary: {
+      activeSubscribers: "Active subscribers",
+      receivedMonths: "Received months",
+      revenue: "Revenue",
+    },
     monthsText: "{received} of {total} months",
     monthsTooltip: "Months received vs months purchased",
     startTooltip: "Filter by subscription start date",

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -1593,6 +1593,11 @@ export default {
       active: "ใช้งาน",
       pending: "รอดำเนินการ",
     },
+    summary: {
+      activeSubscribers: "Active subscribers",
+      receivedMonths: "Received months",
+      revenue: "Revenue",
+    },
     monthsText: "{received} of {total} months",
     monthsTooltip: "Months received vs months purchased",
     startTooltip: "Filter by subscription start date",

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -1598,6 +1598,11 @@ export default {
       active: "Aktif",
       pending: "Beklemede",
     },
+    summary: {
+      activeSubscribers: "Active subscribers",
+      receivedMonths: "Received months",
+      revenue: "Revenue",
+    },
     monthsText: "{received} of {total} months",
     monthsTooltip: "Months received vs months purchased",
     startTooltip: "Filter by subscription start date",

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -1585,6 +1585,11 @@ export default {
       active: "活跃",
       pending: "待处理",
     },
+    summary: {
+      activeSubscribers: "Active subscribers",
+      receivedMonths: "Received months",
+      revenue: "Revenue",
+    },
     monthsText: "{received} of {total} months",
     monthsTooltip: "Months received vs months purchased",
     startTooltip: "Filter by subscription start date",

--- a/src/stores/creatorSubscriptions.ts
+++ b/src/stores/creatorSubscriptions.ts
@@ -11,6 +11,7 @@ export interface CreatorSubscription {
   tierName: string;
   totalMonths: number;
   receivedMonths: number;
+  totalAmount: number;
   status: "pending" | "active";
   nextRenewal: number | null;
   startDate: number | null;
@@ -55,6 +56,7 @@ export const useCreatorSubscriptionsStore = defineStore(
                 "",
               totalMonths: row.totalMonths || 0,
               receivedMonths: 0,
+              totalAmount: 0,
               status: "pending",
               nextRenewal: null,
               startDate: null,
@@ -65,6 +67,7 @@ export const useCreatorSubscriptionsStore = defineStore(
             map.set(id, sub);
           }
           sub.receivedMonths += 1;
+          sub.totalAmount += row.amount;
           if (row.unlockTs != null) {
             if (
               sub.earliestUnlock == null ||
@@ -91,6 +94,7 @@ export const useCreatorSubscriptionsStore = defineStore(
             tierName: s.tierName,
             totalMonths: s.totalMonths,
             receivedMonths: s.receivedMonths,
+            totalAmount: s.totalAmount,
             status:
               s.receivedMonths >= s.totalMonths ? "active" : "pending",
             nextRenewal,


### PR DESCRIPTION
## Summary
- extend creator subscription store with totalAmount and revenue aggregation
- add summary panel with subscriber counts, months, and revenue
- add translation keys for summary labels

## Testing
- `npm test` *(fails: ReferenceError: windowMixin is not defined, etc.)*
- `npm run lint` *(fails: Invalid option '--ext' - perhaps you meant '-c'?)*

------
https://chatgpt.com/codex/tasks/task_e_6892f60fc6748330877b055a005055da