### PR TITLE
Fix conversation virtual scroll width

### DIFF
--- a/src/components/ConversationList.vue
+++ b/src/components/ConversationList.vue
@@ -167,6 +167,10 @@ const deleteConversation = (pubkey: string) => {
   width: 100%;
   max-width: 100%;
 }
+.conversation-vscroll :deep(.q-virtual-scroll__content) {
+  box-sizing: border-box;
+  max-width: 100%;
+}
 /* Safety if a flex wrapper is around */
 :host {
   min-width: 0;


### PR DESCRIPTION
## Summary
- ensure `.conversation-vscroll` inner content uses `border-box` and `max-width:100%`

## Testing
- `pnpm lint src/components/ConversationList.vue` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test:ci` *(fails: 38 failed, 82 failed tests)*

------
https://chatgpt.com/codex/tasks/task_e_689eece9c3f8833096926d6a9584909d