### PR TITLE
Refactor profile fetching with concurrency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "light-bolt11-decoder": "^3.1.1",
         "lucide-vue-next": "^0.453.0",
         "nostr-tools": "^2.5.0",
+        "p-limit": "^3.1.0",
         "pinia": "^2.1.7",
         "qr-scanner": "^1.4.2",
         "qrcode": "^1.5.3",
@@ -49,6 +50,7 @@
         "@noble/curves": "^1.9.6",
         "@noble/secp256k1": "^2.3.0",
         "@quasar/app-vite": "^2.3.0",
+        "@quasar/vite-plugin": "^1.10.0",
         "@types/node": "^20.12.11",
         "@types/uuid": "^10.0.0",
         "@typescript-eslint/eslint-plugin": "^5.62.0",
@@ -17845,7 +17847,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -24886,7 +24887,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "light-bolt11-decoder": "^3.1.1",
     "lucide-vue-next": "^0.453.0",
     "nostr-tools": "^2.5.0",
+    "p-limit": "^3.1.0",
     "pinia": "^2.1.7",
     "qr-scanner": "^1.4.2",
     "qrcode": "^1.5.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,9 @@ importers:
       nostr-tools:
         specifier: ^2.5.0
         version: 2.15.0(typescript@5.8.3)
+      p-limit:
+        specifier: ^3.1.0
+        version: 3.1.0
       pinia:
         specifier: ^2.1.7
         version: 2.3.1(typescript@5.8.3)(vue@3.5.17(typescript@5.8.3))
@@ -128,7 +131,7 @@ importers:
         version: 2.3.0(@types/node@20.19.1)(eslint@8.57.1)(pinia@2.3.1(typescript@5.8.3)(vue@3.5.17(typescript@5.8.3)))(quasar@2.18.1)(rollup@2.79.2)(sass@1.89.2)(terser@5.43.0)(typescript@5.8.3)(vue-router@4.5.1(vue@3.5.17(typescript@5.8.3)))(vue@3.5.17(typescript@5.8.3))(workbox-build@6.6.1)
       '@quasar/vite-plugin':
         specifier: ^1.10.0
-        version: 1.10.0(@vitejs/plugin-vue@6.0.1(vite@5.4.19(@types/node@20.19.1)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.0))(vue@3.5.17(typescript@5.8.3)))(quasar@2.18.1)(vite@5.4.19(@types/node@20.19.1)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.0))(vue@3.5.17(typescript@5.8.3))
+        version: 1.10.0(@vitejs/plugin-vue@6.0.1(vite@6.3.5(@types/node@20.19.1)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.0))(vue@3.5.17(typescript@5.8.3)))(quasar@2.18.1)(vite@6.3.5(@types/node@20.19.1)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.0))(vue@3.5.17(typescript@5.8.3))
       '@types/node':
         specifier: ^20.12.11
         version: 20.19.1
@@ -143,7 +146,7 @@ importers:
         version: 5.62.0(eslint@8.57.1)(typescript@5.8.3)
       '@vitejs/plugin-vue':
         specifier: ^6.0.1
-        version: 6.0.1(vite@5.4.19(@types/node@20.19.1)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.0))(vue@3.5.17(typescript@5.8.3))
+        version: 6.0.1(vite@6.3.5(@types/node@20.19.1)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.0))(vue@3.5.17(typescript@5.8.3))
       '@vitest/ui':
         specifier: ^3.2.4
         version: 3.2.4(vitest@3.2.4)
@@ -8580,11 +8583,11 @@ snapshots:
       vite: 6.3.5(@types/node@20.19.1)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.0)
       vue: 3.5.17(typescript@5.8.3)
 
-  '@quasar/vite-plugin@1.10.0(@vitejs/plugin-vue@6.0.1(vite@5.4.19(@types/node@20.19.1)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.0))(vue@3.5.17(typescript@5.8.3)))(quasar@2.18.1)(vite@5.4.19(@types/node@20.19.1)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.0))(vue@3.5.17(typescript@5.8.3))':
+  '@quasar/vite-plugin@1.10.0(@vitejs/plugin-vue@6.0.1(vite@6.3.5(@types/node@20.19.1)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.0))(vue@3.5.17(typescript@5.8.3)))(quasar@2.18.1)(vite@6.3.5(@types/node@20.19.1)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.0))(vue@3.5.17(typescript@5.8.3))':
     dependencies:
-      '@vitejs/plugin-vue': 6.0.1(vite@5.4.19(@types/node@20.19.1)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.0))(vue@3.5.17(typescript@5.8.3))
+      '@vitejs/plugin-vue': 6.0.1(vite@6.3.5(@types/node@20.19.1)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.0))(vue@3.5.17(typescript@5.8.3))
       quasar: 2.18.1
-      vite: 5.4.19(@types/node@20.19.1)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.0)
+      vite: 6.3.5(@types/node@20.19.1)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.0)
       vue: 3.5.17(typescript@5.8.3)
 
   '@rolldown/pluginutils@1.0.0-beta.29': {}
@@ -9003,10 +9006,10 @@ snapshots:
       vite: 6.3.5(@types/node@20.19.1)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.0)
       vue: 3.5.17(typescript@5.8.3)
 
-  '@vitejs/plugin-vue@6.0.1(vite@5.4.19(@types/node@20.19.1)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.0))(vue@3.5.17(typescript@5.8.3))':
+  '@vitejs/plugin-vue@6.0.1(vite@6.3.5(@types/node@20.19.1)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.0))(vue@3.5.17(typescript@5.8.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-beta.29
-      vite: 5.4.19(@types/node@20.19.1)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.0)
+      vite: 6.3.5(@types/node@20.19.1)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.0)
       vue: 3.5.17(typescript@5.8.3)
 
   '@vitest/expect@3.2.4':


### PR DESCRIPTION
## Summary
- fetch missing subscriber profiles concurrently with p-limit
- log profile fetch errors and mark profiles to avoid retries
- add p-limit dependency

## Testing
- `npm run lint -- src/components/CreatorSubscribers.vue` *(fails: Invalid option '--ext')*
- `npm test` *(fails: e.g., messenger.addIncomingMessage invalid JSON)*

------
https://chatgpt.com/codex/tasks/task_e_68931c6d16d083309668f4c104591ee8