### PR TITLE
fix: improve messenger drawer layout

### DIFF
--- a/src/components/ConversationList.vue
+++ b/src/components/ConversationList.vue
@@ -12,7 +12,7 @@
       :items="virtualItems"
       :virtual-scroll-sizes="virtualSizes"
       :virtual-scroll-item-size="ITEM_HEIGHT"
-      class="full-width"
+      class="full-width conversation-vscroll"
     >
       <template v-slot="{ item }">
         <q-item-label
@@ -158,4 +158,18 @@ const togglePin = (pubkey: string) => {
 const deleteConversation = (pubkey: string) => {
   messenger.deleteConversation(nostr.resolvePubkey(pubkey));
 };
+
 </script>
+
+<style scoped>
+/* Ensure 100% width includes the 1px borders; prevents side overflow */
+.conversation-vscroll {
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 100%;
+}
+/* Safety if a flex wrapper is around */
+:host {
+  min-width: 0;
+}
+</style>

--- a/src/components/ConversationListItem.vue
+++ b/src/components/ConversationListItem.vue
@@ -264,6 +264,15 @@ export default defineComponent({
   font-size: 0.7rem;
   line-height: 1.2;
   white-space: normal;
+  /* Allow single long "words" (tokens/npubs/URLs) to wrap within the column */
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  /* Keep visual height predictable for virtualization: clamp to 2 lines */
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  max-height: calc(1.2em * 2);
 }
 
 .name-section,
@@ -303,7 +312,13 @@ export default defineComponent({
 }
 
 .timestamp-section {
-  min-width: 56px;
+  min-width: 48px;
   text-align: right;
+}
+
+/* Let the controls cluster fit-content instead of forcing extra width */
+:deep(.q-item__section[side]) {
+  flex: 0 0 auto;
+  min-width: fit-content;
 }
 </style>

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -8,7 +8,7 @@
       v-model="messenger.drawerOpen"
       :mini="messenger.drawerMini"
       mini-width="80"
-      :width="$q.screen.lt.md ? 300 : 340"
+      :width="computedDrawerWidth"
       side="left"
       show-if-above
       :breakpoint="600"
@@ -53,6 +53,14 @@
         </q-scroll-area>
         <UserInfo />
       </div>
+      <!-- Desktop resizer handle (hidden on <md and when mini) -->
+      <div
+        v-if="$q.screen.gt.sm && !messenger.drawerMini"
+        class="drawer-resizer"
+        @mousedown="onResizeStart"
+        aria-label="Resize conversations panel"
+        title="Drag to resize"
+      />
     </q-drawer>
     <q-page-container class="text-body1">
       <div class="max-w-7xl mx-auto">
@@ -64,9 +72,9 @@
 </template>
 
 <script>
-import { defineComponent, ref } from "vue";
+import { defineComponent, ref, computed, watch } from "vue";
 import { useRouter } from "vue-router";
-import { useQuasar } from "quasar";
+import { useQuasar, LocalStorage } from "quasar";
 import MainHeader from "components/MainHeader.vue";
 import ConversationList from "components/ConversationList.vue";
 import UserInfo from "components/UserInfo.vue";
@@ -90,6 +98,57 @@ export default defineComponent({
     const conversationSearch = ref("");
     const newChatDialogRef = ref(null);
     const $q = useQuasar();
+
+    const DEFAULT_DESKTOP = 360;
+    const DEFAULT_TABLET = 300;
+    const MIN_W = 280;
+    const MAX_W = 520;
+
+    const saved = LocalStorage.getItem("cashu.messenger.drawerWidth") as
+      | number
+      | null;
+    const drawerWidth = ref<number>(
+      typeof saved === "number"
+        ? saved
+        : $q.screen.lt.md
+          ? DEFAULT_TABLET
+          : DEFAULT_DESKTOP,
+    );
+
+    const computedDrawerWidth = computed(() => {
+      if ($q.screen.lt.md) return Math.max(MIN_W, Math.min(drawerWidth.value, 400));
+      return Math.max(MIN_W, Math.min(drawerWidth.value, MAX_W));
+    });
+
+    watch(drawerWidth, (val) => {
+      LocalStorage.set("cashu.messenger.drawerWidth", val);
+    });
+    watch(
+      () => $q.screen.lt.md,
+      (isLt) => {
+        if (isLt && drawerWidth.value > 400) drawerWidth.value = DEFAULT_TABLET;
+        if (!isLt && drawerWidth.value < MIN_W) drawerWidth.value = DEFAULT_DESKTOP;
+      },
+    );
+
+    // Drag-to-resize
+    let startX = 0;
+    let startW = 0;
+    const onMouseMove = (e: MouseEvent) => {
+      const dx = e.clientX - startX;
+      drawerWidth.value = startW + dx;
+    };
+    const onMouseUp = () => {
+      window.removeEventListener("mousemove", onMouseMove);
+      window.removeEventListener("mouseup", onMouseUp);
+    };
+    const onResizeStart = (e: MouseEvent) => {
+      startX = e.clientX;
+      startW = drawerWidth.value;
+      window.addEventListener("mousemove", onMouseMove);
+      window.addEventListener("mouseup", onMouseUp);
+      e.preventDefault();
+    };
 
     const openNewChatDialog = () => {
       newChatDialogRef.value?.show();
@@ -118,6 +177,8 @@ export default defineComponent({
       openNewChatDialog,
       selectConversation,
       startChat,
+      computedDrawerWidth,
+      onResizeStart,
     };
   },
   async mounted() {
@@ -130,6 +191,7 @@ export default defineComponent({
 </script>
 
 <style scoped>
+/* Keep any internal content from creating side scroll */
 .messenger-drawer :deep(.q-drawer__content),
 .messenger-drawer :deep(.q-scrollarea) {
   overflow-x: hidden;
@@ -140,5 +202,33 @@ export default defineComponent({
 .messenger-drawer :deep(.col) {
   min-width: 0;
   box-sizing: border-box;
+}
+
+/* Desktop resizer handle */
+.drawer-resizer {
+  position: absolute;
+  top: 0;
+  right: -4px;
+  width: 8px;
+  height: 100%;
+  cursor: col-resize;
+  z-index: 3;
+}
+.drawer-resizer::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  right: 2px;
+  transform: translateY(-50%);
+  width: 2px;
+  height: 32px;
+  border-radius: 2px;
+  background: currentColor;
+  opacity: 0.25;
+}
+@media (max-width: 1023px) {
+  .drawer-resizer {
+    display: none;
+  }
 }
 </style>


### PR DESCRIPTION
## Summary
- prevent conversation list overflow by box-sizing the virtual scroll container
- wrap long conversation snippets and relax timestamp sizing
- make messenger drawer resizable with persisted width

## Testing
- `pnpm exec eslint src/components/ConversationList.vue src/components/ConversationListItem.vue src/layouts/MainLayout.vue` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: Test Files 38 failed | 10 passed (48); Errors 1)*

------
https://chatgpt.com/codex/tasks/task_e_689ee21a68848330bf75df64905f061d