### PR TITLE
feat: add subscriber status donut chart

### DIFF
--- a/src/components/CreatorSubscribers.vue
+++ b/src/components/CreatorSubscribers.vue
@@ -16,7 +16,8 @@
       @download-csv="downloadCsv"
     />
     <CreatorSubscribersSummary
-      :total-active-subscribers="totalActiveSubscribers"
+      :active-count="totalActiveSubscribers"
+      :pending-count="totalPendingSubscribers"
       :total-received-periods="totalReceivedPeriods"
       :total-revenue="totalRevenue"
       :format-currency="formatCurrency"
@@ -210,6 +211,9 @@ const filteredSubscriptions = computed(() =>
 
 const totalActiveSubscribers = computed(
   () => filteredSubscriptions.value.filter((s) => s.status === "active").length
+);
+const totalPendingSubscribers = computed(
+  () => filteredSubscriptions.value.filter((s) => s.status === "pending").length
 );
 const totalReceivedPeriods = computed(() =>
   filteredSubscriptions.value.reduce((sum, s) => sum + s.receivedPeriods, 0)

--- a/src/components/CreatorSubscribersSummary.vue
+++ b/src/components/CreatorSubscribersSummary.vue
@@ -2,44 +2,105 @@
   <div class="row q-col-gutter-md q-mb-md">
     <div class="col-12 col-sm-4">
       <q-card flat bordered class="q-pa-sm text-center">
-        <div class="text-h6">{{ totalActiveSubscribers }}</div>
-        <div class="text-caption">
-          {{ t('CreatorSubscribers.summary.activeSubscribers') }}
+        <div class="row items-center justify-center q-mb-sm">
+          <q-icon name="group" size="sm" class="q-mr-xs" />
+          <span class="text-weight-bold">
+            {{ t('CreatorSubscribers.summary.subscribers') }}
+          </span>
+        </div>
+        <div class="flex justify-center q-mb-sm">
+          <svg width="60" height="60" viewBox="0 0 36 36" class="donut">
+            <circle
+              class="text-warning"
+              stroke="currentColor"
+              stroke-width="3.8"
+              fill="transparent"
+              cx="18"
+              cy="18"
+              r="15.9155"
+              stroke-dasharray="100 0"
+            />
+            <circle
+              class="text-positive"
+              stroke="currentColor"
+              stroke-width="3.8"
+              fill="transparent"
+              cx="18"
+              cy="18"
+              r="15.9155"
+              :stroke-dasharray="`${activePercent} ${100 - activePercent}`"
+              stroke-dashoffset="25"
+            />
+          </svg>
+        </div>
+        <div class="row justify-center q-gutter-sm text-caption">
+          <div class="row items-center">
+            <q-icon name="circle" size="xs" color="positive" class="q-mr-xs" />
+            <span>{{ t('CreatorSubscribers.summary.active') }}: {{ activeCount }}</span>
+          </div>
+          <div class="row items-center">
+            <q-icon name="circle" size="xs" color="warning" class="q-mr-xs" />
+            <span>{{ t('CreatorSubscribers.summary.pending') }}: {{ pendingCount }}</span>
+          </div>
         </div>
       </q-card>
     </div>
     <div class="col-12 col-sm-4">
       <q-card flat bordered class="q-pa-sm text-center">
+        <div class="row items-center justify-center q-mb-sm">
+          <q-icon name="event" size="sm" class="q-mr-xs" />
+          <span class="text-weight-bold">
+            {{ t('CreatorSubscribers.summary.receivedPeriods') }}
+          </span>
+        </div>
         <div class="text-h6">{{ totalReceivedPeriods }}</div>
-        <div class="text-caption">
-          {{ t('CreatorSubscribers.summary.receivedPeriods') }}
-        </div>
       </q-card>
     </div>
     <div class="col-12 col-sm-4">
       <q-card flat bordered class="q-pa-sm text-center">
-        <div class="text-h6">{{ formatCurrency(totalRevenue) }}</div>
-        <div class="text-caption">
-          {{ t('CreatorSubscribers.summary.revenue') }}
+        <div class="row items-center justify-center q-mb-sm">
+          <q-icon name="attach_money" size="sm" class="q-mr-xs" />
+          <span class="text-weight-bold">
+            {{ t('CreatorSubscribers.summary.revenue') }}
+          </span>
         </div>
+        <div class="text-h6">{{ formatCurrency(totalRevenue) }}</div>
       </q-card>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { toRefs } from 'vue';
+import { toRefs, computed } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 const props = defineProps<{
-  totalActiveSubscribers: number;
+  activeCount: number;
+  pendingCount: number;
   totalReceivedPeriods: number;
   totalRevenue: number;
   formatCurrency: (amount: number) => string;
 }>();
 
-const { totalActiveSubscribers, totalReceivedPeriods, totalRevenue } = toRefs(props);
+const {
+  activeCount,
+  pendingCount,
+  totalReceivedPeriods,
+  totalRevenue,
+} = toRefs(props);
 const formatCurrency = props.formatCurrency;
+
+const total = computed(() => activeCount.value + pendingCount.value);
+const activePercent = computed(() => {
+  const totalVal = total.value;
+  return totalVal ? (activeCount.value / totalVal) * 100 : 0;
+});
 
 const { t } = useI18n();
 </script>
+
+<style scoped>
+.donut {
+  max-width: 60px;
+}
+</style>

--- a/src/components/__tests__/CreatorSubscribers.spec.ts
+++ b/src/components/__tests__/CreatorSubscribers.spec.ts
@@ -230,7 +230,8 @@ describe("CreatorSubscribers.vue", () => {
 
     const summaryWrapper = mount(CreatorSubscribersSummary, {
       props: {
-        totalActiveSubscribers: 1,
+        activeCount: 1,
+        pendingCount: 1,
         totalReceivedPeriods: 2,
         totalRevenue: 3,
         formatCurrency: (a: number) => `${a}`,

--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -1617,7 +1617,9 @@ export default {
       pending: "معلق",
     },
     summary: {
-      activeSubscribers: "Active subscribers",
+      subscribers: "Subscribers",
+      active: "Active",
+      pending: "Pending",
       receivedPeriods: "Received months",
       revenue: "Revenue",
     },

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -1623,7 +1623,9 @@ export default {
       pending: "Ausstehend",
     },
     summary: {
-      activeSubscribers: "Active subscribers",
+      subscribers: "Subscribers",
+      active: "Active",
+      pending: "Pending",
       receivedPeriods: "Received months",
       revenue: "Revenue",
     },

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -1627,7 +1627,9 @@ export default {
       pending: "Σε εκκρεμότητα",
     },
     summary: {
-      activeSubscribers: "Active subscribers",
+      subscribers: "Subscribers",
+      active: "Active",
+      pending: "Pending",
       receivedPeriods: "Received months",
       revenue: "Revenue",
     },

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1674,7 +1674,9 @@ export const messages = {
       pending: "Pending",
     },
     summary: {
-      activeSubscribers: "Active subscribers",
+      subscribers: "Subscribers",
+      active: "Active",
+      pending: "Pending",
       receivedPeriods: "Received months",
       revenue: "Revenue",
     },

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -1624,7 +1624,9 @@ export default {
       pending: "Pendiente",
     },
     summary: {
-      activeSubscribers: "Active subscribers",
+      subscribers: "Subscribers",
+      active: "Active",
+      pending: "Pending",
       receivedPeriods: "Received months",
       revenue: "Revenue",
     },

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -1614,7 +1614,9 @@ export default {
       pending: "En attente",
     },
     summary: {
-      activeSubscribers: "Active subscribers",
+      subscribers: "Subscribers",
+      active: "Active",
+      pending: "Pending",
       receivedPeriods: "Received months",
       revenue: "Revenue",
     },

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -1606,7 +1606,9 @@ export default {
       pending: "In attesa",
     },
     summary: {
-      activeSubscribers: "Active subscribers",
+      subscribers: "Subscribers",
+      active: "Active",
+      pending: "Pending",
       receivedPeriods: "Received months",
       revenue: "Revenue",
     },

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -1607,7 +1607,9 @@ export default {
       pending: "保留中",
     },
     summary: {
-      activeSubscribers: "Active subscribers",
+      subscribers: "Subscribers",
+      active: "Active",
+      pending: "Pending",
       receivedPeriods: "Received months",
       revenue: "Revenue",
     },

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -1606,7 +1606,9 @@ export default {
       pending: "Väntande",
     },
     summary: {
-      activeSubscribers: "Active subscribers",
+      subscribers: "Subscribers",
+      active: "Active",
+      pending: "Pending",
       receivedPeriods: "Received months",
       revenue: "Revenue",
     },

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -1604,7 +1604,9 @@ export default {
       pending: "รอดำเนินการ",
     },
     summary: {
-      activeSubscribers: "Active subscribers",
+      subscribers: "Subscribers",
+      active: "Active",
+      pending: "Pending",
       receivedPeriods: "Received months",
       revenue: "Revenue",
     },

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -1609,7 +1609,9 @@ export default {
       pending: "Beklemede",
     },
     summary: {
-      activeSubscribers: "Active subscribers",
+      subscribers: "Subscribers",
+      active: "Active",
+      pending: "Pending",
       receivedPeriods: "Received months",
       revenue: "Revenue",
     },

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -1596,7 +1596,9 @@ export default {
       pending: "待处理",
     },
     summary: {
-      activeSubscribers: "Active subscribers",
+      subscribers: "Subscribers",
+      active: "Active",
+      pending: "Pending",
       receivedPeriods: "Received months",
       revenue: "Revenue",
     },


### PR DESCRIPTION
## Summary
- swap numeric KPI headers for icon+text labels and include a donut chart for active vs pending
- pass active/pending counts into summary and compute pending totals
- add i18n strings for new subscriber summary labels

## Testing
- `npm test` *(fails: 7 failed, 6 passed)*


------
https://chatgpt.com/codex/tasks/task_e_689370c09164833086883d28983e1dfd