### PR TITLE
build: prebundle vue-chartjs

### DIFF
--- a/quasar.config.js
+++ b/quasar.config.js
@@ -42,7 +42,7 @@ export default configure(function (/* ctx */) {
       alias: {
         '@': path.resolve(__dirname, 'src'),
       },
-      optimizeDeps: { include: ['process', 'buffer'] },
+      optimizeDeps: { include: ['process', 'buffer', 'vue-chartjs'] },
       target: {
         browser: ["esnext"],
         node: "node16",
@@ -84,6 +84,7 @@ export default configure(function (/* ctx */) {
             ...(viteConf.optimizeDeps?.include || []),
             'buffer',
             'process',
+            'vue-chartjs',
           ],
         };
       },


### PR DESCRIPTION
## Summary
- prebundle `vue-chartjs` in quasar Vite config

## Testing
- `pnpm run build`
- `pnpm run lint` *(fails: Cannot find module './.eslintrc.js')*


------
https://chatgpt.com/codex/tasks/task_e_6899962a2d4c8330baf08d0ec3d9e472