### PR TITLE
feat: enhance subscriber filtering

### DIFF
--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1645,6 +1645,8 @@ export const messages = {
       nextRenewalFrom: "Next renewal from",
       nextRenewalTo: "Next renewal to",
       monthsRemaining: "Periods remaining",
+      revenueFrom: "Revenue from",
+      revenueTo: "Revenue to",
     },
     filters: {
       frequency: "Filter by frequency",
@@ -1674,6 +1676,7 @@ export const messages = {
       sendGroupMessage: "Send Group DM",
       exportSelected: "Export selected",
       filters: "Filters",
+      resetFilters: "Reset filters",
     },
     status: {
       active: "Active",


### PR DESCRIPTION
## Summary
- allow searching subscribers by profile names and npub values
- expand subscriber filters with tier/status multiselects and revenue range
- add reset filters action and fetch profiles for search

## Testing
- `npm test` *(fails: Failed Suites 14, e.g., bucketDialog.spec.ts)*

------
https://chatgpt.com/codex/tasks/task_e_689507c1b9a08330a3e2be8d4e62472d