### PR TITLE
feat: separate profile loading state for subscribers

### DIFF
--- a/src/pages/CreatorSubscribersPage.vue
+++ b/src/pages/CreatorSubscribersPage.vue
@@ -137,6 +137,12 @@
         <q-inner-loading :showing="loading">
           <q-spinner size="50px" color="primary" />
         </q-inner-loading>
+        <q-linear-progress
+          v-if="!loading && profilesLoading"
+          indeterminate
+          color="primary"
+          class="q-mb-md"
+        />
         <!-- KPI Row -->
         <div class="q-mb-lg">
           <div class="text-h6 q-mb-md">Subscribers Overview</div>
@@ -374,7 +380,8 @@ const $q = useQuasar();
 
 const subStore = useCreatorSubscribersStore();
 const viewStore = useSubscribersStore();
-const { filtered, counts, activeTab, loading, error } = storeToRefs(subStore);
+const { filtered, counts, activeTab, loading, profilesLoading, error } =
+  storeToRefs(subStore);
 // `filtered` is maintained by the Pinia store based on the active tab,
 // search query and filter drawer. Treat it as the single source of truth
 // for the subscriber list and KPI counts throughout this page.
@@ -584,6 +591,7 @@ const densityOptions = computed(() => [
 
 onMounted(() => {
   void subStore.loadFromDb();
+  void subStore.fetchProfiles();
 });
 
 // When the list of subscribers changes, fetch profiles for any new npubs.

--- a/src/stores/creatorSubscribers.ts
+++ b/src/stores/creatorSubscribers.ts
@@ -24,6 +24,7 @@ export const useCreatorSubscribersStore = defineStore("creatorSubscribers", {
     _dbSub: null as { unsubscribe(): void } | null,
     activeTab: "all" as Tab,
     loading: false,
+    profilesLoading: false,
     error: null as string | null,
   }),
   getters: {
@@ -247,7 +248,7 @@ export const useCreatorSubscribersStore = defineStore("creatorSubscribers", {
     },
     async fetchProfiles() {
       const nostr = useNostrStore();
-      this.loading = true;
+      this.profilesLoading = true;
       this.error = null;
       try {
         const unique = Array.from(new Set(this.subscribers.map((s) => s.npub)));
@@ -294,7 +295,7 @@ export const useCreatorSubscribersStore = defineStore("creatorSubscribers", {
         console.error(e);
         this.error = e instanceof Error ? e.message : String(e);
       } finally {
-        this.loading = false;
+        this.profilesLoading = false;
       }
     },
     setActiveTab(tab: Tab) {


### PR DESCRIPTION
## Summary
- track profile requests separately from main subscribers load
- show subtle progress bar while subscriber profiles load
- load subscribers and profiles independently on mount and retry

## Testing
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: 32 failed, 62 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689ad400682c83308d219b5bf86ce66b