### PR TITLE
refactor: update subscriber card usage

### DIFF
--- a/src/pages/CreatorSubscribers.vue
+++ b/src/pages/CreatorSubscribers.vue
@@ -128,20 +128,19 @@
           v-slot="{ item }"
         >
           <SubscriberCard
-            :subscription="item"
+            :sub="item"
+            :profile="profilesById[item.subscriptionId]"
             :compact="compact"
-            :status="uiStatus(item)"
-            :next-in="nextIn(item)"
-            :progress="progress(item)"
-            :amount="amountPerInterval(item)"
+            @select="selectSubscriber(item)"
             @open="openSubscriber(item)"
           />
         </q-virtual-scroll>
       </div>
 
       <SubscriberDrawer
+        v-if="current"
         v-model="drawer"
-        :subscription="current"
+        :sub="current"
         :profile="currentProfile"
       />
     </template>
@@ -153,7 +152,7 @@ import { ref, computed, watch } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useI18n } from 'vue-i18n';
 import { useDebounceFn } from '@vueuse/core';
-import SubscriberCard from 'components/SubscriberCard.vue';
+import SubscriberCard from 'components/subscribers/SubscriberCard.vue';
 import SubscriberDrawer from 'components/subscribers/SubscriberDrawer.vue';
 import KpiCard from 'components/subscribers/KpiCard.vue';
 import Sparkline from 'components/subscribers/Sparkline.vue';
@@ -384,6 +383,9 @@ const current = ref<CreatorSubscription | null>(null);
 const currentProfile = computed(() =>
   current.value ? profilesById.value[current.value.subscriptionId] : undefined,
 );
+function selectSubscriber(sub: CreatorSubscription) {
+  current.value = sub;
+}
 function openSubscriber(sub: CreatorSubscription) {
   current.value = sub;
   drawer.value = true;

--- a/test/vitest/__tests__/creatorSubscribers.spec.ts
+++ b/test/vitest/__tests__/creatorSubscribers.spec.ts
@@ -111,9 +111,9 @@ describe('CreatorSubscribers', () => {
         stubs: {
           'q-page': { template: '<div><slot /></div>' },
           SubscriberCard: {
-            props: ['subscription'],
+            props: ['sub', 'profile', 'compact'],
             template:
-              '<div class="subscriber-card">{{ subscription.subscriptionId }} {{ subscription.totalAmount }}</div>',
+              '<div class="subscriber-card">{{ sub.subscriptionId }} {{ sub.totalAmount }}</div>',
           },
           SubscriberDrawer: true,
           KpiCard: true,


### PR DESCRIPTION
## Summary
- import subscriber card from new `components/subscribers` path
- use new subscriber card props and events
- render subscriber drawer only when a subscriber is selected

## Testing
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: multiple tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_68963297d9188330992d885a7120249e