### PR TITLE
docs: document subscriber analytics and comment charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Think Patreon, but built for the Nostr ecosystem and leveraging the privacy and 
 - **Creator Discovery** – Find creators by category, search or Nostr social graphs.
 - **Creator Profiles** – Dedicated pages for creators and their funding needs.
 - **Tiered Support System** – Multiple support levels with unique benefits.
+- **Subscriber Analytics Dashboard** – KPI cards and charts visualize subscriber counts, status mix and projected revenue. The final KPI toggles between upcoming week or month to estimate expected income.
 - **Direct Cashu Donations & Pledges** – One-time or recurring support using P2PK and timelocks.
 - **Nostr Direct Messages** – NIP-04 encrypted chat with creators and other users.
 - **Privacy-Preserving** – Chaumian ecash via Cashu.


### PR DESCRIPTION
## Summary
- mention new subscriber analytics KPI row and chart toggle in README
- annotate CreatorSubscribersPage with data plumbing and Chart.js lifecycle notes

## Testing
- `pnpm test` *(fails: P2PK store and wallet tests)*

------
https://chatgpt.com/codex/tasks/task_e_68973ef6ba408330af4d28d783d262fd