### PR TITLE
feat: hydrate creator subscribers from API

### DIFF
--- a/src/components/subscribers/SubscriberFiltersPopover.vue
+++ b/src/components/subscribers/SubscriberFiltersPopover.vue
@@ -3,6 +3,9 @@
     ref="menu"
     anchor="bottom right"
     self="top right"
+    :offset="[0,8]"
+    :persistent="false"
+    content-class="filters-menu"
     transition-show="jump-down"
     transition-hide="jump-up"
   >

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -323,3 +323,9 @@ body.body--dark .received {
   grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
   gap: 1rem;
 }
+
+.filters-menu { z-index: 3005; }
+.container-xl { max-width: 1440px; margin: 0 auto; }
+.panel-container.chart { height: 180px; }
+@media (max-width: 1024px){ .panel-container.chart { height: 160px; } }
+.z-toolbar { position: relative; z-index: 2; }

--- a/src/data/httpSubscribersSource.ts
+++ b/src/data/httpSubscribersSource.ts
@@ -1,0 +1,51 @@
+import type { ISubscribersSource, Payment } from './subscribersSource';
+import type { Subscriber } from 'src/types/subscriber';
+
+// Expect a JSON endpoint that returns creator subscribers in a shape we can map.
+// Configure with VITE_SUBSCRIBERS_ENDPOINT, e.g. https://api.example.com/subscribers
+const API = import.meta.env.VITE_SUBSCRIBERS_ENDPOINT;
+
+function toSec(v: number | string | null | undefined): number | undefined {
+  if (v == null) return undefined;
+  if (typeof v === 'number') return v > 2_000_000_000 ? Math.floor(v / 1000) : v; // ms→s
+  // try ISO or numeric string
+  const n = Number(v);
+  if (!Number.isNaN(n)) return n > 2_000_000_000 ? Math.floor(n / 1000) : n;
+  const d = Date.parse(v); return isNaN(d) ? undefined : Math.floor(d / 1000);
+}
+
+export class HttpSubscribersSource implements ISubscribersSource {
+  async listByCreator(creatorNpub: string): Promise<Subscriber[]> {
+    if (!API) throw new Error('VITE_SUBSCRIBERS_ENDPOINT missing');
+    const res = await fetch(`${API}?creator=${encodeURIComponent(creatorNpub)}`);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const json = await res.json();
+    // Map API rows → our Subscriber type; adjust mapping to your API
+    return (json.items ?? json).map((r: any): Subscriber => ({
+      id: r.id ?? `${r.subscriberNpub}:${r.tierId}`,
+      name: r.name ?? r.displayName ?? r.nip05 ?? r.subscriberNpub.slice(0,8),
+      npub: r.subscriberNpub,
+      nip05: r.nip05 ?? '',
+      tierId: r.tierId ?? 'unknown',
+      tierName: r.tierName ?? 'Unknown Tier',
+      amountSat: Number(r.amountSat) || 0,
+      frequency: r.frequency as 'weekly'|'biweekly'|'monthly',
+      status: (r.status ?? 'active') as 'active'|'pending'|'ended',
+      startDate: toSec(r.startDate) ?? Math.floor(Date.now()/1000),
+      nextRenewal: toSec(r.nextRenewal),
+      lifetimeSat: Number(r.lifetimeSat) || 0,
+    }));
+  }
+  async paymentsBySubscriber(subscriberNpub: string): Promise<Payment[]> {
+    if (!API) return [];
+    const res = await fetch(`${API}/payments?subscriber=${encodeURIComponent(subscriberNpub)}`);
+    if (!res.ok) return [];
+    const json = await res.json();
+    return (json.items ?? json).map((p: any) => ({
+      ts: toSec(p.ts) ?? Math.floor(Date.now()/1000),
+      amountSat: Number(p.amountSat) || 0,
+      status: p.status ?? 'settled'
+    }));
+  }
+}
+

--- a/src/data/subscribersSource.ts
+++ b/src/data/subscribersSource.ts
@@ -1,0 +1,13 @@
+import type { Subscriber } from 'src/types/subscriber';
+
+export interface Payment {
+  ts: number;            // seconds epoch
+  amountSat: number;
+  status?: 'settled' | 'failed' | 'pending';
+}
+
+export interface ISubscribersSource {
+  listByCreator(creatorNpub: string): Promise<Subscriber[]>;
+  paymentsBySubscriber?(subscriberNpub: string): Promise<Payment[]>;
+}
+


### PR DESCRIPTION
## Summary
- add pluggable subscribers data source with HTTP implementation
- hydrate creator subscribers store and fetch payments on demand
- improve /creator-subscribers layout, filters, toggles and chart sizing

## Testing
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: Cannot find module 'node_modules/vitest/vitest.mjs')*


------
https://chatgpt.com/codex/tasks/task_e_689775d36f788330874bc0810e27d668