### PR TITLE
refactor: batch profile fetching

### DIFF
--- a/test/creatorSubscribers-page.spec.ts
+++ b/test/creatorSubscribers-page.spec.ts
@@ -52,8 +52,15 @@ const routerPush = vi.fn();
 vi.mock('vue-router', () => ({ useRouter: () => ({ push: routerPush }) }));
 vi.mock('src/utils/subscriberCsv', () => ({ default: vi.fn() }));
 vi.mock('src/stores/nostr', () => ({
-  useNostrStore: () => ({ getProfile: vi.fn().mockResolvedValue(null) }),
+  useNostrStore: () => ({
+    initNdkReadOnly: vi.fn().mockResolvedValue(undefined),
+    resolvePubkey: (s: string) => s,
+  }),
 }));
+vi.mock('src/composables/useNdk', () => {
+  const fetchEvents = vi.fn().mockResolvedValue(new Set());
+  return { useNdk: vi.fn().mockResolvedValue({ fetchEvents }) };
+});
 
 import { copyNpub } from 'src/utils/clipboard';
 import downloadCsv from 'src/utils/subscriberCsv';

--- a/test/vitest/__tests__/creatorSubscribers.spec.ts
+++ b/test/vitest/__tests__/creatorSubscribers.spec.ts
@@ -79,12 +79,17 @@ vi.mock('../../../src/stores/creatorSubscriptions', () => ({
   }),
 }));
 
-const getProfileMock = vi.fn().mockResolvedValue(null);
+var fetchEventsMock: any;
 vi.mock('../../../src/stores/nostr', () => ({
   useNostrStore: () => ({
-    getProfile: getProfileMock,
+    initNdkReadOnly: vi.fn().mockResolvedValue(undefined),
+    resolvePubkey: (s: string) => s,
   }),
 }));
+vi.mock('../../../src/composables/useNdk', () => {
+  fetchEventsMock = vi.fn().mockResolvedValue(new Set());
+  return { useNdk: vi.fn().mockResolvedValue({ fetchEvents: fetchEventsMock }) };
+});
 
 vi.mock('vue-i18n', async (importOriginal) => {
   const actual = await importOriginal();
@@ -189,13 +194,13 @@ describe('CreatorSubscribersPage', () => {
     await wrapper.vm.$nextTick();
     await new Promise((r) => setTimeout(r, 0));
 
-    expect(getProfileMock).toHaveBeenCalledTimes(4);
+    expect(fetchEventsMock).toHaveBeenCalledTimes(1);
 
     const store = useCreatorSubscribersStore();
     await store.fetchProfiles();
     await new Promise((r) => setTimeout(r, 0));
 
-    expect(getProfileMock).toHaveBeenCalledTimes(4);
+    expect(fetchEventsMock).toHaveBeenCalledTimes(1);
   });
 });
 


### PR DESCRIPTION
## Summary
- batch fetch Nostr profiles with ndk and cache results
- handle offline mode before fetching and skip when NDK init fails
- track last successful profile batch to avoid repeated offline attempts

## Testing
- `pnpm test` *(fails: failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_689ad61eecc08330afbec8be53abeab8