### PR TITLE
Refactor creator subscribers UI and npub encoding

### DIFF
--- a/src/components/subscribers/SubscriberFilters.vue
+++ b/src/components/subscribers/SubscriberFilters.vue
@@ -1,30 +1,22 @@
 <template>
-  <q-menu
-    ref="menu"
-    anchor="bottom left"
-    self="top left"
-    transition-show="jump-down"
-    transition-hide="jump-up"
-  >
-    <div class="q-pa-md" style="min-width: 200px">
-      <div class="text-subtitle2 q-mb-sm">
-        {{ t('CreatorSubscribers.filters.status') }}
-      </div>
-      <q-option-group v-model="localStatuses" :options="statusOptions" type="checkbox" />
-      <div class="text-subtitle2 q-mt-md q-mb-sm">
-        {{ t('CreatorSubscribers.filters.tier') }}
-      </div>
-      <q-option-group v-model="localTiers" :options="tierOptions" type="checkbox" />
-      <div class="text-subtitle2 q-mt-md q-mb-sm">
-        {{ t('CreatorSubscribers.filters.sort') }}
-      </div>
-      <q-option-group v-model="localSort" :options="sortOptions" type="radio" />
-      <div class="row justify-end q-mt-md q-gutter-sm">
-        <q-btn flat :label="t('CreatorSubscribers.filters.clear')" v-close-popup @click="clear" />
-        <q-btn color="primary" :label="t('CreatorSubscribers.filters.apply')" v-close-popup @click="apply" />
-      </div>
+  <div class="q-pa-md" style="min-width: 200px">
+    <div class="text-subtitle2 q-mb-sm">
+      {{ t('CreatorSubscribers.filters.status') }}
     </div>
-  </q-menu>
+    <q-option-group v-model="localStatuses" :options="statusOptions" type="checkbox" />
+    <div class="text-subtitle2 q-mt-md q-mb-sm">
+      {{ t('CreatorSubscribers.filters.tier') }}
+    </div>
+    <q-option-group v-model="localTiers" :options="tierOptions" type="checkbox" />
+    <div class="text-subtitle2 q-mt-md q-mb-sm">
+      {{ t('CreatorSubscribers.filters.sort') }}
+    </div>
+    <q-option-group v-model="localSort" :options="sortOptions" type="radio" />
+    <div class="row justify-end q-mt-md q-gutter-sm">
+      <q-btn flat :label="t('CreatorSubscribers.filters.clear')" @click="clear" />
+      <q-btn color="primary" :label="t('CreatorSubscribers.filters.apply')" @click="apply" />
+    </div>
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -36,7 +28,6 @@ import { useI18n } from 'vue-i18n';
 
 const store = useCreatorSubscribersStore();
 
-const menu = ref();
 const localStatuses = ref<SubStatus[]>(Array.from(store.statuses));
 const localTiers = ref<string[]>(Array.from(store.tiers));
 const localSort = ref<SortOption>(store.sort);
@@ -73,7 +64,7 @@ function apply() {
   store.applyFilters({
     statuses: new Set(localStatuses.value),
     tiers: new Set(localTiers.value),
-    sort: localSort.value
+    sort: localSort.value,
   });
 }
 
@@ -83,10 +74,4 @@ function clear() {
   localSort.value = 'next';
   store.clearFilters();
 }
-
-function show() {
-  menu.value?.show();
-}
-
-defineExpose({ show });
 </script>

--- a/src/layouts/FullscreenLayout.vue
+++ b/src/layouts/FullscreenLayout.vue
@@ -5,9 +5,7 @@
   >
     <MainHeader />
     <q-page-container class="text-body1">
-      <div class="max-w-7xl mx-auto">
-        <router-view />
-      </div>
+      <router-view />
     </q-page-container>
     <PublishBar
       v-if="loggedIn && showPublishBar"

--- a/src/pages/CreatorSubscribersPage.vue
+++ b/src/pages/CreatorSubscribersPage.vue
@@ -1,70 +1,73 @@
 <template>
-  <q-page padding>
-    <SubscriberFiltersPopover ref="filters" />
-    <q-banner v-if="error" dense class="q-mb-md bg-red-1 text-red">
-      {{ error }}
-      <template #action>
+  <q-layout view="hHh lpR fFf">
+    <q-header class="bg-white text-dark">
+      <q-toolbar class="row items-center q-gutter-sm">
         <q-btn
           flat
-          color="red"
-          :label="t('CreatorSubscribers.actions.retry')"
-          :aria-label="t('CreatorSubscribers.actions.retry')"
-          @click="retry"
+          dense
+          round
+          icon="menu"
+          :aria-label="t('CreatorSubscribers.actions.filters')"
+          @click="filtersOpen = !filtersOpen"
         />
-      </template>
-    </q-banner>
-    <q-inner-loading :showing="loading">
-      <q-spinner size="50px" color="primary" />
-    </q-inner-loading>
-    <!-- Top bar -->
-    <div class="row items-center q-gutter-sm q-mb-md">
-      <div class="text-h6">{{ t('CreatorSubscribers.summary.subscribers') }}</div>
-      <q-input
-        dense
-        v-model="search"
-        :placeholder="t('CreatorSubscribers.toolbar.searchPlaceholder')"
-        class="q-ml-md"
-        clearable
-      >
-        <template #prepend>
-          <q-icon name="search" />
-        </template>
-      </q-input>
-      <q-btn-toggle
-        v-model="view"
-        dense
-        toggle-color="primary"
-        class="q-ml-sm"
-        :options="viewOptions"
-      />
-      <q-btn-toggle
-        v-model="density"
-        dense
-        toggle-color="primary"
-        class="q-ml-sm"
-        :options="densityOptions"
-      />
-      <q-btn
-        dense
-        flat
-        round
-        icon="tune"
-        class="q-ml-sm"
-        @click.stop="openFilters()"
-        :aria-label="t('CreatorSubscribers.actions.filters')"
-      />
-      <q-btn
-        outline
-        color="grey-5"
-        icon="download"
-        :label="t('CreatorSubscribers.toolbar.exportCsv')"
-        class="q-ml-sm"
-        :aria-label="t('CreatorSubscribers.toolbar.exportCsv')"
-        @click="downloadCsv()"
-      />
-    </div>
-
-    <!-- KPI Row -->
+        <div class="text-h6">{{ t('CreatorSubscribers.summary.subscribers') }}</div>
+        <q-input
+          dense
+          v-model="search"
+          :placeholder="t('CreatorSubscribers.toolbar.searchPlaceholder')"
+          class="q-ml-md"
+          clearable
+        >
+          <template #prepend>
+            <q-icon name="search" />
+          </template>
+        </q-input>
+        <q-btn-toggle
+          v-model="view"
+          dense
+          toggle-color="primary"
+          class="q-ml-sm"
+          :options="viewOptions"
+        />
+        <q-btn-toggle
+          v-model="density"
+          dense
+          toggle-color="primary"
+          class="q-ml-sm"
+          :options="densityOptions"
+        />
+        <q-btn
+          outline
+          color="grey-5"
+          icon="download"
+          :label="t('CreatorSubscribers.toolbar.exportCsv')"
+          class="q-ml-sm"
+          :aria-label="t('CreatorSubscribers.toolbar.exportCsv')"
+          @click="downloadCsv()"
+        />
+      </q-toolbar>
+    </q-header>
+    <q-drawer v-model="filtersOpen" side="left" bordered :overlay="$q.screen.lt.md">
+      <SubscriberFilters />
+    </q-drawer>
+    <q-page-container>
+      <q-page class="q-pa-md fit">
+        <q-banner v-if="error" dense class="q-mb-md bg-red-1 text-red">
+          {{ error }}
+          <template #action>
+            <q-btn
+              flat
+              color="red"
+              :label="t('CreatorSubscribers.actions.retry')"
+              :aria-label="t('CreatorSubscribers.actions.retry')"
+              @click="retry"
+            />
+          </template>
+        </q-banner>
+        <q-inner-loading :showing="loading">
+          <q-spinner size="50px" color="primary" />
+        </q-inner-loading>
+        <!-- KPI Row -->
     <div class="row q-col-gutter-md q-mb-md">
       <q-card
         flat
@@ -331,10 +334,10 @@
         @click="clearSelected"
       />
     </div>
-
-    <!-- Drawer -->
-    <q-drawer v-model="drawer" side="right" overlay bordered>
-      <div v-if="current" class="q-pa-md">
+    </q-page>
+  </q-page-container>
+  <q-drawer v-model="drawer" side="right" overlay bordered>
+    <div v-if="current" class="q-pa-md">
         <div class="row items-center q-gutter-sm">
           <q-avatar size="64px">{{ initials(current.name) }}</q-avatar>
           <div>
@@ -404,9 +407,9 @@
             </q-item>
           </q-list>
         </div>
-      </div>
-    </q-drawer>
-  </q-page>
+    </div>
+  </q-drawer>
+</q-layout>
 </template>
 
 <script setup lang="ts">
@@ -451,7 +454,7 @@ import { useRouter } from "vue-router";
 import { useI18n } from "vue-i18n";
 import type { Subscriber, Frequency, SubStatus } from "src/types/subscriber";
 import downloadCsv from "src/utils/subscriberCsv";
-import SubscriberFiltersPopover from "src/components/subscribers/SubscriberFiltersPopover.vue";
+import SubscriberFilters from "src/components/subscribers/SubscriberFilters.vue";
 import SubscriberCard from "src/components/SubscriberCard.vue";
 
 const { t } = useI18n();
@@ -459,7 +462,7 @@ const { t } = useI18n();
 const subStore = useCreatorSubscribersStore();
 const { filtered, counts, activeTab, loading, error } = storeToRefs(subStore);
 // `filtered` is maintained by the Pinia store based on the active tab,
-// search query and filter popover. Treat it as the single source of truth
+// search query and filter drawer. Treat it as the single source of truth
 // for the subscriber list and KPI counts throughout this page.
 
 const activeCount = computed(
@@ -586,11 +589,7 @@ const applySearch = useDebounceFn((v: string) => {
 }, 300);
 watch(search, (v) => applySearch(v));
 
-const filters = ref<InstanceType<typeof SubscriberFiltersPopover> | null>(null);
-
-function openFilters() {
-  filters.value?.show();
-}
+const filtersOpen = ref(false);
 
 function retry() {
   void subStore.loadFromDb();

--- a/src/pages/CreatorSubscribersStoreDemo.vue
+++ b/src/pages/CreatorSubscribersStoreDemo.vue
@@ -2,8 +2,8 @@
   <q-page class="q-pa-md">
     <div class="row items-center q-gutter-sm q-mb-md">
       <q-input dense v-model="search" placeholder="Search" clearable @update:model-value="onSearch" />
-      <q-btn flat icon="filter_list" @click="filters?.show()" />
     </div>
+    <SubscriberFilters class="q-mb-md" />
     <q-tabs v-model="activeTab" dense class="text-grey-7" active-color="primary" indicator-color="primary">
       <q-tab name="all" :label="`All (${counts.all})`" />
       <q-tab name="weekly" :label="`Weekly (${counts.weekly})`" />
@@ -23,7 +23,6 @@
         </div>
       </template>
     </q-virtual-scroll>
-    <SubscriberFiltersPopover ref="filters" />
   </q-page>
 </template>
 
@@ -31,14 +30,13 @@
 import { ref } from 'vue';
 import { useDebounceFn } from '@vueuse/core';
 import { storeToRefs } from 'pinia';
-import SubscriberFiltersPopover from 'src/components/subscribers/SubscriberFiltersPopover.vue';
+import SubscriberFilters from 'src/components/subscribers/SubscriberFilters.vue';
 import { useCreatorSubscribersStore } from 'src/stores/creatorSubscribers';
 
 const store = useCreatorSubscribersStore();
 const { filtered, counts, activeTab } = storeToRefs(store);
 
 const search = ref(store.query);
-const filters = ref<InstanceType<typeof SubscriberFiltersPopover> | null>(null);
 
 const onSearch = useDebounceFn((val: string) => {
   store.setQuery(val);

--- a/src/stores/creatorSubscribers.ts
+++ b/src/stores/creatorSubscribers.ts
@@ -3,6 +3,7 @@ import type { Subscriber, Frequency, SubStatus } from "../types/subscriber";
 import { useNostrStore } from "./nostr";
 import { cashuDb } from "./dexie";
 import { liveQuery } from "dexie";
+import { nip19 } from "nostr-tools";
 import {
   daysToFrequency,
   frequencyToDays,
@@ -200,10 +201,12 @@ export const useCreatorSubscribersStore = defineStore("creatorSubscribers", {
                 dueSoon = status === "active" && nextRenewal - now < 72 * 3600;
               }
 
+              const npub = nip19.npubEncode(g.npub);
+
               return {
                 id: g.id,
-                name: g.npub,
-                npub: g.npub,
+                name: npub,
+                npub,
                 nip05: "",
                 tierId: g.tierId,
                 tierName: g.tierName,

--- a/test/creatorSubscribers-page.spec.ts
+++ b/test/creatorSubscribers-page.spec.ts
@@ -42,7 +42,7 @@ vi.mock('quasar', async (importOriginal) => {
   return {
     ...actual,
     copyToClipboard: vi.fn(),
-    useQuasar: () => ({ clipboard: { writeText: clipboardWrite }, notify: vi.fn() }),
+    useQuasar: () => ({ clipboard: { writeText: clipboardWrite }, notify: vi.fn(), screen: { lt: { md: false } } }),
   };
 });
 const routerPush = vi.fn();
@@ -56,6 +56,10 @@ import downloadCsv from 'src/utils/subscriberCsv';
 import CreatorSubscribersPage from '../src/pages/CreatorSubscribersPage.vue';
 
 const stubs = {
+  'q-layout': { template: '<div><slot /></div>' },
+  'q-header': { template: '<div><slot /></div>' },
+  'q-toolbar': { template: '<div><slot /></div>' },
+  'q-page-container': { template: '<div><slot /></div>' },
   'q-page': { template: '<div><slot /></div>' },
   'q-input': {
     props: ['modelValue'],
@@ -67,7 +71,6 @@ const stubs = {
     template:
       '<button :data-label="label" :aria-label="ariaLabel" @click="$emit(\'click\', $event)"><slot /></button>',
   },
-  'q-menu': { template: '<div><slot /></div>' },
   'q-chip': { template: '<div class="q-chip" @click="$emit(\'click\')"><slot /></div>' },
   'q-select': {
     props: ['modelValue', 'options'],
@@ -92,7 +95,7 @@ const stubs = {
   },
   'q-space': { template: '<span class="q-space"></span>' },
   'q-banner': { template: '<div><slot /><slot name="action" /></div>' },
-  SubscriberFiltersPopover: { template: '<div></div>' },
+  SubscriberFilters: { template: '<div></div>' },
 };
 
 function mountPage() {
@@ -110,6 +113,12 @@ describe('CreatorSubscribersPage', () => {
     const wrapper = mountPage();
     const badges = wrapper.findAll('.q-badge');
     expect(badges.map((b) => b.text())).toEqual(['6', '2', '2', '2', '2', '1']);
+  });
+
+  it('converts npub to bech32', () => {
+    const wrapper = mountPage();
+    const store = useCreatorSubscribersStore(wrapper.vm.$pinia);
+    expect(store.subscribers[0].npub).toMatch(/^npub1/);
   });
 
   it('filters by search, status and tier', async () => {
@@ -204,10 +213,9 @@ describe('CreatorSubscribersPage', () => {
 
   it('opens filters when filter button clicked', async () => {
     const wrapper = mountPage();
-    const show = vi.fn();
-    wrapper.vm.filters = { show } as any;
+    expect(wrapper.vm.filtersOpen).toBe(false);
     await wrapper.find('button[aria-label="Filters"]').trigger('click');
-    expect(show).toHaveBeenCalled();
+    expect(wrapper.vm.filtersOpen).toBe(true);
   });
 
   it('clears selection when clear button clicked', async () => {


### PR DESCRIPTION
## Summary
- replace popover filters with left-hand drawer and responsive full-page layout
- encode subscriber pubkeys to bech32 npub format
- adjust tests for new filter drawer and bech32 values

## Testing
- `pnpm test --run test/creatorSubscribers-page.spec.ts test/e2e/creator-subscribers.spec.ts` *(fails: expected dataset values, e.g., TypeError intervalDays undefined)*

------
https://chatgpt.com/codex/tasks/task_e_6898d91febec8330bd0c35f9c9b8c279