### PR TITLE
Include new subscriber metrics in exports

### DIFF
--- a/src/pages/CreatorSubscribersPage.vue
+++ b/src/pages/CreatorSubscribersPage.vue
@@ -408,8 +408,13 @@ const activeCount = computed(
 const pendingCount = computed(
   () => filtered.value.filter((s) => s.status === "pending").length
 );
+// Lifetime sats are included in the KPI row. Safeguard against undefined
+// values in case the field is missing from older data snapshots.
 const lifetimeRevenue = computed(() =>
-  filtered.value.reduce((sum, s) => sum + s.lifetimeSat, 0)
+  filtered.value.reduce(
+    (sum, s) => sum + (typeof s.lifetimeSat === "number" ? s.lifetimeSat : 0),
+    0,
+  ),
 );
 
 const periodMode = ref<"week" | "month">("month");
@@ -421,10 +426,13 @@ const kpiThisPeriodSat = computed(() => {
     .filter(
       (s) =>
         s.status === "active" &&
-        s.nextRenewal !== undefined &&
-        s.nextRenewal <= end
+        typeof s.nextRenewal === "number" &&
+        s.nextRenewal <= end,
     )
-    .reduce((sum, s) => sum + s.amountSat, 0);
+    .reduce(
+      (sum, s) => sum + (typeof s.amountSat === "number" ? s.amountSat : 0),
+      0,
+    );
 });
 const formattedKpiThisPeriodSat = computed(() =>
   kpiThisPeriodSat.value.toLocaleString()

--- a/src/stores/creatorSubscribers.ts
+++ b/src/stores/creatorSubscribers.ts
@@ -141,13 +141,17 @@ export const useCreatorSubscribersStore = defineStore("creatorSubscribers", {
 
       arr.sort((a, b) => {
         if (state.sort === "amount") {
-          return b.lifetimeSat - a.lifetimeSat;
+          const al = typeof a.lifetimeSat === "number" ? a.lifetimeSat : 0;
+          const bl = typeof b.lifetimeSat === "number" ? b.lifetimeSat : 0;
+          return bl - al;
         }
         if (state.sort === "first") {
           return a.startDate - b.startDate;
         }
-        const an = a.nextRenewal ?? 0;
-        const bn = b.nextRenewal ?? 0;
+        const an =
+          typeof a.nextRenewal === "number" ? a.nextRenewal : Number.POSITIVE_INFINITY;
+        const bn =
+          typeof b.nextRenewal === "number" ? b.nextRenewal : Number.POSITIVE_INFINITY;
         return an - bn;
       });
 


### PR DESCRIPTION
## Summary
- Document CSV export columns and add safeguards for new fields
- Prevent undefined renewal dates from disrupting sort and KPI logic

## Testing
- `pnpm test` *(fails: 12 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68973d315dcc8330a437937947cdf8cc