### PR TITLE
Replace q-segmented with q-btn-toggle

### DIFF
--- a/src/pages/CreatorSubscribersPage.vue
+++ b/src/pages/CreatorSubscribersPage.vue
@@ -113,10 +113,10 @@
                 {{ chip.label }}
               </q-chip>
             </div>
-            <q-segmented
+            <q-btn-toggle
               v-model="activeTab"
               dense
-              color="primary"
+              toggle-color="primary"
               :options="tabOptions"
             />
           </div>


### PR DESCRIPTION
## Summary
- replace deprecated q-segmented with q-btn-toggle for tab selection

## Testing
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: Test Files 29 failed | 17 passed | 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_689adc5a85388330bf92db8d0a279658