### PR TITLE
feat: track subscriber renewal progress

### DIFF
--- a/src/pages/CreatorSubscribersPage.vue
+++ b/src/pages/CreatorSubscribersPage.vue
@@ -783,19 +783,10 @@ function statusIcon(s: SubStatus) {
   return s === 'active' ? 'check' : s === 'pending' ? 'schedule' : 'close';
 }
 function progressPercent(r: Subscriber) {
-  if (!r.nextRenewal) return 0;
-  const days =
-    r.frequency === "weekly" ? 7 : r.frequency === "biweekly" ? 14 : 30;
-  const end = r.nextRenewal * 1000;
-  const start = end - days * 86400000;
-  const now = Date.now();
-  return Math.round(
-    Math.min(Math.max((now - start) / (end - start), 0), 1) * 100
-  );
+  return Math.round((r.progress ?? 0) * 100);
 }
 function dueSoon(r: Subscriber) {
-  if (!r.nextRenewal || r.status !== "active") return false;
-  return r.nextRenewal * 1000 - Date.now() < 72 * 3600 * 1000;
+  return r.dueSoon;
 }
 function rowClass(row: Subscriber) {
   return dueSoon(row) ? "due-soon" : "";

--- a/src/types/subscriber.ts
+++ b/src/types/subscriber.ts
@@ -11,8 +11,18 @@ export interface Subscriber {
   tierName: string;
   amountSat: number;
   frequency: Frequency;
+  /** Number of days between payments */
+  intervalDays: number;
   status: SubStatus;
   startDate: number;
   nextRenewal?: number;
   lifetimeSat: number;
+  receivedPeriods: number;
+  totalPeriods?: number;
+  /**
+   * Progress through the current billing period as a fraction between 0 and 1.
+   */
+  progress: number;
+  /** Whether the subscription renewal is due within the next 72 hours */
+  dueSoon: boolean;
 }


### PR DESCRIPTION
## Summary
- track subscription tokens per subscriber and sort by unlock time
- compute next renewal, progress, and due-soon flags
- expose progress helpers in creator subscribers page and tests

## Testing
- `pnpm test` *(fails: 32 failed, 30 passed)*
- `pnpm exec eslint src/stores/creatorSubscribers.ts src/pages/CreatorSubscribersPage.vue src/types/subscriber.ts test/creatorSubscribers-page.spec.ts` *(fails: Cannot find module './.eslintrc.js')*


------
https://chatgpt.com/codex/tasks/task_e_68987f4a1f048330be042697dffc8175