### PR TITLE
Load creator subscribers from database

### DIFF
--- a/src/pages/CreatorSubscribersPage.vue
+++ b/src/pages/CreatorSubscribersPage.vue
@@ -589,6 +589,7 @@ function openFilters(e: MouseEvent) {
 }
 
 function retry() {
+  void subStore.loadFromDb();
   void subStore.fetchProfiles();
 }
 
@@ -625,7 +626,8 @@ let lineChart: Chart | null = null;
 let doughnutChart: Chart | null = null;
 let barChart: Chart | null = null;
 
-onMounted(() => {
+onMounted(async () => {
+  await subStore.loadFromDb();
   void subStore.fetchProfiles();
   // Instantiate charts after DOM elements are available.
   if (lineEl.value) {


### PR DESCRIPTION
## Summary
- Load creator subscribers from locked token records instead of mock data
- Group locked tokens by subscription and subscriber to compute subscription metrics
- Invoke database-backed loading when the creator subscribers page mounts

## Testing
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: 32 failed, 30 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68987c5bd7e88330879f78bfbd52f3ec