### PR TITLE
test: add subscribers toolbar and drawer specs

### DIFF
--- a/test/e2e/insights-panel.spec.ts
+++ b/test/e2e/insights-panel.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test';
+
+test('toggle insights panel redraws charts', async ({ page }) => {
+  await page.setContent(`
+    <button id="toggle">Toggle</button>
+    <div id="panel" style="display:none"><canvas id="chart"></canvas></div>
+    <script>
+      let redraws = 0;
+      const chart = { update: () => redraws++ };
+      document.getElementById('toggle').addEventListener('click', () => {
+        const p = document.getElementById('panel');
+        p.style.display = p.style.display === 'none' ? 'block' : 'none';
+        chart.update();
+      });
+      window.getRedraws = () => redraws;
+    </script>
+  `);
+  await page.click('#toggle');
+  await page.click('#toggle');
+  const count = await page.evaluate(() => window.getRedraws());
+  expect(count).toBe(2);
+});
+

--- a/test/subscribersToolbar.spec.ts
+++ b/test/subscribersToolbar.spec.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createTestingPinia } from '@pinia/testing';
+import { defineComponent, h } from 'vue';
+import SubscribersToolbar from 'src/components/subscribers/SubscribersToolbar.vue';
+import { useSubscribersStore } from 'src/stores/subscribersStore';
+
+const QInputStub = defineComponent({
+  props: ['modelValue', 'debounce'],
+  emits: ['update:modelValue'],
+  setup(props, { emit }) {
+    let timer: any;
+    const onInput = (e: any) => {
+      const val = e.target.value;
+      const delay = Number(props.debounce) || 0;
+      clearTimeout(timer);
+      if (delay > 0) {
+        timer = setTimeout(() => emit('update:modelValue', val), delay);
+      } else {
+        emit('update:modelValue', val);
+      }
+    };
+    return () => h('input', { value: props.modelValue, onInput });
+  },
+});
+
+const QChipStub = defineComponent({
+  emits: ['remove'],
+  setup(_props, { emit, slots }) {
+    return () =>
+      h(
+        'div',
+        { class: 'filter-chip', onClick: () => emit('remove') },
+        slots.default ? slots.default() : [],
+      );
+  },
+});
+
+function mountToolbar(overrides: Record<string, any> = {}) {
+  const pinia = createTestingPinia({ createSpy: vi.fn, stubActions: false });
+  return mount(SubscribersToolbar, {
+    props: {
+      total: 0,
+      dateRange: '7d',
+      search: '',
+      savedView: '',
+      savedViews: [],
+      filters: [],
+      ...overrides,
+    },
+    global: {
+      plugins: [pinia],
+      stubs: {
+        'q-toolbar': { template: '<div><slot /></div>' },
+        'q-select': {
+          props: ['modelValue', 'options'],
+          template: '<select></select>',
+        },
+        'q-space': { template: '<span />' },
+        'q-btn': { template: '<button><slot /></button>' },
+        DisplayMenu: { template: '<div />' },
+        'q-input': QInputStub,
+        'q-chip': QChipStub,
+      },
+    },
+  });
+}
+
+describe('SubscribersToolbar', () => {
+  it('debounces search updates', async () => {
+    vi.useFakeTimers();
+    const wrapper = mountToolbar();
+    const input = wrapper.find('input');
+    await input.setValue('hello');
+    expect(wrapper.emitted('update:search')).toBeFalsy();
+    vi.advanceTimersByTime(249);
+    expect(wrapper.emitted('update:search')).toBeFalsy();
+    vi.advanceTimersByTime(1);
+    expect(wrapper.emitted('update:search')).toEqual([['hello']]);
+    vi.useRealTimers();
+  });
+
+  it('removes filter chips', async () => {
+    const wrapper = mountToolbar({
+      filters: [{ key: 'status-active', label: 'Active' }],
+    });
+    const store = useSubscribersStore(wrapper.vm.$pinia);
+    store.status = new Set(['active']);
+    const clearFilters = vi.spyOn(store, 'clearFilters');
+    await wrapper.find('.filter-chip').trigger('click');
+    expect(clearFilters).toHaveBeenCalled();
+  });
+});
+

--- a/test/vitest/__tests__/subscriberDrawer.spec.ts
+++ b/test/vitest/__tests__/subscriberDrawer.spec.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createTestingPinia } from '@pinia/testing';
+import { defineComponent, h, ref } from 'vue';
+import SubscriberDrawer from 'src/components/subscribers/SubscriberDrawer.vue';
+
+vi.mock('quasar', () => ({ copyToClipboard: vi.fn() }));
+vi.mock('@vueuse/core', () => ({ onKeyStroke: () => {}, useLocalStorage: (_k: any, v: any) => ref(v) }));
+vi.mock('src/stores/mints', () => ({ useMintsStore: () => ({ activeUnit: { value: 'sat' } }) }));
+vi.mock('src/stores/ui', () => ({ useUiStore: () => ({ formatCurrency: (a: number) => String(a) }) }));
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (k: string) => k }) }));
+vi.mock('stores/dexie', () => ({ cashuDb: {} }));
+
+const DrawerStub = defineComponent({
+  props: ['modelValue', 'width'],
+  emits: ['update:modelValue'],
+  setup(props, { slots }) {
+    return () =>
+      h(
+        'div',
+        { class: 'q-drawer', style: { width: props.width + 'px' } },
+        slots.default ? slots.default() : [],
+      );
+  },
+});
+
+function mountDrawer() {
+  const pinia = createTestingPinia({ createSpy: vi.fn, stubActions: false });
+  return mount(SubscriberDrawer, {
+    props: {
+      modelValue: true,
+      sub: { subscriberNpub: 'npub', intervalDays: 7 } as any,
+    },
+    global: {
+      plugins: [pinia],
+      stubs: {
+        'q-drawer': DrawerStub,
+        'q-toolbar': { template: '<div><slot /></div>' },
+        'q-toolbar-title': { template: '<div><slot /></div>' },
+        'q-btn': { template: '<button @click="$emit(\'click\')"></button>' },
+        'q-tabs': { template: '<div><slot /></div>' },
+        'q-tab': { props: ['name'], template: '<div><slot /></div>' },
+        'q-separator': { template: '<hr />' },
+        'q-tab-panels': { template: '<div><slot /></div>' },
+        'q-tab-panel': { template: '<div><slot /></div>' },
+        'q-list': { template: '<div><slot /></div>' },
+        'q-item': { template: '<div><slot /></div>' },
+        'q-item-section': { template: '<div><slot /></div>' },
+        'q-skeleton': { template: '<div></div>' },
+        'q-input': { template: '<input />' },
+      },
+    },
+  });
+}
+
+describe('SubscriberDrawer', () => {
+  it('sets drawer width', () => {
+    const wrapper = mountDrawer();
+    const el = wrapper.find('.q-drawer').element as HTMLElement;
+    expect(el.style.width).toBe('448px');
+  });
+
+  it('has sticky header', () => {
+    const wrapper = mountDrawer();
+    const header = wrapper.find('.drawer-header').element as HTMLElement;
+    expect(getComputedStyle(header).position).toBe('sticky');
+  });
+
+  it('closes on Escape', async () => {
+    const wrapper = mountDrawer();
+    const drawer = wrapper.find('.q-drawer');
+    await drawer.trigger('keydown', { key: 'Escape' });
+    expect(wrapper.emitted('update:modelValue')).toEqual([[false]]);
+  });
+});
+


### PR DESCRIPTION
## Summary
- add unit tests for SubscribersToolbar search debounce and chip removal
- add component tests for SubscriberDrawer width, sticky header and Esc close
- add playwright e2e harness toggling insights panel and checking chart redraws

## Testing
- `pnpm test` *(fails: test suite failing in repo)*
- `npx playwright test test/e2e/insights-panel.spec.ts` *(fails: requires browser install)*

------
https://chatgpt.com/codex/tasks/task_e_6899d688f1fc8330ac6610474212bb40