### PR TITLE
feat: refine subscriber views

### DIFF
--- a/src/components/SubscriberCard.vue
+++ b/src/components/SubscriberCard.vue
@@ -3,14 +3,18 @@
     <q-card-section class="q-pa-none">
       <div class="row items-center justify-between">
         <div>
-          <div class="text-subtitle2">{{ subscription.tierName }}</div>
+          <div class="text-h6">{{ subscription.tierName }}</div>
           <div class="text-caption text-grey">{{ subscription.subscriberNpub }}</div>
         </div>
-        <div class="text-subtitle2">{{ amount }}</div>
+        <div class="text-h6">{{ amount }}</div>
       </div>
       <q-linear-progress :value="progress" class="q-mt-sm" />
       <div class="row items-center q-mt-sm">
-        <q-chip dense :color="statusColor" text-color="white">{{ status }}</q-chip>
+        <q-chip
+          dense
+          :color="statusColor"
+          :text-color="statusTextColor"
+        >{{ status }}</q-chip>
         <q-chip v-if="nextIn !== '—'" dense class="q-ml-sm" color="grey-6" text-color="white">
           {{ nextIn }}
         </q-chip>
@@ -34,6 +38,10 @@ const props = defineProps<{
 const statusColor = computed(() => {
   if (props.status === 'active') return 'positive';
   if (props.status === 'pending') return 'warning';
-  return 'grey';
+  return 'negative';
 });
+
+const statusTextColor = computed(() =>
+  props.status === 'pending' ? 'black' : 'white'
+);
 </script>

--- a/src/components/subscribers/SubscriberCard.vue
+++ b/src/components/subscribers/SubscriberCard.vue
@@ -7,7 +7,7 @@
     <q-card-section :class="compact ? 'q-pa-xs' : 'q-pa-sm'">
       <div class="row items-start justify-between no-wrap">
         <div class="row items-start no-wrap">
-          <q-avatar size="40px" class="q-mr-sm">
+          <q-avatar size="56px" class="q-mr-sm">
             <img v-if="profile?.picture" :src="profile.picture" />
             <span v-else>{{ initials }}</span>
           </q-avatar>
@@ -18,17 +18,29 @@
               <q-chip dense color="primary" text-color="white" class="q-mr-xs">
                 {{ subscription.tierName }}
               </q-chip>
-              <q-chip dense outline class="q-mr-xs">
-                {{ subscription.frequency }}
-              </q-chip>
-              <q-chip dense :color="statusColor" text-color="white">
-                {{ subscription.status }}
-              </q-chip>
+              <template v-if="$q.screen.gt.xs">
+                <q-chip dense outline class="q-mr-xs">
+                  {{ subscription.frequency }}
+                </q-chip>
+                <q-chip
+                  dense
+                  :color="statusColor"
+                  :text-color="statusTextColor"
+                >
+                  {{ subscription.status }}
+                </q-chip>
+              </template>
+              <q-icon
+                v-else
+                :name="statusIcon"
+                :color="statusColor"
+                class="q-ml-xs"
+              />
             </div>
           </div>
         </div>
         <div class="column items-end">
-          <div class="text-subtitle2">{{ amountPerInterval }}</div>
+          <div class="text-h6">{{ amountPerInterval }}</div>
           <div class="text-caption text-grey-6">{{ renewsText }}</div>
           <q-btn flat dense round icon="chevron_right" @click.stop="emit('open')" />
         </div>
@@ -43,6 +55,7 @@
 
 <script setup lang="ts">
 import { computed } from 'vue';
+import { useQuasar } from 'quasar';
 import { formatDistanceToNow } from 'date-fns';
 import { useMintsStore } from 'stores/mints';
 import { useUiStore } from 'stores/ui';
@@ -61,6 +74,7 @@ const emit = defineEmits<{
 
 const uiStore = useUiStore();
 const { activeUnit } = useMintsStore();
+const $q = useQuasar();
 
 function formatCurrency(amount: number): string {
   return uiStore.formatCurrency(amount, activeUnit.value);
@@ -110,8 +124,20 @@ const lifetimeTotal = computed(() =>
 const statusColor = computed(() => {
   if (props.subscription.status === 'active') return 'positive';
   if (props.subscription.status === 'pending') return 'warning';
-  return 'grey';
+  return 'negative';
 });
+
+const statusTextColor = computed(() =>
+  props.subscription.status === 'pending' ? 'black' : 'white'
+);
+
+const statusIcon = computed(() =>
+  props.subscription.status === 'active'
+    ? 'check'
+    : props.subscription.status === 'pending'
+    ? 'schedule'
+    : 'close'
+);
 
 const renewsText = computed(() => {
   if (!props.subscription.nextRenewal) return 'renews in —';

--- a/src/pages/CreatorSubscribersPage.vue
+++ b/src/pages/CreatorSubscribersPage.vue
@@ -178,13 +178,13 @@
       :rows-per-page-options="[10, 25, 50]"
       :row-class="rowClass"
       :dense="density === 'compact'"
-      :class="['density--' + density, 'q-mb-lg']"
+      :class="['density--' + density, 'q-mb-lg', 'text-body1']"
       v-model:pagination="pagination"
       :row-count="filtered.length"
       @request="onRequest"
     >
       <template #body-cell-subscriber="props">
-        <q-td :props="props">
+        <q-td :props="props" class="q-pa-sm">
           <div class="row items-center q-gutter-sm no-wrap">
             <q-avatar
               size="32px"
@@ -193,28 +193,28 @@
               {{ initials(props.row.name) }}
             </q-avatar>
             <div>
-              <div class="text-body2">{{ props.row.name }}</div>
+              <div class="text-body1">{{ props.row.name }}</div>
               <div class="text-caption text-grey-6">{{ props.row.nip05 }}</div>
             </div>
           </div>
         </q-td>
       </template>
       <template #body-cell-tier="props">
-        <q-td :props="props"
+        <q-td :props="props" class="q-pa-sm"
           ><q-chip dense color="primary" text-color="white">{{
             props.row.tierName
           }}</q-chip></q-td
         >
       </template>
       <template #body-cell-frequency="props">
-        <q-td :props="props"
+        <q-td :props="props" class="q-pa-sm"
           ><q-chip dense outline>{{
             freqShort(props.row.frequency)
           }}</q-chip></q-td
         >
       </template>
       <template #body-cell-status="props">
-        <q-td :props="props"
+        <q-td :props="props" class="q-pa-sm"
           ><q-chip
             dense
             :color="statusColor(props.row.status)"
@@ -224,10 +224,10 @@
           ></q-td>
       </template>
       <template #body-cell-amount="props"
-        ><q-td :props="props">{{ props.row.amountSat }} sat</q-td></template
+        ><q-td :props="props" class="q-pa-sm">{{ props.row.amountSat }} sat</q-td></template
       >
       <template #body-cell-nextRenewal="props">
-        <q-td :props="props">
+        <q-td :props="props" class="q-pa-sm">
           <div class="row items-center no-wrap q-gutter-sm">
             <div
               class="progress-ring"
@@ -268,10 +268,10 @@
         </q-td>
       </template>
       <template #body-cell-lifetime="props"
-        ><q-td :props="props">{{ props.row.lifetimeSat }} sat</q-td></template
+        ><q-td :props="props" class="q-pa-sm">{{ props.row.lifetimeSat }} sat</q-td></template
       >
       <template #body-cell-actions="props"
-        ><q-td :props="props"
+        ><q-td :props="props" class="q-pa-sm"
           ><q-btn
             flat
             dense


### PR DESCRIPTION
## Summary
- bump table text size with padded cells
- enhance subscriber cards with larger avatars, h6 headings and responsive chip layout
- unify status colors across table and cards using Quasar positive/warning/negative

## Testing
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: Tests failed. Watching for file changes...)*

------
https://chatgpt.com/codex/tasks/task_e_68998f4048348330badb392805ea4639