### PR TITLE
Expose messenger store in MainHeader

### DIFF
--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -487,6 +487,7 @@ export default defineComponent({
       countdown,
       reloading,
       uiStore,
+      messenger,
       gotoBuckets,
       gotoFindCreators,
       gotoCreatorHub,


### PR DESCRIPTION
## Summary
- expose messenger store from MainHeader setup so template can check connection status

## Testing
- `pnpm lint src/components/MainHeader.vue` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: Failed to parse P2PK secret JSON: Error: bad point: not on curve)*

------
https://chatgpt.com/codex/tasks/task_e_689d89c1389083309e5f230d400d754d