### PR TITLE
chore: add chart.js dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "bech32": "^2.0.0",
     "buffer": "^6.0.3",
     "capacitor-plugin-safe-area": "^3.0.4",
-    "chart.js": "^4.x",
+    "chart.js": "^4.5.0",
     "core-js": "^3.37.0",
     "date-fns": "^3.6.0",
     "dexie": "^4.0.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,7 +69,7 @@ importers:
         specifier: ^3.0.4
         version: 3.0.4(@capacitor/core@6.2.1)
       chart.js:
-        specifier: ^4.x
+        specifier: ^4.5.0
         version: 4.5.0
       core-js:
         specifier: ^3.37.0


### PR DESCRIPTION
## Summary
- specify `chart.js` v4.5.0 as app dependency to resolve missing module issues

## Testing
- `pnpm run dev`
- `pnpm test` *(fails: useP2PKStore(...).sendToLock is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68976d73d24883308864899b0494d4de