### PR TITLE
feat: add bulk subscriber actions

### DIFF
--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -1601,6 +1601,8 @@ export default {
       viewProfile: "View profile",
       sendMessage: "Send message",
       downloadCsv: "Download CSV",
+      sendGroupMessage: "Send group message",
+      exportSelected: "Export selected",
     },
     status: {
       active: "نشط",

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -1607,6 +1607,8 @@ export default {
       viewProfile: "View profile",
       sendMessage: "Send message",
       downloadCsv: "Download CSV",
+      sendGroupMessage: "Send group message",
+      exportSelected: "Export selected",
     },
     status: {
       active: "Aktiv",

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -1611,6 +1611,8 @@ export default {
       viewProfile: "View profile",
       sendMessage: "Send message",
       downloadCsv: "Download CSV",
+      sendGroupMessage: "Send group message",
+      exportSelected: "Export selected",
     },
     status: {
       active: "Ενεργό",

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1658,6 +1658,8 @@ export const messages = {
       viewProfile: "View profile",
       sendMessage: "Send message",
       downloadCsv: "Download CSV",
+      sendGroupMessage: "Send group message",
+      exportSelected: "Export selected",
     },
     status: {
       active: "Active",

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -1608,6 +1608,8 @@ export default {
       viewProfile: "View profile",
       sendMessage: "Send message",
       downloadCsv: "Download CSV",
+      sendGroupMessage: "Send group message",
+      exportSelected: "Export selected",
     },
     status: {
       active: "Activo",

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -1598,6 +1598,8 @@ export default {
       viewProfile: "View profile",
       sendMessage: "Send message",
       downloadCsv: "Download CSV",
+      sendGroupMessage: "Send group message",
+      exportSelected: "Export selected",
     },
     status: {
       active: "Actif",

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -1590,6 +1590,8 @@ export default {
       viewProfile: "View profile",
       sendMessage: "Send message",
       downloadCsv: "Download CSV",
+      sendGroupMessage: "Send group message",
+      exportSelected: "Export selected",
     },
     status: {
       active: "Attivo",

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -1591,6 +1591,8 @@ export default {
       viewProfile: "View profile",
       sendMessage: "Send message",
       downloadCsv: "Download CSV",
+      sendGroupMessage: "Send group message",
+      exportSelected: "Export selected",
     },
     status: {
       active: "アクティブ",

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -1590,6 +1590,8 @@ export default {
       viewProfile: "View profile",
       sendMessage: "Send message",
       downloadCsv: "Download CSV",
+      sendGroupMessage: "Send group message",
+      exportSelected: "Export selected",
     },
     status: {
       active: "Aktiv",

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -1588,6 +1588,8 @@ export default {
       viewProfile: "View profile",
       sendMessage: "Send message",
       downloadCsv: "Download CSV",
+      sendGroupMessage: "Send group message",
+      exportSelected: "Export selected",
     },
     status: {
       active: "ใช้งาน",

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -1593,6 +1593,8 @@ export default {
       viewProfile: "View profile",
       sendMessage: "Send message",
       downloadCsv: "Download CSV",
+      sendGroupMessage: "Send group message",
+      exportSelected: "Export selected",
     },
     status: {
       active: "Aktif",

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -1580,6 +1580,8 @@ export default {
       viewProfile: "View profile",
       sendMessage: "Send message",
       downloadCsv: "Download CSV",
+      sendGroupMessage: "Send group message",
+      exportSelected: "Export selected",
     },
     status: {
       active: "活跃",


### PR DESCRIPTION
## Summary
- enable multi-select on subscriber table
- add bulk message sending and CSV export
- support selection controls on small screens

## Testing
- `npm test` *(fails: bad point: not on curve, etc.)*
- `npm run lint` *(fails: Invalid option '--ext')*

------
https://chatgpt.com/codex/tasks/task_e_68930a1650f483308a6247f08fe824ef