### PR TITLE
refactor: widen messenger drawer and unify header

### DIFF
--- a/src/components/ConversationListItem.vue
+++ b/src/components/ConversationListItem.vue
@@ -265,11 +265,7 @@ export default defineComponent({
   white-space: normal;
 }
 
-.name-section {
-  flex: 1;
-  min-width: 0;
-}
-
+.name-section,
 .snippet-section {
   flex: 1;
   min-width: 0;

--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -2,6 +2,7 @@
   <q-header class="bg-transparent z-10">
     <q-toolbar>
       <q-btn
+        v-if="!isMessengerPage"
         flat
         dense
         round
@@ -27,7 +28,19 @@
           {{ $t("FullscreenHeader.actions.back.label") }}
         </span>
       </q-btn>
-      <q-toolbar-title></q-toolbar-title>
+      <q-toolbar-title
+        v-if="isMessengerPage"
+        class="row items-center no-wrap"
+      >
+        Nostr Messenger
+        <q-badge
+          :color="messenger.connected ? 'positive' : 'negative'"
+          class="q-ml-sm"
+        >
+          {{ messenger.connected ? 'Online' : 'Offline' }}
+        </q-badge>
+      </q-toolbar-title>
+      <q-toolbar-title v-else></q-toolbar-title>
       <q-btn
         v-if="isMessengerPage"
         flat

--- a/src/components/MessageList.vue
+++ b/src/components/MessageList.vue
@@ -2,21 +2,29 @@
   <q-scroll-area class="col column q-pa-md">
     <div
       v-if="messages.length === 0"
-      class="col flex flex-center text-grey-6"
-      style="min-height: 150px"
+      class="col flex flex-center text-grey-6 empty-placeholder"
     >
-      <span>No messages yet</span>
+      <q-icon name="chat_bubble_outline" size="48px" class="q-mb-sm" />
+      <div class="text-subtitle1">No messages yet</div>
+      <div class="text-caption">Select a conversation to start chatting</div>
     </div>
-    <template v-else v-for="(msg, idx) in messages" :key="msg.id">
-      <div
-        v-if="showDateSeparator(idx)"
-        class="text-caption text-center q-my-md divider-text"
-      >
-        {{ formatDay(msg.created_at) }}
-      </div>
-      <ChatMessageBubble :message="msg" :delivery-status="msg.status" />
-    </template>
-    <div ref="bottom"></div>
+    <q-virtual-scroll
+      v-else
+      ref="virtScroll"
+      :items="messages"
+      virtual-scroll-slice-size="30"
+      class="col"
+    >
+      <template #default="{ item: msg, index: idx }">
+        <div
+          v-if="showDateSeparator(idx)"
+          class="text-caption text-center q-my-md divider-text"
+        >
+          {{ formatDay(msg.created_at) }}
+        </div>
+        <ChatMessageBubble :message="msg" :delivery-status="msg.status" />
+      </template>
+    </q-virtual-scroll>
   </q-scroll-area>
 </template>
 
@@ -26,7 +34,7 @@ import type { MessengerMessage } from "src/stores/messenger";
 import ChatMessageBubble from "./ChatMessageBubble.vue";
 
 const props = defineProps<{ messages: MessengerMessage[] }>();
-const bottom = ref<HTMLElement>();
+const virtScroll = ref<any>();
 
 function formatDay(ts: number) {
   const d = new Date(ts * 1000);
@@ -46,7 +54,9 @@ function showDateSeparator(idx: number) {
 watch(
   () => props.messages,
   () => {
-    nextTick(() => bottom.value?.scrollIntoView({ behavior: "smooth" }));
+    nextTick(() =>
+      virtScroll.value?.scrollTo(props.messages.length - 1),
+    );
   },
   { deep: true },
 );
@@ -55,3 +65,10 @@ const formatDate = (ts: number) => new Date(ts * 1000).toLocaleString();
 
 defineExpose({ formatDay, showDateSeparator });
 </script>
+
+<style scoped>
+.empty-placeholder {
+  min-height: 150px;
+  text-align: center;
+}
+</style>

--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -10,7 +10,7 @@
         show-if-above
         :breakpoint="600"
         bordered
-        :width="drawerOpen ? 320 : 64"
+        :width="drawerOpen ? 360 : 64"
         class="drawer-transition drawer-container"
         :style="{ overflowX: 'hidden' }"
         :class="[
@@ -20,7 +20,7 @@
       >
         <template v-if="drawerOpen">
           <q-slide-transition>
-            <div class="column no-wrap full-height">
+            <div class="column no-wrap full-height drawer-content">
               <div class="row items-center justify-between q-mb-md">
                 <div class="text-subtitle1">Chats</div>
                 <q-btn flat dense round icon="add" @click="openNewChatDialog" />
@@ -58,7 +58,7 @@
         <template v-else>
           <q-slide-transition>
             <div
-              class="column items-center q-gutter-md"
+              class="column items-center q-gutter-md mini-list"
               style="overflow-y: auto"
             >
               <q-avatar
@@ -79,25 +79,6 @@
     </q-responsive>
 
     <div :class="['col column', $q.screen.gt.xs ? 'q-pa-lg' : 'q-pa-md']">
-      <q-toolbar class="q-mb-md bg-transparent">
-        <q-btn
-          flat
-          round
-          dense
-          icon="menu"
-          @click="messenger.toggleDrawer()"
-        />
-        <q-btn flat round dense icon="arrow_back" @click="goBack" />
-        <q-toolbar-title class="text-h6 ellipsis">
-          Nostr Messenger
-          <q-badge
-            :color="messenger.connected ? 'positive' : 'negative'"
-            class="q-ml-sm"
-          >
-            {{ messenger.connected ? "Online" : "Offline" }}
-          </q-badge>
-        </q-toolbar-title>
-      </q-toolbar>
       <q-banner v-if="connecting && !loading" dense class="bg-grey-3">
         Connecting...
       </q-banner>
@@ -136,7 +117,7 @@ import {
   onUnmounted,
   watch,
 } from "vue";
-import { useRouter, useRoute } from "vue-router";
+import { useRoute } from "vue-router";
 import { useLocalStorage } from "@vueuse/core";
 import { useMessengerStore } from "src/stores/messenger";
 import { useNdk } from "src/composables/useNdk";
@@ -229,16 +210,7 @@ export default defineComponent({
       if (timer) clearInterval(timer);
     });
 
-    const router = useRouter();
     const route = useRoute();
-
-    const goBack = () => {
-      if (window.history.length > 1) {
-        router.back();
-      } else {
-        router.push("/wallet");
-      }
-    };
 
     const drawerOpen = computed(() => messenger.drawerOpen);
     const selected = ref("");
@@ -402,7 +374,6 @@ export default defineComponent({
       sendMessage,
       openSendTokenDialog,
       openNewChatDialog,
-      goBack,
       reconnectAll,
       connectedCount,
       totalRelays,
@@ -414,11 +385,18 @@ export default defineComponent({
 });
 </script>
 <style scoped>
-.q-toolbar {
-  flex-wrap: nowrap;
-}
 .drawer-transition {
   transition: width 0.3s;
+}
+
+.drawer-content,
+.mini-list q-avatar {
+  transition: opacity 0.3s, transform 0.3s;
+}
+
+.drawer-collapsed .drawer-content {
+  opacity: 0;
+  transform: translateX(-20px);
 }
 
 .drawer-container {


### PR DESCRIPTION
## Summary
- widen Nostr Messenger drawer to 360px with animated collapse
- show messenger title and connection status in global header
- add empty-state and virtual scrolling to message list
- simplify conversation item layout with flex shrink

## Testing
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: 31 failed tests, 11 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689d810fee0c83309301f21668dd52d5