### PR TITLE
Avoid repeated relay failure logs

### DIFF
--- a/src/utils/relayHealth.ts
+++ b/src/utils/relayHealth.ts
@@ -1,5 +1,14 @@
 import { FREE_RELAYS } from "src/config/relays";
 
+const reportedRelays = new Set<string>();
+
+function reportRelayFailure(url: string) {
+  if (reportedRelays.has(url)) return;
+  reportedRelays.add(url);
+  console.debug("Relay failed", url);
+  setTimeout(() => reportedRelays.delete(url), 5 * 60 * 1000);
+}
+
 export async function pingRelay(url: string): Promise<boolean> {
   return new Promise((resolve) => {
     let settled = false;
@@ -10,6 +19,7 @@ export async function pingRelay(url: string): Promise<boolean> {
         try {
           ws.close();
         } catch {}
+        reportRelayFailure(url);
         resolve(false);
       }
     }, 1000);
@@ -25,6 +35,7 @@ export async function pingRelay(url: string): Promise<boolean> {
       if (!settled) {
         settled = true;
         clearTimeout(timer);
+        reportRelayFailure(url);
         resolve(false);
       }
     };
@@ -37,6 +48,7 @@ export async function pingRelay(url: string): Promise<boolean> {
         settled = true;
         clearTimeout(timer);
         ws.close();
+        reportRelayFailure(url);
         resolve(false);
       }
     };


### PR DESCRIPTION
## Summary
- track failed relay URLs to avoid duplicate logs
- emit debug log once per URL and reset after five minutes

## Testing
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: 22 failed tests, 1 error)*

------
https://chatgpt.com/codex/tasks/task_e_68985d8705f0833087909455a024127f