### PR TITLE
refactor creator subscribers page layout

### DIFF
--- a/src/components/SubscriberCard.vue
+++ b/src/components/SubscriberCard.vue
@@ -1,0 +1,13 @@
+<template>
+  <q-card :class="[{ 'q-mb-sm': !compact }, 'cursor-pointer']" @click="$emit('click')">
+    <q-card-section class="q-pa-sm">
+      <div class="text-subtitle2">{{ subscription.tierName }}</div>
+      <div class="text-caption text-grey">{{ subscription.subscriberNpub }}</div>
+    </q-card-section>
+  </q-card>
+</template>
+<script setup lang="ts">
+import type { CreatorSubscription } from 'stores/creatorSubscriptions';
+
+defineProps<{ subscription: CreatorSubscription; compact?: boolean }>();
+</script>

--- a/src/components/SubscriberDrawer.vue
+++ b/src/components/SubscriberDrawer.vue
@@ -1,0 +1,24 @@
+<template>
+  <q-drawer side="right" v-model="model" bordered>
+    <q-toolbar>
+      <q-toolbar-title>{{ subscription?.subscriberNpub }}</q-toolbar-title>
+      <q-btn flat round dense icon="close" @click="model = false" />
+    </q-toolbar>
+    <div class="q-pa-md" v-if="subscription">
+      <div class="text-subtitle1">{{ subscription.tierName }}</div>
+      <div class="text-body2">{{ subscription.frequency }}</div>
+    </div>
+  </q-drawer>
+</template>
+<script setup lang="ts">
+import { computed } from 'vue';
+import type { CreatorSubscription } from 'stores/creatorSubscriptions';
+
+const props = defineProps<{ modelValue: boolean; subscription: CreatorSubscription | null }>();
+const emit = defineEmits(['update:modelValue']);
+
+const model = computed({
+  get: () => props.modelValue,
+  set: (v: boolean) => emit('update:modelValue', v),
+});
+</script>


### PR DESCRIPTION
## Summary
- replace subscriber table with KPI cards, toolbar filters and grouped virtual lists
- compute subscription metrics and manage subscriber drawer state
- add simple SubscriberCard and SubscriberDrawer components

## Testing
- `pnpm lint` (fails: Cannot find module './.eslintrc.js')
- `pnpm test` (fails: many tests fail including bucket dialogs, messenger, wallet tests)


------
https://chatgpt.com/codex/tasks/task_e_6895d0c8994083308ffb740b76cd197e