### PR TITLE
feat: show follower stats for subscribers

### DIFF
--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -1594,6 +1594,9 @@ export default {
     columns: {
       subscriber: "Subscriber",
       tier: "Tier",
+      followers: "Followers",
+      following: "Following",
+      latestNote: "Latest note",
       start: "Start",
       nextRenewal: "Next renewal",
       months: "Months",

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -1600,6 +1600,9 @@ export default {
     columns: {
       subscriber: "Subscriber",
       tier: "Tier",
+      followers: "Followers",
+      following: "Following",
+      latestNote: "Latest note",
       start: "Start",
       nextRenewal: "Next renewal",
       months: "Months",

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -1604,6 +1604,9 @@ export default {
     columns: {
       subscriber: "Subscriber",
       tier: "Tier",
+      followers: "Followers",
+      following: "Following",
+      latestNote: "Latest note",
       start: "Start",
       nextRenewal: "Next renewal",
       months: "Months",

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1651,6 +1651,9 @@ export const messages = {
     columns: {
       subscriber: "Subscriber",
       tier: "Tier",
+      followers: "Followers",
+      following: "Following",
+      latestNote: "Latest note",
       start: "Start",
       nextRenewal: "Next renewal",
       months: "Months",

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -1601,6 +1601,9 @@ export default {
     columns: {
       subscriber: "Subscriber",
       tier: "Tier",
+      followers: "Followers",
+      following: "Following",
+      latestNote: "Latest note",
       start: "Start",
       nextRenewal: "Next renewal",
       months: "Months",

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -1591,6 +1591,9 @@ export default {
     columns: {
       subscriber: "Subscriber",
       tier: "Tier",
+      followers: "Followers",
+      following: "Following",
+      latestNote: "Latest note",
       start: "Start",
       nextRenewal: "Next renewal",
       months: "Months",

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -1583,6 +1583,9 @@ export default {
     columns: {
       subscriber: "Subscriber",
       tier: "Tier",
+      followers: "Followers",
+      following: "Following",
+      latestNote: "Latest note",
       start: "Start",
       nextRenewal: "Next renewal",
       months: "Months",

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -1584,6 +1584,9 @@ export default {
     columns: {
       subscriber: "Subscriber",
       tier: "Tier",
+      followers: "Followers",
+      following: "Following",
+      latestNote: "Latest note",
       start: "Start",
       nextRenewal: "Next renewal",
       months: "Months",

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -1583,6 +1583,9 @@ export default {
     columns: {
       subscriber: "Subscriber",
       tier: "Tier",
+      followers: "Followers",
+      following: "Following",
+      latestNote: "Latest note",
       start: "Start",
       nextRenewal: "Next renewal",
       months: "Months",

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -1581,6 +1581,9 @@ export default {
     columns: {
       subscriber: "Subscriber",
       tier: "Tier",
+      followers: "Followers",
+      following: "Following",
+      latestNote: "Latest note",
       start: "Start",
       nextRenewal: "Next renewal",
       months: "Months",

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -1586,6 +1586,9 @@ export default {
     columns: {
       subscriber: "Subscriber",
       tier: "Tier",
+      followers: "Followers",
+      following: "Following",
+      latestNote: "Latest note",
       start: "Start",
       nextRenewal: "Next renewal",
       months: "Months",

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -1573,6 +1573,9 @@ export default {
     columns: {
       subscriber: "Subscriber",
       tier: "Tier",
+      followers: "Followers",
+      following: "Following",
+      latestNote: "Latest note",
       start: "Start",
       nextRenewal: "Next renewal",
       months: "Months",


### PR DESCRIPTION
## Summary
- show follower/following counts and latest note in CreatorSubscribers table
- localize new column headers

## Testing
- `npm test` *(fails: Tests failed. Watching for file changes...)*
- `npm run lint` *(fails: Invalid option '--ext' - perhaps you meant '-c'?)*

------
https://chatgpt.com/codex/tasks/task_e_689333ff262483308e830e0e22ac6969