### PR TITLE
feat: add subscribers view store

### DIFF
--- a/src/components/subscribers/SubscriberFilters.vue
+++ b/src/components/subscribers/SubscriberFilters.vue
@@ -22,14 +22,15 @@
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue';
 import { useCreatorSubscribersStore } from 'src/stores/creatorSubscribers';
+import { useSubscribersStore, type SortOption } from 'src/stores/subscribersStore';
 import type { SubStatus } from 'src/types/subscriber';
-import type { SortOption } from 'src/stores/creatorSubscribers';
 import { useI18n } from 'vue-i18n';
 
-const store = useCreatorSubscribersStore();
+const dataStore = useCreatorSubscribersStore();
+const store = useSubscribersStore();
 
-const localStatuses = ref<SubStatus[]>(Array.from(store.statuses));
-const localTiers = ref<string[]>(Array.from(store.tiers));
+const localStatuses = ref<SubStatus[]>(Array.from(store.status));
+const localTiers = ref<string[]>(Array.from(store.tier));
 const localSort = ref<SortOption>(store.sort);
 
 const { t } = useI18n();
@@ -41,7 +42,7 @@ const statusOptions = computed(() => [
 ]);
 
 const tierOptions = computed(() => {
-  const map = new Map(store.subscribers.map(s => [s.tierId, s.tierName]));
+  const map = new Map(dataStore.subscribers.map(s => [s.tierId, s.tierName]));
   return Array.from(map, ([id, name]) => ({ label: name, value: id }));
 });
 
@@ -61,13 +62,13 @@ const sortOptions = computed(() => [
 ]);
 
 watch(
-  () => Array.from(store.statuses),
+  () => Array.from(store.status),
   (v) => {
     localStatuses.value = v as SubStatus[];
   },
 );
 watch(
-  () => Array.from(store.tiers),
+  () => Array.from(store.tier),
   (v) => {
     localTiers.value = v as string[];
   },
@@ -81,8 +82,8 @@ watch(
 
 function apply() {
   store.applyFilters({
-    statuses: new Set(localStatuses.value),
-    tiers: new Set(localTiers.value),
+    status: new Set(localStatuses.value),
+    tier: new Set(localTiers.value),
     sort: localSort.value,
   });
 }

--- a/src/pages/CreatorSubscribersStoreDemo.vue
+++ b/src/pages/CreatorSubscribersStoreDemo.vue
@@ -32,13 +32,15 @@ import { useDebounceFn } from '@vueuse/core';
 import { storeToRefs } from 'pinia';
 import SubscriberFilters from 'src/components/subscribers/SubscriberFilters.vue';
 import { useCreatorSubscribersStore } from 'src/stores/creatorSubscribers';
+import { useSubscribersStore } from 'src/stores/subscribersStore';
 
 const store = useCreatorSubscribersStore();
+const viewStore = useSubscribersStore();
 const { filtered, counts, activeTab } = storeToRefs(store);
 
-const search = ref(store.query);
+const search = ref(viewStore.query);
 
 const onSearch = useDebounceFn((val: string) => {
-  store.setQuery(val);
+  viewStore.applyFilters({ query: val });
 }, 220);
 </script>

--- a/src/stores/dexie.ts
+++ b/src/stores/dexie.ts
@@ -91,6 +91,18 @@ export interface LockedToken {
   htlcSecret?: string | null;
 }
 
+export interface SubscriberView {
+  name: string;
+  query: string;
+  status: string[];
+  freq: string[];
+  tier: string[];
+  sort: string;
+  visibleColumns: string[];
+  density: "comfortable" | "compact";
+  viewMode: "table" | "card";
+}
+
 // export interface Proof {
 //   id: string
 //   C: string
@@ -106,6 +118,7 @@ export class CashuDexie extends Dexie {
   creatorsTierDefinitions!: Table<CreatorTierDefinition, string>;
   subscriptions!: Table<Subscription, string>;
   lockedTokens!: Table<LockedToken, string>;
+  subscriberViews!: Table<SubscriberView, string>;
 
   constructor() {
     super("cashuDatabase");
@@ -536,6 +549,18 @@ export class CashuDexie extends Dexie {
             delete (entry as any).receivedMonths;
           });
       });
+
+    this.version(22).stores({
+      proofs:
+        "secret, id, C, amount, reserved, quote, bucketId, label, description",
+      profiles: "pubkey",
+      creatorsTierDefinitions: "&creatorNpub, eventId, updatedAt",
+      subscriptions:
+        "&id, creatorNpub, tierId, status, createdAt, updatedAt, frequency, intervalDays",
+      lockedTokens:
+        "&id, tokenString, owner, tierId, intervalKey, unlockTs, status, subscriptionEventId, subscriptionId, monthIndex, totalPeriods, autoRedeem, frequency, intervalDays",
+      subscriberViews: "&name",
+    });
   }
 }
 

--- a/src/stores/subscribersStore.ts
+++ b/src/stores/subscribersStore.ts
@@ -1,0 +1,117 @@
+import { defineStore } from "pinia";
+import { useLocalStorage } from "@vueuse/core";
+import { cashuDb } from "./dexie";
+import downloadCsv from "../utils/subscriberCsv";
+import type { SubStatus, Frequency } from "../types/subscriber";
+
+export type SortOption = "next" | "first" | "amount";
+
+const statusStorage = useLocalStorage<string[]>("subscribers.status", []);
+const freqStorage = useLocalStorage<string[]>("subscribers.freq", []);
+const tierStorage = useLocalStorage<string[]>("subscribers.tier", []);
+
+export const useSubscribersStore = defineStore("subscribers", {
+  state: () => ({
+    query: useLocalStorage("subscribers.query", ""),
+    status: new Set<SubStatus>(statusStorage.value as SubStatus[]),
+    freq: new Set<Frequency>(freqStorage.value as Frequency[]),
+    tier: new Set<string>(tierStorage.value),
+    sort: useLocalStorage<SortOption>("subscribers.sort", "next"),
+    visibleColumns: useLocalStorage<string[]>(
+      "subscribers.visibleColumns",
+      []
+    ),
+    density: useLocalStorage<"comfortable" | "compact">(
+      "subscribers.density",
+      "comfortable"
+    ),
+    viewMode: useLocalStorage<"table" | "card">(
+      "subscribers.viewMode",
+      "table"
+    ),
+  }),
+  actions: {
+    applyFilters(opts: {
+      query?: string;
+      status?: Set<SubStatus>;
+      freq?: Set<Frequency>;
+      tier?: Set<string>;
+      sort?: SortOption;
+    }) {
+      if (opts.query !== undefined) {
+        this.query = opts.query;
+      }
+      if (opts.status !== undefined) {
+        this.status = new Set(opts.status);
+        statusStorage.value = Array.from(this.status);
+      }
+      if (opts.freq !== undefined) {
+        this.freq = new Set(opts.freq);
+        freqStorage.value = Array.from(this.freq);
+      }
+      if (opts.tier !== undefined) {
+        this.tier = new Set(opts.tier);
+        tierStorage.value = Array.from(this.tier);
+      }
+      if (opts.sort !== undefined) {
+        this.sort = opts.sort;
+      }
+    },
+    clearFilters() {
+      this.query = "";
+      this.status.clear();
+      this.freq.clear();
+      this.tier.clear();
+      this.sort = "next";
+      statusStorage.value = [];
+      freqStorage.value = [];
+      tierStorage.value = [];
+    },
+    setViewMode(mode: "table" | "card") {
+      this.viewMode = mode;
+    },
+    toggleColumn(col: string) {
+      const idx = this.visibleColumns.indexOf(col);
+      if (idx >= 0) {
+        this.visibleColumns.splice(idx, 1);
+      } else {
+        this.visibleColumns.push(col);
+      }
+    },
+    setDensity(d: "comfortable" | "compact") {
+      this.density = d;
+    },
+    async saveView(name: string) {
+      await cashuDb.subscriberViews.put({
+        name,
+        query: this.query,
+        status: Array.from(this.status),
+        freq: Array.from(this.freq),
+        tier: Array.from(this.tier),
+        sort: this.sort,
+        visibleColumns: this.visibleColumns.slice(),
+        density: this.density,
+        viewMode: this.viewMode,
+      });
+    },
+    async loadView(name: string) {
+      const view = await cashuDb.subscriberViews.get(name);
+      if (view) {
+        this.query = view.query;
+        this.status = new Set(view.status as SubStatus[]);
+        this.freq = new Set(view.freq as Frequency[]);
+        this.tier = new Set(view.tier);
+        this.sort = view.sort as SortOption;
+        this.visibleColumns = view.visibleColumns.slice();
+        this.density = view.density as "comfortable" | "compact";
+        this.viewMode = view.viewMode as "table" | "card";
+        statusStorage.value = view.status;
+        freqStorage.value = view.freq;
+        tierStorage.value = view.tier;
+      }
+    },
+    exportCsv() {
+      downloadCsv();
+    },
+  },
+});

--- a/test/creatorSubscribers-page.spec.ts
+++ b/test/creatorSubscribers-page.spec.ts
@@ -5,6 +5,7 @@ import { ref } from 'vue';
 import { createI18n } from 'vue-i18n';
 import { messages as enMessages } from '../src/i18n/en-US/index.ts';
 import { useCreatorSubscribersStore } from '../src/stores/creatorSubscribers';
+import { useSubscribersStore } from '../src/stores/subscribersStore';
 
 var Chart: any;
 const charts: { type: string; inst: any }[] = [];
@@ -133,6 +134,7 @@ describe('CreatorSubscribersPage', () => {
   it('filters by search, status and tier', async () => {
     const wrapper = mountPage();
     const store = useCreatorSubscribersStore(wrapper.vm.$pinia);
+    const viewStore = useSubscribersStore(wrapper.vm.$pinia);
     const rows = () => wrapper.findAll('.tbody-row').map((r) => r.text());
 
     wrapper.vm.search = 'bob';
@@ -142,11 +144,11 @@ describe('CreatorSubscribersPage', () => {
     wrapper.vm.search = '';
     await wrapper.vm.$nextTick();
 
-    store.applyFilters({ statuses: new Set(['pending']), tiers: new Set(), sort: 'next' });
+    viewStore.applyFilters({ status: new Set(['pending']), tier: new Set(), sort: 'next' });
     await wrapper.vm.$nextTick();
     expect(rows()).toEqual(['Bob', 'Frank']);
 
-    store.applyFilters({ statuses: new Set(['pending']), tiers: new Set(['t3']), sort: 'next' });
+    viewStore.applyFilters({ status: new Set(['pending']), tier: new Set(['t3']), sort: 'next' });
     await wrapper.vm.$nextTick();
     expect(rows()).toEqual(['Frank']);
   });
@@ -154,13 +156,14 @@ describe('CreatorSubscribersPage', () => {
   it('sorts subscribers', async () => {
     const wrapper = mountPage();
     const store = useCreatorSubscribersStore(wrapper.vm.$pinia);
+    const viewStore = useSubscribersStore(wrapper.vm.$pinia);
     const rows = () => wrapper.findAll('.tbody-row').map((r) => r.text());
 
-    store.sort = 'first';
+    viewStore.applyFilters({ sort: 'first' });
     await wrapper.vm.$nextTick();
     expect(rows()[0]).toBe('Dave');
 
-    store.sort = 'amount';
+    viewStore.applyFilters({ sort: 'amount' });
     await wrapper.vm.$nextTick();
     expect(rows()[0]).toBe('Eve');
   });
@@ -262,6 +265,7 @@ describe('CreatorSubscribersPage', () => {
     const wrapper = mountPage();
     await wrapper.vm.$nextTick();
     const store = useCreatorSubscribersStore(wrapper.vm.$pinia);
+    const viewStore = useSubscribersStore(wrapper.vm.$pinia);
 
     const values = () => [
       String(wrapper.vm.counts.all),
@@ -285,7 +289,7 @@ describe('CreatorSubscribersPage', () => {
 
     store.setActiveTab('all');
     await wrapper.vm.$nextTick();
-    store.applyFilters({ statuses: new Set(['pending']), tiers: new Set(['t3']), sort: 'next' });
+    viewStore.applyFilters({ status: new Set(['pending']), tier: new Set(['t3']), sort: 'next' });
     await wrapper.vm.$nextTick();
     expect(values()).toEqual(['1', '0 / 1', '5000 sat', '0 sat']);
 


### PR DESCRIPTION
## Summary
- create subscriber view store with filtering, view options, and CSV export
- integrate creator subscribers store with shared view state
- update filters, page, and tests to use new store and persisted preferences

## Testing
- `pnpm test` *(fails: tokens already spent, numerous component resolution errors)*

------
https://chatgpt.com/codex/tasks/task_e_6899bfd53d5c83308c503126f13fe549