### PR TITLE
Replace legacy chart cards with SubscriptionsCharts component

### DIFF
--- a/src/components/subscribers/SubscriptionsCharts.vue
+++ b/src/components/subscribers/SubscriptionsCharts.vue
@@ -1,18 +1,18 @@
 <template>
-  <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-    <div class="flex flex-col items-center">
+  <div class="row q-col-gutter-lg">
+    <div class="col-12 col-md-4 flex flex-col items-center">
       <MiniDonut :series="frequencySeries" :labels="frequencyLabels" />
       <div class="text-caption q-mt-xs">
         {{ t('CreatorSubscribers.charts.frequency') }}
       </div>
     </div>
-    <div class="flex flex-col items-center">
+    <div class="col-12 col-md-4 flex flex-col items-center">
       <MiniDonut :series="statusSeries" :labels="statusLabels" />
       <div class="text-caption q-mt-xs">
         {{ t('CreatorSubscribers.charts.status') }}
       </div>
     </div>
-    <div class="flex flex-col items-center w-full">
+    <div class="col-12 col-md-4 flex flex-col items-center">
       <MiniBar :series="newSubsSeries" class="w-full" />
       <div class="text-caption q-mt-xs">
         {{ t('CreatorSubscribers.charts.newSubs') }}


### PR DESCRIPTION
## Summary
- replace chart toggle group and q-card charts with `<SubscriptionsCharts>` on subscribers page
- remove Chart.js plumbing and import new component
- align SubscriptionsCharts layout with KPI card spacing

## Testing
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: fetchNutzapProfile > returns compressed hex from npub tag)*

------
https://chatgpt.com/codex/tasks/task_e_6898f441e70c8330b0d265bf0597d808