### PR TITLE
feat: expand CreatorSubscribers i18n

### DIFF
--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -1603,6 +1603,7 @@ export default {
       exportCsv: "Export CSV",
     },
     status: {
+      any: "Any",
       active: "نشط",
       pending: "معلق",
       ended: "Ended",
@@ -1613,8 +1614,14 @@ export default {
       pending: "Pending",
       receivedPeriods: "Received periods",
       revenue: "Revenue",
+      thisPeriod: "This period",
       thisWeek: "this week",
       thisMonth: "this month",
+    },
+    charts: {
+      frequency: "Frequency",
+      status: "Status",
+      newSubs: "New subs",
     },
     periodsText: "{received} of {total} periods",
     periodsTooltip: "Periods received vs periods purchased",
@@ -1624,6 +1631,32 @@ export default {
     nextRenewal: "Renews on {date}",
     noData: "No subscribers yet",
     shareProfile: "Share your profile",
+    drawer: {
+      tabs: {
+        overview: "Overview",
+        payments: "Payments",
+        notes: "Notes",
+      },
+      overview: {
+        nip05: "nip05",
+        lud16: "lud16",
+        about: "about",
+        nextRenewal: "Next renewal",
+        amountPerInterval: "Amount / interval",
+        lifetimeTotal: "Lifetime total",
+        since: "Since",
+      },
+      actions: {
+        dm: "DM",
+        copyNpub: "Copy npub",
+        copyLud16: "Copy lud16",
+        openProfile: "Profile",
+        cancel: "Cancel",
+      },
+      payments: {
+        noPayments: "No payments",
+      },
+    },
   },
   SubscriberDrawer: {
     tabs: {

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -1609,6 +1609,7 @@ export default {
       exportCsv: "Export CSV",
     },
     status: {
+      any: "Any",
       active: "Aktiv",
       pending: "Ausstehend",
       ended: "Ended",
@@ -1619,8 +1620,14 @@ export default {
       pending: "Pending",
       receivedPeriods: "Received periods",
       revenue: "Revenue",
+      thisPeriod: "This period",
       thisWeek: "this week",
       thisMonth: "this month",
+    },
+    charts: {
+      frequency: "Frequency",
+      status: "Status",
+      newSubs: "New subs",
     },
     periodsText: "{received} of {total} periods",
     periodsTooltip: "Periods received vs periods purchased",
@@ -1630,6 +1637,32 @@ export default {
     nextRenewal: "Renews on {date}",
     noData: "No subscribers yet",
     shareProfile: "Share your profile",
+    drawer: {
+      tabs: {
+        overview: "Overview",
+        payments: "Payments",
+        notes: "Notes",
+      },
+      overview: {
+        nip05: "nip05",
+        lud16: "lud16",
+        about: "about",
+        nextRenewal: "Next renewal",
+        amountPerInterval: "Amount / interval",
+        lifetimeTotal: "Lifetime total",
+        since: "Since",
+      },
+      actions: {
+        dm: "DM",
+        copyNpub: "Copy npub",
+        copyLud16: "Copy lud16",
+        openProfile: "Profile",
+        cancel: "Cancel",
+      },
+      payments: {
+        noPayments: "No payments",
+      },
+    },
   },
   SubscriberDrawer: {
     tabs: {

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -1616,6 +1616,7 @@ export default {
       active: "Ενεργό",
       pending: "Σε εκκρεμότητα",
       ended: "Ended",
+      any: "Any",
     },
     summary: {
       subscribers: "Subscribers",
@@ -1623,8 +1624,14 @@ export default {
       pending: "Pending",
       receivedPeriods: "Received periods",
       revenue: "Revenue",
+      thisPeriod: "This period",
       thisWeek: "this week",
       thisMonth: "this month",
+    },
+    charts: {
+      frequency: "Frequency",
+      status: "Status",
+      newSubs: "New subs",
     },
     periodsText: "{received} of {total} periods",
     periodsTooltip: "Periods received vs periods purchased",
@@ -1634,6 +1641,32 @@ export default {
     nextRenewal: "Renews on {date}",
     noData: "No subscribers yet",
     shareProfile: "Share your profile",
+    drawer: {
+      tabs: {
+        overview: "Overview",
+        payments: "Payments",
+        notes: "Notes",
+      },
+      overview: {
+        nip05: "nip05",
+        lud16: "lud16",
+        about: "about",
+        nextRenewal: "Next renewal",
+        amountPerInterval: "Amount / interval",
+        lifetimeTotal: "Lifetime total",
+        since: "Since",
+      },
+      actions: {
+        dm: "DM",
+        copyNpub: "Copy npub",
+        copyLud16: "Copy lud16",
+        openProfile: "Profile",
+        cancel: "Cancel",
+      },
+      payments: {
+        noPayments: "No payments",
+      },
+    },
   },
   SubscriberDrawer: {
     tabs: {

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1682,6 +1682,7 @@ export const messages = {
       exportCsv: "Export CSV",
     },
     status: {
+      any: "Any",
       active: "Active",
       pending: "Pending",
       ended: "Ended",
@@ -1692,8 +1693,14 @@ export const messages = {
       pending: "Pending",
       receivedPeriods: "Received periods",
       revenue: "Revenue",
+      thisPeriod: "This period",
       thisWeek: "this week",
       thisMonth: "this month",
+    },
+    charts: {
+      frequency: "Frequency",
+      status: "Status",
+      newSubs: "New subs",
     },
     periodsText: "{received} of {total} periods",
     periodsTooltip: "Periods received vs periods purchased",

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -1613,6 +1613,7 @@ export default {
       active: "Activo",
       pending: "Pendiente",
       ended: "Ended",
+      any: "Any",
     },
     summary: {
       subscribers: "Subscribers",
@@ -1620,8 +1621,14 @@ export default {
       pending: "Pending",
       receivedPeriods: "Received periods",
       revenue: "Revenue",
+      thisPeriod: "This period",
       thisWeek: "this week",
       thisMonth: "this month",
+    },
+    charts: {
+      frequency: "Frequency",
+      status: "Status",
+      newSubs: "New subs",
     },
     periodsText: "{received} of {total} periods",
     periodsTooltip: "Periods received vs periods purchased",
@@ -1631,6 +1638,32 @@ export default {
     nextRenewal: "Renews on {date}",
     noData: "No subscribers yet",
     shareProfile: "Share your profile",
+    drawer: {
+      tabs: {
+        overview: "Overview",
+        payments: "Payments",
+        notes: "Notes",
+      },
+      overview: {
+        nip05: "nip05",
+        lud16: "lud16",
+        about: "about",
+        nextRenewal: "Next renewal",
+        amountPerInterval: "Amount / interval",
+        lifetimeTotal: "Lifetime total",
+        since: "Since",
+      },
+      actions: {
+        dm: "DM",
+        copyNpub: "Copy npub",
+        copyLud16: "Copy lud16",
+        openProfile: "Profile",
+        cancel: "Cancel",
+      },
+      payments: {
+        noPayments: "No payments",
+      },
+    },
   },
   SubscriberDrawer: {
     tabs: {

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -1603,6 +1603,7 @@ export default {
       active: "Actif",
       pending: "En attente",
       ended: "Ended",
+      any: "Any",
     },
     summary: {
       subscribers: "Subscribers",
@@ -1610,8 +1611,14 @@ export default {
       pending: "Pending",
       receivedPeriods: "Received periods",
       revenue: "Revenue",
+      thisPeriod: "This period",
       thisWeek: "this week",
       thisMonth: "this month",
+    },
+    charts: {
+      frequency: "Frequency",
+      status: "Status",
+      newSubs: "New subs",
     },
     periodsText: "{received} of {total} periods",
     periodsTooltip: "Periods received vs periods purchased",
@@ -1621,6 +1628,32 @@ export default {
     nextRenewal: "Renews on {date}",
     noData: "No subscribers yet",
     shareProfile: "Share your profile",
+    drawer: {
+      tabs: {
+        overview: "Overview",
+        payments: "Payments",
+        notes: "Notes",
+      },
+      overview: {
+        nip05: "nip05",
+        lud16: "lud16",
+        about: "about",
+        nextRenewal: "Next renewal",
+        amountPerInterval: "Amount / interval",
+        lifetimeTotal: "Lifetime total",
+        since: "Since",
+      },
+      actions: {
+        dm: "DM",
+        copyNpub: "Copy npub",
+        copyLud16: "Copy lud16",
+        openProfile: "Profile",
+        cancel: "Cancel",
+      },
+      payments: {
+        noPayments: "No payments",
+      },
+    },
   },
   SubscriberDrawer: {
     tabs: {

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -1595,6 +1595,7 @@ export default {
       active: "Attivo",
       pending: "In attesa",
       ended: "Ended",
+      any: "Any",
     },
     summary: {
       subscribers: "Subscribers",
@@ -1602,8 +1603,14 @@ export default {
       pending: "Pending",
       receivedPeriods: "Received periods",
       revenue: "Revenue",
+      thisPeriod: "This period",
       thisWeek: "this week",
       thisMonth: "this month",
+    },
+    charts: {
+      frequency: "Frequency",
+      status: "Status",
+      newSubs: "New subs",
     },
     periodsText: "{received} of {total} periods",
     periodsTooltip: "Periods received vs periods purchased",
@@ -1613,6 +1620,32 @@ export default {
     nextRenewal: "Renews on {date}",
     noData: "No subscribers yet",
     shareProfile: "Share your profile",
+    drawer: {
+      tabs: {
+        overview: "Overview",
+        payments: "Payments",
+        notes: "Notes",
+      },
+      overview: {
+        nip05: "nip05",
+        lud16: "lud16",
+        about: "about",
+        nextRenewal: "Next renewal",
+        amountPerInterval: "Amount / interval",
+        lifetimeTotal: "Lifetime total",
+        since: "Since",
+      },
+      actions: {
+        dm: "DM",
+        copyNpub: "Copy npub",
+        copyLud16: "Copy lud16",
+        openProfile: "Profile",
+        cancel: "Cancel",
+      },
+      payments: {
+        noPayments: "No payments",
+      },
+    },
   },
   SubscriberDrawer: {
     tabs: {

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -1596,6 +1596,7 @@ export default {
       active: "アクティブ",
       pending: "保留中",
       ended: "Ended",
+      any: "Any",
     },
     summary: {
       subscribers: "Subscribers",
@@ -1603,8 +1604,14 @@ export default {
       pending: "Pending",
       receivedPeriods: "Received periods",
       revenue: "Revenue",
+      thisPeriod: "This period",
       thisWeek: "this week",
       thisMonth: "this month",
+    },
+    charts: {
+      frequency: "Frequency",
+      status: "Status",
+      newSubs: "New subs",
     },
     periodsText: "{received} of {total} periods",
     periodsTooltip: "Periods received vs periods purchased",
@@ -1614,6 +1621,32 @@ export default {
     nextRenewal: "Renews on {date}",
     noData: "No subscribers yet",
     shareProfile: "Share your profile",
+    drawer: {
+      tabs: {
+        overview: "Overview",
+        payments: "Payments",
+        notes: "Notes",
+      },
+      overview: {
+        nip05: "nip05",
+        lud16: "lud16",
+        about: "about",
+        nextRenewal: "Next renewal",
+        amountPerInterval: "Amount / interval",
+        lifetimeTotal: "Lifetime total",
+        since: "Since",
+      },
+      actions: {
+        dm: "DM",
+        copyNpub: "Copy npub",
+        copyLud16: "Copy lud16",
+        openProfile: "Profile",
+        cancel: "Cancel",
+      },
+      payments: {
+        noPayments: "No payments",
+      },
+    },
   },
   SubscriberDrawer: {
     tabs: {

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -1595,6 +1595,7 @@ export default {
       active: "Aktiv",
       pending: "Väntande",
       ended: "Ended",
+      any: "Any",
     },
     summary: {
       subscribers: "Subscribers",
@@ -1602,8 +1603,14 @@ export default {
       pending: "Pending",
       receivedPeriods: "Received periods",
       revenue: "Revenue",
+      thisPeriod: "This period",
       thisWeek: "this week",
       thisMonth: "this month",
+    },
+    charts: {
+      frequency: "Frequency",
+      status: "Status",
+      newSubs: "New subs",
     },
     periodsText: "{received} of {total} periods",
     periodsTooltip: "Periods received vs periods purchased",
@@ -1613,6 +1620,32 @@ export default {
     nextRenewal: "Renews on {date}",
     noData: "No subscribers yet",
     shareProfile: "Share your profile",
+    drawer: {
+      tabs: {
+        overview: "Overview",
+        payments: "Payments",
+        notes: "Notes",
+      },
+      overview: {
+        nip05: "nip05",
+        lud16: "lud16",
+        about: "about",
+        nextRenewal: "Next renewal",
+        amountPerInterval: "Amount / interval",
+        lifetimeTotal: "Lifetime total",
+        since: "Since",
+      },
+      actions: {
+        dm: "DM",
+        copyNpub: "Copy npub",
+        copyLud16: "Copy lud16",
+        openProfile: "Profile",
+        cancel: "Cancel",
+      },
+      payments: {
+        noPayments: "No payments",
+      },
+    },
   },
   SubscriberDrawer: {
     tabs: {

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -1593,6 +1593,7 @@ export default {
       active: "ใช้งาน",
       pending: "รอดำเนินการ",
       ended: "Ended",
+      any: "Any",
     },
     summary: {
       subscribers: "Subscribers",
@@ -1600,8 +1601,14 @@ export default {
       pending: "Pending",
       receivedPeriods: "Received periods",
       revenue: "Revenue",
+      thisPeriod: "This period",
       thisWeek: "this week",
       thisMonth: "this month",
+    },
+    charts: {
+      frequency: "Frequency",
+      status: "Status",
+      newSubs: "New subs",
     },
     periodsText: "{received} of {total} periods",
     periodsTooltip: "Periods received vs periods purchased",
@@ -1611,6 +1618,32 @@ export default {
     nextRenewal: "Renews on {date}",
     noData: "No subscribers yet",
     shareProfile: "Share your profile",
+    drawer: {
+      tabs: {
+        overview: "Overview",
+        payments: "Payments",
+        notes: "Notes",
+      },
+      overview: {
+        nip05: "nip05",
+        lud16: "lud16",
+        about: "about",
+        nextRenewal: "Next renewal",
+        amountPerInterval: "Amount / interval",
+        lifetimeTotal: "Lifetime total",
+        since: "Since",
+      },
+      actions: {
+        dm: "DM",
+        copyNpub: "Copy npub",
+        copyLud16: "Copy lud16",
+        openProfile: "Profile",
+        cancel: "Cancel",
+      },
+      payments: {
+        noPayments: "No payments",
+      },
+    },
   },
   SubscriberDrawer: {
     tabs: {

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -1598,6 +1598,7 @@ export default {
       active: "Aktif",
       pending: "Beklemede",
       ended: "Ended",
+      any: "Any",
     },
     summary: {
       subscribers: "Subscribers",
@@ -1605,8 +1606,14 @@ export default {
       pending: "Pending",
       receivedPeriods: "Received periods",
       revenue: "Revenue",
+      thisPeriod: "This period",
       thisWeek: "this week",
       thisMonth: "this month",
+    },
+    charts: {
+      frequency: "Frequency",
+      status: "Status",
+      newSubs: "New subs",
     },
     periodsText: "{received} of {total} periods",
     periodsTooltip: "Periods received vs periods purchased",
@@ -1616,6 +1623,32 @@ export default {
     nextRenewal: "Renews on {date}",
     noData: "No subscribers yet",
     shareProfile: "Share your profile",
+    drawer: {
+      tabs: {
+        overview: "Overview",
+        payments: "Payments",
+        notes: "Notes",
+      },
+      overview: {
+        nip05: "nip05",
+        lud16: "lud16",
+        about: "about",
+        nextRenewal: "Next renewal",
+        amountPerInterval: "Amount / interval",
+        lifetimeTotal: "Lifetime total",
+        since: "Since",
+      },
+      actions: {
+        dm: "DM",
+        copyNpub: "Copy npub",
+        copyLud16: "Copy lud16",
+        openProfile: "Profile",
+        cancel: "Cancel",
+      },
+      payments: {
+        noPayments: "No payments",
+      },
+    },
   },
   SubscriberDrawer: {
     tabs: {

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -1585,6 +1585,7 @@ export default {
       active: "活跃",
       pending: "待处理",
       ended: "Ended",
+      any: "Any",
     },
     summary: {
       subscribers: "Subscribers",
@@ -1592,8 +1593,14 @@ export default {
       pending: "Pending",
       receivedPeriods: "Received periods",
       revenue: "Revenue",
+      thisPeriod: "This period",
       thisWeek: "this week",
       thisMonth: "this month",
+    },
+    charts: {
+      frequency: "Frequency",
+      status: "Status",
+      newSubs: "New subs",
     },
     periodsText: "{received} of {total} periods",
     periodsTooltip: "Periods received vs periods purchased",
@@ -1603,6 +1610,32 @@ export default {
     nextRenewal: "Renews on {date}",
     noData: "No subscribers yet",
     shareProfile: "Share your profile",
+    drawer: {
+      tabs: {
+        overview: "Overview",
+        payments: "Payments",
+        notes: "Notes",
+      },
+      overview: {
+        nip05: "nip05",
+        lud16: "lud16",
+        about: "about",
+        nextRenewal: "Next renewal",
+        amountPerInterval: "Amount / interval",
+        lifetimeTotal: "Lifetime total",
+        since: "Since",
+      },
+      actions: {
+        dm: "DM",
+        copyNpub: "Copy npub",
+        copyLud16: "Copy lud16",
+        openProfile: "Profile",
+        cancel: "Cancel",
+      },
+      payments: {
+        noPayments: "No payments",
+      },
+    },
   },
   SubscriberDrawer: {
     tabs: {


### PR DESCRIPTION
## Summary
- add KPI, chart, toolbar, drawer, and status strings for CreatorSubscribers
- stub corresponding translations across locales

## Testing
- `pnpm lint` (fails: Cannot find module './.eslintrc.js')
- `pnpm test` (fails: ReferenceError: windowMixin is not defined, etc.)

------
https://chatgpt.com/codex/tasks/task_e_689638e2956883308d8cb52d5f9cae40