### PR TITLE
Improve subscribers layout spacing

### DIFF
--- a/src/components/SubscriberCard.vue
+++ b/src/components/SubscriberCard.vue
@@ -1,6 +1,6 @@
 <template>
-  <q-card :class="[{ 'q-mb-sm': !compact }, 'cursor-pointer']" @click="$emit('click')">
-    <q-card-section class="q-pa-sm">
+  <q-card :class="[{ 'q-mb-sm': !compact }, 'q-pa-md', 'q-ma-sm', 'cursor-pointer']" @click="$emit('click')">
+    <q-card-section class="q-pa-none">
       <div class="row items-center justify-between">
         <div>
           <div class="text-subtitle2">{{ subscription.tierName }}</div>

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -157,8 +157,9 @@ body.body--light {
 .panel-container {
   background-color: var(--panel-bg-color);
   border: var(--border-subtle);
+  border-width: 2px;
   border-radius: 16px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
 }
 
 .chip {
@@ -321,5 +322,5 @@ body.body--dark .received {
 .subscriber-cards {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
-  gap: 1rem;
+  gap: 1.5rem;
 }

--- a/src/pages/CreatorSubscribersPage.vue
+++ b/src/pages/CreatorSubscribersPage.vue
@@ -68,11 +68,11 @@
           <q-spinner size="50px" color="primary" />
         </q-inner-loading>
         <!-- KPI Row -->
-    <div class="row q-col-gutter-md q-mb-md">
+    <div class="row q-col-gutter-lg q-mb-lg">
       <q-card
         flat
         bordered
-        class="col-12 col-sm-6 col-md-3 panel-container q-pa-sm"
+        class="col-12 col-sm-6 col-md-3 panel-container q-pa-md q-ma-sm"
       >
         <div class="text-caption text-grey">
           {{ t('CreatorSubscribers.summary.subscribers') }}
@@ -82,7 +82,7 @@
       <q-card
         flat
         bordered
-        class="col-12 col-sm-6 col-md-3 panel-container q-pa-sm"
+        class="col-12 col-sm-6 col-md-3 panel-container q-pa-md q-ma-sm"
       >
         <div class="text-caption text-grey">
           {{ t('CreatorSubscribers.summary.active') }} /
@@ -93,7 +93,7 @@
       <q-card
         flat
         bordered
-        class="col-12 col-sm-6 col-md-3 panel-container q-pa-sm"
+        class="col-12 col-sm-6 col-md-3 panel-container q-pa-md q-ma-sm"
       >
         <div class="text-caption text-grey">
           {{ t('CreatorSubscribers.summary.lifetimeRevenue') }}
@@ -103,7 +103,7 @@
       <q-card
         flat
         bordered
-        class="col-12 col-sm-6 col-md-3 panel-container q-pa-sm"
+        class="col-12 col-sm-6 col-md-3 panel-container q-pa-md q-ma-sm"
         @click="togglePeriod"
       >
         <div class="text-caption text-grey">
@@ -123,12 +123,12 @@
       class="q-mb-md"
       :options="chartToggleOptions"
     />
-    <div class="row q-col-gutter-md q-mb-md">
+    <div class="row q-col-gutter-lg q-mb-lg">
       <q-card
         v-show="showRevenueChart"
         flat
         bordered
-        class="col-12 col-md-4 panel-container q-pa-sm"
+        class="col-12 col-md-4 panel-container q-pa-md q-ma-sm"
       >
         <div class="text-subtitle2 q-mb-sm">
           {{ t('CreatorSubscribers.charts.revenueOverTime') }}
@@ -144,7 +144,7 @@
           v-show="showFrequencyChart"
           flat
           bordered
-          class="col-12 col-md-4 panel-container q-pa-sm"
+          class="col-12 col-md-4 panel-container q-pa-md q-ma-sm"
         >
         <div class="text-subtitle2 q-mb-sm">
           {{ t('CreatorSubscribers.charts.frequencyMix') }}
@@ -160,7 +160,7 @@
         v-show="showStatusChart"
         flat
         bordered
-        class="col-12 col-md-4 panel-container q-pa-sm"
+        class="col-12 col-md-4 panel-container q-pa-md q-ma-sm"
       >
         <div class="text-subtitle2 q-mb-sm">
           {{ t('CreatorSubscribers.charts.statusByFrequency') }}
@@ -226,7 +226,7 @@
       :rows-per-page-options="[10, 25, 50]"
       :row-class="rowClass"
       :dense="density === 'compact'"
-      :class="['density--' + density]"
+      :class="['density--' + density, 'q-mb-lg']"
       v-model:pagination="pagination"
       :row-count="filtered.length"
       @request="onRequest"
@@ -329,6 +329,7 @@
       :items="filtered"
       :virtual-scroll-item-size="140"
       content-class="subscriber-cards"
+      class="q-mb-lg"
     >
       <template #default="{ item: row }">
         <SubscriberCard


### PR DESCRIPTION
## Summary
- Increase gutters and card padding on CreatorSubscribersPage KPIs and charts for roomier layout
- Strengthen panel-container borders and shadows; widen subscriber card gaps
- Add consistent padding/margins to subscriber cards, table, and virtual scroll

## Testing
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: 35 failed, 72 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6898e9ca190483309fa2629eda9f0642