### PR TITLE
refactor: streamline messenger layout

### DIFF
--- a/src/components/ConversationListItem.vue
+++ b/src/components/ConversationListItem.vue
@@ -265,13 +265,9 @@ export default defineComponent({
   white-space: normal;
 }
 
-.name-section {
-  flex: 1;
-  min-width: 0;
-}
-
+.name-section,
 .snippet-section {
-  flex: 1;
+  flex: 1 1 auto;
   min-width: 0;
 }
 

--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -27,7 +27,17 @@
           {{ $t("FullscreenHeader.actions.back.label") }}
         </span>
       </q-btn>
-      <q-toolbar-title></q-toolbar-title>
+      <q-toolbar-title>
+        <template v-if="isMessengerPage">
+          Nostr Messenger
+          <q-badge
+            :color="messenger.connected ? 'positive' : 'negative'"
+            class="q-ml-sm"
+          >
+            {{ messenger.connected ? 'Online' : 'Offline' }}
+          </q-badge>
+        </template>
+      </q-toolbar-title>
       <q-btn
         v-if="isMessengerPage"
         flat

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -5,10 +5,7 @@
   >
     <MainHeader />
     <q-page-container class="text-body1">
-      <div v-if="!fullWidthRoute" class="max-w-7xl mx-auto">
-        <router-view />
-      </div>
-      <div v-else class="w-full">
+      <div :class="fullWidthRoute ? 'w-full' : 'max-w-7xl mx-auto'">
         <router-view />
       </div>
     </q-page-container>

--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -10,7 +10,7 @@
         show-if-above
         :breakpoint="600"
         bordered
-        :width="drawerOpen ? 320 : 64"
+        :width="drawerOpen ? 360 : 64"
         class="drawer-transition drawer-container"
         :style="{ overflowX: 'hidden' }"
         :class="[
@@ -79,25 +79,6 @@
     </q-responsive>
 
     <div :class="['col column', $q.screen.gt.xs ? 'q-pa-lg' : 'q-pa-md']">
-      <q-toolbar class="q-mb-md bg-transparent">
-        <q-btn
-          flat
-          round
-          dense
-          icon="menu"
-          @click="messenger.toggleDrawer()"
-        />
-        <q-btn flat round dense icon="arrow_back" @click="goBack" />
-        <q-toolbar-title class="text-h6 ellipsis">
-          Nostr Messenger
-          <q-badge
-            :color="messenger.connected ? 'positive' : 'negative'"
-            class="q-ml-sm"
-          >
-            {{ messenger.connected ? "Online" : "Offline" }}
-          </q-badge>
-        </q-toolbar-title>
-      </q-toolbar>
       <q-banner v-if="connecting && !loading" dense class="bg-grey-3">
         Connecting...
       </q-banner>
@@ -231,14 +212,6 @@ export default defineComponent({
 
     const router = useRouter();
     const route = useRoute();
-
-    const goBack = () => {
-      if (window.history.length > 1) {
-        router.back();
-      } else {
-        router.push("/wallet");
-      }
-    };
 
     const drawerOpen = computed(() => messenger.drawerOpen);
     const selected = ref("");
@@ -402,7 +375,6 @@ export default defineComponent({
       sendMessage,
       openSendTokenDialog,
       openNewChatDialog,
-      goBack,
       reconnectAll,
       connectedCount,
       totalRelays,


### PR DESCRIPTION
## Summary
- widen messenger drawer and remove local header
- allow messenger route to span full width
- show messenger status in main header
- flex conversation list item sections for natural text shrink

## Testing
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test:ci` *(fails: multiple failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_689d81133d788330bbb34e378be7933b