### PR TITLE
test: add CreatorSubscribers tests

### DIFF
--- a/src/components/__tests__/CreatorSubscribers.spec.ts
+++ b/src/components/__tests__/CreatorSubscribers.spec.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { ref, nextTick } from 'vue';
+
+// mock quasar and its composables
+const qMock = {
+  dialog: vi.fn(() => ({ onOk: (cb: (val: string) => void) => cb('hello') })),
+  notify: vi.fn(),
+  screen: { lt: { md: false } },
+};
+vi.mock('quasar', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    useQuasar: () => qMock,
+    QIcon: actual.QIcon || { name: 'QIcon', template: '<i />' },
+    Notify: { create: vi.fn() },
+  };
+});
+
+// mock creator subscriptions store
+const subscriptions = ref([
+  {
+    subscriptionId: 'sub1',
+    subscriberNpub: 'pk1',
+    tierName: 'Gold',
+    startDate: 1,
+    nextRenewal: 2,
+    receivedMonths: 1,
+    totalMonths: 3,
+    totalAmount: 1000,
+    status: 'active',
+  },
+  {
+    subscriptionId: 'sub2',
+    subscriberNpub: 'pk2',
+    tierName: 'Silver',
+    startDate: 1,
+    nextRenewal: 2,
+    receivedMonths: 2,
+    totalMonths: 4,
+    totalAmount: 2000,
+    status: 'pending',
+  },
+]);
+const loading = ref(false);
+vi.mock('stores/creatorSubscriptions', () => ({
+  useCreatorSubscriptionsStore: () => ({ subscriptions, loading }),
+}));
+
+// mock messenger store
+const messenger = {
+  started: true,
+  startChat: vi.fn(),
+  sendDm: vi.fn(async () => {}),
+};
+vi.mock('stores/messenger', () => ({
+  useMessengerStore: () => messenger,
+}));
+
+// mock profile cache
+const profilesData: Record<string, any> = {
+  pk1: { display_name: 'Alice' },
+  pk2: { display_name: 'Bob' },
+};
+vi.mock('src/js/profile-cache', () => ({
+  default: {
+    get: (pk: string) => profilesData[pk],
+    set: vi.fn(),
+  },
+}));
+
+// mock nostr store
+vi.mock('stores/nostr', () => ({
+  useNostrStore: () => ({
+    pubkey: 'creator_pk',
+    getProfile: vi.fn(async (pk: string) => profilesData[pk]),
+  }),
+}));
+
+// mock other stores
+vi.mock('stores/creators', () => ({
+  useCreatorsStore: () => ({ tiersMap: { creator_pk: true }, fetchTierDefinitions: vi.fn() }),
+}));
+vi.mock('stores/ui', () => ({
+  useUiStore: () => ({ formatCurrency: (amt: number) => `${amt}` }),
+}));
+vi.mock('stores/mints', () => ({
+  useMintsStore: () => ({ activeUnit: ref('sat') }),
+}));
+
+// mock router
+const routerPush = vi.fn();
+vi.mock('vue-router', () => ({
+  useRouter: () => ({ push: routerPush }),
+}));
+
+// mock nostr-tools
+vi.mock('nostr-tools', () => ({
+  nip19: { npubEncode: (pk: string) => `npub_${pk}` },
+}));
+
+import CreatorSubscribers from '../CreatorSubscribers.vue';
+
+describe('CreatorSubscribers.vue', () => {
+  beforeEach(() => {
+    routerPush.mockClear();
+    messenger.startChat.mockClear();
+    messenger.sendDm.mockClear();
+    subscriptions.value = [
+      {
+        subscriptionId: 'sub1',
+        subscriberNpub: 'pk1',
+        tierName: 'Gold',
+        startDate: 1,
+        nextRenewal: 2,
+        receivedMonths: 1,
+        totalMonths: 3,
+        totalAmount: 1000,
+        status: 'active',
+      },
+      {
+        subscriptionId: 'sub2',
+        subscriberNpub: 'pk2',
+        tierName: 'Silver',
+        startDate: 1,
+        nextRenewal: 2,
+        receivedMonths: 2,
+        totalMonths: 4,
+        totalAmount: 2000,
+        status: 'pending',
+      },
+    ];
+  });
+
+  it('renders subscriber rows with profile names', async () => {
+    const wrapper = mount(CreatorSubscribers);
+    await nextTick();
+    const rows = wrapper.findAll('tbody tr');
+    expect(rows).toHaveLength(2);
+    expect(wrapper.text()).toContain('Alice');
+    expect(wrapper.text()).toContain('Bob');
+  });
+
+  it('filters by tier and status', async () => {
+    const wrapper = mount(CreatorSubscribers);
+    await nextTick();
+
+    // filter by tier
+    wrapper.vm.tierFilter = 'Gold';
+    await nextTick();
+    let rows = wrapper.findAll('tbody tr');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].text()).toContain('Alice');
+
+    // filter by status
+    wrapper.vm.tierFilter = null;
+    wrapper.vm.statusFilter = 'pending';
+    await nextTick();
+    rows = wrapper.findAll('tbody tr');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].text()).toContain('Bob');
+  });
+
+  it('sends messages via actions', async () => {
+    const wrapper = mount(CreatorSubscribers);
+    await nextTick();
+
+    // direct message
+    await wrapper.vm.sendMessage('pk1');
+    expect(routerPush).toHaveBeenCalledWith({ path: '/nostr-messenger', query: { pubkey: 'npub_pk1' } });
+    expect(messenger.startChat).toHaveBeenCalledWith('pk1');
+
+    // group message
+    qMock.dialog.mockClear();
+    qMock.notify.mockClear();
+    wrapper.vm.selected = subscriptions.value.slice();
+    wrapper.vm.sendGroupMessage();
+    await new Promise((r) => setTimeout(r));
+    expect(messenger.sendDm).toHaveBeenCalledTimes(2);
+    expect(qMock.notify).toHaveBeenCalled();
+    expect(wrapper.vm.selected).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add mocked store and profile-based tests for CreatorSubscribers

## Testing
- `npx vitest run src/components/__tests__/CreatorSubscribers.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68930facae388330bd8188ddbf68649b