### PR TITLE
feat(ui): center pages and restyle KPI card

### DIFF
--- a/src/components/subscribers/KpiCard.vue
+++ b/src/components/subscribers/KpiCard.vue
@@ -1,12 +1,15 @@
 <template>
-  <q-card class="rounded-lg bg-white dark:bg-grey-9 text-dark dark:text-white">
+  <q-card class="kpi-card bg-grey-10 text-white">
     <q-card-section>
       <div class="flex items-start justify-between">
         <div>
-          <div class="text-subtitle1">{{ title }}</div>
-          <div class="text-h6">{{ value }}</div>
+          <div class="text-body1">{{ title }}</div>
+          <div class="text-h5">{{ value }}</div>
         </div>
-        <div v-if="diff !== undefined" :class="[diff >= 0 ? 'text-positive' : 'text-negative', 'text-subtitle2']">
+        <div
+          v-if="diff !== undefined"
+          :class="[diff >= 0 ? 'text-positive' : 'text-negative', 'text-subtitle2']"
+        >
           {{ diff >= 0 ? '+' : '' }}{{ diff }}
         </div>
       </div>
@@ -29,7 +32,13 @@ const props = defineProps<{
 </script>
 
 <style scoped>
-.rounded-lg {
-  border-radius: 0.5rem;
+.kpi-card {
+  border: 1px solid #2b2f3a;
+  border-radius: 16px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+.kpi-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.4);
 }
 </style>

--- a/src/layouts/BlankLayout.vue
+++ b/src/layouts/BlankLayout.vue
@@ -4,8 +4,10 @@
     :class="$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark'"
   >
     <MainHeader />
-    <q-page-container>
-      <router-view />
+    <q-page-container class="text-body1">
+      <div class="max-w-7xl mx-auto">
+        <router-view />
+      </div>
     </q-page-container>
   </q-layout>
 </template>

--- a/src/layouts/FullscreenLayout.vue
+++ b/src/layouts/FullscreenLayout.vue
@@ -4,8 +4,10 @@
     :class="$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark'"
   >
     <MainHeader />
-    <q-page-container>
-      <router-view />
+    <q-page-container class="text-body1">
+      <div class="max-w-7xl mx-auto">
+        <router-view />
+      </div>
     </q-page-container>
     <PublishBar
       v-if="loggedIn && showPublishBar"

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -8,8 +8,10 @@
     <NdkErrorDialog />
 
     <MainHeader />
-    <q-page-container>
-      <router-view />
+    <q-page-container class="text-body1">
+      <div class="max-w-7xl mx-auto">
+        <router-view />
+      </div>
     </q-page-container>
   </q-layout>
 </template>


### PR DESCRIPTION
## Summary
- center router content at 1280px and apply body1 base text
- restyle subscribers KPI card with dark panel, border, rounded corners, and hover shadow

## Testing
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: Tests failed. Watching for file changes...)*

------
https://chatgpt.com/codex/tasks/task_e_68964b7e927083308156dcd6afbe9d23