### PR TITLE
refactor: replace quasar toolbar with tailwind

### DIFF
--- a/src/pages/CreatorSubscribersPage.vue
+++ b/src/pages/CreatorSubscribersPage.vue
@@ -1,39 +1,34 @@
 <template>
   <q-page class="q-pa-md">
-    <q-toolbar class="q-mb-md q-gutter-sm" style="flex-wrap: wrap">
-      <q-btn
-        flat
-        round
-        dense
-        icon="arrow_back"
+    <header class="flex flex-wrap items-center gap-2 mb-4">
+      <button
         @click="$router.go(-1)"
         aria-label="Go back"
-        class="q-mr-sm"
-      />
-      <q-toolbar-title>My Subscribers ({{ count }})</q-toolbar-title>
-      <q-space />
-      <q-input
-        v-model="filter"
-        dense
-        outlined
-        debounce="300"
-        clearable
-        placeholder="Search"
-        class="q-mr-sm"
-        style="flex: 1 1 200px; max-width: 300px"
+        class="p-2"
       >
-        <template #prepend>
-          <q-icon name="search" />
-        </template>
-      </q-input>
-      <q-btn
-        flat
-        color="primary"
-        icon="filter_list"
-        label="Filters"
+        <ArrowLeftIcon class="w-5 h-5" />
+      </button>
+      <h1 class="text-lg font-semibold">My Subscribers ({{ count }})</h1>
+      <div class="flex-grow"></div>
+      <div class="relative flex-1 min-w-[200px] max-w-[300px]">
+        <SearchIcon
+          class="absolute left-2 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-500"
+        />
+        <input
+          v-model="filter"
+          type="text"
+          placeholder="Search"
+          class="w-full rounded border pl-8 pr-2 py-1"
+        />
+      </div>
+      <button
         @click="showFilters = true"
-      />
-    </q-toolbar>
+        class="p-2"
+        aria-label="Filters"
+      >
+        <FilterIcon class="w-5 h-5" />
+      </button>
+    </header>
     <CreatorSubscribers
       v-model:filter="filter"
       v-model:showFilters="showFilters"
@@ -46,6 +41,11 @@ import { computed, ref } from 'vue';
 import { storeToRefs } from 'pinia';
 import CreatorSubscribers from 'components/CreatorSubscribers.vue';
 import { useCreatorSubscriptionsStore } from 'stores/creatorSubscriptions';
+import {
+  ArrowLeft as ArrowLeftIcon,
+  Search as SearchIcon,
+  Filter as FilterIcon,
+} from 'lucide-vue-next';
 
 const creatorSubscriptionsStore = useCreatorSubscriptionsStore();
 const { subscriptions } = storeToRefs(creatorSubscriptionsStore);


### PR DESCRIPTION
## Summary
- replace Quasar toolbar in CreatorSubscribersPage with Tailwind-based header
- wire back navigation, search filtering, and filter dialog with Vue refs

## Testing
- `npm test` *(fails: ReferenceError windowMixin is not defined, TypeError useMintsStore is not a function, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6893974bb5088330b72514a95f54fb91