### PR TITLE
Fix Creator Hub i18n keys and add translation check

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test:ci": "vitest run",
     "types": "tsc -p tsconfig.local.json --noEmit",
     "ci:verify": "pnpm run types && pnpm run lint && pnpm run build && pnpm run build:pwa",
-    "lint:fix": "eslint . --fix"
+    "lint:fix": "eslint . --fix",
+    "check:i18n": "node scripts/check-i18n.js"
   },
   "dependencies": {
     "@capacitor/android": "^6.2.0",

--- a/scripts/check-i18n.js
+++ b/scripts/check-i18n.js
@@ -1,0 +1,69 @@
+import { promises as fs } from "fs";
+import path from "path";
+
+const SRC_DIR = "src";
+const LOCALE_FILE = path.join("src", "i18n", "en-US", "index.ts");
+
+async function collectFiles(dir) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const res = path.resolve(dir, entry.name);
+      if (entry.isDirectory()) return collectFiles(res);
+      if (/[.](vue|js|ts|jsx|tsx|html)$/.test(entry.name)) return [res];
+      return [];
+    }),
+  );
+  return files.flat();
+}
+
+function extractKeys(src) {
+  const re = /\$t\(\s*['"`]([^'"`]+)['"`]\s*\)|i18n\.t\(\s*['"`]([^'"`]+)['"`]\s*\)/g;
+  const keys = new Set();
+  let m;
+  while ((m = re.exec(src)) !== null) {
+    const key = m[1] || m[2];
+    if (key && !key.includes("${")) keys.add(key);
+  }
+  return keys;
+}
+
+function flatten(obj, prefix = "", out = new Set()) {
+  for (const [k, v] of Object.entries(obj)) {
+    const key = prefix ? `${prefix}.${k}` : k;
+    if (v && typeof v === "object" && !Array.isArray(v)) flatten(v, key, out);
+    else out.add(key);
+  }
+  return out;
+}
+
+async function loadLocaleKeys() {
+  const content = await fs.readFile(LOCALE_FILE, "utf8");
+  const match = content.match(/export const messages = (\{[\s\S]*?\n\});/);
+  if (!match) throw new Error("Could not parse locale file");
+  // eslint-disable-next-line no-new-func
+  const messages = new Function(`return ${match[1]}`)();
+  return flatten(messages);
+}
+
+async function main() {
+  const files = await collectFiles(SRC_DIR);
+  const usedKeys = new Set();
+  for (const file of files) {
+    const content = await fs.readFile(file, "utf8");
+    extractKeys(content).forEach((k) => usedKeys.add(k));
+  }
+
+  const localeKeys = await loadLocaleKeys();
+  const missing = [...usedKeys].filter((k) => !localeKeys.has(k));
+  if (missing.length) {
+    console.error("Missing i18n keys:\n" + missing.join("\n"));
+    process.exit(1);
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});
+

--- a/src/components/CreatorProfileForm.vue
+++ b/src/components/CreatorProfileForm.vue
@@ -3,14 +3,14 @@
     <div class="text-h6 q-mb-sm">{{ $t("creatorHub.profileHeader") }}</div>
     <q-input
       v-model="display_nameLocal"
-      label="Display Name"
+      :label="$t('creatorHub.displayName')"
       dense
       outlined
-      :rules="[(v) => !!v || 'Required']"
+      :rules="[(v) => !!v || t('creatorHub.required')]"
     />
     <q-input
       v-model="pictureLocal"
-      label="Profile Picture URL"
+      :label="$t('creatorHub.profilePictureUrl')"
       dense
       outlined
       :rules="[urlRule]"
@@ -23,7 +23,7 @@
     />
     <q-input
       v-model="aboutLocal"
-      label="About"
+      :label="$t('creatorHub.about')"
       type="textarea"
       autogrow
       dense
@@ -41,24 +41,24 @@
         use-input
         fill-input
         input-debounce="0"
-        label="P2PK Public Key"
+        :label="$t('creatorHub.p2pkPublicKey')"
       >
         <template #append>
           <q-btn flat dense icon="add" @click="generateP2PK" />
         </template>
         <template #after-options>
           <q-item clickable @click="generateP2PK">
-            <q-item-section>Generate new key</q-item-section>
+          <q-item-section>{{ $t('creatorHub.generateNewKey') }}</q-item-section>
           </q-item>
         </template>
       </q-select>
       <div v-else class="row items-center q-gutter-sm">
-        <div class="text-caption">You don't have a P2PK Public key.</div>
+        <div class="text-caption">{{ $t('creatorHub.noP2pkPublicKey') }}</div>
         <q-btn
           flat
           dense
           color="primary"
-          label="Generate"
+          :label="$t('creatorHub.generate')"
           @click="generateP2PK"
         />
       </div>
@@ -78,12 +78,12 @@
       outlined
       persistent-hint
       :rules="[urlListRule]"
-      hint="Press Enter after typing each URL"
+      :hint="$t('creatorHub.urlListHint')"
     >
       <template #label>
         <div class="row items-center no-wrap">
-          <span>Trusted Mints</span>
-          <InfoTooltip class="q-ml-xs" text="Type a mint URL and press Enter" />
+          <span>{{ $t('creatorHub.trustedMints') }}</span>
+          <InfoTooltip class="q-ml-xs" :text="$t('creatorHub.mintUrlInfo')" />
         </div>
       </template>
     </q-select>
@@ -99,14 +99,14 @@
       outlined
       persistent-hint
       :rules="[urlListRule]"
-      hint="Press Enter after typing each URL"
+      :hint="$t('creatorHub.urlListHint')"
     >
       <template #label>
         <div class="row items-center no-wrap">
-          <span>Relays</span>
+          <span>{{ $t('creatorHub.relays') }}</span>
           <InfoTooltip
             class="q-ml-xs"
-            text="Type a relay URL and press Enter"
+            :text="$t('creatorHub.relayUrlInfo')"
           />
         </div>
       </template>
@@ -117,11 +117,13 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import { storeToRefs } from "pinia";
+import { useI18n } from "vue-i18n";
 import InfoTooltip from "./InfoTooltip.vue";
 import { useCreatorProfileStore } from "stores/creatorProfile";
 import { useP2PKStore } from "stores/p2pk";
 import { shortenString } from "src/js/string-utils";
 
+const { t } = useI18n();
 const profileStore = useCreatorProfileStore();
 const p2pkStore = useP2PKStore();
 
@@ -178,7 +180,8 @@ const profileRelaysLocal = computed({
 });
 
 const validUrl = computed(() => /^https?:\/\/.+/.test(pictureLocal.value));
-const urlRule = (val: string) => /^https?:\/\/.+/.test(val) || "Invalid URL";
+const urlRule = (val: string) =>
+  /^https?:\/\/.+/.test(val) || t("creatorHub.invalidUrl");
 const urlListRule = (val: string[]) =>
-  val.every((u) => /^wss?:\/\//.test(u)) || "Invalid URL";
+  val.every((u) => /^wss?:\/\//.test(u)) || t("creatorHub.invalidUrl");
 </script>

--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -162,10 +162,10 @@
         </q-item-section>
         <q-item-section>
           <q-item-label>{{
-            $t("MainHeader.menu.creatorHub.creatorHub.title")
+            $t("MainHeader.menu.creatorHub.title")
           }}</q-item-label>
           <q-item-label caption>{{
-            $t("MainHeader.menu.creatorHub.creatorHub.caption")
+            $t("MainHeader.menu.creatorHub.caption")
           }}</q-item-label>
         </q-item-section>
       </q-item>

--- a/src/components/MoveTokensModal.vue
+++ b/src/components/MoveTokensModal.vue
@@ -78,7 +78,7 @@
                 <span>{{ $t("BucketDetail.inputs.target_bucket.label") }}</span>
                 <InfoTooltip
                   class="q-ml-xs"
-                  :text="$t('BucketDetail.inputs.target_bucket.tooltip')"
+                  :text="$t('BucketDetail.tooltips.target_bucket')"
                 />
               </div>
             </template>

--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -39,10 +39,6 @@ export default {
       send: {
         label: "إرسال",
       },
-      creatorHub: {
-        publish: "Publish Profile",
-        profileHeader: "Profile details",
-      },
       swap: {
         label: "تبديل",
       },
@@ -113,6 +109,10 @@ export default {
           title: "الإعدادات",
           caption: "تهيئة المحفظة",
         },
+      },
+      creatorHub: {
+        title: "Creator Hub",
+        caption: "Creator tools",
       },
       terms: {
         title: "الشروط",
@@ -1404,8 +1404,12 @@ export default {
     filter: {
       status: "تصفية حسب الحالة",
       bucket: "تصفية حسب الحاوية",
+      frequency: "Filter by frequency",
     },
-  },
+    actions: {
+      retry_now: "Retry now",
+    },
+},
   SendBucketDmDialog: {
     title: "Send Bucket Tokens",
     inputs: {
@@ -1713,5 +1717,23 @@ export default {
       note_saved: "Note saved",
       note_save_failed: "Failed to save note",
     },
+  },
+  creatorHub: {
+    publish: "Publish Profile",
+    profileHeader: "Profile details",
+    displayName: "Display Name",
+    profilePictureUrl: "Profile Picture URL",
+    about: "About",
+    p2pkPublicKey: "P2PK Public Key",
+    generateNewKey: "Generate new key",
+    noP2pkPublicKey: "You don't have a P2PK Public key.",
+    generate: "Generate",
+    trustedMints: "Trusted Mints",
+    mintUrlInfo: "Type a mint URL and press Enter",
+    relays: "Relays",
+    relayUrlInfo: "Type a relay URL and press Enter",
+    urlListHint: "Press Enter after typing each URL",
+    required: "Required",
+    invalidUrl: "Invalid URL",
   },
 };

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -39,10 +39,6 @@ export default {
       send: {
         label: "Senden",
       },
-      creatorHub: {
-        publish: "Publish Profile",
-        profileHeader: "Profile details",
-      },
       swap: {
         label: "Tauschen",
       },
@@ -114,6 +110,10 @@ export default {
           title: "Einstellungen",
           caption: "Wallet-Konfiguration",
         },
+      },
+      creatorHub: {
+        title: "Creator Hub",
+        caption: "Creator tools",
       },
       terms: {
         title: "Bedingungen",
@@ -1410,8 +1410,12 @@ export default {
     filter: {
       status: "Nach Status filtern",
       bucket: "Nach Bucket filtern",
+      frequency: "Filter by frequency",
     },
-  },
+    actions: {
+      retry_now: "Retry now",
+    },
+},
   SendBucketDmDialog: {
     title: "Send Bucket Tokens",
     inputs: {
@@ -1719,5 +1723,23 @@ export default {
       note_saved: "Note saved",
       note_save_failed: "Failed to save note",
     },
+  },
+  creatorHub: {
+    publish: "Publish Profile",
+    profileHeader: "Profile details",
+    displayName: "Display Name",
+    profilePictureUrl: "Profile Picture URL",
+    about: "About",
+    p2pkPublicKey: "P2PK Public Key",
+    generateNewKey: "Generate new key",
+    noP2pkPublicKey: "You don't have a P2PK Public key.",
+    generate: "Generate",
+    trustedMints: "Trusted Mints",
+    mintUrlInfo: "Type a mint URL and press Enter",
+    relays: "Relays",
+    relayUrlInfo: "Type a relay URL and press Enter",
+    urlListHint: "Press Enter after typing each URL",
+    required: "Required",
+    invalidUrl: "Invalid URL",
   },
 };

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -39,10 +39,6 @@ export default {
       send: {
         label: "Αποστολή",
       },
-      creatorHub: {
-        publish: "Publish Profile",
-        profileHeader: "Profile details",
-      },
       swap: {
         label: "Ανταλλαγή",
       },
@@ -114,6 +110,10 @@ export default {
           title: "Ρυθμίσεις",
           caption: "Διαμόρφωση πορτοφολιού",
         },
+      },
+      creatorHub: {
+        title: "Creator Hub",
+        caption: "Creator tools",
       },
       terms: {
         title: "Όροι",
@@ -1414,8 +1414,12 @@ export default {
     filter: {
       status: "Φιλτράρισμα κατά κατάσταση",
       bucket: "Φιλτράρισμα ανά κάδο",
+      frequency: "Filter by frequency",
     },
-  },
+    actions: {
+      retry_now: "Retry now",
+    },
+},
   SendBucketDmDialog: {
     title: "Send Bucket Tokens",
     inputs: {
@@ -1723,5 +1727,23 @@ export default {
       note_saved: "Note saved",
       note_save_failed: "Failed to save note",
     },
+  },
+  creatorHub: {
+    publish: "Publish Profile",
+    profileHeader: "Profile details",
+    displayName: "Display Name",
+    profilePictureUrl: "Profile Picture URL",
+    about: "About",
+    p2pkPublicKey: "P2PK Public Key",
+    generateNewKey: "Generate new key",
+    noP2pkPublicKey: "You don't have a P2PK Public key.",
+    generate: "Generate",
+    trustedMints: "Trusted Mints",
+    mintUrlInfo: "Type a mint URL and press Enter",
+    relays: "Relays",
+    relayUrlInfo: "Type a relay URL and press Enter",
+    urlListHint: "Press Enter after typing each URL",
+    required: "Required",
+    invalidUrl: "Invalid URL",
   },
 };

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -128,6 +128,7 @@ export const messages = {
       },
       creatorHub: {
         title: "Creator Hub",
+        caption: "Creator tools",
       },
       myProfile: {
         title: "My Profile",
@@ -1596,6 +1597,7 @@ export const messages = {
     filter: {
       status: "Filter by status",
       bucket: "Filter by bucket",
+      frequency: "Filter by frequency",
     },
     sort_by: "Sort by",
     sort: {
@@ -1613,7 +1615,7 @@ export const messages = {
     },
     pending_retry: "Queued { count } payments for resend",
     actions: {
-      retry_now: { label: "Retry now" },
+      retry_now: "Retry now",
       open_filters: { label: "Open filters" },
       more_actions: { label: "More actions" },
     },
@@ -1981,6 +1983,24 @@ export const messages = {
         },
       },
     },
+  },
+  creatorHub: {
+    publish: "Publish Profile",
+    profileHeader: "Profile details",
+    displayName: "Display Name",
+    profilePictureUrl: "Profile Picture URL",
+    about: "About",
+    p2pkPublicKey: "P2PK Public Key",
+    generateNewKey: "Generate new key",
+    noP2pkPublicKey: "You don't have a P2PK Public key.",
+    generate: "Generate",
+    trustedMints: "Trusted Mints",
+    mintUrlInfo: "Type a mint URL and press Enter",
+    relays: "Relays",
+    relayUrlInfo: "Type a relay URL and press Enter",
+    urlListHint: "Press Enter after typing each URL",
+    required: "Required",
+    invalidUrl: "Invalid URL",
   },
 };
 

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -39,10 +39,6 @@ export default {
       send: {
         label: "Enviar",
       },
-      creatorHub: {
-        publish: "Publish Profile",
-        profileHeader: "Profile details",
-      },
       swap: {
         label: "Intercambiar",
       },
@@ -114,6 +110,10 @@ export default {
           title: "Configuración",
           caption: "Configuración de la billetera",
         },
+      },
+      creatorHub: {
+        title: "Creator Hub",
+        caption: "Creator tools",
       },
       terms: {
         title: "Términos",
@@ -1411,8 +1411,12 @@ export default {
     filter: {
       status: "Filtrar por estado",
       bucket: "Filtrar por bucket",
+      frequency: "Filter by frequency",
     },
-  },
+    actions: {
+      retry_now: "Retry now",
+    },
+},
   SendBucketDmDialog: {
     title: "Send Bucket Tokens",
     inputs: {
@@ -1720,5 +1724,23 @@ export default {
       note_saved: "Note saved",
       note_save_failed: "Failed to save note",
     },
+  },
+  creatorHub: {
+    publish: "Publish Profile",
+    profileHeader: "Profile details",
+    displayName: "Display Name",
+    profilePictureUrl: "Profile Picture URL",
+    about: "About",
+    p2pkPublicKey: "P2PK Public Key",
+    generateNewKey: "Generate new key",
+    noP2pkPublicKey: "You don't have a P2PK Public key.",
+    generate: "Generate",
+    trustedMints: "Trusted Mints",
+    mintUrlInfo: "Type a mint URL and press Enter",
+    relays: "Relays",
+    relayUrlInfo: "Type a relay URL and press Enter",
+    urlListHint: "Press Enter after typing each URL",
+    required: "Required",
+    invalidUrl: "Invalid URL",
   },
 };

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -39,10 +39,6 @@ export default {
       send: {
         label: "Envoyer",
       },
-      creatorHub: {
-        publish: "Publish Profile",
-        profileHeader: "Profile details",
-      },
       swap: {
         label: "Échanger",
       },
@@ -114,6 +110,10 @@ export default {
           title: "Paramètres",
           caption: "Configuration du portefeuille",
         },
+      },
+      creatorHub: {
+        title: "Creator Hub",
+        caption: "Creator tools",
       },
       terms: {
         title: "Conditions",
@@ -1401,8 +1401,12 @@ export default {
     filter: {
       status: "Filtrer par statut",
       bucket: "Filtrer par bucket",
+      frequency: "Filter by frequency",
     },
-  },
+    actions: {
+      retry_now: "Retry now",
+    },
+},
   SendBucketDmDialog: {
     title: "Send Bucket Tokens",
     inputs: {
@@ -1710,5 +1714,23 @@ export default {
       note_saved: "Note saved",
       note_save_failed: "Failed to save note",
     },
+  },
+  creatorHub: {
+    publish: "Publish Profile",
+    profileHeader: "Profile details",
+    displayName: "Display Name",
+    profilePictureUrl: "Profile Picture URL",
+    about: "About",
+    p2pkPublicKey: "P2PK Public Key",
+    generateNewKey: "Generate new key",
+    noP2pkPublicKey: "You don't have a P2PK Public key.",
+    generate: "Generate",
+    trustedMints: "Trusted Mints",
+    mintUrlInfo: "Type a mint URL and press Enter",
+    relays: "Relays",
+    relayUrlInfo: "Type a relay URL and press Enter",
+    urlListHint: "Press Enter after typing each URL",
+    required: "Required",
+    invalidUrl: "Invalid URL",
   },
 };

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -39,10 +39,6 @@ export default {
       send: {
         label: "Invia",
       },
-      creatorHub: {
-        publish: "Publish Profile",
-        profileHeader: "Profile details",
-      },
       swap: {
         label: "Scambia",
       },
@@ -114,6 +110,10 @@ export default {
           title: "Impostazioni",
           caption: "Configurazione portafoglio",
         },
+      },
+      creatorHub: {
+        title: "Creator Hub",
+        caption: "Creator tools",
       },
       terms: {
         title: "Termini",
@@ -1393,8 +1393,12 @@ export default {
     filter: {
       status: "Filtra per stato",
       bucket: "Filtra per bucket",
+      frequency: "Filter by frequency",
     },
-  },
+    actions: {
+      retry_now: "Retry now",
+    },
+},
   SendBucketDmDialog: {
     title: "Send Bucket Tokens",
     inputs: {
@@ -1702,5 +1706,23 @@ export default {
       note_saved: "Note saved",
       note_save_failed: "Failed to save note",
     },
+  },
+  creatorHub: {
+    publish: "Publish Profile",
+    profileHeader: "Profile details",
+    displayName: "Display Name",
+    profilePictureUrl: "Profile Picture URL",
+    about: "About",
+    p2pkPublicKey: "P2PK Public Key",
+    generateNewKey: "Generate new key",
+    noP2pkPublicKey: "You don't have a P2PK Public key.",
+    generate: "Generate",
+    trustedMints: "Trusted Mints",
+    mintUrlInfo: "Type a mint URL and press Enter",
+    relays: "Relays",
+    relayUrlInfo: "Type a relay URL and press Enter",
+    urlListHint: "Press Enter after typing each URL",
+    required: "Required",
+    invalidUrl: "Invalid URL",
   },
 };

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -39,10 +39,6 @@ export default {
       send: {
         label: "送る",
       },
-      creatorHub: {
-        publish: "Publish Profile",
-        profileHeader: "Profile details",
-      },
       swap: {
         label: "スワップ",
       },
@@ -114,6 +110,10 @@ export default {
           title: "設定",
           caption: "ウォレット構成",
         },
+      },
+      creatorHub: {
+        title: "Creator Hub",
+        caption: "Creator tools",
       },
       terms: {
         title: "規約",
@@ -1394,8 +1394,12 @@ export default {
     filter: {
       status: "ステータスでフィルタ",
       bucket: "バケットでフィルタ",
+      frequency: "Filter by frequency",
     },
-  },
+    actions: {
+      retry_now: "Retry now",
+    },
+},
   SendBucketDmDialog: {
     title: "Send Bucket Tokens",
     inputs: {
@@ -1703,5 +1707,23 @@ export default {
       note_saved: "Note saved",
       note_save_failed: "Failed to save note",
     },
+  },
+  creatorHub: {
+    publish: "Publish Profile",
+    profileHeader: "Profile details",
+    displayName: "Display Name",
+    profilePictureUrl: "Profile Picture URL",
+    about: "About",
+    p2pkPublicKey: "P2PK Public Key",
+    generateNewKey: "Generate new key",
+    noP2pkPublicKey: "You don't have a P2PK Public key.",
+    generate: "Generate",
+    trustedMints: "Trusted Mints",
+    mintUrlInfo: "Type a mint URL and press Enter",
+    relays: "Relays",
+    relayUrlInfo: "Type a relay URL and press Enter",
+    urlListHint: "Press Enter after typing each URL",
+    required: "Required",
+    invalidUrl: "Invalid URL",
   },
 };

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -39,10 +39,6 @@ export default {
       send: {
         label: "Skicka",
       },
-      creatorHub: {
-        publish: "Publish Profile",
-        profileHeader: "Profile details",
-      },
       swap: {
         label: "Byt",
       },
@@ -113,6 +109,10 @@ export default {
           title: "Inställningar",
           caption: "Plånboksinställningar",
         },
+      },
+      creatorHub: {
+        title: "Creator Hub",
+        caption: "Creator tools",
       },
       terms: {
         title: "Villkor",
@@ -1393,8 +1393,12 @@ export default {
     filter: {
       status: "Filtrera efter status",
       bucket: "Filtrera efter bucket",
+      frequency: "Filter by frequency",
     },
-  },
+    actions: {
+      retry_now: "Retry now",
+    },
+},
   SendBucketDmDialog: {
     title: "Send Bucket Tokens",
     inputs: {
@@ -1702,5 +1706,23 @@ export default {
       note_saved: "Note saved",
       note_save_failed: "Failed to save note",
     },
+  },
+  creatorHub: {
+    publish: "Publish Profile",
+    profileHeader: "Profile details",
+    displayName: "Display Name",
+    profilePictureUrl: "Profile Picture URL",
+    about: "About",
+    p2pkPublicKey: "P2PK Public Key",
+    generateNewKey: "Generate new key",
+    noP2pkPublicKey: "You don't have a P2PK Public key.",
+    generate: "Generate",
+    trustedMints: "Trusted Mints",
+    mintUrlInfo: "Type a mint URL and press Enter",
+    relays: "Relays",
+    relayUrlInfo: "Type a relay URL and press Enter",
+    urlListHint: "Press Enter after typing each URL",
+    required: "Required",
+    invalidUrl: "Invalid URL",
   },
 };

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -39,10 +39,6 @@ export default {
       send: {
         label: "ส่ง",
       },
-      creatorHub: {
-        publish: "Publish Profile",
-        profileHeader: "Profile details",
-      },
       swap: {
         label: "แลกเปลี่ยน",
       },
@@ -114,6 +110,10 @@ export default {
           title: "การตั้งค่า",
           caption: "การกำหนดค่า Wallet",
         },
+      },
+      creatorHub: {
+        title: "Creator Hub",
+        caption: "Creator tools",
       },
       terms: {
         title: "เงื่อนไข",
@@ -1391,8 +1391,12 @@ export default {
     filter: {
       status: "กรองตามสถานะ",
       bucket: "กรองตามบัคเก็ต",
+      frequency: "Filter by frequency",
     },
-  },
+    actions: {
+      retry_now: "Retry now",
+    },
+},
   SendBucketDmDialog: {
     title: "Send Bucket Tokens",
     inputs: {
@@ -1700,5 +1704,23 @@ export default {
       note_saved: "Note saved",
       note_save_failed: "Failed to save note",
     },
+  },
+  creatorHub: {
+    publish: "Publish Profile",
+    profileHeader: "Profile details",
+    displayName: "Display Name",
+    profilePictureUrl: "Profile Picture URL",
+    about: "About",
+    p2pkPublicKey: "P2PK Public Key",
+    generateNewKey: "Generate new key",
+    noP2pkPublicKey: "You don't have a P2PK Public key.",
+    generate: "Generate",
+    trustedMints: "Trusted Mints",
+    mintUrlInfo: "Type a mint URL and press Enter",
+    relays: "Relays",
+    relayUrlInfo: "Type a relay URL and press Enter",
+    urlListHint: "Press Enter after typing each URL",
+    required: "Required",
+    invalidUrl: "Invalid URL",
   },
 };

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -39,10 +39,6 @@ export default {
       send: {
         label: "Gönder",
       },
-      creatorHub: {
-        publish: "Publish Profile",
-        profileHeader: "Profile details",
-      },
       swap: {
         label: "Değiştir",
       },
@@ -114,6 +110,10 @@ export default {
           title: "Ayarlar",
           caption: "Cüzdan yapılandırması",
         },
+      },
+      creatorHub: {
+        title: "Creator Hub",
+        caption: "Creator tools",
       },
       terms: {
         title: "Şartlar",
@@ -1396,8 +1396,12 @@ export default {
     filter: {
       status: "Duruma göre filtrele",
       bucket: "Buckete göre filtrele",
+      frequency: "Filter by frequency",
     },
-  },
+    actions: {
+      retry_now: "Retry now",
+    },
+},
   SendBucketDmDialog: {
     title: "Send Bucket Tokens",
     inputs: {
@@ -1705,5 +1709,23 @@ export default {
       note_saved: "Note saved",
       note_save_failed: "Failed to save note",
     },
+  },
+  creatorHub: {
+    publish: "Publish Profile",
+    profileHeader: "Profile details",
+    displayName: "Display Name",
+    profilePictureUrl: "Profile Picture URL",
+    about: "About",
+    p2pkPublicKey: "P2PK Public Key",
+    generateNewKey: "Generate new key",
+    noP2pkPublicKey: "You don't have a P2PK Public key.",
+    generate: "Generate",
+    trustedMints: "Trusted Mints",
+    mintUrlInfo: "Type a mint URL and press Enter",
+    relays: "Relays",
+    relayUrlInfo: "Type a relay URL and press Enter",
+    urlListHint: "Press Enter after typing each URL",
+    required: "Required",
+    invalidUrl: "Invalid URL",
   },
 };

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -39,10 +39,6 @@ export default {
       send: {
         label: "发送",
       },
-      creatorHub: {
-        publish: "Publish Profile",
-        profileHeader: "Profile details",
-      },
       swap: {
         label: "兑换",
       },
@@ -113,6 +109,10 @@ export default {
           title: "设置",
           caption: "钱包配置",
         },
+      },
+      creatorHub: {
+        title: "Creator Hub",
+        caption: "Creator tools",
       },
       terms: {
         title: "条款",
@@ -1383,8 +1383,12 @@ export default {
     filter: {
       status: "按状态筛选",
       bucket: "按桶筛选",
+      frequency: "Filter by frequency",
     },
-  },
+    actions: {
+      retry_now: "Retry now",
+    },
+},
   SendBucketDmDialog: {
     title: "Send Bucket Tokens",
     inputs: {
@@ -1692,5 +1696,23 @@ export default {
       note_saved: "Note saved",
       note_save_failed: "Failed to save note",
     },
+  },
+  creatorHub: {
+    publish: "Publish Profile",
+    profileHeader: "Profile details",
+    displayName: "Display Name",
+    profilePictureUrl: "Profile Picture URL",
+    about: "About",
+    p2pkPublicKey: "P2PK Public Key",
+    generateNewKey: "Generate new key",
+    noP2pkPublicKey: "You don't have a P2PK Public key.",
+    generate: "Generate",
+    trustedMints: "Trusted Mints",
+    mintUrlInfo: "Type a mint URL and press Enter",
+    relays: "Relays",
+    relayUrlInfo: "Type a relay URL and press Enter",
+    urlListHint: "Press Enter after typing each URL",
+    required: "Required",
+    invalidUrl: "Invalid URL",
   },
 };

--- a/src/pages/BucketDetail.vue
+++ b/src/pages/BucketDetail.vue
@@ -70,7 +70,7 @@
             <span>{{ $t("BucketDetail.inputs.target_bucket.label") }}</span>
             <InfoTooltip
               class="q-ml-xs"
-              :text="$t('BucketDetail.inputs.target_bucket.tooltip')"
+              :text="$t('BucketDetail.tooltips.target_bucket')"
             />
           </div>
         </template>

--- a/src/pages/welcome/WelcomeSlide3.vue
+++ b/src/pages/welcome/WelcomeSlide3.vue
@@ -18,7 +18,7 @@
             <span>{{ $t("WelcomeSlide3.inputs.seed_phrase.label") }}</span>
             <InfoTooltip
               class="q-ml-xs"
-              :text="$t('WelcomeSlide3.tooltips.seed_phrase')"
+              :text="$t('WelcomeSlide3.inputs.seed_phrase.tooltip')"
             />
           </div>
         </template>


### PR DESCRIPTION
## Summary
- normalize Creator Hub menu translations and add caption
- localize Creator profile form fields and actions
- add i18n consistency check script and wire it into package.json

## Testing
- `node scripts/check-i18n.js`
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_689cd12bfa2483309df96a79fa1fea4a