### PR TITLE
Lazy chart loading and CSV export improvements

### DIFF
--- a/src/utils/subscriberCsv.ts
+++ b/src/utils/subscriberCsv.ts
@@ -16,7 +16,10 @@ const HEADER = [
   "start_date_iso",
 ].join(",");
 
-export function downloadCsv(rows?: Subscriber[], filenameSuffix?: string) {
+export function downloadCsv(
+  rows?: Subscriber[],
+  opts?: { filenameSuffix?: string },
+) {
   const store = useCreatorSubscribersStore();
   const data = rows ?? store.filtered;
 
@@ -48,7 +51,7 @@ export function downloadCsv(rows?: Subscriber[], filenameSuffix?: string) {
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
   a.href = url;
-  const suffix = filenameSuffix ? `-${filenameSuffix}` : "";
+  const suffix = opts?.filenameSuffix ?? "";
   a.download = `subscribers-${Date.now()}${suffix}.csv`;
   a.click();
   URL.revokeObjectURL(url);

--- a/test/creatorSubscribers-page.spec.ts
+++ b/test/creatorSubscribers-page.spec.ts
@@ -154,13 +154,17 @@ describe('CreatorSubscribersPage', () => {
     (downloadCsv as unknown as vi.Mock).mockClear();
 
     await wrapper.find('button[data-label="Export CSV"]').trigger('click');
-    expect(downloadCsv).toHaveBeenCalledWith();
+    expect(downloadCsv).toHaveBeenCalledWith(undefined, {
+      filenameSuffix: '-filtered',
+    });
 
     (downloadCsv as unknown as vi.Mock).mockClear();
     wrapper.vm.selected = [store.subscribers[0]];
     await wrapper.vm.$nextTick();
     await wrapper.find('button[data-label="Export selection"]').trigger('click');
-    expect(downloadCsv).toHaveBeenCalledWith([store.subscribers[0]]);
+    expect(downloadCsv).toHaveBeenCalledWith([store.subscribers[0]], {
+      filenameSuffix: '-selection',
+    });
   });
 
   it('updates KPI numbers when searching, switching tabs and applying filters', async () => {


### PR DESCRIPTION
## Summary
- lazy-load subscriber charts and remove static Chart.js usage
- align CSV export utility and calls with option-based suffix
- add per-subscriber CSV export and show last-updated chip

## Testing
- `pnpm run lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm run types`
- `pnpm run build`
- `pnpm test` *(fails: 34 failed, 2 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6898404d30c483308bd0f3e943193629