### PR TITLE
style: tweak messenger drawer

### DIFF
--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -8,7 +8,7 @@
       v-model="messenger.drawerOpen"
       :mini="messenger.drawerMini"
       mini-width="80"
-      :width="$q.screen.lt.md ? 260 : 320"
+      :width="$q.screen.lt.md ? 300 : 340"
       side="left"
       show-if-above
       :breakpoint="600"
@@ -16,7 +16,7 @@
       :behavior="$q.screen.lt.md ? 'mobile' : 'default'"
       :overlay="$q.screen.lt.md"
       :class="[
-        $q.screen.gt.xs ? 'q-pa-lg column' : 'q-pa-md column',
+        'q-pa-md column messenger-drawer',
         { 'drawer-collapsed': messenger.drawerMini }
       ]"
       style="overflow-x: hidden"
@@ -38,7 +38,7 @@
             <q-icon name="search" />
           </template>
         </q-input>
-        <q-scroll-area class="col" style="min-height: 0">
+        <q-scroll-area class="col" style="min-height: 0; min-width: 0">
           <Suspense>
             <template #default>
               <ConversationList
@@ -129,3 +129,17 @@ export default defineComponent({
   },
 });
 </script>
+
+<style scoped>
+.messenger-drawer :deep(.q-drawer__content),
+.messenger-drawer :deep(.q-scrollarea) {
+  overflow-x: hidden;
+}
+
+.messenger-drawer :deep(.column),
+.messenger-drawer :deep(.row),
+.messenger-drawer :deep(.col) {
+  min-width: 0;
+  box-sizing: border-box;
+}
+</style>


### PR DESCRIPTION
## Summary
- adjust messenger drawer width and classes
- hide horizontal overflow and ensure columns have min-width

## Testing
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: TypeError: Cannot spy on export "useQuasar". Module namespace is not configurable in ESM.)*

------
https://chatgpt.com/codex/tasks/task_e_689ed4d955b083308f9c203c3d7df778