### PR TITLE
Fix subscriber insights layout and npub displays

### DIFF
--- a/src/components/SubscriberCard.vue
+++ b/src/components/SubscriberCard.vue
@@ -7,8 +7,14 @@
       <div class="row items-center justify-between">
         <div>
           <div class="text-h6">{{ subscription.tierName }}</div>
-          <div class="text-caption text-grey">
-            {{ subscription.subscriberNpub }}
+          <div class="text-caption text-grey row items-center q-gutter-xs">
+            <span>{{ shortenNpub(subscription.subscriberNpub) }}</span>
+            <q-icon
+              name="content_copy"
+              size="16px"
+              class="cursor-pointer"
+              @click.stop="copyNpub(subscription.subscriberNpub)"
+            />
           </div>
         </div>
         <div class="text-h6">{{ amount }}</div>
@@ -34,6 +40,7 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import type { CreatorSubscription } from "stores/creatorSubscriptions";
+import { copyNpub, shortenNpub } from "src/utils/clipboard";
 
 const props = defineProps<{
   subscription: CreatorSubscription;

--- a/src/components/subscribers/SubscriberDrawer.vue
+++ b/src/components/subscribers/SubscriberDrawer.vue
@@ -25,7 +25,7 @@
           <div class="col" style="min-width: 0">
             <div class="text-h6 break-word">{{ subscriber.name }}</div>
             <div class="text-body2 text-secondary break-word">
-              {{ subscriber.nip05 }}
+              {{ subscriber.nip05 || shortenNpub(subscriber.npub) }}
             </div>
           </div>
         </div>
@@ -36,8 +36,19 @@
           header-class="card-bg"
           label="npub"
         >
-          <div class="q-pa-sm card-bg text-body2 monospace break-word">
-            {{ subscriber.npub }}
+          <div
+            class="q-pa-sm card-bg text-body2 monospace break-word row items-center justify-between"
+          >
+            <span>{{ subscriber.npub }}</span>
+            <q-btn
+              flat
+              dense
+              round
+              icon="content_copy"
+              aria-label="Copy npub"
+              @click="copyCurrentNpub"
+              class="focus-outline"
+            />
           </div>
         </q-expansion-item>
 
@@ -191,7 +202,7 @@ import { useI18n } from "vue-i18n";
 import { format, formatDistanceToNow } from "date-fns";
 import { useQuasar } from "quasar";
 import type { Subscriber } from "src/types/subscriber";
-import { copyNpub } from "src/utils/clipboard";
+import { copyNpub, shortenNpub } from "src/utils/clipboard";
 
 const props = defineProps<{
   modelValue: boolean;

--- a/src/components/subscribers/SubscribersTable.vue
+++ b/src/components/subscribers/SubscribersTable.vue
@@ -10,6 +10,15 @@
     v-model:pagination="pagination"
     @row-click="onRowClick"
   >
+    <template #body-cell-subscriber="cell">
+      <q-td :props="cell">
+        <span v-if="cell.row.name">{{ cell.row.name }}</span>
+        <span v-else>
+          {{ shortenNpub(cell.row.npub) }}
+          <q-tooltip>{{ cell.row.npub }}</q-tooltip>
+        </span>
+      </q-td>
+    </template>
     <template #bottom="scope">
       <div class="q-table__bottom row items-center justify-end q-pa-sm">
         <q-pagination
@@ -40,6 +49,7 @@ import { useI18n } from "vue-i18n";
 import { useSubscribersStore } from "src/stores/subscribersStore";
 import { storeToRefs } from "pinia";
 import type { Subscriber } from "src/types/subscriber";
+import { shortenNpub } from "src/utils/clipboard";
 
 defineOptions({ name: "SubscribersTable" });
 

--- a/src/components/subscribers/SubscriptionsCharts.vue
+++ b/src/components/subscribers/SubscriptionsCharts.vue
@@ -1,13 +1,14 @@
 <template>
-  <q-expansion-item label="Insights" expand-separator>
-    <div class="row q-col-gutter-lg">
-      <q-card class="col-12">
+  <q-expansion-item label="Insights" expand-separator @show="redrawCharts">
+    <div class="row q-gutter-lg q-pa-sm">
+      <q-card class="col-12 col-md-4">
         <q-card-section>
           <div id="frequencyChartDesc" class="text-caption text-grey-7 q-mb-sm">
             Shows number of subscriptions by frequency.
           </div>
           <div style="height: 300px">
             <Pie
+              ref="frequencyChart"
               :data="frequencyData"
               :options="pieOptions"
               aria-label="Frequency distribution pie chart"
@@ -17,13 +18,14 @@
           </div>
         </q-card-section>
       </q-card>
-      <q-card class="col-12">
+      <q-card class="col-12 col-md-4">
         <q-card-section>
           <div id="statusChartDesc" class="text-caption text-grey-7 q-mb-sm">
             Shows number of subscriptions by status.
           </div>
           <div style="height: 300px">
             <Bar
+              ref="statusChart"
               :data="statusData"
               :options="barOptions"
               aria-label="Subscription status bar chart"
@@ -33,13 +35,14 @@
           </div>
         </q-card-section>
       </q-card>
-      <q-card class="col-12">
+      <q-card class="col-12 col-md-4">
         <q-card-section>
           <div id="newSubsChartDesc" class="text-caption text-grey-7 q-mb-sm">
             Shows new subscribers over the past week.
           </div>
           <div style="height: 300px">
             <Line
+              ref="newSubsChart"
               :data="newSubsData"
               :options="lineOptions"
               aria-label="New subscribers line chart"
@@ -54,7 +57,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import {
   Chart as ChartJS,
@@ -288,4 +291,14 @@ const lineOptions = computed(() => ({
     },
   },
 }));
+
+const frequencyChart = ref<any>(null);
+const statusChart = ref<any>(null);
+const newSubsChart = ref<any>(null);
+
+function redrawCharts() {
+  frequencyChart.value?.chart?.update();
+  statusChart.value?.chart?.update();
+  newSubsChart.value?.chart?.update();
+}
 </script>

--- a/src/pages/CreatorSubscribersPage.vue
+++ b/src/pages/CreatorSubscribersPage.vue
@@ -214,15 +214,6 @@
           </template>
         </q-virtual-scroll>
 
-        <q-menu ref="avatarMenuRef">
-          <q-list class="card-bg">
-            <q-item clickable v-close-popup @click="copyNpub(menuNpub)">
-              <q-item-section>{{
-                t("CreatorSubscribers.drawer.actions.copyNpub")
-              }}</q-item-section>
-            </q-item>
-          </q-list>
-        </q-menu>
       </q-page>
     </q-page-container>
     <SubscriberDrawer v-model="drawer" :subscriber="current" />
@@ -268,7 +259,6 @@ import {
 import { storeToRefs } from "pinia";
 import { useDebounceFn } from "@vueuse/core";
 import { useQuasar } from "quasar";
-import type { QMenu } from "quasar";
 import { useI18n } from "vue-i18n";
 import type { Subscriber, Frequency, SubStatus } from "src/types/subscriber";
 import downloadCsv from "src/utils/subscriberCsv";
@@ -278,7 +268,6 @@ import SubscriptionsCharts from "src/components/subscribers/SubscriptionsCharts.
 import KpiCard from "src/components/subscribers/KpiCard.vue";
 import SubscribersTable from "src/components/subscribers/SubscribersTable.vue";
 import SubscriberDrawer from "src/components/subscribers/SubscriberDrawer.vue";
-import { copyNpub } from "src/utils/clipboard";
 
 const { t } = useI18n();
 const $q = useQuasar();
@@ -594,12 +583,6 @@ const current = ref<Subscriber | null>(null);
 function openDrawer(r: Subscriber) {
   current.value = r;
   drawer.value = true;
-}
-const avatarMenuRef = ref<QMenu | null>(null);
-const menuNpub = ref("");
-function showAvatarMenu(e: Event, row: Subscriber) {
-  menuNpub.value = row.npub;
-  avatarMenuRef.value?.show(e);
 }
 </script>
 

--- a/src/utils/clipboard.ts
+++ b/src/utils/clipboard.ts
@@ -12,3 +12,8 @@ export async function copyNpub(npub: string) {
     Notify.create({ message: "Copy failed", color: "negative" });
   }
 }
+
+export function shortenNpub(npub: string) {
+  if (npub.length <= 12) return npub;
+  return `${npub.slice(0, 6)}…${npub.slice(-4)}`;
+}


### PR DESCRIPTION
## Summary
- Keep Insights charts inside panel and redraw on expand
- Remove unused Copy npub menu and shorten npubs in table/cards
- Hide full npub in drawer until expanded with copy button

## Testing
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: some tests failed)*

------
https://chatgpt.com/codex/tasks/task_e_689d75460da8833085d0305389af0253