### PR TITLE
Expand messenger layout and polish UX

### DIFF
--- a/src/components/ConversationListItem.vue
+++ b/src/components/ConversationListItem.vue
@@ -276,7 +276,6 @@ export default defineComponent({
 }
 
 .conversation-item .ellipsis {
-  flex: 1;
   min-width: 0;
 }
 

--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -2,6 +2,7 @@
   <q-header class="bg-transparent z-10">
     <q-toolbar>
       <q-btn
+        v-if="!isMessengerPage"
         flat
         dense
         round
@@ -21,13 +22,12 @@
         color="primary"
         aria-label="Back"
         no-caps
-        class="q-ml-sm"
+        class="q-mr-sm"
       >
         <span class="q-mx-md text-weight-bold">
           {{ $t("FullscreenHeader.actions.back.label") }}
         </span>
       </q-btn>
-      <q-toolbar-title></q-toolbar-title>
       <q-btn
         v-if="isMessengerPage"
         flat
@@ -39,6 +39,17 @@
         @click.stop="toggleMessengerDrawer"
         class="q-mr-sm"
       />
+      <q-toolbar-title class="row items-center">
+        <template v-if="isMessengerPage">
+          Nostr Messenger
+          <q-badge
+            :color="messenger.connected ? 'positive' : 'negative'"
+            class="q-ml-sm"
+          >
+            {{ messenger.connected ? 'Online' : 'Offline' }}
+          </q-badge>
+        </template>
+      </q-toolbar-title>
       <transition
         appear
         enter-active-class="animated wobble"

--- a/src/components/MessageList.vue
+++ b/src/components/MessageList.vue
@@ -2,10 +2,13 @@
   <q-scroll-area class="col column q-pa-md">
     <div
       v-if="messages.length === 0"
-      class="col flex flex-center text-grey-6"
+      class="col flex flex-center text-grey-6 q-my-xl"
       style="min-height: 150px"
     >
-      <span>No messages yet</span>
+      <div class="column items-center">
+        <q-icon name="chat_bubble_outline" size="48px" class="q-mb-sm" />
+        <span>No messages yet</span>
+      </div>
     </div>
     <template v-else v-for="(msg, idx) in messages" :key="msg.id">
       <div
@@ -52,6 +55,8 @@ watch(
 );
 
 const formatDate = (ts: number) => new Date(ts * 1000).toLocaleString();
+
+// TODO: consider using QVirtualScroll for better performance with long lists
 
 defineExpose({ formatDay, showDateSeparator });
 </script>

--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -10,7 +10,7 @@
         show-if-above
         :breakpoint="600"
         bordered
-        :width="drawerOpen ? 320 : 64"
+        :width="drawerOpen ? 360 : 64"
         class="drawer-transition drawer-container"
         :style="{ overflowX: 'hidden' }"
         :class="[
@@ -20,7 +20,7 @@
       >
         <template v-if="drawerOpen">
           <q-slide-transition>
-            <div class="column no-wrap full-height">
+            <div class="column no-wrap full-height drawer-content">
               <div class="row items-center justify-between q-mb-md">
                 <div class="text-subtitle1">Chats</div>
                 <q-btn flat dense round icon="add" @click="openNewChatDialog" />
@@ -79,25 +79,6 @@
     </q-responsive>
 
     <div :class="['col column', $q.screen.gt.xs ? 'q-pa-lg' : 'q-pa-md']">
-      <q-toolbar class="q-mb-md bg-transparent">
-        <q-btn
-          flat
-          round
-          dense
-          icon="menu"
-          @click="messenger.toggleDrawer()"
-        />
-        <q-btn flat round dense icon="arrow_back" @click="goBack" />
-        <q-toolbar-title class="text-h6 ellipsis">
-          Nostr Messenger
-          <q-badge
-            :color="messenger.connected ? 'positive' : 'negative'"
-            class="q-ml-sm"
-          >
-            {{ messenger.connected ? "Online" : "Offline" }}
-          </q-badge>
-        </q-toolbar-title>
-      </q-toolbar>
       <q-banner v-if="connecting && !loading" dense class="bg-grey-3">
         Connecting...
       </q-banner>
@@ -136,7 +117,7 @@ import {
   onUnmounted,
   watch,
 } from "vue";
-import { useRouter, useRoute } from "vue-router";
+import { useRoute } from "vue-router";
 import { useLocalStorage } from "@vueuse/core";
 import { useMessengerStore } from "src/stores/messenger";
 import { useNdk } from "src/composables/useNdk";
@@ -229,16 +210,7 @@ export default defineComponent({
       if (timer) clearInterval(timer);
     });
 
-    const router = useRouter();
     const route = useRoute();
-
-    const goBack = () => {
-      if (window.history.length > 1) {
-        router.back();
-      } else {
-        router.push("/wallet");
-      }
-    };
 
     const drawerOpen = computed(() => messenger.drawerOpen);
     const selected = ref("");
@@ -402,7 +374,6 @@ export default defineComponent({
       sendMessage,
       openSendTokenDialog,
       openNewChatDialog,
-      goBack,
       reconnectAll,
       connectedCount,
       totalRelays,
@@ -414,15 +385,21 @@ export default defineComponent({
 });
 </script>
 <style scoped>
-.q-toolbar {
-  flex-wrap: nowrap;
-}
 .drawer-transition {
   transition: width 0.3s;
 }
 
 .drawer-container {
   min-width: 0;
+}
+
+.drawer-content {
+  transition: opacity 0.3s, transform 0.3s;
+}
+
+.drawer-collapsed .drawer-content {
+  opacity: 0;
+  transform: translateX(-10px);
 }
 
 /* When the drawer is collapsed, only show the avatar */


### PR DESCRIPTION
## Summary
- widen messenger drawer and add fade/slide transitions
- show messenger title and status in global header
- add empty-state placeholder for message list
- ensure conversation items flex to prevent overflow

## Testing
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_689d810fee0c83309301f21668dd52d5