### PR TITLE
chore: configure @ alias for bucket constants

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "paths": {
+  "paths": {
+      "@/*": ["src/*"],
       "src/*": ["src/*"],
       "app/*": ["*"],
       "components/*": ["src/components/*"],

--- a/quasar.config.js
+++ b/quasar.config.js
@@ -39,6 +39,9 @@ export default configure(function (/* ctx */) {
 
     // Full list of options: https://v2.quasar.dev/quasar-cli-vite/quasar-config-js#build
     build: {
+      alias: {
+        '@': path.resolve(__dirname, 'src'),
+      },
       optimizeDeps: { include: ['process', 'buffer'] },
       target: {
         browser: ["esnext"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,10 +3,13 @@
   "compilerOptions": {
     "baseUrl": ".",
     "target": "ES2020",
-    "paths": {
-      "src/*": [
-        "src/*"
-      ],
+      "paths": {
+        "@/*": [
+          "src/*"
+        ],
+        "src/*": [
+          "src/*"
+        ],
       "app/*": [
         "*"
       ],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -26,11 +26,12 @@ export default defineConfig({
       "test/vitest/__tests__/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}",
     ],
   },
-  resolve: {
-    alias: {
-      src: path.resolve(__dirname, "src"),
-      app: path.resolve(__dirname),
-      components: path.resolve(__dirname, "src/components"),
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, 'src'),
+        src: path.resolve(__dirname, "src"),
+        app: path.resolve(__dirname),
+        components: path.resolve(__dirname, "src/components"),
       layouts: path.resolve(__dirname, "src/layouts"),
       pages: path.resolve(__dirname, "src/pages"),
       assets: path.resolve(__dirname, "src/assets"),


### PR DESCRIPTION
## Summary
- map `@` to `src` for build and test configs
- expose `@/*` path mappings in TS and JS config

## Testing
- `pnpm test` *(fails: windowMixin is not defined, etc.)*
- `rg "DEFAULT_BUCKET_ID.*stores/buckets" -n src test`
- `npx -y madge --circular --ts-config tsconfig.json src`

------
https://chatgpt.com/codex/tasks/task_e_6896493397648330ad038c485bb51440