### PR TITLE
feat: add subscriber helpers and card display

### DIFF
--- a/src/components/SubscriberCard.vue
+++ b/src/components/SubscriberCard.vue
@@ -1,13 +1,39 @@
 <template>
   <q-card :class="[{ 'q-mb-sm': !compact }, 'cursor-pointer']" @click="$emit('click')">
     <q-card-section class="q-pa-sm">
-      <div class="text-subtitle2">{{ subscription.tierName }}</div>
-      <div class="text-caption text-grey">{{ subscription.subscriberNpub }}</div>
+      <div class="row items-center justify-between">
+        <div>
+          <div class="text-subtitle2">{{ subscription.tierName }}</div>
+          <div class="text-caption text-grey">{{ subscription.subscriberNpub }}</div>
+        </div>
+        <div class="text-subtitle2">{{ amount }}</div>
+      </div>
+      <q-linear-progress :value="progress" class="q-mt-sm" />
+      <div class="row items-center q-mt-sm">
+        <q-chip dense :color="statusColor" text-color="white">{{ status }}</q-chip>
+        <q-chip v-if="nextIn !== '—'" dense class="q-ml-sm" color="grey-6" text-color="white">
+          {{ nextIn }}
+        </q-chip>
+      </div>
     </q-card-section>
   </q-card>
 </template>
 <script setup lang="ts">
+import { computed } from 'vue';
 import type { CreatorSubscription } from 'stores/creatorSubscriptions';
 
-defineProps<{ subscription: CreatorSubscription; compact?: boolean }>();
+const props = defineProps<{
+  subscription: CreatorSubscription;
+  compact?: boolean;
+  status: 'active' | 'pending' | 'ended';
+  nextIn: string;
+  progress: number;
+  amount: string;
+}>();
+
+const statusColor = computed(() => {
+  if (props.status === 'active') return 'positive';
+  if (props.status === 'pending') return 'warning';
+  return 'grey';
+});
 </script>


### PR DESCRIPTION
## Summary
- implement helper functions to derive subscriber status, renewal countdown, interval progress, and amount
- pass helper results into `SubscriberCard` and render chips, progress bar, and amount label

## Testing
- `pnpm eslint src/pages/CreatorSubscribers.vue src/components/SubscriberCard.vue` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: multiple module errors and failing specs)*
- `pnpm types` *(fails: Cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_6895d6c26f1c8330a2b7678f319f2bf9