### PR TITLE
feat: add creator hub style helpers

### DIFF
--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -1,6 +1,6 @@
 // app global css in SCSS form
 @import "tokens.scss";
-
+@import "creator-hub.scss";
 // Use Inter if installed locally and fall back to system fonts
 body {
   font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
@@ -102,6 +102,7 @@ body,
   --bucket-text-light: #000000;
   --bucket-accent-dark: #ec4899;
   --bucket-accent-light: #ec4899;
+  --border-subtle: 1px solid var(--border-subtle-light);
 }
 
 body.body--dark {
@@ -115,6 +116,7 @@ body.body--dark {
   --bucket-background: var(--bucket-bg-dark);
   --bucket-text-color: var(--bucket-text-dark);
   --bucket-accent: var(--bucket-accent-dark);
+  --border-subtle: 1px solid var(--border-subtle-dark);
 }
 
 body.body--light {
@@ -128,6 +130,7 @@ body.body--light {
   --bucket-background: var(--bucket-bg-light);
   --bucket-text-color: var(--bucket-text-light);
   --bucket-accent: var(--bucket-accent-light);
+  --border-subtle: 1px solid var(--border-subtle-light);
 }
 
 /* utility background classes */
@@ -216,4 +219,3 @@ body.body--dark .received {
   max-width: 500px;
 }
 
-@import './creator-hub.scss';

--- a/src/css/creator-hub.scss
+++ b/src/css/creator-hub.scss
@@ -13,6 +13,19 @@
   background: linear-gradient(135deg, #334155 0%, #1e293b 100%);
 }
 
+/* Soft gradient backgrounds */
+.gradient-soft-blue {
+  background: linear-gradient(135deg, #93c5fd 0%, #bfdbfe 100%);
+}
+.gradient-soft-green {
+  background: linear-gradient(135deg, #a7f3d0 0%, #d1fae5 100%);
+}
+
+/* Subtle border helpers */
+.border-subtle {
+  border: var(--border-subtle);
+}
+
 /* Rounded card helpers */
 .card-rounded-16 {
   border-radius: 16px;
@@ -23,14 +36,17 @@
 
 /* Chip variants */
 .chip-outline {
-  border: 1px solid var(--q-color-grey-5);
+  border: var(--border-subtle);
   background-color: transparent;
   color: var(--q-color-grey-8);
 }
-.chip-filled {
+.chip-solid {
   background-color: var(--q-color-grey-8);
   color: #fff;
   border: none;
+}
+.chip-filled {
+  @extend .chip-solid;
 }
 
 /* Compact spacing utilities */

--- a/src/css/tokens.scss
+++ b/src/css/tokens.scss
@@ -10,6 +10,8 @@ $h3-size: 20px;
 $body-size: 16px;
 $caption-size: 14px;
 $spacing-base: 8px;
+$border-subtle-light: #e5e7eb;
+$border-subtle-dark: #374151;
 
 :root {
   --color-primary-pink: #ff2d75;
@@ -18,4 +20,6 @@ $spacing-base: 8px;
   --color-accent-green: #15c972;
   --color-accent-orange: #ff9f0a;
   --font-family-base: "Inter", system-ui, sans-serif;
+  --border-subtle-light: #e5e7eb;
+  --border-subtle-dark: #374151;
 }


### PR DESCRIPTION
## Summary
- add soft gradient background helpers and border utilities
- provide chip outline/solid variants
- wire up creator-hub styles in app and tokens

## Testing
- `pnpm test` *(fails: InfoTooltip > shows tooltip on hover)*

------
https://chatgpt.com/codex/tasks/task_e_6896355cee5083308a206f9723705986