### PR TITLE
fix: handle zero totalMonths in sorting

### DIFF
--- a/src/components/CreatorSubscribers.vue
+++ b/src/components/CreatorSubscribers.vue
@@ -441,8 +441,8 @@ const columns = computed(() => [
     align: "center",
     sortable: true,
     sort: (a, b, rowA, rowB) =>
-      rowA.receivedMonths / rowA.totalMonths -
-      rowB.receivedMonths / rowB.totalMonths,
+      rowA.receivedMonths / (rowA.totalMonths || 1) -
+      rowB.receivedMonths / (rowB.totalMonths || 1),
   },
   {
     name: "remaining",

--- a/src/components/__tests__/CreatorSubscribers.spec.ts
+++ b/src/components/__tests__/CreatorSubscribers.spec.ts
@@ -175,6 +175,34 @@ describe('CreatorSubscribers.vue', () => {
     expect(rows[0].text()).toContain('Bob');
   });
 
+  it('sorts rows predictably when totalMonths is zero', async () => {
+    subscriptions.value.push({
+      subscriptionId: 'sub3',
+      subscriberNpub: 'pk3',
+      tierName: 'Bronze',
+      startDate: 1,
+      nextRenewal: 2,
+      receivedMonths: 1,
+      totalMonths: 0,
+      totalAmount: 500,
+      status: 'active',
+    });
+
+    const wrapper = mount(CreatorSubscribers);
+    await nextTick();
+
+    const monthsCol = wrapper.vm.columns.find((c: any) => c.name === 'months');
+    const sorted = subscriptions.value
+      .slice()
+      .sort((a, b) => monthsCol.sort(a.receivedMonths, b.receivedMonths, a, b));
+
+    expect(sorted.map((r: any) => r.subscriptionId)).toEqual([
+      'sub1',
+      'sub2',
+      'sub3',
+    ]);
+  });
+
   it('sends messages via actions', async () => {
     const wrapper = mount(CreatorSubscribers);
     await nextTick();


### PR DESCRIPTION
## Summary
- ensure CreatorSubscribers months column sorts even when totalMonths is zero
- add unit test covering zero totalMonths sorting

## Testing
- `npm test` *(fails: vitest mock errors and other existing test failures)*
- `npx vitest run src/components/__tests__/CreatorSubscribers.spec.ts -t "sorts rows predictably when totalMonths is zero"`

------
https://chatgpt.com/codex/tasks/task_e_689328b116d08330bd8fd11e9dd00cb7