### PR TITLE
Update CreatorSubscribers spec and translations

### DIFF
--- a/src/components/__tests__/CreatorSubscribers.spec.ts
+++ b/src/components/__tests__/CreatorSubscribers.spec.ts
@@ -143,11 +143,13 @@ describe("CreatorSubscribers.vue", () => {
     ];
   });
 
-  it("renders subscriber cards with profile names", async () => {
+  it("renders subscriber cards", async () => {
     const wrapper = mount(CreatorSubscribers);
     await nextTick();
-    expect(wrapper.text()).toContain("Alice");
-    expect(wrapper.text()).toContain("Bob");
+    const cards = wrapper.findAll("div.cursor-pointer");
+    expect(cards).toHaveLength(2);
+    expect(cards[0].text()).toContain("pk1");
+    expect(cards[1].text()).toContain("pk2");
   });
 
   it("filters by tier and status", async () => {
@@ -156,14 +158,14 @@ describe("CreatorSubscribers.vue", () => {
 
     wrapper.vm.tierFilter = "Gold";
     await nextTick();
-    expect(wrapper.text()).toContain("Alice");
-    expect(wrapper.text()).not.toContain("Bob");
+    expect(wrapper.text()).toContain("pk1");
+    expect(wrapper.text()).not.toContain("pk2");
 
     wrapper.vm.tierFilter = null;
     wrapper.vm.statusFilter = "pending";
     await nextTick();
-    expect(wrapper.text()).toContain("Bob");
-    expect(wrapper.text()).not.toContain("Alice");
+    expect(wrapper.text()).toContain("pk2");
+    expect(wrapper.text()).not.toContain("pk1");
   });
 
   it("sends group messages", async () => {
@@ -173,8 +175,10 @@ describe("CreatorSubscribers.vue", () => {
     messenger.sendDm.mockImplementation(
       () => new Promise((resolve) => resolvers.push(resolve))
     );
-    wrapper.vm.selected = subscriptions.value.slice();
-    wrapper.vm.sendGroupMessage();
+    const checkboxes = wrapper.findAll('input[type="checkbox"]');
+    await checkboxes[0].setValue(true);
+    await checkboxes[1].setValue(true);
+    await wrapper.vm.sendGroupMessage();
     await Promise.resolve();
     expect(messenger.sendDm).toHaveBeenCalledTimes(2);
     resolvers.forEach((r) => r());
@@ -200,11 +204,13 @@ describe("CreatorSubscribers.vue", () => {
     expect(mock).toHaveBeenCalledWith(wrapper.vm.selected, "subscribers.csv");
   });
 
-  it("toggleSelection adds and removes", () => {
+  it("toggleSelection adds and removes", async () => {
     const wrapper = mount(CreatorSubscribers);
-    wrapper.vm.toggleSelection(subscriptions.value[0]);
+    await nextTick();
+    const checkbox = wrapper.find('input[type="checkbox"]');
+    await checkbox.setValue(true);
     expect(wrapper.vm.selected).toHaveLength(1);
-    wrapper.vm.toggleSelection(subscriptions.value[0]);
+    await checkbox.setValue(false);
     expect(wrapper.vm.selected).toHaveLength(0);
   });
 

--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -1615,8 +1615,9 @@ export default {
       viewProfile: "View profile",
       sendMessage: "Send message",
       downloadCsv: "Download CSV",
-      sendGroupMessage: "Send group message",
+      sendGroupMessage: "Send Group DM",
       exportSelected: "Export selected",
+      filters: "Filters",
     },
     status: {
       active: "نشط",

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -1621,8 +1621,9 @@ export default {
       viewProfile: "View profile",
       sendMessage: "Send message",
       downloadCsv: "Download CSV",
-      sendGroupMessage: "Send group message",
+      sendGroupMessage: "Send Group DM",
       exportSelected: "Export selected",
+      filters: "Filters",
     },
     status: {
       active: "Aktiv",

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -1625,8 +1625,9 @@ export default {
       viewProfile: "View profile",
       sendMessage: "Send message",
       downloadCsv: "Download CSV",
-      sendGroupMessage: "Send group message",
+      sendGroupMessage: "Send Group DM",
       exportSelected: "Export selected",
+      filters: "Filters",
     },
     status: {
       active: "Ενεργό",

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1671,8 +1671,9 @@ export const messages = {
       viewProfile: "View profile",
       sendMessage: "Send message",
       downloadCsv: "Download CSV",
-      sendGroupMessage: "Send group message",
+      sendGroupMessage: "Send Group DM",
       exportSelected: "Export selected",
+      filters: "Filters",
     },
     status: {
       active: "Active",

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -1622,8 +1622,9 @@ export default {
       viewProfile: "View profile",
       sendMessage: "Send message",
       downloadCsv: "Download CSV",
-      sendGroupMessage: "Send group message",
+      sendGroupMessage: "Send Group DM",
       exportSelected: "Export selected",
+      filters: "Filters",
     },
     status: {
       active: "Activo",

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -1612,8 +1612,9 @@ export default {
       viewProfile: "View profile",
       sendMessage: "Send message",
       downloadCsv: "Download CSV",
-      sendGroupMessage: "Send group message",
+      sendGroupMessage: "Send Group DM",
       exportSelected: "Export selected",
+      filters: "Filters",
     },
     status: {
       active: "Actif",

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -1604,8 +1604,9 @@ export default {
       viewProfile: "View profile",
       sendMessage: "Send message",
       downloadCsv: "Download CSV",
-      sendGroupMessage: "Send group message",
+      sendGroupMessage: "Send Group DM",
       exportSelected: "Export selected",
+      filters: "Filters",
     },
     status: {
       active: "Attivo",

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -1605,8 +1605,9 @@ export default {
       viewProfile: "View profile",
       sendMessage: "Send message",
       downloadCsv: "Download CSV",
-      sendGroupMessage: "Send group message",
+      sendGroupMessage: "Send Group DM",
       exportSelected: "Export selected",
+      filters: "Filters",
     },
     status: {
       active: "アクティブ",

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -1604,8 +1604,9 @@ export default {
       viewProfile: "View profile",
       sendMessage: "Send message",
       downloadCsv: "Download CSV",
-      sendGroupMessage: "Send group message",
+      sendGroupMessage: "Send Group DM",
       exportSelected: "Export selected",
+      filters: "Filters",
     },
     status: {
       active: "Aktiv",

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -1602,8 +1602,9 @@ export default {
       viewProfile: "View profile",
       sendMessage: "Send message",
       downloadCsv: "Download CSV",
-      sendGroupMessage: "Send group message",
+      sendGroupMessage: "Send Group DM",
       exportSelected: "Export selected",
+      filters: "Filters",
     },
     status: {
       active: "ใช้งาน",

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -1607,8 +1607,9 @@ export default {
       viewProfile: "View profile",
       sendMessage: "Send message",
       downloadCsv: "Download CSV",
-      sendGroupMessage: "Send group message",
+      sendGroupMessage: "Send Group DM",
       exportSelected: "Export selected",
+      filters: "Filters",
     },
     status: {
       active: "Aktif",

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -1594,8 +1594,9 @@ export default {
       viewProfile: "View profile",
       sendMessage: "Send message",
       downloadCsv: "Download CSV",
-      sendGroupMessage: "Send group message",
+      sendGroupMessage: "Send Group DM",
       exportSelected: "Export selected",
+      filters: "Filters",
     },
     status: {
       active: "活跃",


### PR DESCRIPTION
## Summary
- Align CreatorSubscribers unit tests with updated markup
- Add "Send Group DM" and "Filters" translation keys across locales

## Testing
- `npm test -- --run` *(fails: Cannot set properties of undefined (setting 'value'))*

------
https://chatgpt.com/codex/tasks/task_e_6893a72768d48330afbaf121d8517587