### PR TITLE
feat(nostr): add readonly connection backoff and retry

### DIFF
--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -33,6 +33,10 @@ export const useSettingsStore = defineStore("settings", {
         "cashu.settings.defaultNostrRelays",
         DEFAULT_RELAYS,
       ),
+      nostrReadonlyBackoffMs: useLocalStorage<number>(
+        "cashu.settings.nostrReadonlyBackoffMs",
+        30000,
+      ),
       includeFeesInSendAmount: useLocalStorage<boolean>(
         "cashu.settings.includeFeesInSendAmount",
         false


### PR DESCRIPTION
## Summary
- reuse a shared connection attempt in `initNdkReadOnly`
- cache relay failures and skip reconnecting until backoff expires
- add manual retry action and configurable backoff setting

## Testing
- `pnpm test --run test/vitest/__tests__/messenger-send-token.spec.ts` *(fails: expect(success).toBe(true))*

------
https://chatgpt.com/codex/tasks/task_e_689acd46749883308af4a53dbf58c9f1