### PR TITLE
Remove share actions from subscribers page

### DIFF
--- a/src/pages/CreatorSubscribersPage.vue
+++ b/src/pages/CreatorSubscribersPage.vue
@@ -306,9 +306,6 @@
         <q-item clickable v-close-popup @click="copyAnyNpub(menuNpub)">
           <q-item-section>{{ t('CreatorSubscribers.drawer.actions.copyNpub') }}</q-item-section>
         </q-item>
-        <q-item clickable v-close-popup @click="shareAnyNpub(menuNpub)">
-          <q-item-section>Share</q-item-section>
-        </q-item>
       </q-list>
     </q-menu>
 
@@ -408,14 +405,6 @@
             icon="content_copy"
             :aria-label="t('CreatorSubscribers.drawer.actions.copyNpub')"
             @click="copyNpub"
-          />
-          <q-btn
-            flat
-            dense
-            round
-            icon="share"
-            aria-label="Share npub"
-            @click="shareNpub"
           />
         </div>
         <q-expansion-item
@@ -714,17 +703,6 @@ function copyAnyNpub(npub: string) {
 function copyNpub() {
   if (!current.value) return;
   copyAnyNpub(current.value.npub);
-}
-function shareAnyNpub(npub: string) {
-  if ((navigator as any).share) {
-    (navigator as any).share({ text: npub });
-  } else {
-    copyAnyNpub(npub);
-  }
-}
-function shareNpub() {
-  if (!current.value) return;
-  shareAnyNpub(current.value.npub);
 }
 
 function dmSubscriber() {


### PR DESCRIPTION
## Summary
- remove "Share" option from avatar menu and drawer action row
- delete unused shareNpub helpers

## Testing
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm types` *(fails: Type 'unknown' cannot be used as an index type)*
- `pnpm test` *(fails: 32 failed, 29 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68998d3d043c8330bf83007300d9c50a