### PR TITLE
Improve messenger drawer responsiveness

### DIFF
--- a/src/components/ConversationListItem.vue
+++ b/src/components/ConversationListItem.vue
@@ -277,6 +277,9 @@ export default defineComponent({
   min-width: 0;
 }
 
+.drawer-collapsed .conversation-item .name-section,
+.drawer-collapsed .conversation-item .snippet-section,
+.drawer-collapsed .conversation-item .timestamp-section,
 .drawer-collapsed .conversation-item .ellipsis {
   display: none;
 }

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -7,15 +7,19 @@
     <q-drawer
       v-model="messenger.drawerOpen"
       :mini="messenger.drawerMini"
-      mini-width="64"
-      :width="360"
+      mini-width="80"
+      :width="$q.screen.lt.md ? 260 : 320"
       side="left"
       show-if-above
       :breakpoint="600"
       bordered
       :behavior="$q.screen.lt.md ? 'mobile' : 'default'"
       :overlay="$q.screen.lt.md"
-      :class="$q.screen.gt.xs ? 'q-pa-lg column' : 'q-pa-md column'"
+      :class="[
+        $q.screen.gt.xs ? 'q-pa-lg column' : 'q-pa-md column',
+        { 'drawer-collapsed': messenger.drawerMini }
+      ]"
+      style="overflow-x: hidden"
     >
       <div class="column no-wrap full-height">
         <div class="row items-center justify-between q-mb-md">


### PR DESCRIPTION
## Summary
- Adjust drawer to use wider mini-width and responsive full width
- Add `drawer-collapsed` class and hide text sections when the drawer is collapsed
- Suppress horizontal scrollbars on the drawer

## Testing
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: Failed to parse P2PK secret JSON and other test errors)*

------
https://chatgpt.com/codex/tasks/task_e_689e4364d5e083309242e7506b6f451f