### PR TITLE
test: cover subscriber KPIs and charts

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
     ],
     include: [
       "src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}",
+      "test/creatorSubscribers-page.spec.ts",
       "test/vitest/__tests__/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}",
     ],
   },


### PR DESCRIPTION
## Summary
- verify CreatorSubscribersPage KPIs react to searching, tab changes and filter selections
- ensure chart instances persist when filters change or period toggles
- include creator subscriber spec in vitest run

## Testing
- `pnpm test --run creatorSubscribers-page.spec.ts`

------
https://chatgpt.com/codex/tasks/task_e_6897331d9ab48330b02a3e7069cbb80f