### PR TITLE
refactor: centralize npub copying

### DIFF
--- a/src/components/subscribers/SubscriberDrawer.vue
+++ b/src/components/subscribers/SubscriberDrawer.vue
@@ -154,7 +154,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue';
 import { onKeyStroke, useLocalStorage } from '@vueuse/core';
-import { copyToClipboard } from 'quasar';
+import { copyNpub } from 'src/utils/clipboard';
 import { useI18n } from 'vue-i18n';
 import { cashuDb } from 'stores/dexie';
 import { useUiStore } from 'stores/ui';
@@ -224,7 +224,7 @@ const sinceDate = computed(() => {
 
 function copy(text?: string) {
   if (!text) return;
-  copyToClipboard(text);
+  copyNpub(text);
 }
 
 const payments = ref<Array<{ id: string; status: string; date: string; amount: number }>>([]);

--- a/src/pages/CreatorSubscribersPage.vue
+++ b/src/pages/CreatorSubscribersPage.vue
@@ -196,7 +196,7 @@
 
     <q-menu ref="avatarMenuRef">
       <q-list class="card-bg">
-        <q-item clickable v-close-popup @click="copyAnyNpub(menuNpub)">
+        <q-item clickable v-close-popup @click="copyNpub(menuNpub)">
           <q-item-section>{{ t('CreatorSubscribers.drawer.actions.copyNpub') }}</q-item-section>
         </q-item>
       </q-list>
@@ -307,7 +307,7 @@
             flat
             :label="t('CreatorSubscribers.drawer.actions.copyNpub')"
             :aria-label="t('CreatorSubscribers.drawer.actions.copyNpub')"
-            @click="copyNpub"
+            @click="copyCurrentNpub"
             class="focus-outline"
           />
           <q-btn
@@ -367,6 +367,7 @@ import SubscriberCard from "src/components/SubscriberCard.vue";
 import SubscriptionsCharts from "src/components/subscribers/SubscriptionsCharts.vue";
 import KpiCard from "src/components/subscribers/KpiCard.vue";
 import SubscribersTable from "src/components/subscribers/SubscribersTable.vue";
+import { copyNpub } from "src/utils/clipboard";
 
 const { t } = useI18n();
 const $q = useQuasar();
@@ -682,13 +683,9 @@ function showAvatarMenu(e: Event, row: Subscriber) {
 }
 const router = useRouter();
 
-function copyAnyNpub(npub: string) {
-  $q.clipboard.writeText(npub);
-  $q.notify({ message: t("copied_to_clipboard"), color: "positive" });
-}
-function copyNpub() {
+function copyCurrentNpub() {
   if (!current.value) return;
-  copyAnyNpub(current.value.npub);
+  copyNpub(current.value.npub);
 }
 
 function dmSubscriber() {

--- a/src/utils/clipboard.ts
+++ b/src/utils/clipboard.ts
@@ -1,0 +1,9 @@
+import { copyToClipboard, Notify } from 'quasar';
+export async function copyNpub(npub: string) {
+  try {
+    await copyToClipboard(npub);
+    Notify.create({ message: 'npub copied', color: 'positive', position: 'top', timeout: 1500 });
+  } catch {
+    Notify.create({ message: 'Copy failed', color: 'negative' });
+  }
+}

--- a/test/creatorSubscribers-page.spec.ts
+++ b/test/creatorSubscribers-page.spec.ts
@@ -37,14 +37,12 @@ vi.mock('@vueuse/core', () => ({
   useLocalStorage: (_k: any, v: any) => ref(v),
   onKeyStroke: () => {},
 }));
-const clipboardWrite = vi.fn();
+vi.mock('src/utils/clipboard', () => ({ copyNpub: vi.fn() }));
 vi.mock('quasar', async (importOriginal) => {
   const actual = await importOriginal();
   return {
     ...actual,
-    copyToClipboard: vi.fn(),
     useQuasar: () => ({
-      clipboard: { writeText: clipboardWrite },
       notify: vi.fn(),
       screen: { lt: { md: false }, gt: { xs: true } },
     }),
@@ -57,6 +55,7 @@ vi.mock('src/stores/nostr', () => ({
   useNostrStore: () => ({ getProfile: vi.fn().mockResolvedValue(null) }),
 }));
 
+import { copyNpub } from 'src/utils/clipboard';
 import downloadCsv from 'src/utils/subscriberCsv';
 import CreatorSubscribersPage from '../src/pages/CreatorSubscribersPage.vue';
 
@@ -255,9 +254,9 @@ describe('CreatorSubscribersPage', () => {
       startDate: 0,
     } as any);
     await wrapper.vm.$nextTick();
-    clipboardWrite.mockReset();
-    wrapper.vm.copyNpub();
-    expect(clipboardWrite).toHaveBeenCalledWith(npub);
+    ;(copyNpub as any).mockReset();
+    wrapper.vm.copyCurrentNpub();
+    expect(copyNpub).toHaveBeenCalledWith(npub);
   });
 
   it('updates KPI numbers when searching, switching tabs and applying filters', async () => {

--- a/test/vitest/__tests__/subscriberDrawer.spec.ts
+++ b/test/vitest/__tests__/subscriberDrawer.spec.ts
@@ -4,7 +4,7 @@ import { createTestingPinia } from '@pinia/testing';
 import { defineComponent, h, ref } from 'vue';
 import SubscriberDrawer from 'src/components/subscribers/SubscriberDrawer.vue';
 
-vi.mock('quasar', () => ({ copyToClipboard: vi.fn() }));
+vi.mock('src/utils/clipboard', () => ({ copyNpub: vi.fn() }));
 vi.mock('@vueuse/core', () => ({ onKeyStroke: () => {}, useLocalStorage: (_k: any, v: any) => ref(v) }));
 vi.mock('src/stores/mints', () => ({ useMintsStore: () => ({ activeUnit: { value: 'sat' } }) }));
 vi.mock('src/stores/ui', () => ({ useUiStore: () => ({ formatCurrency: (a: number) => String(a) }) }));


### PR DESCRIPTION
## Summary
- add reusable `copyNpub` helper for clipboard and toast
- use `copyNpub` in subscriber drawer and creator subscribers page
- adjust unit tests to mock new helper

## Testing
- `pnpm test` *(fails: shows multiple failing tests)*
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*


------
https://chatgpt.com/codex/tasks/task_e_689a4450d8b88330b26d0a5ac52f3236