### PR TITLE
feat: improve subscriber selection actions

### DIFF
--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1694,6 +1694,16 @@ export const messages = {
     nextRenewal: "Renews on {date}",
     noData: "No subscribers yet",
     shareProfile: "Share your profile",
+    selectionCount: "{count} selected",
+    tooltips: {
+      noSelection: "Select subscribers first",
+      notLoggedIn: "Connect to Nostr to send messages",
+    },
+    notifications: {
+      export_success: "Subscribers exported",
+      export_failed: "Failed to export subscribers",
+      dm_not_ready: "Messenger not ready",
+    },
   },
   restore: {
     mnemonic_error_text: "Please enter a mnemonic",


### PR DESCRIPTION
## Summary
- show selected subscriber count and disable actions when selection is empty or messenger unavailable
- verify messenger readiness before group DM, notify on DM/CSV operations, and reset selection
- add i18n strings for subscriber action tooltips and notifications

## Testing
- `npm test` *(fails: P2PK store and wallet tests)*
- `npm run lint` *(fails: Invalid option '--ext')*


------
https://chatgpt.com/codex/tasks/task_e_68944e0d1fa0833083c1d4178e6b96d3