### PR TITLE
fix(messenger-drawer): remove horizontal scroll and ease cramped layout

### DIFF
--- a/src/components/ConversationList.vue
+++ b/src/components/ConversationList.vue
@@ -12,7 +12,7 @@
       :items="virtualItems"
       :virtual-scroll-sizes="virtualSizes"
       :virtual-scroll-item-size="ITEM_HEIGHT"
-      class="full-width"
+      class="full-width conversation-vscroll"
     >
       <template v-slot="{ item }">
         <q-item-label
@@ -159,3 +159,15 @@ const deleteConversation = (pubkey: string) => {
   messenger.deleteConversation(nostr.resolvePubkey(pubkey));
 };
 </script>
+
+<style scoped>
+/* Ensure 100% width includes the 1px border on each side; prevents side overflow */
+.conversation-vscroll {
+  box-sizing: border-box;
+  width: 100%;
+}
+/* Extra safety in case the wrapper uses flex */
+:host {
+  min-width: 0;
+}
+</style>

--- a/src/components/ConversationListItem.vue
+++ b/src/components/ConversationListItem.vue
@@ -264,6 +264,9 @@ export default defineComponent({
   font-size: 0.7rem;
   line-height: 1.2;
   white-space: normal;
+  /* allow long tokens/npubs/URLs to break without creating horizontal scroll */
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .name-section,
@@ -303,7 +306,7 @@ export default defineComponent({
 }
 
 .timestamp-section {
-  min-width: 56px;
+  min-width: 48px;
   text-align: right;
 }
 </style>

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -8,7 +8,7 @@
       v-model="messenger.drawerOpen"
       :mini="messenger.drawerMini"
       mini-width="80"
-      :width="$q.screen.lt.md ? 260 : 320"
+      :width="$q.screen.lt.md ? 300 : 340"
       side="left"
       show-if-above
       :breakpoint="600"
@@ -16,7 +16,7 @@
       :behavior="$q.screen.lt.md ? 'mobile' : 'default'"
       :overlay="$q.screen.lt.md"
       :class="[
-        $q.screen.gt.xs ? 'q-pa-lg column' : 'q-pa-md column',
+        'q-pa-md column messenger-drawer',
         { 'drawer-collapsed': messenger.drawerMini }
       ]"
       style="overflow-x: hidden"
@@ -38,7 +38,7 @@
             <q-icon name="search" />
           </template>
         </q-input>
-        <q-scroll-area class="col" style="min-height: 0">
+        <q-scroll-area class="col" style="min-height: 0; min-width: 0">
           <Suspense>
             <template #default>
               <ConversationList
@@ -129,3 +129,20 @@ export default defineComponent({
   },
 });
 </script>
+
+<style scoped>
+/* Prevent any internal content from creating side scroll inside this drawer */
+.messenger-drawer :deep(.q-drawer__content) {
+  overflow-x: hidden;
+}
+.messenger-drawer :deep(.q-scrollarea) {
+  overflow-x: hidden;
+}
+/* Safety: let flex children shrink to avoid overflow */
+.messenger-drawer :deep(.column),
+.messenger-drawer :deep(.row),
+.messenger-drawer :deep(.col) {
+  min-width: 0;
+  box-sizing: border-box;
+}
+</style>


### PR DESCRIPTION
## Summary
- widen messenger drawer and normalize padding
- prevent horizontal overflow inside drawer and virtual scroll
- wrap long snippets and relax timestamp width

## Testing
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: multiple failing suites)*

------
https://chatgpt.com/codex/tasks/task_e_689ed265fa188330967fcfd008aa1c37