### PR TITLE
Normalize creator subscriber grouping

### DIFF
--- a/src/constants/subscriptionFrequency.ts
+++ b/src/constants/subscriptionFrequency.ts
@@ -9,3 +9,11 @@ export const FREQUENCY_TO_DAYS: Record<SubscriptionFrequency, number> = {
 export function frequencyToDays(freq: SubscriptionFrequency): number {
   return FREQUENCY_TO_DAYS[freq] || 30;
 }
+
+export function daysToFrequency(
+  days: number,
+): SubscriptionFrequency {
+  if (days === 7) return 'weekly';
+  if (days === 14) return 'biweekly';
+  return 'monthly';
+}


### PR DESCRIPTION
## Summary
- derive subscription frequency with `freqKey` using `daysToFrequency`
- compute `uiStatus` from start/end dates and group subscriptions by normalized frequency
- render grouped `SubscriberCard`s in grids and export CSV safely when rows exist

## Testing
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: multiple test failures, ReferenceError: windowMixin is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689644b552848330add7d4c24e538776