### PR TITLE
Improve chat bubble styling and avatar logic

### DIFF
--- a/src/components/MessageList.vue
+++ b/src/components/MessageList.vue
@@ -7,7 +7,11 @@
       >
         {{ formatDay(msg.created_at) }}
       </div>
-      <ChatMessageBubble :message="msg" :delivery-status="msg.status" />
+      <ChatMessageBubble
+        :message="msg"
+        :delivery-status="msg.status"
+        :prev-message="messages[idx - 1]"
+      />
     </template>
     <div ref="bottom"></div>
   </q-scroll-area>


### PR DESCRIPTION
## Summary
- add drop-shadowed incoming/outgoing bubble styles with distinct colors and rounded corners
- hide avatars for consecutive messages by the same author
- pass previous message from message list to determine avatar visibility

## Testing
- `pnpm run lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: multiple failing test suites)*

------
https://chatgpt.com/codex/tasks/task_e_689e2b1ee8188330a9b6de5ce2fea99e