### PR TITLE
feat: dedupe tier options by id

### DIFF
--- a/src/components/subscribers/SubscriberFiltersPopover.vue
+++ b/src/components/subscribers/SubscriberFiltersPopover.vue
@@ -35,8 +35,8 @@ const statusOptions = [
 ];
 
 const tierOptions = computed(() => {
-  const ids = Array.from(new Set(store.subscribers.map(s => s.tierId)));
-  return ids.map(id => ({ label: id, value: id }));
+  const map = new Map(store.subscribers.map(s => [s.tierId, s.tierName]));
+  return Array.from(map, ([id, name]) => ({ label: name, value: id }));
 });
 
 const sortOptions = [


### PR DESCRIPTION
## Summary
- dedupe tier options by tier ID and map to tier names

## Testing
- `pnpm test` *(fails: Test Files 31 failed | 30 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6897146cc9648330825bd1d41fb09a7f