### PR TITLE
feat: dexie-backed subscribers with http fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+VITE_SUBSCRIBERS_SOURCE=auto
+# VITE_SUBSCRIBERS_ENDPOINT=https://api.example.com/subscribers

--- a/README.md
+++ b/README.md
@@ -202,6 +202,17 @@ pnpm install
 pnpm test
 ```
 
+### Environment variables
+
+Create a `.env` file in the project root (or export variables in your shell):
+
+```
+VITE_SUBSCRIBERS_SOURCE=auto
+# VITE_SUBSCRIBERS_ENDPOINT=https://api.example.com/subscribers
+```
+
+`VITE_SUBSCRIBERS_SOURCE` selects the data source for the subscribers page. Use `auto` to check Dexie first and fall back to HTTP, or force `dexie` or `http`.
+
 ### Verifying the NDK refactor
 
 After migrating away from direct `NDK` instances, check that no lingering instantiations remain.

--- a/src/data/dexieSubscribersSource.ts
+++ b/src/data/dexieSubscribersSource.ts
@@ -1,0 +1,99 @@
+import type { ISubscribersSource, Payment } from './subscribersSource';
+import type { Subscriber } from '@/types/subscriber';
+import { cashuDb, type LockedToken } from '@/stores/dexie';
+import { daysToFrequency } from '@/constants/subscriptionFrequency';
+import { toSec } from '@/utils/time';
+
+function median(nums: number[]): number {
+  const n = nums.filter((x) => Number.isFinite(x)).sort((a, b) => a - b);
+  if (!n.length) return 0;
+  const m = Math.floor(n.length / 2);
+  return n.length % 2 ? n[m] : Math.floor((n[m - 1] + n[m]) / 2);
+}
+
+function safe(n: any): number {
+  const v = Number(n);
+  return Number.isFinite(v) && v > 0 ? Math.floor(v) : 0;
+}
+
+export class DexieSubscribersSource implements ISubscribersSource {
+  async listByCreator(creatorNpub: string): Promise<Subscriber[]> {
+    const rows = await cashuDb.lockedTokens
+      .where('creatorNpub')
+      .equals(creatorNpub)
+      .and((t) => t.owner === 'creator' && !!t.subscriptionId)
+      .toArray();
+
+    const groups = new Map<string, LockedToken[]>();
+    for (const r of rows) {
+      const key = r.subscriptionId || `${r.subscriberNpub}:${r.tierId}`;
+      if (!groups.has(key)) groups.set(key, []);
+      groups.get(key)!.push(r);
+    }
+
+    const out: Subscriber[] = [];
+    const now = Math.floor(Date.now() / 1000);
+
+    for (const [key, tokens] of groups.entries()) {
+      const any = tokens[0];
+      const subRec = any.subscriptionId
+        ? await cashuDb.subscriptions.get(any.subscriptionId)
+        : null;
+      const amounts = tokens.map((t) => safe(t.amount));
+      const received = tokens.filter((t) => t.status === 'claimed').length;
+      const pending = tokens.filter((t) => t.status !== 'claimed');
+      const totalPeriods =
+        subRec?.commitmentLength ?? any.totalPeriods ?? received + pending.length;
+      const remaining = totalPeriods - received;
+      const totalAmount = amounts.reduce((s, a) => s + a, 0);
+      let amountSat = 0;
+      if (subRec?.amountPerInterval != null)
+        amountSat = safe(subRec.amountPerInterval);
+      else if (amounts.length >= 2) amountSat = median(amounts);
+      else if (totalPeriods > 0) amountSat = Math.floor(totalAmount / totalPeriods);
+      else if (amounts.length) amountSat = amounts[0];
+      if (!Number.isFinite(amountSat) || amountSat < 0) amountSat = 0;
+
+      const nextTok = pending.sort((a, b) => (a.unlockTs ?? 0) - (b.unlockTs ?? 0))[0];
+      const startDate = Math.min(...tokens.map((t) => toSec(t.unlockTs) ?? now));
+      const lifetimeSat = tokens
+        .filter((t) => t.status === 'claimed')
+        .reduce((s, t) => s + safe(t.amount), 0);
+      let status: 'pending' | 'active' | 'ended';
+      if (received === 0) status = 'pending';
+      else if (remaining <= 0 || (tokens.every((t) => (t.unlockTs ?? 0) < now))) status = 'ended';
+      else status = 'active';
+
+      out.push({
+        id: any.subscriptionId || key,
+        name: any.subscriberNpub?.slice(0, 8) || '',
+        npub: any.subscriberNpub || '',
+        nip05: '',
+        tierId: any.tierId,
+        tierName: any.tierName || 'Unknown Tier',
+        amountSat,
+        frequency: daysToFrequency(any.intervalDays ?? 30),
+        status,
+        startDate: startDate || now,
+        nextRenewal: nextTok ? toSec(nextTok.unlockTs) : undefined,
+        lifetimeSat,
+      });
+    }
+
+    return out;
+  }
+
+  async paymentsBySubscriber(subscriberNpub: string): Promise<Payment[]> {
+    const rows = await cashuDb.lockedTokens
+      .where('subscriberNpub')
+      .equals(subscriberNpub)
+      .and((t) => t.owner === 'creator')
+      .toArray();
+    const list: Payment[] = rows.map((t) => ({
+      ts: toSec(t.unlockTs) ?? Math.floor(Date.now() / 1000),
+      amountSat: safe(t.amount),
+      status: t.status === 'claimed' ? 'settled' : t.status === 'expired' ? 'failed' : 'pending',
+    }));
+    return list.sort((a, b) => a.ts - b.ts);
+  }
+}

--- a/src/data/httpSubscribersSource.ts
+++ b/src/data/httpSubscribersSource.ts
@@ -1,18 +1,10 @@
 import type { ISubscribersSource, Payment } from './subscribersSource';
 import type { Subscriber } from 'src/types/subscriber';
+import { toSec } from '@/utils/time';
 
 // Expect a JSON endpoint that returns creator subscribers in a shape we can map.
 // Configure with VITE_SUBSCRIBERS_ENDPOINT, e.g. https://api.example.com/subscribers
 const API = import.meta.env.VITE_SUBSCRIBERS_ENDPOINT;
-
-function toSec(v: number | string | null | undefined): number | undefined {
-  if (v == null) return undefined;
-  if (typeof v === 'number') return v > 2_000_000_000 ? Math.floor(v / 1000) : v; // ms→s
-  // try ISO or numeric string
-  const n = Number(v);
-  if (!Number.isNaN(n)) return n > 2_000_000_000 ? Math.floor(n / 1000) : n;
-  const d = Date.parse(v); return isNaN(d) ? undefined : Math.floor(d / 1000);
-}
 
 export class HttpSubscribersSource implements ISubscribersSource {
   async listByCreator(creatorNpub: string): Promise<Subscriber[]> {

--- a/src/pages/CreatorSubscribersPage.vue
+++ b/src/pages/CreatorSubscribersPage.vue
@@ -57,6 +57,15 @@
         @click.stop="openFilters"
         aria-label="Filters"
       />
+      <q-chip
+        v-if="sourceKind === 'auto' && usedFallback"
+        dense
+        outline
+        color="grey-6"
+        class="q-ml-sm"
+      >
+        Using HTTP (no local data)
+      </q-chip>
       <q-btn
         outline
         color="grey-5"
@@ -367,7 +376,12 @@
           <q-list bordered dense>
             <q-item v-for="p in payments" :key="p.ts">
               <q-item-section>{{ formatDate(p.ts) }}</q-item-section>
-              <q-item-section side>{{ p.amountSat }} sat</q-item-section>
+              <q-item-section side>
+                <div class="row items-center no-wrap q-gutter-xs">
+                  <q-chip dense :color="paymentStatusColor(p.status)" text-color="white">{{ p.status }}</q-chip>
+                  <span>{{ p.amountSat }} sat</span>
+                </div>
+              </q-item-section>
             </q-item>
           </q-list>
         </div>
@@ -433,7 +447,8 @@ import SubscriberFiltersPopover from "src/components/subscribers/SubscriberFilte
 import SubscriberCard from "src/components/SubscriberCard.vue";
 
 const subStore = useCreatorSubscribersStore();
-const { filtered, counts, activeTab, loading, error } = storeToRefs(subStore);
+const { filtered, counts, activeTab, loading, error, sourceKind, usedFallback } =
+  storeToRefs(subStore);
 const showEndpointBanner = ref(!import.meta.env.VITE_SUBSCRIBERS_ENDPOINT);
 const creatorNpub =
   localStorage.getItem('creator_npub') || import.meta.env.VITE_CREATOR_NPUB || '';
@@ -676,6 +691,9 @@ function freqShort(f: Frequency) {
 }
 function statusColor(s: SubStatus) {
   return s === "active" ? "positive" : s === "pending" ? "warning" : "negative";
+}
+function paymentStatusColor(s: string | undefined) {
+  return s === 'settled' ? 'positive' : s === 'failed' ? 'negative' : 'warning';
 }
 function progressPercent(r: Subscriber) {
   if (!r.nextRenewal) return 0;

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,0 +1,9 @@
+export function toSec(v: number | string | Date | null | undefined): number | undefined {
+  if (v == null) return undefined;
+  if (v instanceof Date) return Math.floor(v.getTime() / 1000);
+  if (typeof v === 'number') return v > 2_000_000_000 ? Math.floor(v / 1000) : Math.floor(v);
+  const n = Number(v);
+  if (!Number.isNaN(n)) return n > 2_000_000_000 ? Math.floor(n / 1000) : Math.floor(n);
+  const d = Date.parse(String(v));
+  return Number.isNaN(d) ? undefined : Math.floor(d / 1000);
+}

--- a/test/e2e/creator-subscribers.spec.ts
+++ b/test/e2e/creator-subscribers.spec.ts
@@ -52,3 +52,26 @@ test('drives subscribers page layout', async ({ page }) => {
   await expect(page.locator('#drawer')).toHaveText('Bob');
 });
 
+test('shows http fallback chip in auto mode', async ({ page }) => {
+  await page.setContent(`
+    <div id="toolbar"></div>
+    <script>
+      const chip = document.createElement('div');
+      chip.id = 'chip';
+      chip.textContent = 'Using HTTP (no local data)';
+      document.getElementById('toolbar').appendChild(chip);
+    </script>
+  `);
+  await expect(page.locator('#chip')).toHaveText('Using HTTP (no local data)');
+});
+
+test('hides chip when dexie has data', async ({ page }) => {
+  await page.setContent(`
+    <div id="toolbar"></div>
+    <script>
+      // no chip rendered
+    </script>
+  `);
+  await expect(page.locator('#toolbar').locator('#chip')).toHaveCount(0);
+});
+

--- a/test/vitest/__tests__/creatorSubscribersStore.spec.ts
+++ b/test/vitest/__tests__/creatorSubscribersStore.spec.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import { useCreatorSubscribersStore } from '@/stores/creatorSubscribers';
+
+const dexieRows = [{ id: '1', name: 'd', npub: 'npub', nip05: '', tierId: 't', tierName: 'T', amountSat: 1, frequency: 'monthly', status: 'active', startDate: 1, lifetimeSat: 1 }];
+
+vi.mock('@/data/dexieSubscribersSource', () => ({
+  DexieSubscribersSource: vi.fn().mockImplementation(() => ({
+    listByCreator: vi.fn(async () => dexieRows),
+    paymentsBySubscriber: vi.fn(async () => []),
+  })),
+}));
+
+vi.mock('@/data/httpSubscribersSource', () => ({
+  HttpSubscribersSource: vi.fn().mockImplementation(() => ({
+    listByCreator: vi.fn(async () => [{ ...dexieRows[0], id: 'h1' }]),
+    paymentsBySubscriber: vi.fn(async () => []),
+  })),
+}));
+
+describe('creatorSubscribers store source selection', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.unstubAllEnvs();
+  });
+
+  it('auto uses dexie when rows exist', async () => {
+    const store = useCreatorSubscribersStore();
+    store.setSource();
+    await store.hydrate('npub');
+    expect(store.usedFallback).toBe(false);
+    expect(store.subscribers[0].id).toBe('1');
+  });
+
+  it('auto falls back to http when dexie empty', async () => {
+    dexieRows.length = 0;
+    const store = useCreatorSubscribersStore();
+    store.setSource();
+    await store.hydrate('npub');
+    expect(store.usedFallback).toBe(true);
+    expect(store.subscribers[0].id).toBe('h1');
+  });
+
+  it('forces dexie when env set', async () => {
+    vi.stubEnv('VITE_SUBSCRIBERS_SOURCE', 'dexie');
+    const store = useCreatorSubscribersStore();
+    store.setSource();
+    await store.hydrate('npub');
+    expect(store.sourceKind).toBe('dexie');
+    expect(store.usedFallback).toBe(false);
+    expect(store.subscribers[0].id).toBe('1');
+  });
+
+  it('forces http when env set', async () => {
+    vi.stubEnv('VITE_SUBSCRIBERS_SOURCE', 'http');
+    const store = useCreatorSubscribersStore();
+    store.setSource();
+    await store.hydrate('npub');
+    expect(store.sourceKind).toBe('http');
+    expect(store.subscribers[0].id).toBe('h1');
+  });
+});

--- a/test/vitest/__tests__/dexieSubscribersSource.spec.ts
+++ b/test/vitest/__tests__/dexieSubscribersSource.spec.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { cashuDb } from '@/stores/dexie';
+import { DexieSubscribersSource } from '@/data/dexieSubscribersSource';
+
+beforeEach(async () => {
+  await cashuDb.close();
+  await cashuDb.open();
+  await cashuDb.lockedTokens.clear();
+  await cashuDb.subscriptions.clear();
+});
+
+describe('DexieSubscribersSource', () => {
+  it('maps dexie records to subscribers and payments', async () => {
+    await cashuDb.subscriptions.add({
+      id: 'sub1',
+      creatorNpub: 'npubCreator',
+      tierId: 'tierA',
+      creatorP2PK: '',
+      mintUrl: '',
+      amountPerInterval: 1000,
+      frequency: 'monthly',
+      intervalDays: 30,
+      startDate: 0,
+      commitmentLength: 3,
+      tierName: 'Gold',
+      benefits: [],
+      creatorName: '',
+      creatorAvatar: '',
+      intervals: [],
+      status: 'active',
+      createdAt: 0,
+      updatedAt: 0,
+    });
+    await cashuDb.lockedTokens.bulkAdd([
+      {
+        id: 't0', tokenString: '', amount: 1000, owner: 'creator', subscriberNpub: 'npubSub1', creatorNpub: 'npubCreator', tierId: 'tierA', tierName: 'Gold', intervalKey: '0', unlockTs: 1697418000, status: 'expired', subscriptionEventId: null, subscriptionId: 'sub1', frequency: 'monthly', intervalDays: 30,
+      },
+      {
+        id: 't1', tokenString: '', amount: 900, owner: 'creator', subscriberNpub: 'npubSub1', creatorNpub: 'npubCreator', tierId: 'tierA', tierName: 'Gold', intervalKey: '1', unlockTs: 1700000000, status: 'claimed', subscriptionEventId: null, subscriptionId: 'sub1', frequency: 'monthly', intervalDays: 30,
+      },
+      {
+        id: 't2', tokenString: '', amount: 1100, owner: 'creator', subscriberNpub: 'npubSub1', creatorNpub: 'npubCreator', tierId: 'tierA', tierName: 'Gold', intervalKey: '2', unlockTs: 1702592000, status: 'pending', subscriptionEventId: null, subscriptionId: 'sub1', frequency: 'monthly', intervalDays: 30,
+      },
+    ]);
+
+    const src = new DexieSubscribersSource();
+    const list = await src.listByCreator('npubCreator');
+    expect(list).toHaveLength(1);
+    const s = list[0];
+    expect(s.id).toBe('sub1');
+    expect(s.npub).toBe('npubSub1');
+    expect(s.tierName).toBe('Gold');
+    expect(s.frequency).toBe('monthly');
+    expect(s.amountSat).toBe(1000);
+    expect(s.startDate).toBe(1697418000);
+    expect(s.nextRenewal).toBe(1702592000);
+    expect(s.lifetimeSat).toBe(900);
+    expect(s.status).toBe('active');
+
+    const pays = await src.paymentsBySubscriber('npubSub1');
+    expect(pays.map((p) => p.status)).toEqual(['failed', 'settled', 'pending']);
+    expect(pays.map((p) => p.ts)).toEqual([1697418000, 1700000000, 1702592000]);
+  });
+
+  it('honors median and fallback calculations', async () => {
+    await cashuDb.lockedTokens.bulkAdd([
+      {
+        id: 'a1', tokenString: '', amount: 800, owner: 'creator', subscriberNpub: 'npubA', creatorNpub: 'npubCreator', tierId: 'tierB', tierName: 'TierB', intervalKey: '1', unlockTs: 1, status: 'pending', subscriptionEventId: null, subscriptionId: null, frequency: 'monthly', intervalDays: 30,
+      },
+      {
+        id: 'a2', tokenString: '', amount: 1200, owner: 'creator', subscriberNpub: 'npubA', creatorNpub: 'npubCreator', tierId: 'tierB', tierName: 'TierB', intervalKey: '2', unlockTs: 2, status: 'pending', subscriptionEventId: null, subscriptionId: null, frequency: 'monthly', intervalDays: 30,
+      },
+    ]);
+    await cashuDb.lockedTokens.add({
+      id: 'b1', tokenString: '', amount: 1000, owner: 'creator', subscriberNpub: 'npubB', creatorNpub: 'npubCreator', tierId: 'tierC', tierName: 'TierC', intervalKey: '1', unlockTs: 3, status: 'claimed', subscriptionEventId: null, subscriptionId: null, frequency: 'monthly', intervalDays: 30, totalPeriods: 4,
+    });
+
+    const src = new DexieSubscribersSource();
+    const list = await src.listByCreator('npubCreator');
+    const a = list.find((s) => s.npub === 'npubA')!;
+    const b = list.find((s) => s.npub === 'npubB')!;
+    expect(a.amountSat).toBe(1000); // median of 800 & 1200
+    expect(b.amountSat).toBe(250); // totalAmount/periods
+  });
+});


### PR DESCRIPTION
## Summary
- add DexieSubscribersSource and timestamp utils
- auto-select Dexie or HTTP via creatorSubscribers store
- show subtle chip when falling back to HTTP
- document VITE_SUBSCRIBERS_SOURCE env and add tests

## Testing
- `pnpm test` *(fails: DM chats store, nutzapProfile, InfoTooltip, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689785961eac8330b7db31d608a85c5c