### PR TITLE
Refactor CreatorSubscribers page

### DIFF
--- a/src/pages/CreatorSubscribers.vue
+++ b/src/pages/CreatorSubscribers.vue
@@ -1,27 +1,120 @@
 <template>
-  <div class="subscribers-wrapper">
-    <iframe
-      src="/creator-subscribers.html"
-      class="subscribers-frame"
-      title="Creator Subscribers"
-    />
-  </div>
+  <q-page class="q-pa-md">
+    <div class="row q-col-gutter-md q-mb-lg">
+      <div class="col-12 col-sm-6 col-md-3">
+        <q-card>
+          <q-card-section class="text-center">
+            <div class="text-h6">
+              {{ $t("CreatorSubscribers.summary.subscribers") }}
+            </div>
+            <div class="text-subtitle1">{{ total }}</div>
+          </q-card-section>
+        </q-card>
+      </div>
+      <div class="col-12 col-sm-6 col-md-3">
+        <q-card>
+          <q-card-section class="text-center">
+            <div class="text-h6">
+              {{ $t("CreatorSubscribers.summary.active") }}
+            </div>
+            <div class="text-subtitle1">{{ active }}</div>
+          </q-card-section>
+        </q-card>
+      </div>
+      <div class="col-12 col-sm-6 col-md-3">
+        <q-card>
+          <q-card-section class="text-center">
+            <div class="text-h6">
+              {{ $t("CreatorSubscribers.summary.pending") }}
+            </div>
+            <div class="text-subtitle1">{{ pending }}</div>
+          </q-card-section>
+        </q-card>
+      </div>
+      <div class="col-12 col-sm-6 col-md-3">
+        <q-card>
+          <q-card-section class="text-center">
+            <div class="text-h6">
+              {{ $t("CreatorSubscribers.summary.revenue") }}
+            </div>
+            <div class="text-subtitle1">{{ formatCurrency(revenue) }}</div>
+          </q-card-section>
+        </q-card>
+      </div>
+    </div>
+
+    <div
+      v-if="!loading && subscriptions.length === 0"
+      class="text-center q-mt-xl"
+    >
+      {{ $t("CreatorSubscribers.noData") }}
+    </div>
+
+    <div v-else>
+      <q-card
+        v-for="sub in subscriptions"
+        :key="sub.subscriptionId"
+        class="q-mb-md"
+      >
+        <q-card-section>
+          <div class="text-subtitle1">{{ sub.tierName }}</div>
+          <div>
+            {{ $t("CreatorSubscribers.columns.subscriber") }}:
+            {{ sub.subscriberNpub }}
+          </div>
+          <div>
+            {{ $t("CreatorSubscribers.columns.status") }}:
+            {{ $t(`CreatorSubscribers.status.${sub.status}`) }}
+          </div>
+          <div>
+            {{ $t("CreatorSubscribers.columns.nextRenewal") }}:
+            {{ sub.nextRenewal ? formatTs(sub.nextRenewal) : "-" }}
+          </div>
+          <div>
+            {{ $t("CreatorSubscribers.summary.revenue") }}:
+            {{ formatCurrency(sub.totalAmount) }}
+          </div>
+        </q-card-section>
+      </q-card>
+    </div>
+  </q-page>
 </template>
 
-<script setup>
-// no additional script needed
+<script setup lang="ts">
+import { computed } from "vue";
+import { storeToRefs } from "pinia";
+import { useCreatorSubscriptionsStore } from "stores/creatorSubscriptions";
+import { useMintsStore } from "stores/mints";
+import { useUiStore } from "stores/ui";
+
+const creatorSubscriptionsStore = useCreatorSubscriptionsStore();
+const { subscriptions, loading } = storeToRefs(creatorSubscriptionsStore);
+
+const mintsStore = useMintsStore();
+const uiStore = useUiStore();
+const { activeUnit } = storeToRefs(mintsStore);
+
+function formatCurrency(amount: number): string {
+  return uiStore.formatCurrency(amount, activeUnit.value);
+}
+
+function formatTs(ts: number): string {
+  const d = new Date(ts * 1000);
+  return `${d.getFullYear()}-${("0" + (d.getMonth() + 1)).slice(-2)}-${(
+    "0" + d.getDate()
+  ).slice(-2)}`;
+}
+
+const total = computed(() => subscriptions.value.length);
+const active = computed(
+  () => subscriptions.value.filter((s) => s.status === "active").length
+);
+const pending = computed(
+  () => subscriptions.value.filter((s) => s.status === "pending").length
+);
+const revenue = computed(() =>
+  subscriptions.value.reduce((sum, s) => sum + s.totalAmount, 0)
+);
 </script>
 
-<style scoped>
-.subscribers-wrapper {
-  height: 100vh;
-  padding: 0;
-  margin: 0;
-}
-.subscribers-frame {
-  width: 100%;
-  height: 100%;
-  border: none;
-}
-</style>
-
+<style scoped></style>


### PR DESCRIPTION
## Summary
- replace iframe with Quasar-based layout and summary cards
- hook up creator subscription store and compute totals, active, pending, and revenue
- show subscriptions list with translations for status and labels

## Testing
- `pnpm lint` *(fails: Invalid option '--ext' - perhaps you meant '-c'?)*
- `pnpm test` *(fails: 6 failed | 7 passed | 2 skipped)*


------
https://chatgpt.com/codex/tasks/task_e_689437e112b483309e09b587f9faee48