### PR TITLE
refactor: extract subscriber filters and summary

### DIFF
--- a/src/components/CreatorSubscribers.vue
+++ b/src/components/CreatorSubscribers.vue
@@ -1,150 +1,26 @@
 <template>
   <div>
-    <div class="q-mb-md">
-      <div class="row q-gutter-sm q-mb-sm">
-        <q-btn
-          v-if="isSmallScreen"
-          flat
-          color="primary"
-          icon="filter_list"
-          label="Filters"
-          @click="showFilters = !showFilters"
-        />
-        <q-btn
-          flat
-          color="primary"
-          icon="download"
-          :label="t('CreatorSubscribers.actions.downloadCsv')"
-          @click="downloadCsv"
-        />
-      </div>
-      <q-slide-transition>
-        <div v-show="!isSmallScreen || showFilters" class="row q-gutter-sm">
-          <q-input
-            v-model="filter"
-            dense
-            outlined
-            debounce="300"
-            clearable
-            :placeholder="$t('CreatorSubscribers.filter.placeholder')"
-            class="col"
-          >
-            <template #prepend>
-              <q-icon name="search" />
-            </template>
-          </q-input>
-          <q-select
-            v-model="tierFilter"
-            :options="tierOptions"
-            dense
-            outlined
-            clearable
-            emit-value
-            map-options
-            :label="t('CreatorSubscribers.columns.tier')"
-            class="col-3"
-          />
-          <q-select
-            v-model="statusFilter"
-            :options="statusOptions"
-            dense
-            outlined
-            clearable
-            :label="t('CreatorSubscribers.columns.status')"
-            class="col-3"
-          />
-          <q-input
-            v-model="startFrom"
-            type="date"
-            dense
-            outlined
-            clearable
-            :label="t('CreatorSubscribers.filter.startFrom')"
-            class="col-3"
-          >
-            <q-tooltip>{{ t("CreatorSubscribers.startTooltip") }}</q-tooltip>
-          </q-input>
-          <q-input
-            v-model="startTo"
-            type="date"
-            dense
-            outlined
-            clearable
-            :label="t('CreatorSubscribers.filter.startTo')"
-            class="col-3"
-          >
-            <q-tooltip>{{ t("CreatorSubscribers.startTooltip") }}</q-tooltip>
-          </q-input>
-          <q-input
-            v-model="nextRenewalFrom"
-            type="date"
-            dense
-            outlined
-            clearable
-            :label="t('CreatorSubscribers.filter.nextRenewalFrom')"
-            class="col-3"
-          >
-            <q-tooltip>{{
-              t("CreatorSubscribers.nextRenewalTooltip")
-            }}</q-tooltip>
-          </q-input>
-          <q-input
-            v-model="nextRenewalTo"
-            type="date"
-            dense
-            outlined
-            clearable
-            :label="t('CreatorSubscribers.filter.nextRenewalTo')"
-            class="col-3"
-          >
-            <q-tooltip>{{
-              t("CreatorSubscribers.nextRenewalTooltip")
-            }}</q-tooltip>
-          </q-input>
-          <q-input
-            v-model.number="monthsRemaining"
-            type="number"
-            dense
-            outlined
-            clearable
-            :label="t('CreatorSubscribers.filter.monthsRemaining')"
-            class="col-3"
-          >
-            <q-tooltip>{{
-              t("CreatorSubscribers.monthsRemainingTooltip")
-            }}</q-tooltip>
-          </q-input>
-        </div>
-      </q-slide-transition>
-    </div>
-    <div class="row q-col-gutter-md q-mb-md">
-      <div class="col-12 col-sm-4">
-        <q-card flat bordered class="q-pa-sm text-center">
-          <div class="text-h6">{{ totalActiveSubscribers }}</div>
-          <div class="text-caption">
-            {{ t('CreatorSubscribers.summary.activeSubscribers') }}
-          </div>
-        </q-card>
-      </div>
-      <div class="col-12 col-sm-4">
-        <q-card flat bordered class="q-pa-sm text-center">
-          <div class="text-h6">{{ totalReceivedMonths }}</div>
-          <div class="text-caption">
-            {{ t('CreatorSubscribers.summary.receivedMonths') }}
-          </div>
-        </q-card>
-      </div>
-      <div class="col-12 col-sm-4">
-        <q-card flat bordered class="q-pa-sm text-center">
-          <div class="text-h6">
-            {{ formatCurrency(totalRevenue) }}
-          </div>
-          <div class="text-caption">
-            {{ t('CreatorSubscribers.summary.revenue') }}
-          </div>
-        </q-card>
-      </div>
-    </div>
+    <CreatorSubscribersFilters
+      v-model:filter="filter"
+      v-model:tierFilter="tierFilter"
+      v-model:statusFilter="statusFilter"
+      v-model:startFrom="startFrom"
+      v-model:startTo="startTo"
+      v-model:nextRenewalFrom="nextRenewalFrom"
+      v-model:nextRenewalTo="nextRenewalTo"
+      v-model:monthsRemaining="monthsRemaining"
+      :tier-options="tierOptions"
+      :status-options="statusOptions"
+      :is-small-screen="isSmallScreen"
+      v-model:showFilters="showFilters"
+      @download-csv="downloadCsv"
+    />
+    <CreatorSubscribersSummary
+      :total-active-subscribers="totalActiveSubscribers"
+      :total-received-months="totalReceivedMonths"
+      :total-revenue="totalRevenue"
+      :format-currency="formatCurrency"
+    />
     <div
       v-if="selected.length"
       class="row q-gutter-sm q-mb-md"
@@ -472,6 +348,8 @@ import { useMessengerStore } from "stores/messenger";
 import { useQuasar } from "quasar";
 import profileCache from "src/js/profile-cache";
 import SubscriberProfileDialog from "./SubscriberProfileDialog.vue";
+import CreatorSubscribersFilters from "./CreatorSubscribersFilters.vue";
+import CreatorSubscribersSummary from "./CreatorSubscribersSummary.vue";
 import { useCreatorsStore } from "stores/creators";
 import { useUiStore } from "stores/ui";
 import { useMintsStore } from "stores/mints";

--- a/src/components/CreatorSubscribersFilters.vue
+++ b/src/components/CreatorSubscribersFilters.vue
@@ -1,0 +1,191 @@
+<template>
+  <div class="q-mb-md">
+    <div class="row q-gutter-sm q-mb-sm">
+      <q-btn
+        v-if="isSmallScreen"
+        flat
+        color="primary"
+        icon="filter_list"
+        label="Filters"
+        @click="showFiltersModel = !showFiltersModel"
+      />
+      <q-btn
+        flat
+        color="primary"
+        icon="download"
+        :label="t('CreatorSubscribers.actions.downloadCsv')"
+        @click="$emit('downloadCsv')"
+      />
+    </div>
+    <q-slide-transition>
+      <div v-show="!isSmallScreen || showFiltersModel" class="row q-gutter-sm">
+        <q-input
+          v-model="filterModel"
+          dense
+          outlined
+          debounce="300"
+          clearable
+          :placeholder="t('CreatorSubscribers.filter.placeholder')"
+          class="col"
+        >
+          <template #prepend>
+            <q-icon name="search" />
+          </template>
+        </q-input>
+        <q-select
+          v-model="tierFilterModel"
+          :options="tierOptions"
+          dense
+          outlined
+          clearable
+          emit-value
+          map-options
+          :label="t('CreatorSubscribers.columns.tier')"
+          class="col-3"
+        />
+        <q-select
+          v-model="statusFilterModel"
+          :options="statusOptions"
+          dense
+          outlined
+          clearable
+          :label="t('CreatorSubscribers.columns.status')"
+          class="col-3"
+        />
+        <q-input
+          v-model="startFromModel"
+          type="date"
+          dense
+          outlined
+          clearable
+          :label="t('CreatorSubscribers.filter.startFrom')"
+          class="col-3"
+        >
+          <q-tooltip>{{ t('CreatorSubscribers.startTooltip') }}</q-tooltip>
+        </q-input>
+        <q-input
+          v-model="startToModel"
+          type="date"
+          dense
+          outlined
+          clearable
+          :label="t('CreatorSubscribers.filter.startTo')"
+          class="col-3"
+        >
+          <q-tooltip>{{ t('CreatorSubscribers.startTooltip') }}</q-tooltip>
+        </q-input>
+        <q-input
+          v-model="nextRenewalFromModel"
+          type="date"
+          dense
+          outlined
+          clearable
+          :label="t('CreatorSubscribers.filter.nextRenewalFrom')"
+          class="col-3"
+        >
+          <q-tooltip>{{ t('CreatorSubscribers.nextRenewalTooltip') }}</q-tooltip>
+        </q-input>
+        <q-input
+          v-model="nextRenewalToModel"
+          type="date"
+          dense
+          outlined
+          clearable
+          :label="t('CreatorSubscribers.filter.nextRenewalTo')"
+          class="col-3"
+        >
+          <q-tooltip>{{ t('CreatorSubscribers.nextRenewalTooltip') }}</q-tooltip>
+        </q-input>
+        <q-input
+          v-model.number="monthsRemainingModel"
+          type="number"
+          dense
+          outlined
+          clearable
+          :label="t('CreatorSubscribers.filter.monthsRemaining')"
+          class="col-3"
+        >
+          <q-tooltip>{{ t('CreatorSubscribers.monthsRemainingTooltip') }}</q-tooltip>
+        </q-input>
+      </div>
+    </q-slide-transition>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, toRefs } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+const props = defineProps<{
+  filter: string;
+  tierFilter: string | null;
+  statusFilter: string | null;
+  startFrom: string | null;
+  startTo: string | null;
+  nextRenewalFrom: string | null;
+  nextRenewalTo: string | null;
+  monthsRemaining: number | null;
+  tierOptions: { label: string; value: string }[];
+  statusOptions: { label: string; value: string }[];
+  isSmallScreen: boolean;
+  showFilters: boolean;
+}>();
+
+const emit = defineEmits([
+  'update:filter',
+  'update:tierFilter',
+  'update:statusFilter',
+  'update:startFrom',
+  'update:startTo',
+  'update:nextRenewalFrom',
+  'update:nextRenewalTo',
+  'update:monthsRemaining',
+  'update:showFilters',
+  'downloadCsv',
+]);
+
+const {
+  tierOptions,
+  statusOptions,
+  isSmallScreen,
+} = toRefs(props);
+
+const filterModel = computed({
+  get: () => props.filter,
+  set: (val: string) => emit('update:filter', val),
+});
+const tierFilterModel = computed({
+  get: () => props.tierFilter,
+  set: (val: string | null) => emit('update:tierFilter', val),
+});
+const statusFilterModel = computed({
+  get: () => props.statusFilter,
+  set: (val: string | null) => emit('update:statusFilter', val),
+});
+const startFromModel = computed({
+  get: () => props.startFrom,
+  set: (val: string | null) => emit('update:startFrom', val),
+});
+const startToModel = computed({
+  get: () => props.startTo,
+  set: (val: string | null) => emit('update:startTo', val),
+});
+const nextRenewalFromModel = computed({
+  get: () => props.nextRenewalFrom,
+  set: (val: string | null) => emit('update:nextRenewalFrom', val),
+});
+const nextRenewalToModel = computed({
+  get: () => props.nextRenewalTo,
+  set: (val: string | null) => emit('update:nextRenewalTo', val),
+});
+const monthsRemainingModel = computed({
+  get: () => props.monthsRemaining,
+  set: (val: number | null) => emit('update:monthsRemaining', val),
+});
+const showFiltersModel = computed({
+  get: () => props.showFilters,
+  set: (val: boolean) => emit('update:showFilters', val),
+});
+
+const { t } = useI18n();
+</script>

--- a/src/components/CreatorSubscribersSummary.vue
+++ b/src/components/CreatorSubscribersSummary.vue
@@ -1,0 +1,45 @@
+<template>
+  <div class="row q-col-gutter-md q-mb-md">
+    <div class="col-12 col-sm-4">
+      <q-card flat bordered class="q-pa-sm text-center">
+        <div class="text-h6">{{ totalActiveSubscribers }}</div>
+        <div class="text-caption">
+          {{ t('CreatorSubscribers.summary.activeSubscribers') }}
+        </div>
+      </q-card>
+    </div>
+    <div class="col-12 col-sm-4">
+      <q-card flat bordered class="q-pa-sm text-center">
+        <div class="text-h6">{{ totalReceivedMonths }}</div>
+        <div class="text-caption">
+          {{ t('CreatorSubscribers.summary.receivedMonths') }}
+        </div>
+      </q-card>
+    </div>
+    <div class="col-12 col-sm-4">
+      <q-card flat bordered class="q-pa-sm text-center">
+        <div class="text-h6">{{ formatCurrency(totalRevenue) }}</div>
+        <div class="text-caption">
+          {{ t('CreatorSubscribers.summary.revenue') }}
+        </div>
+      </q-card>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { toRefs } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+const props = defineProps<{
+  totalActiveSubscribers: number;
+  totalReceivedMonths: number;
+  totalRevenue: number;
+  formatCurrency: (amount: number) => string;
+}>();
+
+const { totalActiveSubscribers, totalReceivedMonths, totalRevenue } = toRefs(props);
+const formatCurrency = props.formatCurrency;
+
+const { t } = useI18n();
+</script>

--- a/src/components/__tests__/CreatorSubscribers.spec.ts
+++ b/src/components/__tests__/CreatorSubscribers.spec.ts
@@ -101,6 +101,8 @@ vi.mock('nostr-tools', () => ({
 }));
 
 import CreatorSubscribers from '../CreatorSubscribers.vue';
+import CreatorSubscribersFilters from '../CreatorSubscribersFilters.vue';
+import CreatorSubscribersSummary from '../CreatorSubscribersSummary.vue';
 
 describe('CreatorSubscribers.vue', () => {
   beforeEach(() => {
@@ -180,5 +182,35 @@ describe('CreatorSubscribers.vue', () => {
     expect(messenger.sendDm).toHaveBeenCalledTimes(2);
     expect(qMock.notify).toHaveBeenCalled();
     expect(wrapper.vm.selected).toHaveLength(0);
+  });
+
+  it('mounts filter and summary components', () => {
+    const filtersWrapper = mount(CreatorSubscribersFilters, {
+      props: {
+        filter: '',
+        tierFilter: null,
+        statusFilter: null,
+        startFrom: null,
+        startTo: null,
+        nextRenewalFrom: null,
+        nextRenewalTo: null,
+        monthsRemaining: null,
+        tierOptions: [],
+        statusOptions: [],
+        isSmallScreen: false,
+        showFilters: true,
+      },
+    });
+    expect(filtersWrapper.exists()).toBe(true);
+
+    const summaryWrapper = mount(CreatorSubscribersSummary, {
+      props: {
+        totalActiveSubscribers: 1,
+        totalReceivedMonths: 2,
+        totalRevenue: 3,
+        formatCurrency: (a: number) => `${a}`,
+      },
+    });
+    expect(summaryWrapper.exists()).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- refactor CreatorSubscribers layout by using dedicated filter and summary components
- cover new CreatorSubscribersFilters and CreatorSubscribersSummary in tests

## Testing
- `npm test` *(fails: 17 failed, 16 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689316fd25c48330b5e98ef26237d56a