### PR TITLE
refactor: tailwind subscriber summary and card

### DIFF
--- a/src/components/CreatorSubscribersSummary.vue
+++ b/src/components/CreatorSubscribersSummary.vue
@@ -1,78 +1,83 @@
 <template>
-  <div class="row q-col-gutter-md q-mb-md">
-    <div class="col-12 col-sm-4">
-      <q-card flat bordered class="q-pa-sm text-center">
-        <div class="row items-center justify-center q-mb-sm">
-          <q-icon name="group" size="sm" class="q-mr-xs" />
-          <span class="text-weight-bold">
-            {{ t('CreatorSubscribers.summary.subscribers') }}
-          </span>
+  <div class="grid grid-cols-1 gap-4 mb-4 sm:grid-cols-3">
+    <div class="p-4 border rounded text-center">
+      <div class="flex items-center justify-center mb-2">
+        <UsersIcon class="w-4 h-4 mr-1" />
+        <span class="font-semibold">
+          {{ t("CreatorSubscribers.summary.subscribers") }}
+        </span>
+      </div>
+      <div class="flex justify-center mb-2">
+        <svg width="60" height="60" viewBox="0 0 36 36" class="donut">
+          <circle
+            class="text-yellow-500"
+            stroke="currentColor"
+            stroke-width="3.8"
+            fill="transparent"
+            cx="18"
+            cy="18"
+            r="15.9155"
+            stroke-dasharray="100 0"
+          />
+          <circle
+            class="text-green-500"
+            stroke="currentColor"
+            stroke-width="3.8"
+            fill="transparent"
+            cx="18"
+            cy="18"
+            r="15.9155"
+            :stroke-dasharray="`${activePercent} ${100 - activePercent}`"
+            stroke-dashoffset="25"
+          />
+        </svg>
+      </div>
+      <div class="flex justify-center gap-2 text-xs">
+        <div class="flex items-center">
+          <span class="w-2 h-2 mr-1 bg-green-500 rounded-full"></span>
+          <span
+            >{{ t("CreatorSubscribers.summary.active") }}:
+            {{ activeCount }}</span
+          >
         </div>
-        <div class="flex justify-center q-mb-sm">
-          <svg width="60" height="60" viewBox="0 0 36 36" class="donut">
-            <circle
-              class="text-warning"
-              stroke="currentColor"
-              stroke-width="3.8"
-              fill="transparent"
-              cx="18"
-              cy="18"
-              r="15.9155"
-              stroke-dasharray="100 0"
-            />
-            <circle
-              class="text-positive"
-              stroke="currentColor"
-              stroke-width="3.8"
-              fill="transparent"
-              cx="18"
-              cy="18"
-              r="15.9155"
-              :stroke-dasharray="`${activePercent} ${100 - activePercent}`"
-              stroke-dashoffset="25"
-            />
-          </svg>
+        <div class="flex items-center">
+          <span class="w-2 h-2 mr-1 bg-yellow-500 rounded-full"></span>
+          <span
+            >{{ t("CreatorSubscribers.summary.pending") }}:
+            {{ pendingCount }}</span
+          >
         </div>
-        <div class="row justify-center q-gutter-sm text-caption">
-          <div class="row items-center">
-            <q-icon name="circle" size="xs" color="positive" class="q-mr-xs" />
-            <span>{{ t('CreatorSubscribers.summary.active') }}: {{ activeCount }}</span>
-          </div>
-          <div class="row items-center">
-            <q-icon name="circle" size="xs" color="warning" class="q-mr-xs" />
-            <span>{{ t('CreatorSubscribers.summary.pending') }}: {{ pendingCount }}</span>
-          </div>
-        </div>
-      </q-card>
+      </div>
     </div>
-    <div class="col-12 col-sm-4">
-      <q-card flat bordered class="q-pa-sm text-center">
-        <div class="row items-center justify-center q-mb-sm">
-          <q-icon name="event" size="sm" class="q-mr-xs" />
-          <span class="text-weight-bold">
-            {{ t('CreatorSubscribers.summary.receivedPeriods') }}
-          </span>
-        </div>
-        <div class="text-h6">{{ totalReceivedPeriods }}</div>
-      </q-card>
+    <div class="p-4 border rounded text-center">
+      <div class="flex items-center justify-center mb-2">
+        <CalendarIcon class="w-4 h-4 mr-1" />
+        <span class="font-semibold">
+          {{ t("CreatorSubscribers.summary.receivedPeriods") }}
+        </span>
+      </div>
+      <div class="text-xl">{{ totalReceivedPeriods }}</div>
     </div>
-    <div class="col-12 col-sm-4">
-      <q-card flat bordered class="q-pa-sm text-center">
-        <div class="row items-center justify-center q-mb-sm">
-          <q-icon name="attach_money" size="sm" class="q-mr-xs" />
-          <span class="text-weight-bold">
-            {{ t('CreatorSubscribers.summary.revenue') }}
-          </span>
-        </div>
-        <div class="text-h6">{{ formatCurrency(totalRevenue) }}</div>
-      </q-card>
+    <div class="p-4 border rounded text-center">
+      <div class="flex items-center justify-center mb-2">
+        <DollarSignIcon class="w-4 h-4 mr-1" />
+        <span class="font-semibold">
+          {{ t("CreatorSubscribers.summary.revenue") }}
+        </span>
+      </div>
+      <div class="text-xl">{{ formatCurrency(totalRevenue) }}</div>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { toRefs, computed } from 'vue';
-import { useI18n } from 'vue-i18n';
+import { toRefs, computed } from "vue";
+import { useI18n } from "vue-i18n";
+import {
+  Users as UsersIcon,
+  Calendar as CalendarIcon,
+  DollarSign as DollarSignIcon,
+} from "lucide-vue-next";
 
 const props = defineProps<{
   activeCount: number;
@@ -82,12 +87,8 @@ const props = defineProps<{
   formatCurrency: (amount: number) => string;
 }>();
 
-const {
-  activeCount,
-  pendingCount,
-  totalReceivedPeriods,
-  totalRevenue,
-} = toRefs(props);
+const { activeCount, pendingCount, totalReceivedPeriods, totalRevenue } =
+  toRefs(props);
 const formatCurrency = props.formatCurrency;
 
 const total = computed(() => activeCount.value + pendingCount.value);

--- a/src/components/SubscriberCard.vue
+++ b/src/components/SubscriberCard.vue
@@ -1,72 +1,99 @@
 <template>
-  <q-card class="subscriber-card cursor-pointer" @click="emit('view')">
-    <div class="row items-center no-wrap q-pa-sm">
-      <q-avatar size="40px">
+  <div
+    class="flex items-center gap-3 p-2 border rounded cursor-pointer"
+    @click="emit('view')"
+  >
+    <input
+      type="checkbox"
+      class="w-4 h-4"
+      :checked="selected"
+      @change.stop="toggleSelected"
+    />
+    <div
+      class="flex items-center justify-center w-10 h-10 rounded-full bg-gray-200 overflow-hidden"
+    >
+      <template v-if="profile === undefined">
+        <div class="w-full h-full bg-gray-300 animate-pulse"></div>
+      </template>
+      <template v-else-if="profile?.picture">
+        <img :src="profile.picture" class="object-cover w-full h-full" />
+      </template>
+      <template v-else>
+        <UserIcon class="w-6 h-6 text-gray-500" />
+      </template>
+    </div>
+    <div class="flex-1">
+      <div class="flex flex-wrap items-center gap-1">
         <template v-if="profile === undefined">
-          <q-skeleton type="circle" size="40px" />
-        </template>
-        <template v-else-if="profile?.picture">
-          <img :src="profile.picture" />
+          <div class="w-28 h-4 rounded bg-gray-300 animate-pulse"></div>
         </template>
         <template v-else>
-          <q-icon name="account_circle" />
-        </template>
-      </q-avatar>
-      <div class="q-ml-sm column flex">
-        <div class="row items-center q-gutter-xs">
-          <template v-if="profile === undefined">
-            <q-skeleton type="text" width="120px" />
-          </template>
-          <template v-else>
-            <div class="text-subtitle2">
-              {{
-                profile?.display_name ||
-                profile?.name ||
-                shortenString(pubkeyNpub(subscription.subscriberNpub), 15, 6)
-              }}
-            </div>
-          </template>
-          <q-chip dense size="sm" class="q-ml-xs" v-if="subscription.tierName">
-            {{ subscription.tierName }}
-          </q-chip>
-          <q-chip dense size="sm" class="q-ml-xs">
-            {{ frequencyLabel }}
-          </q-chip>
-        </div>
-        <q-linear-progress
-          class="q-mt-xs"
-          :value="progress"
-          color="primary"
-          track-color="grey-3"
-        >
-          <div class="absolute-center text-caption text-white">
-            {{ progressLabel }}
+          <div class="text-sm font-medium">
+            {{
+              profile?.display_name ||
+              profile?.name ||
+              shortenString(pubkeyNpub(subscription.subscriberNpub), 15, 6)
+            }}
           </div>
-        </q-linear-progress>
+        </template>
+        <span
+          v-if="subscription.tierName"
+          class="px-1 text-xs rounded"
+          :class="tierColorClass"
+        >
+          {{ subscription.tierName }}
+        </span>
+        <span class="px-1 text-xs rounded bg-gray-100 text-gray-600">
+          {{ frequencyLabel }}
+        </span>
       </div>
-      <q-space />
-      <q-badge
-        :color="subscription.status === 'active' ? 'positive' : 'warning'"
-      >
-        {{ t("CreatorSubscribers.status." + subscription.status) }}
-      </q-badge>
+      <div class="relative w-full h-3 mt-1 bg-gray-200 rounded">
+        <div
+          class="h-full bg-blue-500 rounded"
+          :style="{ width: `${progress * 100}%` }"
+        ></div>
+        <div
+          class="absolute inset-0 flex items-center justify-center text-[10px] text-white"
+        >
+          {{ progressLabel }}
+        </div>
+      </div>
     </div>
-  </q-card>
+    <span class="px-2 py-1 text-xs rounded" :class="statusColorClass">
+      {{ t("CreatorSubscribers.status." + subscription.status) }}
+    </span>
+    <button
+      @click.stop="emit('view')"
+      class="ml-2 text-sm text-blue-600 hover:underline"
+    >
+      {{ t("CreatorSubscribers.view") }}
+    </button>
+  </div>
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, toRefs, withDefaults } from "vue";
 import { nip19 } from "nostr-tools";
 import { shortenString } from "src/js/string-utils";
 import { useI18n } from "vue-i18n";
+import { User as UserIcon } from "lucide-vue-next";
 import type { CreatorSubscription } from "stores/creatorSubscriptions";
 
-const props = defineProps<{
-  subscription: CreatorSubscription;
-  profile: any;
-}>();
-const emit = defineEmits(["view"]);
+const props = withDefaults(
+  defineProps<{
+    subscription: CreatorSubscription;
+    profile: any;
+    selected?: boolean;
+  }>(),
+  { selected: false }
+);
+const emit = defineEmits(["view", "update:selected"]);
 const { t } = useI18n();
+const { selected } = toRefs(props);
+
+function toggleSelected() {
+  emit("update:selected", !selected.value);
+}
 
 function pubkeyNpub(hex: string): string {
   try {
@@ -97,5 +124,24 @@ const progressLabel = computed(() => {
   return props.subscription.totalPeriods != null
     ? `${props.subscription.receivedPeriods}/${props.subscription.totalPeriods}`
     : `${props.subscription.receivedPeriods}/\u221E`;
+});
+
+const statusColorClass = computed(() =>
+  props.subscription.status === "active"
+    ? "bg-green-100 text-green-800"
+    : "bg-yellow-100 text-yellow-800"
+);
+
+const tierColorClass = computed(() => {
+  switch (props.subscription.tierName) {
+    case "Gold":
+      return "bg-yellow-100 text-yellow-800";
+    case "Silver":
+      return "bg-gray-200 text-gray-800";
+    case "Bronze":
+      return "bg-orange-100 text-orange-800";
+    default:
+      return "bg-gray-100 text-gray-800";
+  }
 });
 </script>


### PR DESCRIPTION
## Summary
- replace Quasar-based subscriber summary with Tailwind grid and Lucide icons
- rebuild subscriber card using Tailwind layout with selection checkbox, tier/status colors, and view button

## Testing
- `npx eslint . --config eslint.config.js` *(fails: ReferenceError: module is not defined in ES module scope)*
- `npm test` *(fails: Test Files 31 failed | 30 passed (61))*

------
https://chatgpt.com/codex/tasks/task_e_6893a23dd63083309578694e37b1e310