### PR TITLE
Improve subscriber accessibility

### DIFF
--- a/src/components/subscribers/SubscriberCard.vue
+++ b/src/components/subscribers/SubscriberCard.vue
@@ -13,7 +13,7 @@
           </q-avatar>
           <div class="column">
             <div class="text-body2">{{ displayName }}</div>
-            <div class="text-caption text-grey-6">{{ nip05Domain }}</div>
+            <div class="text-caption text-grey-7">{{ nip05Domain }}</div>
             <div class="row items-center q-mt-xs no-wrap">
               <q-chip dense color="primary" text-color="white" class="q-mr-xs">
                 {{ subscription.tierName }}
@@ -41,12 +41,19 @@
         </div>
         <div class="column items-end">
           <div class="text-h6">{{ amountPerInterval }}</div>
-          <div class="text-caption text-grey-6">{{ renewsText }}</div>
-          <q-btn flat dense round icon="chevron_right" @click.stop="emit('open')" />
+          <div class="text-caption text-grey-7">{{ renewsText }}</div>
+          <q-btn
+            flat
+            dense
+            round
+            icon="chevron_right"
+            aria-label="Open subscriber details"
+            @click.stop="emit('open')"
+          />
         </div>
       </div>
       <q-linear-progress :value="progress" class="q-mt-sm" />
-      <div class="text-caption text-grey-6 q-mt-xs">
+      <div class="text-caption text-grey-7 q-mt-xs">
         Lifetime {{ lifetimeTotal }}
       </div>
     </q-card-section>

--- a/src/components/subscribers/SubscriptionsCharts.vue
+++ b/src/components/subscribers/SubscriptionsCharts.vue
@@ -1,24 +1,51 @@
 <template>
   <q-expansion-item label="Insights" expand-separator>
     <div class="row q-col-gutter-lg">
-      <q-card class="col-12" aria-label="Frequency distribution pie chart">
+      <q-card class="col-12">
         <q-card-section>
+          <div id="frequencyChartDesc" class="text-caption text-grey-7 q-mb-sm">
+            Shows number of subscriptions by frequency.
+          </div>
           <div style="height: 300px">
-            <Pie :data="frequencyData" :options="pieOptions" aria-label="Frequency distribution pie chart" role="img" />
+            <Pie
+              :data="frequencyData"
+              :options="pieOptions"
+              aria-label="Frequency distribution pie chart"
+              aria-describedby="frequencyChartDesc"
+              role="img"
+            />
           </div>
         </q-card-section>
       </q-card>
-      <q-card class="col-12" aria-label="Subscription status bar chart">
+      <q-card class="col-12">
         <q-card-section>
+          <div id="statusChartDesc" class="text-caption text-grey-7 q-mb-sm">
+            Shows number of subscriptions by status.
+          </div>
           <div style="height: 300px">
-            <Bar :data="statusData" :options="barOptions" aria-label="Subscription status bar chart" role="img" />
+            <Bar
+              :data="statusData"
+              :options="barOptions"
+              aria-label="Subscription status bar chart"
+              aria-describedby="statusChartDesc"
+              role="img"
+            />
           </div>
         </q-card-section>
       </q-card>
-      <q-card class="col-12" aria-label="New subscribers line chart">
+      <q-card class="col-12">
         <q-card-section>
+          <div id="newSubsChartDesc" class="text-caption text-grey-7 q-mb-sm">
+            Shows new subscribers over the past week.
+          </div>
           <div style="height: 300px">
-            <Line :data="newSubsData" :options="lineOptions" aria-label="New subscribers line chart" role="img" />
+            <Line
+              :data="newSubsData"
+              :options="lineOptions"
+              aria-label="New subscribers line chart"
+              aria-describedby="newSubsChartDesc"
+              role="img"
+            />
           </div>
         </q-card-section>
       </q-card>
@@ -194,6 +221,9 @@ const pieOptions = computed(() => ({
       font: { size: 16 },
     },
     tooltip: {
+      backgroundColor: '#2f2f2f',
+      titleColor: '#fff',
+      bodyColor: '#fff',
       callbacks: {
         label: (ctx: any) => `${ctx.label}: ${ctx.parsed}`,
       },
@@ -212,6 +242,9 @@ const barOptions = computed(() => ({
       font: { size: 16 },
     },
     tooltip: {
+      backgroundColor: '#2f2f2f',
+      titleColor: '#fff',
+      bodyColor: '#fff',
       callbacks: {
         label: (ctx: any) => `${ctx.label}: ${ctx.parsed.y}`,
       },
@@ -239,6 +272,9 @@ const lineOptions = computed(() => ({
       font: { size: 16 },
     },
     tooltip: {
+      backgroundColor: '#2f2f2f',
+      titleColor: '#fff',
+      bodyColor: '#fff',
       callbacks: {
         label: (ctx: any) => `${ctx.label}: ${ctx.parsed.y}`,
       },

--- a/src/pages/CreatorSubscribersPage.vue
+++ b/src/pages/CreatorSubscribersPage.vue
@@ -79,7 +79,12 @@
           :aria-label="t('CreatorSubscribers.toolbar.exportCsv')"
           @click="downloadCsv()"
         />
-        <q-btn class="q-ml-sm" flat icon="event">
+        <q-btn
+          class="q-ml-sm"
+          flat
+          icon="event"
+          aria-label="Date range"
+        >
           <q-popup-proxy transition-show="scale" transition-hide="scale">
             <q-date v-model="chartRange" range mask="YYYY-MM-DD" />
           </q-popup-proxy>
@@ -112,7 +117,7 @@
     </q-header>
     <q-page-container>
       <q-page class="q-pa-md fit">
-        <q-banner v-if="error" dense class="q-mb-md bg-red-1 text-red">
+        <q-banner v-if="error" dense class="q-mb-md bg-red-1 text-red-9">
           {{ error }}
           <template #action>
             <q-btn
@@ -201,7 +206,7 @@
             </q-avatar>
             <div>
               <div class="text-body1">{{ props.row.name }}</div>
-              <div class="text-caption text-grey-6">{{ props.row.nip05 }}</div>
+              <div class="text-caption text-grey-7">{{ props.row.nip05 }}</div>
             </div>
           </div>
         </q-td>
@@ -275,7 +280,7 @@
                   label="Soon"
                 />
               </div>
-              <div class="text-caption text-grey-6">
+              <div class="text-caption text-grey-7">
                 {{
                   props.row.nextRenewal ? formatDate(props.row.nextRenewal) : ''
                 }}
@@ -343,7 +348,7 @@
           <q-avatar size="64px">{{ initials(current.name) }}</q-avatar>
           <div>
             <div class="text-h6">{{ current.name }}</div>
-            <div class="text-body2 text-grey-6">{{ current.nip05 }}</div>
+            <div class="text-body2 text-grey-7">{{ current.nip05 }}</div>
           </div>
           <q-space />
         </div>
@@ -410,7 +415,7 @@
           <q-list bordered dense>
             <q-item v-for="a in activity" :key="a.ts">
               <q-item-section>{{ a.text }}</q-item-section>
-              <q-item-section side class="text-caption text-grey">
+              <q-item-section side class="text-caption text-grey-7">
                 {{ distToNow(a.ts) }}
               </q-item-section>
             </q-item>


### PR DESCRIPTION
## Summary
- improve color contrast on subscriber pages
- add ARIA labels and descriptions for charts and icon buttons

## Testing
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_6899b07342d88330a91b27536794079d