### PR TITLE
feat: add subscriber mini charts

### DIFF
--- a/src/components/subscribers/MiniBar.vue
+++ b/src/components/subscribers/MiniBar.vue
@@ -1,0 +1,36 @@
+<template>
+  <div class="w-full">
+    <q-skeleton v-if="!series || series.length === 0" class="w-full h-6" />
+    <svg v-else :viewBox="`0 0 ${width} ${height}`" class="w-full h-6">
+      <rect
+        v-for="(v, i) in series"
+        :key="i"
+        :x="i * barWidth"
+        :y="height - (v / maxValue) * height"
+        :width="barWidth - gap"
+        :height="(v / maxValue) * height"
+        rx="1"
+        ry="1"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+const props = defineProps<{ series: number[]; max?: number }>();
+
+const width = 100;
+const height = 24;
+const gap = 1;
+
+const barWidth = computed(() =>
+  props.series.length > 0 ? width / props.series.length : 0,
+);
+
+const maxValue = computed(() =>
+  props.max !== undefined ? props.max : Math.max(...props.series, 1),
+);
+</script>

--- a/src/components/subscribers/MiniDonut.vue
+++ b/src/components/subscribers/MiniDonut.vue
@@ -1,0 +1,76 @@
+<template>
+  <div class="flex items-center">
+    <q-skeleton v-if="segments.length === 0" type="circle" class="w-12 h-12" />
+    <template v-else>
+      <svg viewBox="0 0 32 32" class="w-12 h-12">
+        <circle
+          cx="16"
+          cy="16"
+          r="14"
+          fill="none"
+          stroke="var(--q-grey-4)"
+          stroke-width="4"
+        />
+        <g transform="rotate(-90 16 16)">
+          <circle
+            v-for="(seg, i) in segments"
+            :key="i"
+            cx="16"
+            cy="16"
+            r="14"
+            fill="none"
+            stroke-width="4"
+            stroke-linecap="butt"
+            :stroke="colors[i]"
+            pathLength="100"
+            :stroke-dasharray="`${seg.percent} 100`"
+            :stroke-dashoffset="seg.offset"
+          />
+        </g>
+      </svg>
+      <ul v-if="labels.length" class="text-caption q-ml-sm">
+        <li v-for="(label, i) in labels" :key="i" class="flex items-center">
+          <span
+            class="w-2 h-2 rounded-sm q-mr-xs"
+            :style="{ backgroundColor: colors[i] }"
+          />
+          {{ label }}
+        </li>
+      </ul>
+    </template>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+const props = defineProps<{ series: number[]; labels: string[] }>();
+
+const colors = [
+  'var(--q-positive)',
+  'var(--q-warning)',
+  'var(--q-negative)',
+  'var(--q-primary)',
+  'var(--q-accent)',
+  'var(--q-secondary)',
+];
+
+const total = computed(() => props.series.reduce((a, b) => a + b, 0));
+
+const segments = computed(() => {
+  if (total.value === 0) return [] as { percent: number; offset: number }[];
+  let acc = 0;
+  return props.series.map((val) => {
+    const percent = (val / total.value) * 100;
+    const seg = { percent, offset: -acc };
+    acc += percent;
+    return seg;
+  });
+});
+</script>
+
+<style scoped>
+li + li {
+  margin-top: 2px;
+}
+</style>

--- a/src/components/subscribers/SubscriptionsCharts.vue
+++ b/src/components/subscribers/SubscriptionsCharts.vue
@@ -1,7 +1,79 @@
 <template>
-  <div class="subscriptions-charts"></div>
+  <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+    <div class="flex flex-col items-center">
+      <MiniDonut :series="frequencySeries" :labels="frequencyLabels" />
+      <div class="text-caption q-mt-xs">Frequency</div>
+    </div>
+    <div class="flex flex-col items-center">
+      <MiniDonut :series="statusSeries" :labels="statusLabels" />
+      <div class="text-caption q-mt-xs">Status</div>
+    </div>
+    <div class="flex flex-col items-center w-full">
+      <MiniBar :series="newSubsSeries" class="w-full" />
+      <div class="text-caption q-mt-xs">New subs</div>
+    </div>
+  </div>
 </template>
 
 <script setup lang="ts">
-const props = defineProps<{ rows: any[] }>();
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import MiniDonut from './MiniDonut.vue';
+import MiniBar from './MiniBar.vue';
+import type { CreatorSubscription } from 'stores/creatorSubscriptions';
+
+const props = defineProps<{ rows: CreatorSubscription[] }>();
+
+const { t } = useI18n();
+
+const frequencyLabels = computed(() => [
+  t('CreatorSubscribers.frequency.weekly'),
+  t('CreatorSubscribers.frequency.biweekly'),
+  t('CreatorSubscribers.frequency.monthly'),
+]);
+
+const frequencySeries = computed(() => {
+  const counts = { weekly: 0, biweekly: 0, monthly: 0 };
+  props.rows.forEach((r) => {
+    counts[r.frequency] = (counts[r.frequency] || 0) + 1;
+  });
+  return [counts.weekly, counts.biweekly, counts.monthly];
+});
+
+function uiStatus(
+  sub: CreatorSubscription,
+): 'active' | 'pending' | 'ended' {
+  if (sub.status === 'pending') return 'pending';
+  const now = Date.now() / 1000;
+  if (sub.endDate && sub.endDate < now) return 'ended';
+  return 'active';
+}
+
+const statusLabels = computed(() => [
+  t('CreatorSubscribers.status.active'),
+  t('CreatorSubscribers.status.pending'),
+  t('CreatorSubscribers.status.ended'),
+]);
+
+const statusSeries = computed(() => {
+  const counts = { active: 0, pending: 0, ended: 0 };
+  props.rows.forEach((r) => {
+    counts[uiStatus(r)]++;
+  });
+  return [counts.active, counts.pending, counts.ended];
+});
+
+const newSubsSeries = computed(() => {
+  const days = 7;
+  const now = Date.now() / 1000;
+  const arr = Array(days).fill(0);
+  props.rows.forEach((r) => {
+    if (!r.startDate) return;
+    const diff = Math.floor((now - r.startDate) / (24 * 60 * 60));
+    if (diff >= 0 && diff < days) {
+      arr[days - diff - 1]++;
+    }
+  });
+  return arr;
+});
 </script>


### PR DESCRIPTION
## Summary
- add SVG MiniDonut component and MiniBar component for simple charts
- render subscriber frequency and status donuts plus new subscription bar chart

## Testing
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: ReferenceError: windowMixin is not defined, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68961ac541d48330819aed593a379f3a