### PR TITLE
Improve messenger drawer layout and conversation list UX

### DIFF
--- a/src/components/ConversationList.vue
+++ b/src/components/ConversationList.vue
@@ -15,6 +15,9 @@
           :avatar="item.avatar"
           :online="item.online"
           :starred="item.starred"
+          :selected="selectedPubkey === item.pubkey"
+          :unread-count="unreadCounts[item.pubkey]"
+          :comfy-mode="comfyMode"
           @click="select(item.pubkey)"
         />
         <q-separator v-if="filteredRegular.length" spaced />
@@ -33,6 +36,9 @@
         :avatar="item.avatar"
         :online="item.online"
         :starred="item.starred"
+        :selected="selectedPubkey === item.pubkey"
+        :unread-count="unreadCounts[item.pubkey]"
+        :comfy-mode="comfyMode"
         @click="select(item.pubkey)"
       />
       <div
@@ -50,6 +56,7 @@ import { computed, watch, onMounted, ref } from "vue";
 import { storeToRefs } from "pinia";
 import { useMessengerStore } from "src/stores/messenger";
 import { useNostrStore } from "src/stores/nostr";
+import { useMessengerUiStore } from "src/stores/messengerUi";
 import { nip19 } from "nostr-tools";
 import { formatDistanceToNow } from "date-fns";
 import ChatListItem from "src/components/messenger/ChatListItem.vue";
@@ -59,7 +66,8 @@ const props = defineProps<{ selectedPubkey: string; search?: string }>();
 const emit = defineEmits(["select"]);
 const messenger = useMessengerStore();
 const nostr = useNostrStore();
-const { conversations } = storeToRefs(messenger);
+const ui = useMessengerUiStore();
+const { conversations, unreadCounts } = storeToRefs(messenger);
 const filterQuery = ref(props.search || "");
 watch(
   () => props.search,
@@ -132,4 +140,6 @@ onMounted(loadProfiles);
 watch(enrichedConversations, loadProfiles);
 
 const select = (pubkey: string) => emit("select", nostr.resolvePubkey(pubkey));
+
+const comfyMode = computed(() => ui.comfyMode);
 </script>

--- a/src/components/messenger/ChatListItem.vue
+++ b/src/components/messenger/ChatListItem.vue
@@ -1,10 +1,22 @@
 <template>
-  <q-item clickable dense class="h-14">
+  <q-item
+    clickable
+    :dense="!comfyMode"
+    :class="['h-14', selected && 'bg-primary text-white', comfyMode && 'q-pt-sm q-pb-sm']"
+    :active="selected"
+  >
     <!-- Left: avatar + presence -->
     <q-item-section avatar>
       <q-avatar size="36px">
         <img v-if="avatar" :src="avatar" alt="" />
         <span v-else>{{ initials }}</span>
+        <q-badge
+          v-if="unreadCount"
+          color="accent"
+          floating
+          rounded
+          :label="unreadCount"
+        />
       </q-avatar>
       <div class="presence-dot" :class="online ? 'bg-positive' : 'bg-grey-6'"></div>
     </q-item-section>
@@ -44,11 +56,17 @@ const props = defineProps<{
   avatar?: string;
   online?: boolean;
   starred?: boolean;
+  selected?: boolean;
+  unreadCount?: number;
+  comfyMode?: boolean;
 }>();
 
 const displayName = computed(() => props.name || shortNpub(props.npub || ""));
 const preview = computed(() => previewText(props.lastMessage || ""));
 const initials = computed(() => (props.name || props.npub || "?").slice(0, 1).toUpperCase());
+const selected = computed(() => props.selected || false);
+const unreadCount = computed(() => props.unreadCount || 0);
+const comfyMode = computed(() => props.comfyMode || false);
 </script>
 
 <style scoped>

--- a/src/stores/messenger.ts
+++ b/src/stores/messenger.ts
@@ -23,6 +23,7 @@ import tokenUtil from "src/js/token";
 import { subscriptionPayload } from "src/utils/receipt-utils";
 import { useCreatorsStore } from "./creators";
 import { frequencyToDays } from "src/constants/subscriptionFrequency";
+import { useMessengerUiStore } from "./messengerUi";
 
 function parseSubscriptionPaymentPayload(obj: any):
   | {
@@ -833,10 +834,18 @@ export const useMessengerStore = defineStore("messenger", {
 
     toggleDrawer() {
       this.drawerOpen = !this.drawerOpen;
+      try {
+        const ui = useMessengerUiStore();
+        ui.setOpen(this.drawerOpen);
+      } catch {}
     },
 
     setDrawer(open: boolean) {
       this.drawerOpen = open;
+      try {
+        const ui = useMessengerUiStore();
+        ui.setOpen(open);
+      } catch {}
     },
   },
 });

--- a/src/stores/messengerUi.ts
+++ b/src/stores/messengerUi.ts
@@ -1,0 +1,20 @@
+import { defineStore } from 'pinia'
+import { useLocalStorage } from '@vueuse/core'
+
+export const useMessengerUiStore = defineStore('messengerUi', {
+  state: () => ({
+    drawerOpen: useLocalStorage<boolean>('cashu.messenger.drawerOpen', true),
+    drawerMini: false,
+    drawerWidth: 320,
+    drawerMiniWidth: 68,
+    comfyMode: useLocalStorage<boolean>('cashu.messenger.comfyMode', false)
+  }),
+  getters: {
+    effectiveDrawerWidth: (s) => (s.drawerOpen ? (s.drawerMini ? s.drawerMiniWidth : s.drawerWidth) : 0)
+  },
+  actions: {
+    toggleDrawer() { this.drawerOpen = !this.drawerOpen },
+    setMini(val: boolean) { this.drawerMini = val },
+    setOpen(val: boolean) { this.drawerOpen = val }
+  }
+})


### PR DESCRIPTION
## Summary
- introduce messenger UI store to centralize drawer state
- highlight active chats and show unread badges in conversation list
- refactor messenger page layout for responsive push/overlay drawer

## Testing
- `pnpm lint src/components/messenger/ChatListItem.vue src/components/ConversationList.vue src/pages/NostrMessenger.vue src/stores/messengerUi.ts src/stores/messenger.ts` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm types`
- `pnpm test` *(fails: LockedTokens store > deletes token, adds many tokens)*

------
https://chatgpt.com/codex/tasks/task_e_689dcb58886c83309aabaee68d7984dd