### PR TITLE
feat: add creator hub utility styles

### DIFF
--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -215,3 +215,5 @@ body.body--dark .received {
   width: 100%;
   max-width: 500px;
 }
+
+@import './creator-hub.scss';

--- a/src/css/creator-hub.scss
+++ b/src/css/creator-hub.scss
@@ -4,3 +4,84 @@
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
   border-radius: 8px;
 }
+
+/* Dark slate gradient backgrounds */
+.gradient-dark-slate {
+  background: linear-gradient(135deg, #1e293b 0%, #0f172a 100%);
+}
+.gradient-dark-slate-alt {
+  background: linear-gradient(135deg, #334155 0%, #1e293b 100%);
+}
+
+/* Rounded card helpers */
+.card-rounded-16 {
+  border-radius: 16px;
+}
+.card-rounded-20 {
+  border-radius: 20px;
+}
+
+/* Chip variants */
+.chip-outline {
+  border: 1px solid var(--q-color-grey-5);
+  background-color: transparent;
+  color: var(--q-color-grey-8);
+}
+.chip-filled {
+  background-color: var(--q-color-grey-8);
+  color: #fff;
+  border: none;
+}
+
+/* Compact spacing utilities */
+$compact-spacing: (xs: 4px, sm: 8px);
+
+@each $name, $size in $compact-spacing {
+  .m-#{$name} {
+    margin: $size;
+  }
+  .p-#{$name} {
+    padding: $size;
+  }
+  .mx-#{$name} {
+    margin-left: $size;
+    margin-right: $size;
+  }
+  .my-#{$name} {
+    margin-top: $size;
+    margin-bottom: $size;
+  }
+  .mt-#{$name} {
+    margin-top: $size;
+  }
+  .mr-#{$name} {
+    margin-right: $size;
+  }
+  .mb-#{$name} {
+    margin-bottom: $size;
+  }
+  .ml-#{$name} {
+    margin-left: $size;
+  }
+  .px-#{$name} {
+    padding-left: $size;
+    padding-right: $size;
+  }
+  .py-#{$name} {
+    padding-top: $size;
+    padding-bottom: $size;
+  }
+  .pt-#{$name} {
+    padding-top: $size;
+  }
+  .pr-#{$name} {
+    padding-right: $size;
+  }
+  .pb-#{$name} {
+    padding-bottom: $size;
+  }
+  .pl-#{$name} {
+    padding-left: $size;
+  }
+}
+


### PR DESCRIPTION
## Summary
- style: add dark slate gradients and chip variants for creator hub
- style: include card radius helpers and compact spacing utilities
- chore: import creator hub styles into app.scss

## Testing
- `pnpm test` *(fails: Failed Suites 12)*
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*

------
https://chatgpt.com/codex/tasks/task_e_6895e29261a88330a1f10624a77d80cf