### PR TITLE
feat: add sidebar layout for subscribers page

### DIFF
--- a/src/stories/CreatorSubscribersPage.stories.ts
+++ b/src/stories/CreatorSubscribersPage.stories.ts
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/vue3';
+import CreatorSubscribersPage from '../pages/CreatorSubscribersPage.vue';
+
+const meta: Meta<typeof CreatorSubscribersPage> = {
+  title: 'Pages/CreatorSubscribersPage',
+  component: CreatorSubscribersPage,
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Desktop: Story = {
+  render: () => ({
+    components: { CreatorSubscribersPage },
+    template: '<creator-subscribers-page />',
+  }),
+};
+
+export const Mobile: Story = {
+  render: () => ({
+    components: { CreatorSubscribersPage },
+    template: '<div style="width: 360px"><creator-subscribers-page /></div>',
+  }),
+};


### PR DESCRIPTION
## Summary
- redesign CreatorSubscribersPage with QSplitter and vertical tabs sidebar
- add scoped styling for responsive sidebar layout
- include Storybook entries for desktop and mobile layouts

## Testing
- `pnpm test test/creatorSubscribers-page.spec.ts` *(fails: expected badge counts to match, due to test adjustments pending)*

------
https://chatgpt.com/codex/tasks/task_e_6898c5096cfc83308a8d1eabdbbb8728