### PR TITLE
Adjust subscriber filters menu positioning

### DIFF
--- a/src/components/subscribers/SubscriberFiltersPopover.vue
+++ b/src/components/subscribers/SubscriberFiltersPopover.vue
@@ -1,8 +1,8 @@
 <template>
   <q-menu
     ref="menu"
-    anchor="bottom right"
-    self="top right"
+    anchor="bottom left"
+    self="top left"
     transition-show="jump-down"
     transition-hide="jump-up"
   >
@@ -84,8 +84,8 @@ function clear() {
   store.clearFilters();
 }
 
-function show(evt?: MouseEvent) {
-  menu.value?.show(evt);
+function show() {
+  menu.value?.show();
 }
 
 defineExpose({ show });

--- a/src/pages/CreatorSubscribersPage.vue
+++ b/src/pages/CreatorSubscribersPage.vue
@@ -49,7 +49,7 @@
         round
         icon="tune"
         class="q-ml-sm"
-        @click.stop="openFilters"
+        @click.stop="openFilters()"
         :aria-label="t('CreatorSubscribers.actions.filters')"
       />
       <q-btn
@@ -584,8 +584,8 @@ watch(search, (v) => applySearch(v));
 
 const filters = ref<InstanceType<typeof SubscriberFiltersPopover> | null>(null);
 
-function openFilters(e: MouseEvent) {
-  filters.value?.show(e);
+function openFilters() {
+  filters.value?.show();
 }
 
 function retry() {


### PR DESCRIPTION
## Summary
- Re-anchor subscriber filter popover to the left side and simplify show logic
- Ensure CreatorSubscribers filter button opens the updated left-aligned menu

## Testing
- `pnpm exec eslint src/components/subscribers/SubscriberFiltersPopover.vue src/pages/CreatorSubscribersPage.vue` (fails: Cannot find module './.eslintrc.js')
- `pnpm test` (fails: QDrawer needs to be child of QLayout, other errors)


------
https://chatgpt.com/codex/tasks/task_e_6898830a4f888330ae1203babba521db