### PR TITLE
feat: add subscriber csv export

### DIFF
--- a/src/pages/CreatorSubscribers.vue
+++ b/src/pages/CreatorSubscribers.vue
@@ -144,7 +144,7 @@ import SubscriberDrawer from 'components/subscribers/SubscriberDrawer.vue';
 import KpiCard from 'components/subscribers/KpiCard.vue';
 import Sparkline from 'components/subscribers/Sparkline.vue';
 import { useCreatorSubscriptionsStore, type CreatorSubscription } from 'stores/creatorSubscriptions';
-import { exportSubscribers } from 'src/utils/subscriberCsv';
+import { downloadCsv } from 'src/utils/subscriberCsv';
 import { useNostrStore } from 'stores/nostr';
 import type { NDKUserProfile as Profile } from '@nostr-dev-kit/ndk';
 
@@ -387,7 +387,15 @@ function keyLabel(key: string) {
 }
 
 function exportCsv() {
-  exportSubscribers(filtered.value.all, 'subscribers.csv');
+  const rows = filtered.value.all.map((s) => ({
+    ...s,
+    npub: s.subscriberNpub,
+    displayName: displayName.value[s.subscriptionId],
+    nip05: nip05.value[s.subscriptionId],
+    lud16: lud16.value[s.subscriptionId],
+    tier: s.tierName,
+  }));
+  downloadCsv(rows);
 }
 
 // drawer

--- a/src/utils/subscriberCsv.ts
+++ b/src/utils/subscriberCsv.ts
@@ -1,46 +1,63 @@
 import type { CreatorSubscription } from "stores/creatorSubscriptions";
 
-export function exportSubscribers(
-  subscribers: CreatorSubscription[],
-  filename: string,
-) {
+export function downloadCsv(rows: CreatorSubscription[]) {
   const headers = [
-    "Subscriber",
-    "Tier",
-    "Start",
-    "Next Renewal",
-    "Periods received",
-    "Remaining periods",
-    "Frequency",
+    "subscriptionId",
+    "displayName",
+    "npub",
+    "nip05",
+    "lud16",
+    "tier",
+    "frequency",
+    "status",
+    "nextRenewal",
+    "intervalDays",
+    "totalAmount",
+    "startDate",
+    "endDate",
   ];
   const lines = [headers.join(",")];
-  for (const sub of subscribers) {
-    const start = sub.startDate ? new Date(sub.startDate).toISOString() : "";
-    const next = sub.nextRenewal ? new Date(sub.nextRenewal).toISOString() : "";
-    const periods = `${sub.receivedPeriods}/${sub.totalPeriods ?? ""}`;
-    const remaining =
-      (sub.totalPeriods ?? sub.receivedPeriods) - sub.receivedPeriods;
+
+  for (const sub of rows) {
+    const r: any = sub as any;
+    const next = sub.nextRenewal
+      ? new Date(sub.nextRenewal * 1000).toISOString()
+      : "";
+    const start = sub.startDate
+      ? new Date(sub.startDate * 1000).toISOString()
+      : "";
+    const end = sub.endDate
+      ? new Date(sub.endDate * 1000).toISOString()
+      : "";
     const row = [
-      sub.subscriberNpub,
-      sub.tierName,
-      start,
-      next,
-      periods,
-      remaining,
+      sub.subscriptionId,
+      r.displayName ?? "",
+      r.npub ?? sub.subscriberNpub,
+      r.nip05 ?? "",
+      r.lud16 ?? "",
+      r.tier ?? sub.tierName,
       sub.frequency,
+      sub.status,
+      next,
+      sub.intervalDays,
+      sub.totalAmount,
+      start,
+      end,
     ]
-      .map((v) => `"${String(v).replace(/"/g, '""')}"`)
+      .map((v) => `"${String(v ?? "").replace(/"/g, '""')}"`)
       .join(",");
     lines.push(row);
   }
+
   const csv = lines.join("\n");
   const blob = new Blob([csv], { type: "text/csv" });
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
   a.href = url;
-  a.download = filename;
+  a.download = "subscribers.csv";
   a.click();
   URL.revokeObjectURL(url);
 }
 
-export default exportSubscribers;
+export default downloadCsv;
+


### PR DESCRIPTION
## Summary
- add reusable `downloadCsv` utility to export subscriber details
- wire CSV export button to use filtered results with profile info

## Testing
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: 49 failed, 219 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6895e4af8b408330b6cb9eb616dcc849