### PR TITLE
feat: improve subscribers filtering

### DIFF
--- a/src/components/subscribers/SubscriberFiltersPopover.vue
+++ b/src/components/subscribers/SubscriberFiltersPopover.vue
@@ -1,0 +1,70 @@
+<template>
+  <q-popup-proxy ref="popup" cover transition-show="scale" transition-hide="scale">
+    <div class="q-pa-md" style="min-width: 200px">
+      <div class="text-subtitle2 q-mb-sm">Status</div>
+      <q-option-group v-model="localStatuses" :options="statusOptions" type="checkbox" />
+      <div class="text-subtitle2 q-mt-md q-mb-sm">Tier</div>
+      <q-option-group v-model="localTiers" :options="tierOptions" type="checkbox" />
+      <div class="text-subtitle2 q-mt-md q-mb-sm">Sort</div>
+      <q-option-group v-model="localSort" :options="sortOptions" type="radio" />
+      <div class="row justify-end q-mt-md q-gutter-sm">
+        <q-btn flat label="Clear" @click="clear" />
+        <q-btn color="primary" label="Apply" @click="apply" />
+      </div>
+    </div>
+  </q-popup-proxy>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue';
+import { useCreatorSubscribersStore } from 'src/stores/creatorSubscribers';
+import type { SubStatus } from 'src/types/subscriber';
+import type { SortOption } from 'src/stores/creatorSubscribers';
+
+const store = useCreatorSubscribersStore();
+
+const popup = ref();
+const localStatuses = ref<SubStatus[]>(Array.from(store.statuses));
+const localTiers = ref<string[]>(Array.from(store.tiers));
+const localSort = ref<SortOption>(store.sort);
+
+const statusOptions = [
+  { label: 'Active', value: 'active' },
+  { label: 'Pending', value: 'pending' },
+  { label: 'Ended', value: 'ended' }
+];
+
+const tierOptions = computed(() => {
+  const ids = Array.from(new Set(store.subscribers.map(s => s.tierId)));
+  return ids.map(id => ({ label: id, value: id }));
+});
+
+const sortOptions = [
+  { label: 'Next renewal', value: 'next' },
+  { label: 'First seen', value: 'first' },
+  { label: 'Lifetime sats', value: 'amount' }
+];
+
+function apply() {
+  store.applyFilters({
+    statuses: new Set(localStatuses.value),
+    tiers: new Set(localTiers.value),
+    sort: localSort.value
+  });
+  popup.value?.hide();
+}
+
+function clear() {
+  localStatuses.value = [];
+  localTiers.value = [];
+  localSort.value = 'next';
+  store.clearFilters();
+  popup.value?.hide();
+}
+
+function show() {
+  popup.value?.show();
+}
+
+defineExpose({ show });
+</script>

--- a/src/pages/CreatorSubscribersStoreDemo.vue
+++ b/src/pages/CreatorSubscribersStoreDemo.vue
@@ -1,0 +1,40 @@
+<template>
+  <q-page class="q-pa-md">
+    <div class="row items-center q-gutter-sm q-mb-md">
+      <q-input dense v-model="search" placeholder="Search" clearable @update:model-value="onSearch" />
+      <q-btn flat icon="filter_list" @click="filters?.show()" />
+    </div>
+    <q-tabs v-model="activeTab" dense class="text-grey-7" active-color="primary" indicator-color="primary">
+      <q-tab name="all" :label="`All (${counts.all})`" />
+      <q-tab name="weekly" :label="`Weekly (${counts.weekly})`" />
+      <q-tab name="biweekly" :label="`Bi-weekly (${counts.biweekly})`" />
+      <q-tab name="monthly" :label="`Monthly (${counts.monthly})`" />
+      <q-tab name="pending" :label="`Pending (${counts.pending})`" />
+      <q-tab name="ended" :label="`Ended (${counts.ended})`" />
+    </q-tabs>
+    <div class="q-mt-md">
+      <div v-for="s in filtered" :key="s.id" class="q-pa-sm">
+        {{ s.name }} - {{ s.tierName }}
+      </div>
+    </div>
+    <SubscriberFiltersPopover ref="filters" />
+  </q-page>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+import { useDebounceFn } from '@vueuse/core';
+import { storeToRefs } from 'pinia';
+import SubscriberFiltersPopover from 'src/components/subscribers/SubscriberFiltersPopover.vue';
+import { useCreatorSubscribersStore } from 'src/stores/creatorSubscribers';
+
+const store = useCreatorSubscribersStore();
+const { filtered, counts, activeTab } = storeToRefs(store);
+
+const search = ref(store.query);
+const filters = ref<InstanceType<typeof SubscriberFiltersPopover> | null>(null);
+
+const onSearch = useDebounceFn((val: string) => {
+  store.setQuery(val);
+}, 220);
+</script>

--- a/src/stores/creatorSubscribers.ts
+++ b/src/stores/creatorSubscribers.ts
@@ -3,7 +3,7 @@ import type { Subscriber, Frequency, SubStatus } from "../types/subscriber";
 
 type Tab = "all" | Frequency | "pending" | "ended";
 
-type SortOption = "next" | "first" | "amount";
+export type SortOption = "next" | "first" | "amount";
 
 const mockSubscribers: Subscriber[] = [
   {
@@ -102,6 +102,9 @@ export const useCreatorSubscribersStore = defineStore("creatorSubscribers", {
   }),
   getters: {
     filtered(state): Subscriber[] {
+      // accessing the active tab here ensures this getter recomputes whenever
+      // the user switches tabs in the UI
+      const currentTab = state.activeTab;
       let arr = state.subscribers.slice();
 
       if (state.statuses.size) {
@@ -151,6 +154,9 @@ export const useCreatorSubscribersStore = defineStore("creatorSubscribers", {
       return arr;
     },
     counts(state) {
+      // state.sort is included to make the getter reactive to sort changes,
+      // even though the sorting itself does not affect the totals
+      void state.sort;
       let arr = state.subscribers.slice();
 
       if (state.statuses.size) {
@@ -177,6 +183,24 @@ export const useCreatorSubscribersStore = defineStore("creatorSubscribers", {
         pending: arr.filter((s) => s.status === "pending").length,
         ended: arr.filter((s) => s.status === "ended").length,
       };
+    },
+  },
+  actions: {
+    setActiveTab(tab: Tab) {
+      this.activeTab = tab;
+    },
+    setQuery(q: string) {
+      this.query = q;
+    },
+    applyFilters(opts: { statuses: Set<SubStatus>; tiers: Set<string>; sort: SortOption }) {
+      this.statuses = new Set(opts.statuses);
+      this.tiers = new Set(opts.tiers);
+      this.sort = opts.sort;
+    },
+    clearFilters() {
+      this.statuses.clear();
+      this.tiers.clear();
+      this.sort = "next";
     },
   },
 });


### PR DESCRIPTION
## Summary
- handle active tab, filters and counts in creator subscribers store
- add filter popover with apply/clear actions
- add demo page with debounced search bound to store

## Testing
- `npm test` *(fails: p2pk store errors, creator subscribers page errors, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6896f13762148330b4b549457e4f4f92