### PR TITLE
feat: speed up subscriber drawer

### DIFF
--- a/src/components/subscribers/SubscriberDrawer.vue
+++ b/src/components/subscribers/SubscriberDrawer.vue
@@ -4,6 +4,7 @@
     side="right"
     bordered
     overlay
+    :transition-duration="100"
     @keydown.esc.prevent="close"
   >
     <q-toolbar>


### PR DESCRIPTION
## Summary
- ensure subscriber drawer uses a 100ms transition for faster opening

## Testing
- `pnpm test` *(fails: [vitest] There was an error when mocking a module)*

------
https://chatgpt.com/codex/tasks/task_e_689653adb4dc8330a300135be543068c