### PR TITLE
Add loading/error state for creator subscribers

### DIFF
--- a/src/stores/creatorSubscribers.ts
+++ b/src/stores/creatorSubscribers.ts
@@ -17,6 +17,8 @@ export const useCreatorSubscribersStore = defineStore("creatorSubscribers", {
     sort: "next" as SortOption,
     source: null as ISubscribersSource | null,
     hydrated: false,
+    loading: false,
+    error: null as string | null,
   }),
   getters: {
     filtered(state): Subscriber[] {
@@ -113,9 +115,17 @@ export const useCreatorSubscribersStore = defineStore("creatorSubscribers", {
     },
     async hydrate(creatorNpub: string) {
       if (!this.source) this.setSource();
-      const rows = await this.source!.listByCreator(creatorNpub);
-      this.subscribers = rows;
-      this.hydrated = true;
+      this.loading = true;
+      this.error = null;
+      try {
+        const rows = await this.source!.listByCreator(creatorNpub);
+        this.subscribers = rows;
+        this.hydrated = true;
+      } catch (e: any) {
+        this.error = String(e?.message || e);
+      } finally {
+        this.loading = false;
+      }
     },
     async fetchPayments(npub: string) {
       if (!this.source?.paymentsBySubscriber) return [];


### PR DESCRIPTION
## Summary
- track loading and error state in creator subscribers store
- make hydrate() set and reset loading/error around fetch

## Testing
- `pnpm test` (fails: Tests failed. Watching for file changes...)
- `pnpm lint` (fails: Cannot find module './.eslintrc.js')

------
https://chatgpt.com/codex/tasks/task_e_68977bd99d188330bfff99e1f7230387