### PR TITLE
feat: add subscriber filter menu

### DIFF
--- a/src/components/CreatorSubscribers.vue
+++ b/src/components/CreatorSubscribers.vue
@@ -1,7 +1,6 @@
 <template>
   <div>
     <CreatorSubscribersFilters
-      v-model:filter="filter"
       v-model:tierFilter="tierFilter"
       v-model:statusFilter="statusFilter"
       v-model:startFrom="startFrom"
@@ -9,6 +8,7 @@
       v-model:nextRenewalFrom="nextRenewalFrom"
       v-model:nextRenewalTo="nextRenewalTo"
       v-model:monthsRemaining="monthsRemaining"
+      v-model:frequencyFilter="frequencyFilter"
       :tier-options="tierOptions"
       :status-options="statusOptions"
       :is-small-screen="isSmallScreen"
@@ -120,12 +120,20 @@ const { activeUnit } = storeToRefs(mints);
 const nostr = useNostrStore();
 
 const isSmallScreen = computed(() => $q.screen.lt.md);
-const showFilters = ref(!isSmallScreen.value);
-watch(isSmallScreen, (val) => {
-  showFilters.value = !val;
-});
 
-const filter = ref("");
+const props = withDefaults(
+  defineProps<{ filter?: string; showFilters?: boolean }>(),
+  { filter: "", showFilters: false }
+);
+const emit = defineEmits(["update:filter", "update:showFilters"]);
+const filter = computed({
+  get: () => props.filter,
+  set: (val: string) => emit("update:filter", val),
+});
+const showFilters = computed({
+  get: () => props.showFilters,
+  set: (val: boolean) => emit("update:showFilters", val),
+});
 const tierFilter = ref<string | null>(null);
 const statusFilter = ref<string | null>(null);
 const startFrom = ref<string | null>(null);
@@ -133,6 +141,7 @@ const startTo = ref<string | null>(null);
 const nextRenewalFrom = ref<string | null>(null);
 const nextRenewalTo = ref<string | null>(null);
 const monthsRemaining = ref<number | null>(null);
+const frequencyFilter = ref<string | null>(null);
 
 function dateStringToTs(val: string | null): number | null {
   return val ? Math.floor(new Date(val).getTime() / 1000) : null;
@@ -189,6 +198,7 @@ const filteredSubscriptions = computed(() =>
       matchesText &&
       (!tierFilter.value || s.tierName === tierFilter.value) &&
       (!statusFilter.value || s.status === statusFilter.value) &&
+      (!frequencyFilter.value || s.frequency === frequencyFilter.value) &&
       (!startFromTs.value || start >= startFromTs.value) &&
       (!startToTs.value || start <= startToTs.value) &&
       (!nextRenewalFromTs.value || next >= nextRenewalFromTs.value) &&

--- a/src/components/CreatorSubscribersFilters.vue
+++ b/src/components/CreatorSubscribersFilters.vue
@@ -1,37 +1,12 @@
 <template>
-  <div class="q-mb-md">
-    <div class="row q-gutter-sm q-mb-sm">
-      <q-btn
-        v-if="isSmallScreen"
-        flat
-        color="primary"
-        icon="filter_list"
-        label="Filters"
-        @click="showFiltersModel = !showFiltersModel"
-      />
-      <q-btn
-        flat
-        color="primary"
-        icon="download"
-        :label="t('CreatorSubscribers.actions.downloadCsv')"
-        @click="$emit('downloadCsv')"
-      />
-    </div>
-    <q-slide-transition>
-      <div v-show="!isSmallScreen || showFiltersModel" class="row q-gutter-sm">
-        <q-input
-          v-model="filterModel"
-          dense
-          outlined
-          debounce="300"
-          clearable
-          :placeholder="t('CreatorSubscribers.filter.placeholder')"
-          class="col"
-        >
-          <template #prepend>
-            <q-icon name="search" />
-          </template>
-        </q-input>
+  <q-dialog v-model="showFiltersModel" position="right" :maximized="isSmallScreen">
+    <q-card style="min-width: 250px">
+      <q-card-section class="row items-center q-pb-none">
+        <div class="text-h6">Filters</div>
+        <q-space />
+        <q-btn icon="close" flat round dense v-close-popup />
+      </q-card-section>
+      <q-card-section class="column q-gutter-sm">
         <q-select
           v-model="tierFilterModel"
           :options="tierOptions"
@@ -41,7 +16,6 @@
           emit-value
           map-options
           :label="t('CreatorSubscribers.columns.tier')"
-          class="col-3"
         />
         <q-select
           v-model="statusFilterModel"
@@ -50,7 +24,16 @@
           outlined
           clearable
           :label="t('CreatorSubscribers.columns.status')"
-          class="col-3"
+        />
+        <q-select
+          v-model="frequencyFilterModel"
+          :options="frequencyOptions"
+          dense
+          outlined
+          clearable
+          emit-value
+          map-options
+          :label="t('CreatorSubscribers.filter.frequency')"
         />
         <q-input
           v-model="startFromModel"
@@ -59,7 +42,6 @@
           outlined
           clearable
           :label="t('CreatorSubscribers.filter.startFrom')"
-          class="col-3"
         >
           <q-tooltip>{{ t('CreatorSubscribers.startTooltip') }}</q-tooltip>
         </q-input>
@@ -70,7 +52,6 @@
           outlined
           clearable
           :label="t('CreatorSubscribers.filter.startTo')"
-          class="col-3"
         >
           <q-tooltip>{{ t('CreatorSubscribers.startTooltip') }}</q-tooltip>
         </q-input>
@@ -81,7 +62,6 @@
           outlined
           clearable
           :label="t('CreatorSubscribers.filter.nextRenewalFrom')"
-          class="col-3"
         >
           <q-tooltip>{{ t('CreatorSubscribers.nextRenewalTooltip') }}</q-tooltip>
         </q-input>
@@ -92,7 +72,6 @@
           outlined
           clearable
           :label="t('CreatorSubscribers.filter.nextRenewalTo')"
-          class="col-3"
         >
           <q-tooltip>{{ t('CreatorSubscribers.nextRenewalTooltip') }}</q-tooltip>
         </q-input>
@@ -103,13 +82,19 @@
           outlined
           clearable
           :label="t('CreatorSubscribers.filter.monthsRemaining')"
-          class="col-3"
         >
           <q-tooltip>{{ t('CreatorSubscribers.monthsRemainingTooltip') }}</q-tooltip>
         </q-input>
-      </div>
-    </q-slide-transition>
-  </div>
+        <q-btn
+          flat
+          color="primary"
+          icon="download"
+          :label="t('CreatorSubscribers.actions.downloadCsv')"
+          @click="$emit('downloadCsv')"
+        />
+      </q-card-section>
+    </q-card>
+  </q-dialog>
 </template>
 
 <script setup lang="ts">
@@ -117,7 +102,6 @@ import { computed, toRefs } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 const props = defineProps<{
-  filter: string;
   tierFilter: string | null;
   statusFilter: string | null;
   startFrom: string | null;
@@ -125,6 +109,7 @@ const props = defineProps<{
   nextRenewalFrom: string | null;
   nextRenewalTo: string | null;
   monthsRemaining: number | null;
+  frequencyFilter: string | null;
   tierOptions: { label: string; value: string }[];
   statusOptions: { label: string; value: string }[];
   isSmallScreen: boolean;
@@ -132,7 +117,6 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits([
-  'update:filter',
   'update:tierFilter',
   'update:statusFilter',
   'update:startFrom',
@@ -140,6 +124,7 @@ const emit = defineEmits([
   'update:nextRenewalFrom',
   'update:nextRenewalTo',
   'update:monthsRemaining',
+  'update:frequencyFilter',
   'update:showFilters',
   'downloadCsv',
 ]);
@@ -150,10 +135,6 @@ const {
   isSmallScreen,
 } = toRefs(props);
 
-const filterModel = computed({
-  get: () => props.filter,
-  set: (val: string) => emit('update:filter', val),
-});
 const tierFilterModel = computed({
   get: () => props.tierFilter,
   set: (val: string | null) => emit('update:tierFilter', val),
@@ -161,6 +142,10 @@ const tierFilterModel = computed({
 const statusFilterModel = computed({
   get: () => props.statusFilter,
   set: (val: string | null) => emit('update:statusFilter', val),
+});
+const frequencyFilterModel = computed({
+  get: () => props.frequencyFilter,
+  set: (val: string | null) => emit('update:frequencyFilter', val),
 });
 const startFromModel = computed({
   get: () => props.startFrom,
@@ -187,5 +172,12 @@ const showFiltersModel = computed({
   set: (val: boolean) => emit('update:showFilters', val),
 });
 
+const frequencyOptions = [
+  { label: 'Weekly', value: 'weekly' },
+  { label: 'Twice Monthly', value: 'biweekly' },
+  { label: 'Monthly', value: 'monthly' },
+];
+
 const { t } = useI18n();
 </script>
+

--- a/src/components/__tests__/CreatorSubscribers.spec.ts
+++ b/src/components/__tests__/CreatorSubscribers.spec.ts
@@ -212,7 +212,6 @@ describe("CreatorSubscribers.vue", () => {
   it("mounts filter and summary components", () => {
     const filtersWrapper = mount(CreatorSubscribersFilters, {
       props: {
-        filter: "",
         tierFilter: null,
         statusFilter: null,
         startFrom: null,
@@ -220,6 +219,7 @@ describe("CreatorSubscribers.vue", () => {
         nextRenewalFrom: null,
         nextRenewalTo: null,
         monthsRemaining: null,
+        frequencyFilter: null,
         tierOptions: [],
         statusOptions: [],
         isSmallScreen: false,

--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -1590,6 +1590,7 @@ export default {
       nextRenewalFrom: "Next renewal from",
       nextRenewalTo: "Next renewal to",
       monthsRemaining: "Months remaining",
+      frequency: "تصفية حسب التكرار",
     },
     columns: {
       subscriber: "Subscriber",

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -1596,6 +1596,7 @@ export default {
       nextRenewalFrom: "Next renewal from",
       nextRenewalTo: "Next renewal to",
       monthsRemaining: "Months remaining",
+      frequency: "Nach Frequenz filtern",
     },
     columns: {
       subscriber: "Subscriber",

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -1600,6 +1600,7 @@ export default {
       nextRenewalFrom: "Next renewal from",
       nextRenewalTo: "Next renewal to",
       monthsRemaining: "Months remaining",
+      frequency: "Φιλτράρισμα ανά συχνότητα",
     },
     columns: {
       subscriber: "Subscriber",

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1647,6 +1647,7 @@ export const messages = {
       nextRenewalFrom: "Next renewal from",
       nextRenewalTo: "Next renewal to",
       monthsRemaining: "Months remaining",
+      frequency: "Frequency",
     },
     columns: {
       subscriber: "Subscriber",

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -1597,6 +1597,7 @@ export default {
       nextRenewalFrom: "Next renewal from",
       nextRenewalTo: "Next renewal to",
       monthsRemaining: "Months remaining",
+      frequency: "Filtrar por frecuencia",
     },
     columns: {
       subscriber: "Subscriber",

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -1587,6 +1587,7 @@ export default {
       nextRenewalFrom: "Next renewal from",
       nextRenewalTo: "Next renewal to",
       monthsRemaining: "Months remaining",
+      frequency: "Filtrer par fréquence",
     },
     columns: {
       subscriber: "Subscriber",

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -1579,6 +1579,7 @@ export default {
       nextRenewalFrom: "Next renewal from",
       nextRenewalTo: "Next renewal to",
       monthsRemaining: "Months remaining",
+      frequency: "Filtra per frequenza",
     },
     columns: {
       subscriber: "Subscriber",

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -1580,6 +1580,7 @@ export default {
       nextRenewalFrom: "Next renewal from",
       nextRenewalTo: "Next renewal to",
       monthsRemaining: "Months remaining",
+      frequency: "頻度でフィルタ",
     },
     columns: {
       subscriber: "Subscriber",

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -1579,6 +1579,7 @@ export default {
       nextRenewalFrom: "Next renewal from",
       nextRenewalTo: "Next renewal to",
       monthsRemaining: "Months remaining",
+      frequency: "Filtrera efter frekvens",
     },
     columns: {
       subscriber: "Subscriber",

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -1577,6 +1577,7 @@ export default {
       nextRenewalFrom: "Next renewal from",
       nextRenewalTo: "Next renewal to",
       monthsRemaining: "Months remaining",
+      frequency: "กรองตามความถี่",
     },
     columns: {
       subscriber: "Subscriber",

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -1582,6 +1582,7 @@ export default {
       nextRenewalFrom: "Next renewal from",
       nextRenewalTo: "Next renewal to",
       monthsRemaining: "Months remaining",
+      frequency: "Sıklığa göre filtrele",
     },
     columns: {
       subscriber: "Subscriber",

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -1569,6 +1569,7 @@ export default {
       nextRenewalFrom: "Next renewal from",
       nextRenewalTo: "Next renewal to",
       monthsRemaining: "Months remaining",
+      frequency: "按频率筛选",
     },
     columns: {
       subscriber: "Subscriber",

--- a/src/pages/CreatorSubscribersPage.vue
+++ b/src/pages/CreatorSubscribersPage.vue
@@ -1,6 +1,6 @@
 <template>
   <q-page class="q-pa-md">
-    <div class="row items-center q-mb-md">
+    <q-toolbar class="q-mb-md q-gutter-sm" style="flex-wrap: wrap">
       <q-btn
         flat
         round
@@ -10,14 +10,39 @@
         aria-label="Go back"
         class="q-mr-sm"
       />
-      <h5 class="q-my-none">My Subscribers ({{ count }})</h5>
-    </div>
-    <CreatorSubscribers />
+      <q-toolbar-title>My Subscribers ({{ count }})</q-toolbar-title>
+      <q-space />
+      <q-input
+        v-model="filter"
+        dense
+        outlined
+        debounce="300"
+        clearable
+        placeholder="Search"
+        class="q-mr-sm"
+        style="flex: 1 1 200px; max-width: 300px"
+      >
+        <template #prepend>
+          <q-icon name="search" />
+        </template>
+      </q-input>
+      <q-btn
+        flat
+        color="primary"
+        icon="filter_list"
+        label="Filters"
+        @click="showFilters = true"
+      />
+    </q-toolbar>
+    <CreatorSubscribers
+      v-model:filter="filter"
+      v-model:showFilters="showFilters"
+    />
   </q-page>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 import { storeToRefs } from 'pinia';
 import CreatorSubscribers from 'components/CreatorSubscribers.vue';
 import { useCreatorSubscriptionsStore } from 'stores/creatorSubscriptions';
@@ -25,4 +50,7 @@ import { useCreatorSubscriptionsStore } from 'stores/creatorSubscriptions';
 const creatorSubscriptionsStore = useCreatorSubscriptionsStore();
 const { subscriptions } = storeToRefs(creatorSubscriptionsStore);
 const count = computed(() => subscriptions.value.length);
+
+const filter = ref('');
+const showFilters = ref(false);
 </script>


### PR DESCRIPTION
## Summary
- add top toolbar with search and filters to subscribers page
- move advanced filters into dialog with new frequency option
- wire CreatorSubscribers component to external search and frequency filter

## Testing
- `npm test` *(fails: multiple suites such as bucketDialog.spec.ts and wallet.test.ts)*
- `npx eslint --ext .js,.vue ./` *(fails: CreatorSubscribers.spec.ts and others)*

------
https://chatgpt.com/codex/tasks/task_e_68936a8a41e48330b39691b0473274f9