### PR TITLE
feat: tidy subscribers header

### DIFF
--- a/src/pages/CreatorSubscribersPage.vue
+++ b/src/pages/CreatorSubscribersPage.vue
@@ -22,26 +22,26 @@
             <q-icon name="search" />
           </template>
         </q-input>
-        <q-btn-toggle
-          v-model="view"
-          dense
-          toggle-color="primary"
-          class="q-ml-sm"
-          :options="viewOptions"
-        />
-        <q-btn-toggle
-          v-model="density"
-          dense
-          toggle-color="primary"
-          class="q-ml-sm"
-          :options="densityOptions"
-        />
+        <q-btn-group flat rounded class="q-ml-sm">
+          <q-btn-toggle
+            v-model="view"
+            dense
+            toggle-color="primary"
+            :options="viewOptions"
+          />
+          <q-btn-toggle
+            v-model="density"
+            dense
+            toggle-color="primary"
+            :options="densityOptions"
+          />
+        </q-btn-group>
+        <q-space />
         <q-btn
-          outline
-          color="grey-5"
+          flat
+          color="primary"
           icon="download"
           :label="t('CreatorSubscribers.toolbar.exportCsv')"
-          class="q-ml-sm"
           :aria-label="t('CreatorSubscribers.toolbar.exportCsv')"
           @click="downloadCsv()"
         />

--- a/test/creatorSubscribers-page.spec.ts
+++ b/test/creatorSubscribers-page.spec.ts
@@ -59,6 +59,7 @@ const stubs = {
   'q-layout': { template: '<div><slot /></div>' },
   'q-header': { template: '<div><slot /></div>' },
   'q-toolbar': { template: '<div><slot /></div>' },
+  'q-btn-group': { template: '<div><slot /></div>' },
   'q-page-container': { template: '<div><slot /></div>' },
   'q-page': { template: '<div><slot /></div>' },
   'q-input': {


### PR DESCRIPTION
## Summary
- group view and density controls in subscribers header
- push CSV export to the end and update styling
- add QBtnGroup stub for unit tests

## Testing
- `pnpm lint` (fails: Cannot find module './.eslintrc.js')
- `pnpm test` (fails: TypeError: Cannot read properties of undefined (reading 'proofs'))

------
https://chatgpt.com/codex/tasks/task_e_6898f6e7c21483309019874240d1ce4c