### PR TITLE
refactor: consolidate Vite aliases

### DIFF
--- a/quasar.config.js
+++ b/quasar.config.js
@@ -65,18 +65,26 @@ export default configure(function (/* ctx */) {
       // distDir
 
       extendViteConf(viteConf) {
-      viteConf.resolve = viteConf.resolve || {};
-      viteConf.resolve.alias = { ...(viteConf.resolve.alias || {}), buffer: 'buffer', process: 'process/browser' };
-
-      viteConf.define = { ...(viteConf.define || {}), global: 'globalThis' };
-
-      viteConf.optimizeDeps = { ...(viteConf.optimizeDeps || {}), include: [ ...(viteConf.optimizeDeps?.include || []), 'buffer', 'process' ] };
-
-viteConf.resolve = viteConf.resolve || {
-};
+        viteConf.resolve = viteConf.resolve || {};
         viteConf.resolve.alias = {
           ...(viteConf.resolve.alias || {}),
-          "@cashu/cashu-ts": path.resolve(__dirname, "src/lib/cashu-ts/src/index.ts"),
+          buffer: 'buffer',
+          process: 'process/browser',
+          "@cashu/cashu-ts": path.resolve(
+            __dirname,
+            "src/lib/cashu-ts/src/index.ts"
+          ),
+        };
+
+        viteConf.define = { ...(viteConf.define || {}), global: 'globalThis' };
+
+        viteConf.optimizeDeps = {
+          ...(viteConf.optimizeDeps || {}),
+          include: [
+            ...(viteConf.optimizeDeps?.include || []),
+            'buffer',
+            'process',
+          ],
         };
       },
       // viteVuePluginOptions: {},


### PR DESCRIPTION
## Summary
- clean up `extendViteConf` by merging alias entries for buffer, process, and `@cashu/cashu-ts`
- ensure `viteConf.resolve`, `viteConf.define`, and `viteConf.optimizeDeps` are each set once

## Testing
- `pnpm run dev`

------
https://chatgpt.com/codex/tasks/task_e_689706a45d9883308246982710ca511c