### PR TITLE
Filter spent tokens when syncing creator subscribers

### DIFF
--- a/test/vitest/__tests__/creatorSubscribers.spec.ts
+++ b/test/vitest/__tests__/creatorSubscribers.spec.ts
@@ -78,4 +78,143 @@ describe('creatorSubscribers sync', () => {
     );
     expect(statuses).toEqual({ npubA: 'active', npubB: 'pending' });
   });
+
+  it('drops spent tokens and sets status pending', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    checkSpy.mockImplementation(async (proofs: Proof[]) =>
+      proofs.map((p) => ({
+        state: p.secret === 'spent1' ? CheckStateEnum.SPENT : CheckStateEnum.UNSPENT,
+        Y: '',
+      }))
+    );
+
+    await cashuDb.lockedTokens.bulkAdd([
+      {
+        id: 'p1',
+        tokenString: getEncodedToken(
+          {
+            mint: 'https://mint.test',
+            proofs: [{ amount: 1, secret: 'spent1', C: '', id: '00' } as Proof],
+            unit: 'sat',
+          } as Token,
+          { version: 3 }
+        ),
+        owner: 'creator',
+        tierId: 't2',
+        tierName: 'Tier2',
+        intervalKey: 'k1',
+        unlockTs: now - 60,
+        status: 'pending',
+        subscriptionEventId: null,
+        subscriptionId: 'subP',
+        subscriberNpub: 'npubP',
+        amount: 1,
+        frequency: 'monthly',
+        intervalDays: 30,
+        totalPeriods: 2,
+      },
+      {
+        id: 'p2',
+        tokenString: getEncodedToken(
+          {
+            mint: 'https://mint.test',
+            proofs: [{ amount: 1, secret: 'valid1', C: '', id: '00' } as Proof],
+            unit: 'sat',
+          } as Token,
+          { version: 3 }
+        ),
+        owner: 'creator',
+        tierId: 't2',
+        tierName: 'Tier2',
+        intervalKey: 'k2',
+        unlockTs: now + 60,
+        status: 'pending',
+        subscriptionEventId: null,
+        subscriptionId: 'subP',
+        subscriberNpub: 'npubP',
+        amount: 1,
+        frequency: 'monthly',
+        intervalDays: 30,
+        totalPeriods: 2,
+      },
+    ] as any);
+
+    const store = useCreatorSubscribersStore();
+    await store.sync();
+
+    expect(checkSpy).toHaveBeenCalledTimes(2);
+    const sub = store.subscribers.find((s) => s.npub === 'npubP');
+    expect(sub?.receivedPeriods).toBe(1);
+    expect(sub?.status).toBe('pending');
+    expect(sub?.nextRenewal).toBe(now + 60 + 30 * 86400);
+  });
+
+  it('drops spent tokens but keeps subscription ended when valid tokens meet total', async () => {
+    const now = Math.floor(Date.now() / 1000);
+    checkSpy.mockImplementation(async (proofs: Proof[]) =>
+      proofs.map((p) => ({
+        state: p.secret === 'spent2' ? CheckStateEnum.SPENT : CheckStateEnum.UNSPENT,
+        Y: '',
+      }))
+    );
+
+    await cashuDb.lockedTokens.bulkAdd([
+      {
+        id: 'e1',
+        tokenString: getEncodedToken(
+          {
+            mint: 'https://mint.test',
+            proofs: [{ amount: 1, secret: 'valid2', C: '', id: '00' } as Proof],
+            unit: 'sat',
+          } as Token,
+          { version: 3 }
+        ),
+        owner: 'creator',
+        tierId: 't3',
+        tierName: 'Tier3',
+        intervalKey: 'k1',
+        unlockTs: now - 60,
+        status: 'pending',
+        subscriptionEventId: null,
+        subscriptionId: 'subE',
+        subscriberNpub: 'npubE',
+        amount: 1,
+        frequency: 'monthly',
+        intervalDays: 30,
+        totalPeriods: 1,
+      },
+      {
+        id: 'e2',
+        tokenString: getEncodedToken(
+          {
+            mint: 'https://mint.test',
+            proofs: [{ amount: 1, secret: 'spent2', C: '', id: '00' } as Proof],
+            unit: 'sat',
+          } as Token,
+          { version: 3 }
+        ),
+        owner: 'creator',
+        tierId: 't3',
+        tierName: 'Tier3',
+        intervalKey: 'k2',
+        unlockTs: now - 30,
+        status: 'pending',
+        subscriptionEventId: null,
+        subscriptionId: 'subE',
+        subscriberNpub: 'npubE',
+        amount: 1,
+        frequency: 'monthly',
+        intervalDays: 30,
+        totalPeriods: 1,
+      },
+    ] as any);
+
+    const store = useCreatorSubscribersStore();
+    await store.sync();
+
+    expect(checkSpy).toHaveBeenCalledTimes(2);
+    const sub = store.subscribers.find((s) => s.npub === 'npubE');
+    expect(sub?.receivedPeriods).toBe(1);
+    expect(sub?.status).toBe('ended');
+  });
 });


### PR DESCRIPTION
## Summary
- verify each locked token with the mint's API and ignore spent proofs when aggregating creator subscribers
- recompute subscriber status, progress, periods, and renewal using only valid proofs
- add tests ensuring spent tokens are dropped and subscriptions move to `pending` or stay `ended` as appropriate

## Testing
- `pnpm vitest run test/vitest/__tests__/creatorSubscribers.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_6898c020ddb883309441b8973a103160