### PR TITLE
feat: add subscribers toolbar

### DIFF
--- a/src/components/subscribers/DisplayMenu.vue
+++ b/src/components/subscribers/DisplayMenu.vue
@@ -1,0 +1,6 @@
+<template>
+  <q-btn flat round icon="view_module" />
+</template>
+
+<script setup lang="ts">
+</script>

--- a/src/components/subscribers/FilterChips.vue
+++ b/src/components/subscribers/FilterChips.vue
@@ -1,0 +1,17 @@
+<template>
+  <div class="filter-chips row q-gutter-xs">
+    <q-chip
+      v-for="(f, idx) in filters"
+      :key="idx"
+      dense
+      removable
+      @remove="$emit('remove', f)"
+    >
+      {{ f }}
+    </q-chip>
+  </div>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{ filters: any[] }>();
+</script>

--- a/src/components/subscribers/SubscribersToolbar.vue
+++ b/src/components/subscribers/SubscribersToolbar.vue
@@ -1,0 +1,119 @@
+<template>
+  <div class="subscribers-toolbar">
+    <q-toolbar>
+      <!-- Left section -->
+      <div class="row items-center q-gutter-sm">
+        <div class="text-h6">
+          Subscribers ({{ total }})
+        </div>
+        <q-select
+          v-model="modelDateRange"
+          :options="dateOptions"
+          dense
+          outlined
+          class="q-ml-sm"
+        />
+      </div>
+
+      <q-space />
+
+      <!-- Center section -->
+      <div class="row items-center q-gutter-sm">
+        <q-input
+          ref="searchRef"
+          v-model="modelSearch"
+          dense
+          outlined
+          debounce="250"
+          placeholder="Search"
+        />
+        <FilterChips :filters="filters" />
+      </div>
+
+      <q-space />
+
+      <!-- Right section -->
+      <div class="row items-center q-gutter-sm">
+        <DisplayMenu />
+        <q-select
+          v-model="modelSavedView"
+          :options="savedViews"
+          dense
+          outlined
+          placeholder="Saved Views"
+        />
+        <q-btn
+          ref="exportBtn"
+          color="primary"
+          icon="download"
+          label="Export"
+          @click="emit('export')"
+        />
+      </div>
+    </q-toolbar>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted, onBeforeUnmount } from 'vue';
+import FilterChips from './FilterChips.vue';
+import DisplayMenu from './DisplayMenu.vue';
+
+const props = defineProps<{
+  total: number;
+  dateRange: string;
+  search: string;
+  savedView: string;
+  savedViews: { label: string; value: string }[];
+  filters: any[];
+}>();
+
+const emit = defineEmits<{
+  'update:dateRange': [string];
+  'update:search': [string];
+  'update:savedView': [string];
+  'open-filters': [];
+  export: [];
+}>();
+
+const dateOptions = [
+  { label: 'Last 7 days', value: '7d' },
+  { label: 'Last 30 days', value: '30d' },
+];
+
+const modelDateRange = computed({
+  get: () => props.dateRange,
+  set: (val: string) => emit('update:dateRange', val),
+});
+
+const modelSearch = computed({
+  get: () => props.search,
+  set: (val: string) => emit('update:search', val),
+});
+
+const modelSavedView = computed({
+  get: () => props.savedView,
+  set: (val: string) => emit('update:savedView', val),
+});
+
+const searchRef = ref<{ focus: () => void } | null>(null);
+
+function handleKey(event: KeyboardEvent) {
+  const tag = (event.target as HTMLElement).tagName;
+  if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+
+  if (event.key === '/') {
+    event.preventDefault();
+    searchRef.value?.focus();
+  } else if (event.key === 'f') {
+    event.preventDefault();
+    emit('open-filters');
+  } else if (event.key === 'e') {
+    event.preventDefault();
+    emit('export');
+  }
+}
+
+onMounted(() => document.addEventListener('keydown', handleKey));
+onBeforeUnmount(() => document.removeEventListener('keydown', handleKey));
+</script>

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -1,6 +1,7 @@
 // app global css in SCSS form
 @import "tokens.scss";
 @import "creator-hub.scss";
+@import "toolbar.scss";
 // Use Inter if installed locally and fall back to system fonts
 body {
   font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,

--- a/src/css/toolbar.scss
+++ b/src/css/toolbar.scss
@@ -1,0 +1,16 @@
+.subscribers-toolbar {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  background-color: var(--panel-bg-color);
+
+  .q-toolbar {
+    min-height: 56px;
+  }
+
+  @media (min-width: 600px) {
+    .q-toolbar {
+      min-height: 64px;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add sticky subscribers toolbar with search, filtering and export
- style toolbar and wire up keyboard shortcuts

## Testing
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: multiple failing tests; see logs)*

------
https://chatgpt.com/codex/tasks/task_e_6899ba1ea11c83309756eec896dace57