### PR TITLE
feat: add reusable display menu

### DIFF
--- a/src/components/common/DisplayMenu.vue
+++ b/src/components/common/DisplayMenu.vue
@@ -1,0 +1,131 @@
+<template>
+  <q-btn-dropdown
+    :flat="flat"
+    :icon="icon"
+    :label="label"
+    dense
+  >
+    <q-list class="display-menu" style="min-width: 200px">
+      <q-item>
+        <q-item-section>
+          <div class="q-mb-sm">View Mode</div>
+          <q-btn-toggle
+            v-model="viewMode"
+            dense
+            toggle-color="primary"
+            :options="viewOptions"
+          />
+        </q-item-section>
+      </q-item>
+      <q-item>
+        <q-item-section>
+          <div class="q-mb-sm">Density</div>
+          <q-btn-toggle
+            v-model="density"
+            dense
+            toggle-color="primary"
+            :options="densityOptions"
+          />
+        </q-item-section>
+      </q-item>
+      <template v-if="columns.length">
+        <q-separator />
+        <q-item-label header>Visible Columns</q-item-label>
+        <q-item
+          v-for="col in columns"
+          :key="col.name"
+          clickable
+          class="column-item"
+          tabindex="0"
+          @click="onToggleColumn(col.name)"
+          @keyup.enter.prevent="onToggleColumn(col.name)"
+          @keyup.space.prevent="onToggleColumn(col.name)"
+        >
+          <q-item-section avatar>
+            <q-checkbox
+              :model-value="store.visibleColumns.includes(col.name)"
+              @click.stop="onToggleColumn(col.name)"
+            />
+          </q-item-section>
+          <q-item-section>{{ col.label }}</q-item-section>
+        </q-item>
+      </template>
+    </q-list>
+  </q-btn-dropdown>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useSubscribersStore } from 'src/stores/subscribersStore';
+
+interface Column {
+  name: string;
+  label: string;
+}
+
+const props = withDefaults(
+  defineProps<{
+    columns?: Column[];
+    label?: string;
+    flat?: boolean;
+    icon?: string;
+  }>(),
+  {
+    columns: () => [],
+    label: 'Display',
+    flat: true,
+    icon: 'view_module',
+  },
+);
+
+const emit = defineEmits<{
+  'update:viewMode': ['table' | 'card'];
+  'update:density': ['comfortable' | 'compact'];
+  'update:visibleColumns': [string[]];
+}>();
+
+const store = useSubscribersStore();
+
+if (store.visibleColumns.length === 0 && props.columns.length) {
+  store.visibleColumns.push(...props.columns.map((c) => c.name));
+}
+
+const viewMode = computed({
+  get: () => store.viewMode,
+  set: (val: 'table' | 'card') => {
+    store.setViewMode(val);
+    emit('update:viewMode', val);
+  },
+});
+
+const density = computed({
+  get: () => store.density,
+  set: (val: 'comfortable' | 'compact') => {
+    store.setDensity(val);
+    emit('update:density', val);
+  },
+});
+
+function onToggleColumn(name: string) {
+  store.toggleColumn(name);
+  emit('update:visibleColumns', store.visibleColumns);
+}
+
+const viewOptions = [
+  { label: 'Table', value: 'table' },
+  { label: 'Card', value: 'card' },
+];
+
+const densityOptions = [
+  { label: 'Comfortable', value: 'comfortable' },
+  { label: 'Compact', value: 'compact' },
+];
+</script>
+
+<style scoped>
+.column-item:focus-visible {
+  outline: 2px solid var(--q-primary);
+  outline-offset: 2px;
+}
+</style>
+

--- a/src/components/subscribers/DisplayMenu.vue
+++ b/src/components/subscribers/DisplayMenu.vue
@@ -1,6 +1,0 @@
-<template>
-  <q-btn flat round icon="view_module" />
-</template>
-
-<script setup lang="ts">
-</script>

--- a/src/components/subscribers/SubscribersToolbar.vue
+++ b/src/components/subscribers/SubscribersToolbar.vue
@@ -34,7 +34,7 @@
 
       <!-- Right section -->
       <div class="row items-center q-gutter-sm">
-        <DisplayMenu />
+        <DisplayMenu :columns="columns" />
         <q-select
           v-model="modelSavedView"
           :options="savedViews"
@@ -57,16 +57,19 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, onBeforeUnmount } from 'vue';
 import FilterChips from './FilterChips.vue';
-import DisplayMenu from './DisplayMenu.vue';
+import DisplayMenu from '../common/DisplayMenu.vue';
 
-const props = defineProps<{
+const props = withDefaults(defineProps<{
   total: number;
   dateRange: string;
   search: string;
   savedView: string;
   savedViews: { label: string; value: string }[];
   filters: { key: string; label: string }[];
-}>();
+  columns?: { name: string; label: string }[];
+}>(), {
+  columns: () => [],
+});
 
 const emit = defineEmits<{
   'update:dateRange': [string];


### PR DESCRIPTION
## Summary
- add keyboard-friendly DisplayMenu with view mode, density and column controls
- wire SubscribersToolbar to new DisplayMenu component

## Testing
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: InfoTooltip > shows tooltip on hover, plus other failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_6899c7487d0c83308c328eae2c413f76