### PR TITLE
feat: improve mobile chat drawer

### DIFF
--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -12,6 +12,8 @@
       show-if-above
       :breakpoint="600"
       bordered
+      :behavior="$q.screen.lt.md ? 'mobile' : 'default'"
+      :overlay="$q.screen.lt.md"
       :class="$q.screen.gt.xs ? 'q-pa-lg column' : 'q-pa-md column'"
     >
       <div class="column no-wrap full-height">
@@ -60,6 +62,7 @@
 <script>
 import { defineComponent, ref } from "vue";
 import { useRouter } from "vue-router";
+import { useQuasar } from "quasar";
 import MainHeader from "components/MainHeader.vue";
 import ConversationList from "components/ConversationList.vue";
 import UserInfo from "components/UserInfo.vue";
@@ -82,6 +85,7 @@ export default defineComponent({
     const router = useRouter();
     const conversationSearch = ref("");
     const newChatDialogRef = ref(null);
+    const $q = useQuasar();
 
     const openNewChatDialog = () => {
       newChatDialogRef.value?.show();
@@ -90,6 +94,9 @@ export default defineComponent({
     const selectConversation = (pubkey) => {
       messenger.markRead(pubkey);
       messenger.setCurrentConversation(pubkey);
+      if ($q.screen.lt.md) {
+        messenger.setDrawer(false);
+      }
       if (router.currentRoute.value.path !== "/nostr-messenger") {
         router.push("/nostr-messenger");
       }

--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -2,6 +2,7 @@
   <q-page
     class="row full-height no-horizontal-scroll"
     :class="[$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark']"
+    v-touch-swipe.right="openDrawer"
   >
     <div :class="['col column', $q.screen.gt.xs ? 'q-pa-lg' : 'q-pa-md']">
       <q-header elevated class="q-mb-md bg-transparent">
@@ -11,7 +12,7 @@
             round
             dense
             icon="menu"
-            @click="messenger.toggleDrawer()"
+            @click="toggleDrawer"
           />
           <q-btn flat round dense icon="arrow_back" @click="goBack" />
           <q-toolbar-title class="text-h6 ellipsis">
@@ -49,6 +50,15 @@
       <MessageInput @send="sendMessage" @sendToken="openSendTokenDialog" />
       <ChatSendTokenDialog ref="chatSendTokenDialogRef" :recipient="selected" />
     </div>
+    <q-btn
+      v-if="$q.screen.lt.md && !messenger.drawerOpen"
+      fab
+      icon="menu"
+      color="primary"
+      class="fixed bottom-left"
+      style="bottom: 16px; left: 16px"
+      @click="openDrawer"
+    />
   </q-page>
   <NostrSetupWizard v-model="showSetupWizard" @complete="setupComplete" />
 </template>
@@ -73,9 +83,11 @@ import MessageList from "components/MessageList.vue";
 import MessageInput from "components/MessageInput.vue";
 import ChatSendTokenDialog from "components/ChatSendTokenDialog.vue";
 import NostrSetupWizard from "components/NostrSetupWizard.vue";
+import { useQuasar, TouchSwipe } from "quasar";
 
 export default defineComponent({
   name: "NostrMessenger",
+  directives: { TouchSwipe },
   components: {
     ActiveChatHeader,
     MessageList,
@@ -89,6 +101,7 @@ export default defineComponent({
     const messenger = useMessengerStore();
     const nostr = useNostrStore();
     const showSetupWizard = ref(false);
+    const $q = useQuasar();
 
     const ndkRef = ref<NDK | null>(null);
     const now = ref(Date.now());
@@ -154,6 +167,20 @@ export default defineComponent({
         router.back();
       } else {
         router.push("/wallet");
+      }
+    };
+
+    const openDrawer = () => {
+      if ($q.screen.lt.md) {
+        messenger.setDrawer(true);
+      }
+    };
+
+    const toggleDrawer = () => {
+      if ($q.screen.lt.md) {
+        messenger.setDrawer(true);
+      } else {
+        messenger.toggleDrawer();
       }
     };
 
@@ -257,6 +284,8 @@ export default defineComponent({
       totalRelays,
       nextReconnectIn,
       setupComplete,
+      openDrawer,
+      toggleDrawer,
     };
   },
 });


### PR DESCRIPTION
## Summary
- overlay messenger drawer on small screens
- auto-close drawer when opening conversations on mobile
- add swipe and floating button to reopen drawer

## Testing
- `pnpm test` *(fails: Cannot read properties of undefined (reading 'relays'))*

------
https://chatgpt.com/codex/tasks/task_e_689e261d24d4833092efdbfa72d87a6f