### PR TITLE
feat: widen chat drawer and streamline list items

### DIFF
--- a/src/components/ConversationListItem.vue
+++ b/src/components/ConversationListItem.vue
@@ -239,6 +239,7 @@ export default defineComponent({
   display: flex;
   gap: 10px;
   border-left: 3px solid transparent;
+  overflow-x: hidden;
 }
 .conversation-item.selected {
   background-color: color-mix(in srgb, var(--q-primary), transparent 92%);
@@ -265,12 +266,10 @@ export default defineComponent({
   white-space: normal;
 }
 
-.name-section {
-  max-width: 40%;
-}
-
+.name-section,
 .snippet-section {
-  max-width: 35%;
+  flex: 1;
+  min-width: 0;
 }
 
 .conversation-item .ellipsis {

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -8,6 +8,7 @@
       v-model="messenger.drawerOpen"
       :mini="messenger.drawerMini"
       mini-width="64"
+      :width="360"
       side="left"
       show-if-above
       :breakpoint="600"


### PR DESCRIPTION
## Summary
- widen messenger drawer to 360px for better content display
- simplify conversation list item layout using flex widths and hidden overflow to prevent horizontal scroll

## Testing
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: 38 failed, 10 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689e4038318883308b0a7aed46a8860c