### PR TITLE
refactor: centralize messenger bubble styles

### DIFF
--- a/src/components/ChatMessageBubble.vue
+++ b/src/components/ChatMessageBubble.vue
@@ -285,27 +285,29 @@ async function updateAutoRedeem(val: boolean) {
 
 <style scoped>
 .message-row {
-  margin: 4px 0;
+  margin: var(--messenger-message-row-margin);
 }
 
 .bubble {
-  padding: 16px;
+  padding: var(--messenger-bubble-padding);
   max-width: 70%;
   word-break: break-word;
-  margin: 2px 0;
+  margin: var(--messenger-bubble-margin);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  font-family: var(--messenger-font-family);
+  font-size: var(--messenger-font-size);
 }
 
 .bubble-outgoing {
-  background-color: var(--q-primary);
-  color: #ffffff;
-  border-radius: 12px 0 12px 12px;
+  background-color: var(--messenger-bubble-outgoing-bg);
+  color: var(--messenger-bubble-outgoing-color);
+  border-radius: var(--messenger-bubble-outgoing-radius);
 }
 
 .bubble-incoming {
-  background-color: var(--q-secondary);
-  color: #000000;
-  border-radius: 0 12px 12px 12px;
+  background-color: var(--messenger-bubble-incoming-bg);
+  color: var(--messenger-bubble-incoming-color);
+  border-radius: var(--messenger-bubble-incoming-radius);
 }
 
 .token-wrapper {

--- a/src/css/messenger.scss
+++ b/src/css/messenger.scss
@@ -1,0 +1,18 @@
+:root {
+  --messenger-bubble-padding: 16px;
+  --messenger-bubble-margin: 2px 0;
+  --messenger-message-row-margin: 4px 0;
+  --messenger-font-size: 1rem;
+  --messenger-font-family: var(--font-family-base, sans-serif);
+  --messenger-bubble-outgoing-bg: var(--q-primary);
+  --messenger-bubble-outgoing-color: #ffffff;
+  --messenger-bubble-outgoing-radius: 12px 0 12px 12px;
+  --messenger-bubble-incoming-bg: var(--q-secondary);
+  --messenger-bubble-incoming-color: #000000;
+  --messenger-bubble-incoming-radius: 0 12px 12px 12px;
+}
+
+body.body--dark {
+  --messenger-bubble-incoming-bg: var(--q-color-grey-8);
+  --messenger-bubble-incoming-color: #ffffff;
+}

--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -308,9 +308,13 @@ export default defineComponent({
   },
 });
 </script>
+<style lang="scss">
+@import "../css/messenger.scss";
+</style>
+
 <style scoped>
 .q-toolbar {
   flex-wrap: nowrap;
 }
-  
+
 </style>


### PR DESCRIPTION
## Summary
- centralize messenger bubble color, spacing and typography vars
- apply CSS variables to chat bubbles and import stylesheet in messenger page

## Testing
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_689e3368dc6c8330b3ba465476c56387