### PR TITLE
chore: clarify nostr decrypt errors

### DIFF
--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -127,7 +127,7 @@ async function secureGetItem(key: string): Promise<string | null> {
   try {
     return await decryptString(val);
   } catch (e) {
-    console.error("Failed to decrypt", e);
+    console.debug("[nostr] decrypt failed", e);
     return null;
   }
 }


### PR DESCRIPTION
## Summary
- log nostr decryption failures at debug level

## Testing
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: multiple failing suites)*

------
https://chatgpt.com/codex/tasks/task_e_68985bcf10548330910fcda48332e016