### PR TITLE
feat: enhance subscriber drawer i18n and notes

### DIFF
--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1713,23 +1713,31 @@ export const messages = {
       export_failed: "Failed to export subscribers",
       dm_not_ready: "Messenger not ready",
     },
-  },
-  SubscriberDrawer: {
-    tabs: {
-      overview: "Overview",
-      payments: "Payments",
-      notes: "Notes",
-    },
-    actions: {
-      dm: "DM",
-      copyNpub: "Copy npub",
-      copyLud16: "Copy lud16",
-      openProfile: "Profile",
-      cancel: "Cancel",
-    },
-    notifications: {
-      note_saved: "Note saved",
-      note_save_failed: "Failed to save note",
+    drawer: {
+      tabs: {
+        overview: "Overview",
+        payments: "Payments",
+        notes: "Notes",
+      },
+      overview: {
+        nip05: "nip05",
+        lud16: "lud16",
+        about: "about",
+        nextRenewal: "Next renewal",
+        amountPerInterval: "Amount / interval",
+        lifetimeTotal: "Lifetime total",
+        since: "Since",
+      },
+      actions: {
+        dm: "DM",
+        copyNpub: "Copy npub",
+        copyLud16: "Copy lud16",
+        openProfile: "Profile",
+        cancel: "Cancel",
+      },
+      payments: {
+        noPayments: "No payments",
+      },
     },
   },
   restore: {


### PR DESCRIPTION
## Summary
- localize subscriber drawer tabs, details, actions and messages with `CreatorSubscribers.drawer` keys
- emit note updates and persist subscriber notes keyed by subscription ID

## Testing
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: [vitest] There was an error when mocking a module)*

------
https://chatgpt.com/codex/tasks/task_e_68962a43813883308577be3a69893821