### PR TITLE
Resolve tier names for creator subscriptions

### DIFF
--- a/test/creatorSubscriptions.spec.ts
+++ b/test/creatorSubscriptions.spec.ts
@@ -105,5 +105,30 @@ describe('creatorSubscriptions store', () => {
     expect(biweekly?.nextRenewal).toBe(BIWEEK * 2);
     expect(biweekly?.status).toBe('active');
   });
+
+  it('falls back to Unknown Tier when tier data is missing', async () => {
+    const store = useCreatorSubscriptionsStore();
+
+    await cashuDb.lockedTokens.add({
+      id: 'u1',
+      tokenString: 'tok',
+      amount: 1,
+      owner: 'creator',
+      subscriberNpub: 'npub',
+      tierId: 'tier',
+      intervalKey: 'int1',
+      unlockTs: 0,
+      status: 'unlockable',
+      subscriptionEventId: null,
+      subscriptionId: 'subU',
+      totalPeriods: 1,
+      intervalDays: 30,
+    } as any);
+
+    await new Promise((r) => setTimeout(r, 20));
+
+    const sub = store.subscriptions.find((s) => s.subscriptionId === 'subU');
+    expect(sub?.tierName).toBe('Unknown Tier');
+  });
 });
 


### PR DESCRIPTION
## Summary
- Populate missing creator subscription tier names once creator tier data is available
- Default unresolved tiers to "Unknown Tier" and update existing subscriptions accordingly
- Include regression test for missing tier names

## Testing
- `npm test -- --run test/vitest/__tests__/subscriptions.spec.ts` *(fails: useP2PKStore(...).sendToLock is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_6894477ea36083309756e73556b924f2