### PR TITLE
feat(i18n): add creator subscriber strings

### DIFF
--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -1593,9 +1593,19 @@ export default {
       exportSelected: "Export selected",
       filters: "Filters",
     },
+    toolbar: {
+      searchPlaceholder: "Search",
+      frequency: "Frequency",
+      status: "Status",
+      tier: "Tier",
+      sort: "Sort",
+      compact: "Compact",
+      exportCsv: "Export CSV",
+    },
     status: {
       active: "نشط",
       pending: "معلق",
+      ended: "Ended",
     },
     summary: {
       subscribers: "Subscribers",
@@ -1603,6 +1613,7 @@ export default {
       pending: "Pending",
       receivedPeriods: "Received periods",
       revenue: "Revenue",
+      thisWeek: "this week",
       thisMonth: "this month",
     },
     periodsText: "{received} of {total} periods",
@@ -1613,5 +1624,23 @@ export default {
     nextRenewal: "Renews on {date}",
     noData: "No subscribers yet",
     shareProfile: "Share your profile",
+  },
+  SubscriberDrawer: {
+    tabs: {
+      overview: "Overview",
+      payments: "Payments",
+      notes: "Notes",
+    },
+    actions: {
+      dm: "DM",
+      copyNpub: "Copy npub",
+      copyLud16: "Copy lud16",
+      openProfile: "Profile",
+      cancel: "Cancel",
+    },
+    notifications: {
+      note_saved: "Note saved",
+      note_save_failed: "Failed to save note",
+    },
   },
 };

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -1599,9 +1599,19 @@ export default {
       exportSelected: "Export selected",
       filters: "Filters",
     },
+    toolbar: {
+      searchPlaceholder: "Search",
+      frequency: "Frequency",
+      status: "Status",
+      tier: "Tier",
+      sort: "Sort",
+      compact: "Compact",
+      exportCsv: "Export CSV",
+    },
     status: {
       active: "Aktiv",
       pending: "Ausstehend",
+      ended: "Ended",
     },
     summary: {
       subscribers: "Subscribers",
@@ -1609,6 +1619,7 @@ export default {
       pending: "Pending",
       receivedPeriods: "Received periods",
       revenue: "Revenue",
+      thisWeek: "this week",
       thisMonth: "this month",
     },
     periodsText: "{received} of {total} periods",
@@ -1619,5 +1630,23 @@ export default {
     nextRenewal: "Renews on {date}",
     noData: "No subscribers yet",
     shareProfile: "Share your profile",
+  },
+  SubscriberDrawer: {
+    tabs: {
+      overview: "Overview",
+      payments: "Payments",
+      notes: "Notes",
+    },
+    actions: {
+      dm: "DM",
+      copyNpub: "Copy npub",
+      copyLud16: "Copy lud16",
+      openProfile: "Profile",
+      cancel: "Cancel",
+    },
+    notifications: {
+      note_saved: "Note saved",
+      note_save_failed: "Failed to save note",
+    },
   },
 };

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -1603,9 +1603,19 @@ export default {
       exportSelected: "Export selected",
       filters: "Filters",
     },
+    toolbar: {
+      searchPlaceholder: "Search",
+      frequency: "Frequency",
+      status: "Status",
+      tier: "Tier",
+      sort: "Sort",
+      compact: "Compact",
+      exportCsv: "Export CSV",
+    },
     status: {
       active: "Ενεργό",
       pending: "Σε εκκρεμότητα",
+      ended: "Ended",
     },
     summary: {
       subscribers: "Subscribers",
@@ -1613,6 +1623,7 @@ export default {
       pending: "Pending",
       receivedPeriods: "Received periods",
       revenue: "Revenue",
+      thisWeek: "this week",
       thisMonth: "this month",
     },
     periodsText: "{received} of {total} periods",
@@ -1623,5 +1634,23 @@ export default {
     nextRenewal: "Renews on {date}",
     noData: "No subscribers yet",
     shareProfile: "Share your profile",
+  },
+  SubscriberDrawer: {
+    tabs: {
+      overview: "Overview",
+      payments: "Payments",
+      notes: "Notes",
+    },
+    actions: {
+      dm: "DM",
+      copyNpub: "Copy npub",
+      copyLud16: "Copy lud16",
+      openProfile: "Profile",
+      cancel: "Cancel",
+    },
+    notifications: {
+      note_saved: "Note saved",
+      note_save_failed: "Failed to save note",
+    },
   },
 };

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1672,9 +1672,19 @@ export const messages = {
       exportSelected: "Export selected",
       filters: "Filters",
     },
+    toolbar: {
+      searchPlaceholder: "Search",
+      frequency: "Frequency",
+      status: "Status",
+      tier: "Tier",
+      sort: "Sort",
+      compact: "Compact",
+      exportCsv: "Export CSV",
+    },
     status: {
       active: "Active",
       pending: "Pending",
+      ended: "Ended",
     },
     summary: {
       subscribers: "Subscribers",
@@ -1682,6 +1692,7 @@ export const messages = {
       pending: "Pending",
       receivedPeriods: "Received periods",
       revenue: "Revenue",
+      thisWeek: "this week",
       thisMonth: "this month",
     },
     periodsText: "{received} of {total} periods",
@@ -1701,6 +1712,24 @@ export const messages = {
       export_success: "Subscribers exported",
       export_failed: "Failed to export subscribers",
       dm_not_ready: "Messenger not ready",
+    },
+  },
+  SubscriberDrawer: {
+    tabs: {
+      overview: "Overview",
+      payments: "Payments",
+      notes: "Notes",
+    },
+    actions: {
+      dm: "DM",
+      copyNpub: "Copy npub",
+      copyLud16: "Copy lud16",
+      openProfile: "Profile",
+      cancel: "Cancel",
+    },
+    notifications: {
+      note_saved: "Note saved",
+      note_save_failed: "Failed to save note",
     },
   },
   restore: {

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -1600,9 +1600,19 @@ export default {
       exportSelected: "Export selected",
       filters: "Filters",
     },
+    toolbar: {
+      searchPlaceholder: "Search",
+      frequency: "Frequency",
+      status: "Status",
+      tier: "Tier",
+      sort: "Sort",
+      compact: "Compact",
+      exportCsv: "Export CSV",
+    },
     status: {
       active: "Activo",
       pending: "Pendiente",
+      ended: "Ended",
     },
     summary: {
       subscribers: "Subscribers",
@@ -1610,6 +1620,7 @@ export default {
       pending: "Pending",
       receivedPeriods: "Received periods",
       revenue: "Revenue",
+      thisWeek: "this week",
       thisMonth: "this month",
     },
     periodsText: "{received} of {total} periods",
@@ -1620,5 +1631,23 @@ export default {
     nextRenewal: "Renews on {date}",
     noData: "No subscribers yet",
     shareProfile: "Share your profile",
+  },
+  SubscriberDrawer: {
+    tabs: {
+      overview: "Overview",
+      payments: "Payments",
+      notes: "Notes",
+    },
+    actions: {
+      dm: "DM",
+      copyNpub: "Copy npub",
+      copyLud16: "Copy lud16",
+      openProfile: "Profile",
+      cancel: "Cancel",
+    },
+    notifications: {
+      note_saved: "Note saved",
+      note_save_failed: "Failed to save note",
+    },
   },
 };

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -1590,9 +1590,19 @@ export default {
       exportSelected: "Export selected",
       filters: "Filters",
     },
+    toolbar: {
+      searchPlaceholder: "Search",
+      frequency: "Frequency",
+      status: "Status",
+      tier: "Tier",
+      sort: "Sort",
+      compact: "Compact",
+      exportCsv: "Export CSV",
+    },
     status: {
       active: "Actif",
       pending: "En attente",
+      ended: "Ended",
     },
     summary: {
       subscribers: "Subscribers",
@@ -1600,6 +1610,7 @@ export default {
       pending: "Pending",
       receivedPeriods: "Received periods",
       revenue: "Revenue",
+      thisWeek: "this week",
       thisMonth: "this month",
     },
     periodsText: "{received} of {total} periods",
@@ -1610,5 +1621,23 @@ export default {
     nextRenewal: "Renews on {date}",
     noData: "No subscribers yet",
     shareProfile: "Share your profile",
+  },
+  SubscriberDrawer: {
+    tabs: {
+      overview: "Overview",
+      payments: "Payments",
+      notes: "Notes",
+    },
+    actions: {
+      dm: "DM",
+      copyNpub: "Copy npub",
+      copyLud16: "Copy lud16",
+      openProfile: "Profile",
+      cancel: "Cancel",
+    },
+    notifications: {
+      note_saved: "Note saved",
+      note_save_failed: "Failed to save note",
+    },
   },
 };

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -1582,9 +1582,19 @@ export default {
       exportSelected: "Export selected",
       filters: "Filters",
     },
+    toolbar: {
+      searchPlaceholder: "Search",
+      frequency: "Frequency",
+      status: "Status",
+      tier: "Tier",
+      sort: "Sort",
+      compact: "Compact",
+      exportCsv: "Export CSV",
+    },
     status: {
       active: "Attivo",
       pending: "In attesa",
+      ended: "Ended",
     },
     summary: {
       subscribers: "Subscribers",
@@ -1592,6 +1602,7 @@ export default {
       pending: "Pending",
       receivedPeriods: "Received periods",
       revenue: "Revenue",
+      thisWeek: "this week",
       thisMonth: "this month",
     },
     periodsText: "{received} of {total} periods",
@@ -1602,5 +1613,23 @@ export default {
     nextRenewal: "Renews on {date}",
     noData: "No subscribers yet",
     shareProfile: "Share your profile",
+  },
+  SubscriberDrawer: {
+    tabs: {
+      overview: "Overview",
+      payments: "Payments",
+      notes: "Notes",
+    },
+    actions: {
+      dm: "DM",
+      copyNpub: "Copy npub",
+      copyLud16: "Copy lud16",
+      openProfile: "Profile",
+      cancel: "Cancel",
+    },
+    notifications: {
+      note_saved: "Note saved",
+      note_save_failed: "Failed to save note",
+    },
   },
 };

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -1583,9 +1583,19 @@ export default {
       exportSelected: "Export selected",
       filters: "Filters",
     },
+    toolbar: {
+      searchPlaceholder: "Search",
+      frequency: "Frequency",
+      status: "Status",
+      tier: "Tier",
+      sort: "Sort",
+      compact: "Compact",
+      exportCsv: "Export CSV",
+    },
     status: {
       active: "アクティブ",
       pending: "保留中",
+      ended: "Ended",
     },
     summary: {
       subscribers: "Subscribers",
@@ -1593,6 +1603,7 @@ export default {
       pending: "Pending",
       receivedPeriods: "Received periods",
       revenue: "Revenue",
+      thisWeek: "this week",
       thisMonth: "this month",
     },
     periodsText: "{received} of {total} periods",
@@ -1603,5 +1614,23 @@ export default {
     nextRenewal: "Renews on {date}",
     noData: "No subscribers yet",
     shareProfile: "Share your profile",
+  },
+  SubscriberDrawer: {
+    tabs: {
+      overview: "Overview",
+      payments: "Payments",
+      notes: "Notes",
+    },
+    actions: {
+      dm: "DM",
+      copyNpub: "Copy npub",
+      copyLud16: "Copy lud16",
+      openProfile: "Profile",
+      cancel: "Cancel",
+    },
+    notifications: {
+      note_saved: "Note saved",
+      note_save_failed: "Failed to save note",
+    },
   },
 };

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -1582,9 +1582,19 @@ export default {
       exportSelected: "Export selected",
       filters: "Filters",
     },
+    toolbar: {
+      searchPlaceholder: "Search",
+      frequency: "Frequency",
+      status: "Status",
+      tier: "Tier",
+      sort: "Sort",
+      compact: "Compact",
+      exportCsv: "Export CSV",
+    },
     status: {
       active: "Aktiv",
       pending: "Väntande",
+      ended: "Ended",
     },
     summary: {
       subscribers: "Subscribers",
@@ -1592,6 +1602,7 @@ export default {
       pending: "Pending",
       receivedPeriods: "Received periods",
       revenue: "Revenue",
+      thisWeek: "this week",
       thisMonth: "this month",
     },
     periodsText: "{received} of {total} periods",
@@ -1602,5 +1613,23 @@ export default {
     nextRenewal: "Renews on {date}",
     noData: "No subscribers yet",
     shareProfile: "Share your profile",
+  },
+  SubscriberDrawer: {
+    tabs: {
+      overview: "Overview",
+      payments: "Payments",
+      notes: "Notes",
+    },
+    actions: {
+      dm: "DM",
+      copyNpub: "Copy npub",
+      copyLud16: "Copy lud16",
+      openProfile: "Profile",
+      cancel: "Cancel",
+    },
+    notifications: {
+      note_saved: "Note saved",
+      note_save_failed: "Failed to save note",
+    },
   },
 };

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -1580,9 +1580,19 @@ export default {
       exportSelected: "Export selected",
       filters: "Filters",
     },
+    toolbar: {
+      searchPlaceholder: "Search",
+      frequency: "Frequency",
+      status: "Status",
+      tier: "Tier",
+      sort: "Sort",
+      compact: "Compact",
+      exportCsv: "Export CSV",
+    },
     status: {
       active: "ใช้งาน",
       pending: "รอดำเนินการ",
+      ended: "Ended",
     },
     summary: {
       subscribers: "Subscribers",
@@ -1590,6 +1600,7 @@ export default {
       pending: "Pending",
       receivedPeriods: "Received periods",
       revenue: "Revenue",
+      thisWeek: "this week",
       thisMonth: "this month",
     },
     periodsText: "{received} of {total} periods",
@@ -1600,5 +1611,23 @@ export default {
     nextRenewal: "Renews on {date}",
     noData: "No subscribers yet",
     shareProfile: "Share your profile",
+  },
+  SubscriberDrawer: {
+    tabs: {
+      overview: "Overview",
+      payments: "Payments",
+      notes: "Notes",
+    },
+    actions: {
+      dm: "DM",
+      copyNpub: "Copy npub",
+      copyLud16: "Copy lud16",
+      openProfile: "Profile",
+      cancel: "Cancel",
+    },
+    notifications: {
+      note_saved: "Note saved",
+      note_save_failed: "Failed to save note",
+    },
   },
 };

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -1585,9 +1585,19 @@ export default {
       exportSelected: "Export selected",
       filters: "Filters",
     },
+    toolbar: {
+      searchPlaceholder: "Search",
+      frequency: "Frequency",
+      status: "Status",
+      tier: "Tier",
+      sort: "Sort",
+      compact: "Compact",
+      exportCsv: "Export CSV",
+    },
     status: {
       active: "Aktif",
       pending: "Beklemede",
+      ended: "Ended",
     },
     summary: {
       subscribers: "Subscribers",
@@ -1595,6 +1605,7 @@ export default {
       pending: "Pending",
       receivedPeriods: "Received periods",
       revenue: "Revenue",
+      thisWeek: "this week",
       thisMonth: "this month",
     },
     periodsText: "{received} of {total} periods",
@@ -1605,5 +1616,23 @@ export default {
     nextRenewal: "Renews on {date}",
     noData: "No subscribers yet",
     shareProfile: "Share your profile",
+  },
+  SubscriberDrawer: {
+    tabs: {
+      overview: "Overview",
+      payments: "Payments",
+      notes: "Notes",
+    },
+    actions: {
+      dm: "DM",
+      copyNpub: "Copy npub",
+      copyLud16: "Copy lud16",
+      openProfile: "Profile",
+      cancel: "Cancel",
+    },
+    notifications: {
+      note_saved: "Note saved",
+      note_save_failed: "Failed to save note",
+    },
   },
 };

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -1572,9 +1572,19 @@ export default {
       exportSelected: "Export selected",
       filters: "Filters",
     },
+    toolbar: {
+      searchPlaceholder: "Search",
+      frequency: "Frequency",
+      status: "Status",
+      tier: "Tier",
+      sort: "Sort",
+      compact: "Compact",
+      exportCsv: "Export CSV",
+    },
     status: {
       active: "活跃",
       pending: "待处理",
+      ended: "Ended",
     },
     summary: {
       subscribers: "Subscribers",
@@ -1582,6 +1592,7 @@ export default {
       pending: "Pending",
       receivedPeriods: "Received periods",
       revenue: "Revenue",
+      thisWeek: "this week",
       thisMonth: "this month",
     },
     periodsText: "{received} of {total} periods",
@@ -1592,5 +1603,23 @@ export default {
     nextRenewal: "Renews on {date}",
     noData: "No subscribers yet",
     shareProfile: "Share your profile",
+  },
+  SubscriberDrawer: {
+    tabs: {
+      overview: "Overview",
+      payments: "Payments",
+      notes: "Notes",
+    },
+    actions: {
+      dm: "DM",
+      copyNpub: "Copy npub",
+      copyLud16: "Copy lud16",
+      openProfile: "Profile",
+      cancel: "Cancel",
+    },
+    notifications: {
+      note_saved: "Note saved",
+      note_save_failed: "Failed to save note",
+    },
   },
 };


### PR DESCRIPTION
## Summary
- extend CreatorSubscribers with ended status and toolbar translations
- add new KPI and drawer strings with note save notifications
- provide placeholders for new keys across all locales

## Testing
- `pnpm test` *(fails: bad point not on curve, missing module, etc.)*
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*


------
https://chatgpt.com/codex/tasks/task_e_6895eb2246fc833080c194b9044dd5d1