### PR TITLE
Refine nostr messenger layout and drawer

### DIFF
--- a/src/components/ConversationListItem.vue
+++ b/src/components/ConversationListItem.vue
@@ -265,12 +265,10 @@ export default defineComponent({
   white-space: normal;
 }
 
-.name-section {
-  max-width: 40%;
-}
-
+.name-section,
 .snippet-section {
-  max-width: 35%;
+  flex: 1;
+  min-width: 0;
 }
 
 .conversation-item .ellipsis {

--- a/src/components/EmptyChatPlaceholder.vue
+++ b/src/components/EmptyChatPlaceholder.vue
@@ -1,0 +1,8 @@
+<template>
+  <div class="column items-center justify-center q-my-lg text-grey">
+    <q-icon name="chat" size="48px" class="q-mb-sm" />
+    <div>No messages yet</div>
+  </div>
+</template>
+
+<script setup lang="ts"></script>

--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -27,7 +27,17 @@
           {{ $t("FullscreenHeader.actions.back.label") }}
         </span>
       </q-btn>
-      <q-toolbar-title></q-toolbar-title>
+      <q-toolbar-title class="text-h6">
+        <template v-if="isMessengerPage">
+          Nostr Messenger
+          <q-badge
+            :color="messenger.connected ? 'positive' : 'negative'"
+            class="q-ml-sm"
+          >
+            {{ messenger.connected ? 'Online' : 'Offline' }}
+          </q-badge>
+        </template>
+      </q-toolbar-title>
       <q-btn
         v-if="isMessengerPage"
         flat
@@ -489,6 +499,7 @@ export default defineComponent({
       isMessengerPage,
       toggleDarkMode,
       darkIcon,
+      messenger,
     };
   },
 });

--- a/src/components/MessageList.vue
+++ b/src/components/MessageList.vue
@@ -1,6 +1,7 @@
 <template>
   <q-scroll-area class="col column q-pa-md">
-    <template v-for="(msg, idx) in messages" :key="msg.id">
+    <EmptyChatPlaceholder v-if="messages.length === 0" />
+    <template v-else v-for="(msg, idx) in messages" :key="msg.id">
       <div
         v-if="showDateSeparator(idx)"
         class="text-caption text-center q-my-md divider-text"
@@ -17,6 +18,7 @@
 import { nextTick, ref, watch } from "vue";
 import type { MessengerMessage } from "src/stores/messenger";
 import ChatMessageBubble from "./ChatMessageBubble.vue";
+import EmptyChatPlaceholder from "./EmptyChatPlaceholder.vue";
 
 const props = defineProps<{ messages: MessengerMessage[] }>();
 const bottom = ref<HTMLElement>();

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -5,7 +5,7 @@
   >
     <MainHeader />
     <q-page-container class="text-body1">
-      <div class="max-w-7xl mx-auto">
+      <div :class="containerClass">
         <router-view />
       </div>
     </q-page-container>
@@ -13,7 +13,8 @@
 </template>
 
 <script>
-import { defineComponent } from "vue";
+import { defineComponent, computed } from "vue";
+import { useRoute } from "vue-router";
 import MainHeader from "components/MainHeader.vue";
 import { useNostrStore } from "src/stores/nostr";
 import { useNutzapStore } from "src/stores/nutzap";
@@ -23,6 +24,13 @@ export default defineComponent({
   mixins: [windowMixin],
   components: {
     MainHeader,
+  },
+  setup() {
+    const route = useRoute();
+    const containerClass = computed(() =>
+      route.path.startsWith("/nostr-messenger") ? "" : "max-w-7xl mx-auto",
+    );
+    return { containerClass };
   },
   async mounted() {
     const nostr = useNostrStore();

--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -10,7 +10,7 @@
         show-if-above
         :breakpoint="600"
         bordered
-        :width="drawerOpen ? 240 : 64"
+        :width="drawerOpen ? 320 : 64"
         class="drawer-transition drawer-container"
         :style="{ overflowX: 'hidden' }"
         :class="[
@@ -72,27 +72,6 @@
     </q-responsive>
 
     <div :class="['col column', $q.screen.gt.xs ? 'q-pa-lg' : 'q-pa-md']">
-      <q-header elevated class="q-mb-md bg-transparent">
-        <q-toolbar>
-          <q-btn
-            flat
-            round
-            dense
-            icon="menu"
-            @click="messenger.toggleDrawer()"
-          />
-          <q-btn flat round dense icon="arrow_back" @click="goBack" />
-          <q-toolbar-title class="text-h6 ellipsis">
-            Nostr Messenger
-            <q-badge
-              :color="messenger.connected ? 'positive' : 'negative'"
-              class="q-ml-sm"
-            >
-              {{ messenger.connected ? "Online" : "Offline" }}
-            </q-badge>
-          </q-toolbar-title>
-        </q-toolbar>
-      </q-header>
       <q-banner v-if="connecting && !loading" dense class="bg-grey-3">
         Connecting...
       </q-banner>
@@ -131,7 +110,7 @@ import {
   onUnmounted,
   watch,
 } from "vue";
-import { useRouter, useRoute } from "vue-router";
+import { useRoute } from "vue-router";
 import { useLocalStorage } from "@vueuse/core";
 import { useMessengerStore } from "src/stores/messenger";
 import { useNdk } from "src/composables/useNdk";
@@ -224,16 +203,7 @@ export default defineComponent({
       if (timer) clearInterval(timer);
     });
 
-    const router = useRouter();
     const route = useRoute();
-
-    const goBack = () => {
-      if (window.history.length > 1) {
-        router.back();
-      } else {
-        router.push("/wallet");
-      }
-    };
 
     const drawerOpen = computed(() => messenger.drawerOpen);
     const selected = ref("");
@@ -397,7 +367,6 @@ export default defineComponent({
       sendMessage,
       openSendTokenDialog,
       openNewChatDialog,
-      goBack,
       reconnectAll,
       connectedCount,
       totalRelays,
@@ -413,7 +382,11 @@ export default defineComponent({
   flex-wrap: nowrap;
 }
 .drawer-transition {
-  transition: transform 0.3s;
+  transition: width 0.3s;
+}
+
+.drawer-transition .conversation-item .q-item-section:not([avatar]) {
+  transition: opacity 0.3s, width 0.3s;
 }
 
 .drawer-container {
@@ -427,8 +400,13 @@ export default defineComponent({
   overflow: hidden;
 }
 
-.drawer-collapsed .conversation-item .q-item-section:not([avatar]) {
-  display: none;
+.drawer-collapsed
+  .conversation-item
+  .q-item-section:not([avatar]) {
+  opacity: 0;
+  width: 0;
+  padding: 0;
+  margin: 0;
 }
 
 .drawer-collapsed .conversation-item q-avatar {


### PR DESCRIPTION
## Summary
- widen messenger drawer and animate collapse
- let messenger page span full width
- consolidate messenger header into MainHeader with connection badge
- show empty chat placeholder when no messages

## Testing
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: missing dependencies such as windowMixin and IndexedDB)*

------
https://chatgpt.com/codex/tasks/task_e_689d71fd90408330b15c06be4c3ec950