### PR TITLE
feat(messenger): add mini drawer mode

### DIFF
--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -376,10 +376,10 @@ export default defineComponent({
     });
 
     const toggleMessengerDrawer = () => {
-      console.log("toggleMessengerDrawer", messenger.drawerOpen);
+      console.log("toggleMessengerDrawer", messenger.drawerMini);
       messenger.toggleDrawer();
       vm?.notify(
-        messenger.drawerOpen ? "Messenger closed" : "Messenger opened",
+        messenger.drawerMini ? "Messenger collapsed" : "Messenger expanded",
       );
     };
 

--- a/src/constants/localStorageKeys.ts
+++ b/src/constants/localStorageKeys.ts
@@ -15,6 +15,7 @@ export const LOCAL_STORAGE_KEYS = {
   CASHU_LOCKEDTOKENS: "cashu.lockedTokens",
   CASHU_MESSENGER_CONVERSATIONS: "cashu.messenger.conversations",
   CASHU_MESSENGER_DRAWEROPEN: "cashu.messenger.drawerOpen",
+  CASHU_MESSENGER_DRAWERMINI: "cashu.messenger.drawerMini",
   CASHU_MESSENGER_EVENTLOG: "cashu.messenger.eventLog",
   CASHU_MESSENGER_PINNED: "cashu.messenger.pinned",
   CASHU_MESSENGER_UNREAD: "cashu.messenger.unread",

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -6,6 +6,8 @@
     <MainHeader />
     <q-drawer
       v-model="messenger.drawerOpen"
+      :mini="messenger.drawerMini"
+      mini-width="64"
       side="left"
       show-if-above
       :breakpoint="600"

--- a/src/stores/messenger.ts
+++ b/src/stores/messenger.ts
@@ -104,6 +104,7 @@ export const useMessengerStore = defineStore("messenger", {
       sendQueue: [] as MessengerMessage[],
       currentConversation: "",
       drawerOpen: useLocalStorage<boolean>("cashu.messenger.drawerOpen", true),
+      drawerMini: useLocalStorage<boolean>("cashu.messenger.drawerMini", false),
       started: false,
       watchInitialized: false,
     };
@@ -797,7 +798,7 @@ export const useMessengerStore = defineStore("messenger", {
     },
 
     toggleDrawer() {
-      this.drawerOpen = !this.drawerOpen;
+      this.drawerMini = !this.drawerMini;
     },
 
     setDrawer(open: boolean) {


### PR DESCRIPTION
## Summary
- add mini state to messenger drawer with 64px width
- toggle mini mode from messenger store and header
- record drawer mini state in local storage

## Testing
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: 38 failed, 10 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689e228be6f08330ac69a36f9d54e4dd