### PR TITLE
feat: add chart.js and register controllers

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "bech32": "^2.0.0",
     "buffer": "^6.0.3",
     "capacitor-plugin-safe-area": "^3.0.4",
+    "chart.js": "^4.x",
     "core-js": "^3.37.0",
     "date-fns": "^3.6.0",
     "dexie": "^4.0.9",

--- a/src/pages/CreatorSubscribersPage.vue
+++ b/src/pages/CreatorSubscribersPage.vue
@@ -369,6 +369,35 @@
 </template>
 
 <script setup lang="ts">
+import {
+  Chart,
+  LineController,
+  DoughnutController,
+  BarController,
+  LineElement,
+  ArcElement,
+  BarElement,
+  PointElement,
+  CategoryScale,
+  LinearScale,
+  Legend,
+  Tooltip,
+} from "chart.js";
+
+Chart.register(
+  LineController,
+  DoughnutController,
+  BarController,
+  LineElement,
+  ArcElement,
+  BarElement,
+  PointElement,
+  CategoryScale,
+  LinearScale,
+  Legend,
+  Tooltip
+);
+
 import { ref, computed, watch } from "vue";
 import { useCreatorSubscribersStore } from "src/stores/creatorSubscribers";
 import { storeToRefs } from "pinia";


### PR DESCRIPTION
## Summary
- add Chart.js dependency
- register line, doughnut, and bar controllers for subscriber charts

## Testing
- `npm test` *(fails: Cannot read properties of null (reading 'matches'))*
- `npm test test/vitest/__tests__/creatorSubscribers.spec.ts` *(fails: Failed to resolve import "chart.js")*


------
https://chatgpt.com/codex/tasks/task_e_689728f1b974833094250e7637307169