### PR TITLE
feat: overhaul creator subscribers dashboard

### DIFF
--- a/src/components/subscribers/EmptyState.vue
+++ b/src/components/subscribers/EmptyState.vue
@@ -1,0 +1,16 @@
+<template>
+  <div class="q-pa-xl text-center">
+    <div class="text-h6 q-mb-xs">{{ title }}</div>
+    <div class="text-caption text-grey-6 q-mb-md">{{ subtitle }}</div>
+    <div class="row justify-center q-gutter-sm">
+      <q-btn v-if="onRetry" size="sm" outline icon="refresh" label="Retry" @click="onRetry()" />
+      <q-btn v-if="showConnect" size="sm" color="primary" icon="link" label="Connect data source" @click="emit('connect')" />
+    </div>
+  </div>
+</template>
+<script setup lang="ts">
+const props = withDefaults(defineProps<{
+  title?: string; subtitle?: string; showConnect?: boolean; onRetry?: () => void
+}>(), { title: 'No subscribers found', subtitle: ''});
+const emit = defineEmits<{(e:'connect'):void}>();
+</script>

--- a/src/components/subscribers/KpiRow.vue
+++ b/src/components/subscribers/KpiRow.vue
@@ -1,0 +1,47 @@
+<template>
+  <div class="row q-col-gutter-md q-mb-md">
+    <q-card flat bordered class="col-12 col-sm-6 col-md-3 q-pa-sm">
+      <div class="text-caption text-grey">Subscribers</div>
+      <div class="text-h6">
+        <q-skeleton v-if="loading" type="text" width="40%" />
+        <span v-else>{{ counts.all.toLocaleString() }}</span>
+      </div>
+    </q-card>
+
+    <q-card flat bordered class="col-12 col-sm-6 col-md-3 q-pa-sm">
+      <div class="text-caption text-grey">Active / Pending</div>
+      <div class="text-h6">
+        <q-skeleton v-if="loading" type="text" width="60%" />
+        <span v-else>{{ active }} / {{ pending }}</span>
+      </div>
+    </q-card>
+
+    <q-card flat bordered class="col-12 col-sm-6 col-md-3 q-pa-sm">
+      <div class="text-caption text-grey">Lifetime revenue</div>
+      <div class="text-h6">
+        <q-skeleton v-if="loading" type="text" width="70%" />
+        <span v-else>{{ lifetime.toLocaleString() }} sat</span>
+      </div>
+    </q-card>
+
+    <q-card flat bordered class="col-12 col-sm-6 col-md-3 q-pa-sm cursor-pointer" @click="$emit('togglePeriod')">
+      <div class="text-caption text-grey">Next {{ period }}</div>
+      <div class="text-h6">
+        <q-skeleton v-if="loading" type="text" width="50%" />
+        <span v-else>{{ upcoming.toLocaleString() }} sat</span>
+      </div>
+    </q-card>
+  </div>
+</template>
+<script setup lang="ts">
+defineProps<{
+  loading: boolean;
+  counts: { all:number };
+  active: number;
+  pending: number;
+  lifetime: number;
+  period: 'week'|'month';
+  upcoming: number;
+}>();
+defineEmits<{ (e:'togglePeriod'): void }>();
+</script>

--- a/src/components/subscribers/SubscriberFiltersPopover.vue
+++ b/src/components/subscribers/SubscriberFiltersPopover.vue
@@ -12,6 +12,7 @@
     <div class="q-pa-md" style="min-width: 200px">
       <div class="text-subtitle2 q-mb-sm">Status</div>
       <q-option-group v-model="localStatuses" :options="statusOptions" type="checkbox" />
+      <q-checkbox v-model="localDueSoon" label="Due soon (72h)" size="sm" class="q-mt-xs" />
       <div class="text-subtitle2 q-mt-md q-mb-sm">Tier</div>
       <q-option-group v-model="localTiers" :options="tierOptions" type="checkbox" />
       <div class="text-subtitle2 q-mt-md q-mb-sm">Sort</div>
@@ -36,6 +37,7 @@ const menu = ref();
 const localStatuses = ref<SubStatus[]>(Array.from(store.statuses));
 const localTiers = ref<string[]>(Array.from(store.tiers));
 const localSort = ref<SortOption>(store.sort);
+const localDueSoon = ref<boolean>(store.dueSoonOnly);
 
 const statusOptions = [
   { label: 'Active', value: 'active' },
@@ -58,7 +60,8 @@ function apply() {
   store.applyFilters({
     statuses: new Set(localStatuses.value),
     tiers: new Set(localTiers.value),
-    sort: localSort.value
+    sort: localSort.value,
+    dueSoonOnly: localDueSoon.value
   });
 }
 
@@ -66,6 +69,7 @@ function clear() {
   localStatuses.value = [];
   localTiers.value = [];
   localSort.value = 'next';
+  localDueSoon.value = false;
   store.clearFilters();
 }
 

--- a/src/components/subscribers/SubscribersTable.vue
+++ b/src/components/subscribers/SubscribersTable.vue
@@ -1,0 +1,51 @@
+<template>
+  <q-table
+    v-bind="$attrs"
+    flat
+    :rows="rows"
+    row-key="id"
+    selection="multiple"
+    v-model:selected="selected"
+    :columns="visibleColumns"
+    :rows-per-page-options="[10,25,50]"
+    :dense="density === 'compact'"
+    :class="['density--' + density]"
+    virtual-scroll
+    :virtual-scroll-item-size="56"
+    :virtual-scroll-sticky-size-start="42"
+  >
+    <template #top-right>
+      <q-btn dense flat icon="view_column" aria-label="Columns" @click="colMenu=true" />
+      <q-menu v-model="colMenu" anchor="bottom right" self="top right">
+        <q-list dense style="min-width:220px">
+          <q-item v-for="c in allColumns" :key="c.name" clickable @click="toggle(c.name)">
+            <q-item-section>{{ c.label }}</q-item-section>
+            <q-item-section side><q-toggle v-model="cols[c.name]" /></q-item-section>
+          </q-item>
+        </q-list>
+      </q-menu>
+    </template>
+
+    <!-- existing body cell slots can be reused verbatim from the page -->
+    <slot name="cells" />
+  </q-table>
+</template>
+<script setup lang="ts">
+import { ref, computed, watch, onMounted } from 'vue';
+import type { QTableColumn } from 'quasar';
+const props = defineProps<{
+  rows: any[];
+  columns: QTableColumn[];
+  density: 'compact'|'comfortable';
+  modelValue: any[];
+}>();
+const emit = defineEmits<{(e:'update:modelValue',v:any[]):void}>();
+const selected = ref(props.modelValue);
+watch(selected, v => emit('update:modelValue', v));
+const colMenu = ref(false);
+const cols = ref<Record<string, boolean>>({});
+const allColumns = computed(() => props.columns);
+const visibleColumns = computed(() => props.columns.filter(c => cols.value[c.name] !== false));
+function toggle(name: string){ cols.value[name] = !(cols.value[name] ?? true); localStorage.setItem('cs_columns', JSON.stringify(cols.value)); }
+onMounted(()=>{ cols.value = JSON.parse(localStorage.getItem('cs_columns')||'{}') });
+</script>

--- a/src/pages/CreatorSubscribersPage.vue
+++ b/src/pages/CreatorSubscribersPage.vue
@@ -18,117 +18,60 @@
         />
       </template>
     </q-banner>
-    <!-- Top bar -->
-    <div class="row items-center q-gutter-sm q-mb-md">
-      <div class="text-h6">Subscribers</div>
-      <q-input
-        dense
-        v-model="search"
-        placeholder="Search"
-        class="q-ml-md"
-        clearable
-      >
-        <template #prepend>
-          <q-icon name="search" />
-        </template>
-      </q-input>
-      <div class="row items-center no-wrap q-gutter-sm z-toolbar">
-        <q-btn-toggle v-model="view" toggle-color="primary"
-          :options="[
-            { label:'Table',  icon:'table_rows', value:'table'  },
-            { label:'Cards',  icon:'grid_view',   value:'cards'  }
-          ]" aria-label="Change list view">
-          <q-tooltip anchor="bottom middle" self="top middle">Switch between table and cards</q-tooltip>
-        </q-btn-toggle>
-        <q-btn-toggle v-model="density" toggle-color="primary"
-          :options="[
-            { label:'Comfy',  icon:'view_comfy',   value:'comfortable' },
-            { label:'Compact',icon:'view_compact', value:'compact'     }
-          ]" aria-label="Row density">
-          <q-tooltip anchor="bottom middle" self="top middle">Adjust row density</q-tooltip>
-        </q-btn-toggle>
+    <!-- Toolbar -->
+    <q-toolbar class="q-mb-md q-gutter-sm no-wrap">
+      <div class="row items-center col-12 col-md-4 no-wrap q-gutter-sm">
+        <div class="text-h6">Subscribers</div>
+        <q-input
+          ref="searchInput"
+          dense
+          v-model="search"
+          placeholder="Search"
+          clearable
+          class="col"
+        >
+          <template #prepend><q-icon name="search" /></template>
+        </q-input>
       </div>
-      <q-btn
-        dense
-        flat
-        round
-        icon="tune"
-        class="q-ml-sm"
-        @click.stop="openFilters"
-        aria-label="Filters"
-      />
-      <q-chip
-        v-if="sourceKind === 'auto' && usedFallback"
-        dense
-        outline
-        color="grey-6"
-        class="q-ml-sm"
-      >
-        Using HTTP (no local data)
-      </q-chip>
-      <q-btn
-        outline
-        color="grey-5"
-        icon="download"
-        label="Export CSV"
-        class="q-ml-sm"
-        @click="downloadCsv()"
-      />
-    </div>
-
+      <div class="row items-center col-12 col-md-4 justify-center q-gutter-sm">
+        <q-btn-toggle v-model="view" toggle-color="primary" :options="viewOpts" aria-label="Change list view" />
+        <q-btn-toggle v-model="density" toggle-color="primary" :options="densityOpts" aria-label="Row density" />
+      </div>
+      <div class="row items-center col-12 col-md-4 justify-end q-gutter-sm">
+        <q-btn dense flat round icon="tune" @click.stop="openFilters" aria-label="Filters" />
+        <q-btn dense flat round icon="refresh" @click="refresh" aria-label="Refresh" />
+        <q-btn outline color="grey-5" icon="download" label="Export CSV" @click="downloadCsv(undefined,'filtered')" />
+      </div>
+    </q-toolbar>
     <q-linear-progress v-if="loading" indeterminate class="q-mb-md" />
+    <q-chip v-if="lastUpdated" dense outline color="grey-6" class="q-mb-md">Last updated: {{ lastUpdated }}</q-chip>
 
-    <!-- KPI Row -->
-    <div class="row q-col-gutter-md q-mb-md">
-      <q-card
-        flat
-        bordered
-        class="col-12 col-sm-6 col-md-3 panel-container q-pa-sm"
-      >
-        <div class="text-caption text-grey">Subscribers</div>
-        <div class="text-h6">{{ counts.all }}</div>
-      </q-card>
-      <q-card
-        flat
-        bordered
-        class="col-12 col-sm-6 col-md-3 panel-container q-pa-sm"
-      >
-        <div class="text-caption text-grey">Active / Pending</div>
-        <div class="text-h6">{{ activeCount }} / {{ pendingCount }}</div>
-      </q-card>
-      <q-card
-        flat
-        bordered
-        class="col-12 col-sm-6 col-md-3 panel-container q-pa-sm"
-      >
-        <div class="text-caption text-grey">Lifetime revenue</div>
-        <div class="text-h6">{{ lifetimeRevenue }} sat</div>
-      </q-card>
-      <q-card
-        flat
-        bordered
-        class="col-12 col-sm-6 col-md-3 panel-container q-pa-sm"
-        @click="togglePeriod"
-      >
-        <div class="text-caption text-grey">Next {{ periodMode }}</div>
-        <div class="text-h6">{{ formattedKpiThisPeriodSat }} sat</div>
-      </q-card>
-    </div>
+    <KpiRow
+      :loading="loading"
+      :counts="counts"
+      :active="activeCount"
+      :pending="pendingCount"
+      :lifetime="lifetimeRevenue"
+      :period="periodMode"
+      :upcoming="kpiThisPeriodSat"
+      @togglePeriod="togglePeriod"
+    />
 
-    <!-- Charts -->
-    <div class="row q-col-gutter-md q-mb-md">
-      <q-card flat bordered class="col-12 col-lg-5 panel-container chart q-pa-sm">
-        <div class="text-subtitle2 q-mb-sm">Revenue over time</div>
-        <canvas ref="lineEl" />
-      </q-card>
-      <q-card flat bordered class="col-12 col-lg-4 panel-container chart q-pa-sm">
-        <div class="text-subtitle2 q-mb-sm">Frequency mix</div>
-        <canvas ref="doughnutEl" />
-      </q-card>
-      <q-card flat bordered class="col-12 col-lg-3 panel-container chart q-pa-sm">
-        <div class="text-subtitle2 q-mb-sm">Status by frequency</div>
-        <canvas ref="barEl" />
-      </q-card>
+    <div v-intersection="onChartsIntersection" class="q-mb-md">
+      <div v-if="chartsReady" class="row q-col-gutter-md">
+        <q-card flat bordered class="col-12 col-lg-5 q-pa-sm">
+          <div class="text-subtitle2 q-mb-sm">Revenue over time</div>
+          <canvas ref="lineEl" />
+        </q-card>
+        <q-card flat bordered class="col-12 col-lg-4 q-pa-sm">
+          <div class="text-subtitle2 q-mb-sm">Frequency mix</div>
+          <canvas ref="doughnutEl" />
+        </q-card>
+        <q-card flat bordered class="col-12 col-lg-3 q-pa-sm">
+          <div class="text-subtitle2 q-mb-sm">Status by frequency</div>
+          <canvas ref="barEl" />
+        </q-card>
+      </div>
     </div>
 
     <!-- Tabs -->
@@ -179,37 +122,24 @@
       >
     </q-tabs>
 
-    <!-- Empty State -->
-    <div
+    <EmptyState
       v-if="!loading && filtered.length === 0"
-      class="q-pa-xl text-center"
-    >
-      <div class="text-h6 q-mb-sm">No subscribers found</div>
-      <div class="text-caption">
-        <span v-if="error" class="q-mr-sm">{{ error }}</span>
-        <q-btn
-          size="sm"
-          flat
-          label="Retry"
-          @click="subStore.hydrate(creatorNpub)"
-        />
-      </div>
-    </div>
+      :subtitle="error || 'Try refreshing or connecting your data source.'"
+      :show-connect="!import.meta.env.VITE_SUBSCRIBERS_ENDPOINT"
+      :on-retry="() => subStore.hydrate(creatorNpub)"
+      @connect="connectDialog = true"
+    />
 
     <!-- Table -->
-    <q-table
+    <SubscribersTable
       v-else-if="view === 'table'"
-      flat
+      v-model="selected"
       :rows="filtered"
-      row-key="id"
-      selection="multiple"
-      v-model:selected="selected"
       :columns="columns"
-      :rows-per-page-options="[10, 25, 50]"
+      :density="density"
       :row-class="rowClass"
-      :dense="density === 'compact'"
-      :class="['density--' + density]"
     >
+      <template #cells>
       <template #body-cell-subscriber="props">
         <q-td :props="props">
           <div class="row items-center q-gutter-sm no-wrap">
@@ -300,9 +230,14 @@
             icon="chevron_right"
             @click="openDrawer(props.row)" /></q-td
       ></template>
-    </q-table>
+      </template>
+    </SubscribersTable>
     <div v-else class="subscriber-cards">
+      <div v-if="loading" class="q-gutter-y-sm">
+        <q-skeleton v-for="n in 6" :key="n" type="rect" height="80px" />
+      </div>
       <SubscriberCard
+        v-else
         v-for="row in filtered"
         :key="row.id"
         :subscription="{ tierName: row.tierName, subscriberNpub: row.npub } as any"
@@ -322,14 +257,9 @@
     >
       <div>{{ selected.length }} selected</div>
       <q-space />
-      <q-btn
-        outline
-        dense
-        color="white"
-        icon="download"
-        label="Export selection"
-        @click="downloadCsv(selected)"
-      />
+      <q-btn outline dense color="white" icon="download" label="Export filtered" @click="downloadCsv(undefined,'filtered')" />
+      <q-btn outline dense color="white" icon="download" label="Export selection" @click="downloadCsv(selected,'selection')" />
+      <q-btn v-if="selected.length" outline dense color="white" icon="chat" label="DM selected" @click="dmSelected" />
       <q-btn flat dense color="white" label="Clear" @click="selected = []" />
     </div>
 
@@ -343,95 +273,69 @@
             <div class="text-body2 text-grey-6">{{ current.nip05 }}</div>
           </div>
         </div>
-        <div class="row q-gutter-xs q-mt-md">
-          <q-chip dense color="primary" text-color="white">{{
-            current.tierName
-          }}</q-chip>
-          <q-chip dense outline>{{ current.frequency }}</q-chip>
-          <q-chip
-            dense
-            :color="statusColor(current.status)"
-            text-color="white"
-            >{{ current.status }}</q-chip
-          >
-        </div>
-        <div class="q-mt-md">
-          {{ current.amountSat }} sat / {{ current.frequency }}
-        </div>
-        <div class="q-mt-sm">
-          Next renewal:
-          {{ current.nextRenewal ? formatDate(current.nextRenewal) : "—" }}
-          <span v-if="current.nextRenewal" class="text-grey-6"
-            >({{ distToNow(current.nextRenewal) }})</span
-          >
-        </div>
-        <div class="q-mt-sm">Lifetime: {{ current.lifetimeSat }} sat</div>
-        <div class="q-mt-sm">Since {{ formatDate(current.startDate) }}</div>
         <div class="row q-gutter-sm q-mt-md">
           <q-btn outline label="DM" @click="dmSubscriber" />
           <q-btn outline label="Copy npub" @click="copyNpub" />
         </div>
-        <div class="q-mt-lg">
-          <div class="text-subtitle2 q-mb-sm">Payments</div>
-          <q-list bordered dense>
-            <q-item v-for="p in payments" :key="p.ts">
-              <q-item-section>{{ formatDate(p.ts) }}</q-item-section>
-              <q-item-section side>
-                <div class="row items-center no-wrap q-gutter-xs">
-                  <q-chip dense :color="paymentStatusColor(p.status)" text-color="white">{{ p.status }}</q-chip>
-                  <span>{{ p.amountSat }} sat</span>
-                </div>
-              </q-item-section>
-            </q-item>
-          </q-list>
-        </div>
-        <div class="q-mt-lg">
-          <div class="text-subtitle2 q-mb-sm">Activity</div>
-          <q-list bordered dense>
-            <q-item v-for="a in activity" :key="a.ts">
-              <q-item-section>{{ a.text }}</q-item-section>
-              <q-item-section side class="text-caption text-grey">{{
-                distToNow(a.ts)
-              }}</q-item-section>
-            </q-item>
-          </q-list>
-        </div>
+        <q-tabs v-model="drawerTab" dense class="q-mt-md" align="justify" active-color="primary">
+          <q-tab name="overview" label="Overview" />
+          <q-tab name="payments" label="Payments" />
+          <q-tab name="notes" label="Notes" />
+          <q-tab name="activity" label="Activity" />
+        </q-tabs>
+        <q-separator />
+        <q-tab-panels v-model="drawerTab" animated>
+          <q-tab-panel name="overview">
+            <div class="q-mt-md">
+              <div>{{ current.amountSat }} sat / {{ current.frequency }}</div>
+              <div class="q-mt-sm">Next renewal: {{ current.nextRenewal ? formatDate(current.nextRenewal) : '—' }}</div>
+              <div class="q-mt-sm">Lifetime: {{ current.lifetimeSat }} sat</div>
+              <div class="q-mt-sm">Since {{ formatDate(current.startDate) }}</div>
+            </div>
+          </q-tab-panel>
+          <q-tab-panel name="payments">
+            <q-list bordered dense>
+              <q-item v-for="p in payments" :key="p.ts">
+                <q-item-section>{{ formatDate(p.ts) }}</q-item-section>
+                <q-item-section side>
+                  <div class="row items-center no-wrap q-gutter-xs">
+                    <q-chip dense :color="paymentStatusColor(p.status)" text-color="white">{{ p.status }}</q-chip>
+                    <span>{{ p.amountSat }} sat</span>
+                  </div>
+                </q-item-section>
+              </q-item>
+            </q-list>
+          </q-tab-panel>
+          <q-tab-panel name="notes">
+            <q-input v-model="noteText" type="textarea" autogrow />
+          </q-tab-panel>
+          <q-tab-panel name="activity">
+            <q-list bordered dense>
+              <q-item v-for="a in activity" :key="a.ts">
+                <q-item-section>{{ a.text }}</q-item-section>
+                <q-item-section side class="text-caption text-grey">{{ distToNow(a.ts) }}</q-item-section>
+              </q-item>
+            </q-list>
+          </q-tab-panel>
+        </q-tab-panels>
       </div>
     </q-drawer>
+    <q-dialog v-model="connectDialog">
+      <q-card class="q-pa-md" style="max-width:300px">
+        <div class="text-subtitle2 q-mb-sm">Data source not configured</div>
+        <div class="text-caption q-mb-md">Set VITE_SUBSCRIBERS_ENDPOINT at build time or define localStorage.creator_npub for testing.</div>
+        <q-btn size="sm" outline label="Copy variable name" @click="$q.clipboard.writeText('VITE_SUBSCRIBERS_ENDPOINT')" />
+      </q-card>
+    </q-dialog>
   </div>
   </q-page>
 </template>
 
 <script setup lang="ts">
 import {
-  Chart as ChartJS,
-  LineController,
-  DoughnutController,
-  BarController,
-  LineElement,
-  ArcElement,
-  BarElement,
-  PointElement,
-  CategoryScale,
-  LinearScale,
-  Legend,
-  Tooltip,
-  type Chart,
-} from "chart.js";
 
-ChartJS.register(
-  LineController,
-  DoughnutController,
-  BarController,
-  LineElement,
-  ArcElement,
-  BarElement,
-  PointElement,
-  CategoryScale,
-  LinearScale,
-  Legend,
-  Tooltip
-);
+// Chart.js will be imported lazily when charts become visible
+import type { Chart } from 'chart.js';
 
 import { ref, computed, watch, onMounted } from "vue";
 import { useCreatorSubscribersStore } from "src/stores/creatorSubscribers";
@@ -445,18 +349,23 @@ import type { Subscriber, Frequency, SubStatus } from "src/types/subscriber";
 import downloadCsv from "src/utils/subscriberCsv";
 import SubscriberFiltersPopover from "src/components/subscribers/SubscriberFiltersPopover.vue";
 import SubscriberCard from "src/components/SubscriberCard.vue";
+import KpiRow from "src/components/subscribers/KpiRow.vue";
+import EmptyState from "src/components/subscribers/EmptyState.vue";
+import SubscribersTable from "src/components/subscribers/SubscribersTable.vue";
 
 const subStore = useCreatorSubscribersStore();
-const { filtered, counts, activeTab, loading, error, sourceKind, usedFallback } =
-  storeToRefs(subStore);
+const { filtered, counts, activeTab, loading, error } = storeToRefs(subStore);
 const showEndpointBanner = ref(!import.meta.env.VITE_SUBSCRIBERS_ENDPOINT);
 const creatorNpub =
   localStorage.getItem('creator_npub') || import.meta.env.VITE_CREATOR_NPUB || '';
 
 onMounted(async () => {
-  subStore.setSource(); // Http source by default
+  subStore.setSource();
+  const savedTab = localStorage.getItem('cs_tab');
+  if (savedTab) subStore.setActiveTab(savedTab as any);
   if (creatorNpub) await subStore.hydrate(creatorNpub);
 });
+watch(activeTab, v => localStorage.setItem('cs_tab', v));
 // `filtered` is maintained by the Pinia store based on the active tab,
 // search query and filter popover. Treat it as the single source of truth
 // for the subscriber list and KPI counts throughout this page.
@@ -546,95 +455,100 @@ const statusByFreq = computed(() => {
 });
 
 const search = ref(subStore.query);
-// Forward the user-entered search term to the Pinia store (debounced),
-// which recomputes `filtered` for us.
 const applySearch = useDebounceFn((v: string) => {
   subStore.query = v;
 }, 300);
 watch(search, (v) => applySearch(v));
 
 const filters = ref<InstanceType<typeof SubscriberFiltersPopover> | null>(null);
-
-function openFilters(e: MouseEvent) {
-  filters.value?.show(e);
-}
+function openFilters(e: MouseEvent) { filters.value?.show(e); }
 
 const selected = ref<Subscriber[]>([]);
 
-const view = ref<"table" | "cards">("table");
-const density = ref<"compact" | "comfortable">("comfortable");
+const view = ref<'table' | 'cards'>((localStorage.getItem('cs_view') as 'table' | 'cards') || 'table');
+const density = ref<'compact' | 'comfortable'>((localStorage.getItem('cs_density') as 'compact' | 'comfortable') || 'comfortable');
+const viewOpts = [
+  { label: 'Table', icon: 'table_rows', value: 'table' },
+  { label: 'Cards', icon: 'grid_view', value: 'cards' },
+];
+const densityOpts = [
+  { label: 'Comfy', icon: 'view_comfy', value: 'comfortable' },
+  { label: 'Compact', icon: 'view_compact', value: 'compact' },
+];
+watch(view, v => localStorage.setItem('cs_view', v));
+watch(density, v => localStorage.setItem('cs_density', v));
+
+const searchInput = ref<HTMLInputElement>();
+function refresh() { subStore.hydrate(creatorNpub); }
+
+const lastUpdated = computed(() =>
+  subStore.lastHydratedAt
+    ? formatDistanceToNow(subStore.lastHydratedAt, { addSuffix: true })
+    : ''
+);
+
+function onKey(e: KeyboardEvent) {
+  if (e.key === '/' && !e.metaKey) { e.preventDefault(); searchInput.value?.focus(); }
+  if (e.key === 'f') { e.preventDefault(); openFilters(new MouseEvent('click')); }
+  if (e.key === 'r') { e.preventDefault(); refresh(); }
+}
+onMounted(() => window.addEventListener('keydown', onKey));
+onBeforeUnmount(() => window.removeEventListener('keydown', onKey));
 
 const lineEl = ref<HTMLCanvasElement | null>(null);
 const doughnutEl = ref<HTMLCanvasElement | null>(null);
 const barEl = ref<HTMLCanvasElement | null>(null);
-
-// Chart.js instances are created once on mount and then updated reactively.
 let lineChart: Chart | null = null;
 let doughnutChart: Chart | null = null;
 let barChart: Chart | null = null;
+const chartsReady = ref(false);
 
-onMounted(() => {
-  // Instantiate charts after DOM elements are available.
-  if (lineEl.value) {
-    lineChart = new ChartJS(lineEl.value, {
-      type: "line",
-      data: {
-        labels: revenueSeries.value.labels,
-        datasets: [
-          {
-            data: revenueSeries.value.data,
-            borderColor: "#027be3",
-            backgroundColor: "rgba(2,123,227,0.1)",
-            fill: false,
-            pointRadius: 0,
-          },
-        ],
-      },
-      options: { plugins: { legend: { display: false } }, animation: false },
-    });
-  }
-  if (doughnutEl.value) {
-    doughnutChart = new ChartJS(doughnutEl.value, {
-      type: "doughnut",
-      data: {
-        labels: ["Weekly", "Bi-weekly", "Monthly"],
-        datasets: [
-          {
-            data: freqMix.value,
-            backgroundColor: ["#027be3", "#26a69a", "#9c27b0"],
-          },
-        ],
-      },
-      options: { plugins: { legend: { display: false } }, animation: false },
-    });
-  }
-  if (barEl.value) {
-    barChart = new ChartJS(barEl.value, {
-      type: "bar",
-      data: {
-        labels: statusByFreq.value.labels,
-        datasets: [
-          {
-            label: "Active",
-            backgroundColor: "#21ba45",
-            data: statusByFreq.value.active,
-          },
-          {
-            label: "Pending",
-            backgroundColor: "#f2c037",
-            data: statusByFreq.value.pending,
-          },
-          {
-            label: "Ended",
-            backgroundColor: "#f44336",
-            data: statusByFreq.value.ended,
-          },
-        ],
-      },
-      options: { plugins: { legend: { display: false } }, animation: false },
-    });
-  }
-});
+async function onChartsIntersection(entry: any) {
+  if (!entry.isIntersecting || chartsReady.value) return;
+  chartsReady.value = true;
+  const { Chart } = await import('chart.js/auto');
+  lineChart = new Chart(lineEl.value as HTMLCanvasElement, {
+    type: 'line',
+    data: {
+      labels: revenueSeries.value.labels,
+      datasets: [
+        {
+          data: revenueSeries.value.data,
+          borderColor: '#027be3',
+          backgroundColor: 'rgba(2,123,227,0.1)',
+          fill: false,
+          pointRadius: 0,
+        },
+      ],
+    },
+    options: { plugins: { legend: { display: false } }, animation: false },
+  });
+  doughnutChart = new Chart(doughnutEl.value as HTMLCanvasElement, {
+    type: 'doughnut',
+    data: {
+      labels: ['Weekly', 'Bi-weekly', 'Monthly'],
+      datasets: [
+        {
+          data: freqMix.value,
+          backgroundColor: ['#027be3', '#26a69a', '#9c27b0'],
+        },
+      ],
+    },
+    options: { plugins: { legend: { display: false } }, animation: false },
+  });
+  barChart = new Chart(barEl.value as HTMLCanvasElement, {
+    type: 'bar',
+    data: {
+      labels: statusByFreq.value.labels,
+      datasets: [
+        { label: 'Active', backgroundColor: '#21ba45', data: statusByFreq.value.active },
+        { label: 'Pending', backgroundColor: '#f2c037', data: statusByFreq.value.pending },
+        { label: 'Ended', backgroundColor: '#f44336', data: statusByFreq.value.ended },
+      ],
+    },
+    options: { plugins: { legend: { display: false } }, animation: false },
+  });
+}
 
 // When the underlying computed data changes, update the charts without
 // re-creating them. This keeps Chart.js lifecycle simple and avoids leaks.
@@ -722,14 +636,18 @@ function formatDate(ts: number) {
 
 const drawer = ref(false);
 const current = ref<Subscriber | null>(null);
+const drawerTab = ref<'overview'|'payments'|'notes'|'activity'>('overview');
 const payments = computed(() => current.value?._payments ?? []);
+const noteText = ref('');
 async function openDrawer(r: Subscriber) {
-  current.value = r; drawer.value = true;
+  current.value = r; drawer.value = true; drawerTab.value = 'overview';
+  noteText.value = subStore.notes[r.npub] || '';
   if (!('_payments' in r)) {
     const list = await subStore.fetchPayments(r.npub);
     (r as any)._payments = list;
   }
 }
+watch(noteText, v => { if (current.value) subStore.setNote(current.value.npub, v); });
 const $q = useQuasar();
 const router = useRouter();
 const { t } = useI18n();
@@ -747,6 +665,11 @@ function dmSubscriber() {
     query: { pubkey: current.value.npub },
   });
 }
+function dmSelected() {
+  if (!selected.value.length) return;
+  const keys = selected.value.map(r => r.npub).join(',');
+  router.push({ path: '/nostr-messenger', query: { pubkeys: keys } });
+}
 const activity = computed(() => {
   const r = current.value;
   if (!r) return [] as any[];
@@ -754,4 +677,5 @@ const activity = computed(() => {
   if (r.nextRenewal) arr.push({ ts: r.nextRenewal, text: "Next renewal" });
   return arr;
 });
+const connectDialog = ref(false);
 </script>

--- a/src/utils/subscriberCsv.ts
+++ b/src/utils/subscriberCsv.ts
@@ -16,7 +16,7 @@ const HEADER = [
   "start_date_iso",
 ].join(",");
 
-export function downloadCsv(rows?: Subscriber[]) {
+export function downloadCsv(rows?: Subscriber[], filenameSuffix?: string) {
   const store = useCreatorSubscribersStore();
   const data = rows ?? store.filtered;
 
@@ -48,7 +48,8 @@ export function downloadCsv(rows?: Subscriber[]) {
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
   a.href = url;
-  a.download = `subscribers-${Date.now()}.csv`;
+  const suffix = filenameSuffix ? `-${filenameSuffix}` : "";
+  a.download = `subscribers-${Date.now()}${suffix}.csv`;
   a.click();
   URL.revokeObjectURL(url);
 }

--- a/test/e2e/creator-subscribers.spec.ts
+++ b/test/e2e/creator-subscribers.spec.ts
@@ -1,77 +1,77 @@
 import { test, expect } from '@playwright/test';
 
-test('drives subscribers page layout', async ({ page }) => {
+test('subscribers dashboard interactions', async ({ page }) => {
   await page.setContent(`
-    <div id="topbar"><input id="search" /></div>
-    <div id="tabs">
-      <button data-tab="all">All</button>
-      <button data-tab="weekly">Weekly</button>
-      <button data-tab="biweekly">Bi-weekly</button>
-      <button data-tab="monthly">Monthly</button>
+    <div id="toolbar">
+      <button id="btn-filter">Filters</button>
+      <button id="btn-refresh">Refresh</button>
+      <button id="btn-export">Export</button>
     </div>
+    <div id="tabs">
+      <button data-tab="all">All <span class="count"></span></button>
+      <button data-tab="weekly">Weekly <span class="count"></span></button>
+    </div>
+    <button id="density">Density</button>
     <table id="table"><tbody></tbody></table>
-    <div id="drawer" hidden></div>
+    <div id="drawer" hidden>
+      <div id="drawer-tabs">
+        <button data-tab="payments">Payments</button>
+        <button data-tab="notes">Notes</button>
+      </div>
+      <div id="panel-payments">Payment list</div>
+      <div id="panel-notes" hidden><textarea id="note"></textarea></div>
+    </div>
     <script>
-      const subs = [
+      const rows = [
         {id:1,name:'Alice',frequency:'weekly'},
         {id:2,name:'Bob',frequency:'weekly'},
-        {id:3,name:'Carol',frequency:'biweekly'},
-        {id:4,name:'Dave',frequency:'biweekly'},
-        {id:5,name:'Eve',frequency:'monthly'},
-        {id:6,name:'Frank',frequency:'monthly'},
+        {id:3,name:'Carol',frequency:'monthly'},
+        {id:4,name:'Dave',frequency:'monthly'}
       ];
       const tbody = document.querySelector('#table tbody');
-      const drawer = document.getElementById('drawer');
-      const search = document.getElementById('search');
-      let tab = 'all';
+      let tab='all';
       function render(){
-        const term = search.value.toLowerCase();
         tbody.innerHTML='';
-        subs.filter(s => (tab==='all' || s.frequency===tab) && s.name.toLowerCase().includes(term)).forEach(s=>{
-          const tr = document.createElement('tr');
-          tr.textContent = s.name;
-          tr.addEventListener('click',()=>{drawer.hidden=false;drawer.textContent=s.name;});
+        rows.filter(r=>tab==='all'||r.frequency===tab).forEach(r=>{
+          const tr=document.createElement('tr');
+          tr.textContent=r.name;
+          tr.style.height=document.body.classList.contains('compact')?'40px':'56px';
+          tr.addEventListener('click',()=>document.getElementById('drawer').hidden=false);
           tbody.appendChild(tr);
         });
+        document.querySelector('#tabs button[data-tab="all"] .count').textContent=rows.length;
+        document.querySelector('#tabs button[data-tab="weekly"] .count').textContent=rows.filter(r=>r.frequency==='weekly').length;
       }
-      document.getElementById('tabs').addEventListener('click',e=>{
-        if(e.target.dataset.tab){tab=e.target.dataset.tab;render();}
-      });
-      search.addEventListener('input',render);
+      document.getElementById('tabs').addEventListener('click',e=>{if(e.target.dataset.tab){tab=e.target.dataset.tab;render();}});
+      document.getElementById('density').addEventListener('click',()=>{document.body.classList.toggle('compact');render();});
       render();
+      const note=document.getElementById('note');
+      note.value=localStorage.getItem('note')||'';
+      note.addEventListener('input',()=>localStorage.setItem('note',note.value));
+      document.getElementById('drawer-tabs').addEventListener('click',e=>{
+        if(e.target.dataset.tab){
+          document.getElementById('panel-payments').hidden=e.target.dataset.tab!=='payments';
+          document.getElementById('panel-notes').hidden=e.target.dataset.tab!=='notes';
+        }
+      });
     </script>
   `);
 
-  await expect(page.locator('#table tbody tr')).toHaveCount(6);
+  await expect(page.locator('#btn-filter')).toBeVisible();
+  await expect(page.locator('#btn-refresh')).toBeVisible();
+  await expect(page.locator('#btn-export')).toBeVisible();
+
   await page.click('#tabs button[data-tab="weekly"]');
-  await expect(page.locator('#table tbody tr')).toHaveCount(2);
-  await page.fill('#search','Bob');
-  await expect(page.locator('#table tbody tr')).toHaveCount(1);
+  await expect(page.locator('#tabs button[data-tab="weekly"] .count')).toHaveText('2');
+
+  await page.click('#density');
+  const height = await page.locator('#table tbody tr').first().evaluate(el=>el.offsetHeight);
+  expect(height).toBeLessThan(56);
+
   await page.click('#table tbody tr:first-child');
-  await expect(page.locator('#drawer')).toBeVisible();
-  await expect(page.locator('#drawer')).toHaveText('Bob');
+  await page.click('#drawer-tabs button[data-tab="payments"]');
+  await page.click('#drawer-tabs button[data-tab="notes"]');
+  await page.fill('#note','hello');
+  await page.reload();
+  await expect(page.locator('#note')).toHaveValue('hello');
 });
-
-test('shows http fallback chip in auto mode', async ({ page }) => {
-  await page.setContent(`
-    <div id="toolbar"></div>
-    <script>
-      const chip = document.createElement('div');
-      chip.id = 'chip';
-      chip.textContent = 'Using HTTP (no local data)';
-      document.getElementById('toolbar').appendChild(chip);
-    </script>
-  `);
-  await expect(page.locator('#chip')).toHaveText('Using HTTP (no local data)');
-});
-
-test('hides chip when dexie has data', async ({ page }) => {
-  await page.setContent(`
-    <div id="toolbar"></div>
-    <script>
-      // no chip rendered
-    </script>
-  `);
-  await expect(page.locator('#toolbar').locator('#chip')).toHaveCount(0);
-});
-


### PR DESCRIPTION
## Summary
- add KPI row, empty state, and virtualized table components
- enhance subscriber filters with due-soon toggle
- overhaul creator subscribers page with toolbar prefs, lazy charts, notes, and cached payments

## Testing
- `npm test` *(fails: bad point not on curve, module mocking issues)*
- `npx playwright test test/e2e/creator-subscribers.spec.ts` *(fails: browser executable missing)*

------
https://chatgpt.com/codex/tasks/task_e_68983a9e8f8083308d7385a0ef9ea807