### PR TITLE
Improve Nostr messenger layout and responsiveness

### DIFF
--- a/src/components/ConversationListItem.vue
+++ b/src/components/ConversationListItem.vue
@@ -266,11 +266,13 @@ export default defineComponent({
 }
 
 .name-section {
-  max-width: 40%;
+  flex: 1;
+  min-width: 0;
 }
 
 .snippet-section {
-  max-width: 35%;
+  flex: 1;
+  min-width: 0;
 }
 
 .conversation-item .ellipsis {

--- a/src/components/MessageList.vue
+++ b/src/components/MessageList.vue
@@ -1,6 +1,13 @@
 <template>
   <q-scroll-area class="col column q-pa-md">
-    <template v-for="(msg, idx) in messages" :key="msg.id">
+    <div
+      v-if="messages.length === 0"
+      class="col flex flex-center text-grey-6"
+      style="min-height: 150px"
+    >
+      <span>No messages yet</span>
+    </div>
+    <template v-else v-for="(msg, idx) in messages" :key="msg.id">
       <div
         v-if="showDateSeparator(idx)"
         class="text-caption text-center q-my-md divider-text"

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -5,7 +5,10 @@
   >
     <MainHeader />
     <q-page-container class="text-body1">
-      <div class="max-w-7xl mx-auto">
+      <div v-if="!fullWidthRoute" class="max-w-7xl mx-auto">
+        <router-view />
+      </div>
+      <div v-else class="w-full">
         <router-view />
       </div>
     </q-page-container>
@@ -13,7 +16,8 @@
 </template>
 
 <script>
-import { defineComponent } from "vue";
+import { defineComponent, computed } from "vue";
+import { useRoute } from "vue-router";
 import MainHeader from "components/MainHeader.vue";
 import { useNostrStore } from "src/stores/nostr";
 import { useNutzapStore } from "src/stores/nutzap";
@@ -23,6 +27,13 @@ export default defineComponent({
   mixins: [windowMixin],
   components: {
     MainHeader,
+  },
+  setup() {
+    const route = useRoute();
+    const fullWidthRoute = computed(() =>
+      route.path.startsWith("/nostr-messenger"),
+    );
+    return { fullWidthRoute };
   },
   async mounted() {
     const nostr = useNostrStore();

--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -10,7 +10,7 @@
         show-if-above
         :breakpoint="600"
         bordered
-        :width="drawerOpen ? 240 : 64"
+        :width="drawerOpen ? 320 : 64"
         class="drawer-transition drawer-container"
         :style="{ overflowX: 'hidden' }"
         :class="[
@@ -19,11 +19,12 @@
         ]"
       >
         <template v-if="drawerOpen">
-          <div class="column no-wrap full-height">
-            <div class="row items-center justify-between q-mb-md">
-              <div class="text-subtitle1">Chats</div>
-              <q-btn flat dense round icon="add" @click="openNewChatDialog" />
-            </div>
+          <q-slide-transition>
+            <div class="column no-wrap full-height">
+              <div class="row items-center justify-between q-mb-md">
+                <div class="text-subtitle1">Chats</div>
+                <q-btn flat dense round icon="add" @click="openNewChatDialog" />
+              </div>
             <q-input
               dense
               rounded
@@ -51,48 +52,52 @@
               </Suspense>
             </q-scroll-area>
             <UserInfo />
-          </div>
+            </div>
+          </q-slide-transition>
         </template>
         <template v-else>
-          <div class="column items-center q-gutter-md" style="overflow-y: auto">
-            <q-avatar
-              v-for="item in miniList"
-              :key="item.pubkey"
-              size="40px"
+          <q-slide-transition>
+            <div
+              class="column items-center q-gutter-md"
+              style="overflow-y: auto"
+            >
+              <q-avatar
+                v-for="item in miniList"
+                :key="item.pubkey"
+                size="40px"
               class="cursor-pointer"
               @click="selectConversation(item.pubkey)"
             >
               <img v-if="item.profile?.picture" :src="item.profile.picture" />
               <span v-else>{{ item.initials }}</span>
               <q-tooltip>{{ item.displayName }}</q-tooltip>
-            </q-avatar>
-          </div>
+              </q-avatar>
+            </div>
+          </q-slide-transition>
         </template>
       </q-drawer>
     </q-responsive>
 
     <div :class="['col column', $q.screen.gt.xs ? 'q-pa-lg' : 'q-pa-md']">
-      <q-header elevated class="q-mb-md bg-transparent">
-        <q-toolbar>
-          <q-btn
-            flat
-            round
-            dense
-            icon="menu"
-            @click="messenger.toggleDrawer()"
-          />
-          <q-btn flat round dense icon="arrow_back" @click="goBack" />
-          <q-toolbar-title class="text-h6 ellipsis">
-            Nostr Messenger
-            <q-badge
-              :color="messenger.connected ? 'positive' : 'negative'"
-              class="q-ml-sm"
-            >
-              {{ messenger.connected ? "Online" : "Offline" }}
-            </q-badge>
-          </q-toolbar-title>
-        </q-toolbar>
-      </q-header>
+      <q-toolbar class="q-mb-md bg-transparent">
+        <q-btn
+          flat
+          round
+          dense
+          icon="menu"
+          @click="messenger.toggleDrawer()"
+        />
+        <q-btn flat round dense icon="arrow_back" @click="goBack" />
+        <q-toolbar-title class="text-h6 ellipsis">
+          Nostr Messenger
+          <q-badge
+            :color="messenger.connected ? 'positive' : 'negative'"
+            class="q-ml-sm"
+          >
+            {{ messenger.connected ? "Online" : "Offline" }}
+          </q-badge>
+        </q-toolbar-title>
+      </q-toolbar>
       <q-banner v-if="connecting && !loading" dense class="bg-grey-3">
         Connecting...
       </q-banner>
@@ -413,7 +418,7 @@ export default defineComponent({
   flex-wrap: nowrap;
 }
 .drawer-transition {
-  transition: transform 0.3s;
+  transition: width 0.3s;
 }
 
 .drawer-container {


### PR DESCRIPTION
## Summary
- expand messenger drawer and animate open/close
- allow messenger pages to use full-width layout
- clean up toolbar and list item flex behavior
- show placeholder when a chat has no messages

## Testing
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: multiple unit tests erroring)*

------
https://chatgpt.com/codex/tasks/task_e_689d71fd90408330b15c06be4c3ec950