### PR TITLE
feat: add subscriber filter chips component

### DIFF
--- a/src/components/subscribers/FilterChips.vue
+++ b/src/components/subscribers/FilterChips.vue
@@ -1,17 +1,57 @@
 <template>
   <div class="filter-chips row q-gutter-xs">
     <q-chip
-      v-for="(f, idx) in filters"
-      :key="idx"
+      v-for="f in filters"
+      :key="f.key"
       dense
       removable
-      @remove="$emit('remove', f)"
+      tabindex="0"
+      class="filter-chip"
+      :aria-label="`Filter: ${f.label}`"
+      :remove-label="`Remove filter ${f.label}`"
+      @remove="onRemove(f.key)"
     >
-      {{ f }}
+      {{ f.label }}
     </q-chip>
   </div>
 </template>
 
 <script setup lang="ts">
-const props = defineProps<{ filters: any[] }>();
+import { useSubscribersStore, type SortOption } from 'src/stores/subscribersStore';
+import type { SubStatus } from 'src/types/subscriber';
+
+defineProps<{ filters: { key: string; label: string }[] }>();
+
+const emit = defineEmits<{ remove: [string] }>();
+const store = useSubscribersStore();
+
+function onRemove(key: string) {
+  const statuses = new Set(store.status);
+  const tiers = new Set(store.tier);
+  let sort: SortOption = store.sort;
+
+  if (key.startsWith('status-')) {
+    statuses.delete(key.slice('status-'.length) as SubStatus);
+  } else if (key.startsWith('tier-')) {
+    tiers.delete(key.slice('tier-'.length));
+  } else if (key === 'sort') {
+    sort = 'next';
+  }
+
+  if (statuses.size || tiers.size || sort !== 'next') {
+    store.applyFilters({ status: statuses, tier: tiers, sort });
+  } else {
+    store.clearFilters();
+  }
+
+  emit('remove', key);
+}
 </script>
+
+<style scoped>
+.filter-chip:focus-visible,
+.filter-chip:focus-within {
+  outline: 2px solid var(--q-primary);
+  outline-offset: 2px;
+}
+</style>

--- a/src/components/subscribers/SubscribersToolbar.vue
+++ b/src/components/subscribers/SubscribersToolbar.vue
@@ -65,7 +65,7 @@ const props = defineProps<{
   search: string;
   savedView: string;
   savedViews: { label: string; value: string }[];
-  filters: any[];
+  filters: { key: string; label: string }[];
 }>();
 
 const emit = defineEmits<{


### PR DESCRIPTION
## Summary
- enhance FilterChips to manage filters via subscribers store and emit remove events
- type subscribers toolbar filter props

## Testing
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: 14 failed, 10 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6899c5147f1c833097b57b53043a8dd1