### PR TITLE
Expand layout for nostr messenger routes

### DIFF
--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -63,7 +63,7 @@
       />
     </q-drawer>
     <q-page-container class="text-body1">
-      <div class="max-w-7xl mx-auto">
+      <div :class="isMessengerRoute ? 'w-full' : 'max-w-7xl mx-auto'">
         <router-view />
       </div>
     </q-page-container>
@@ -172,6 +172,10 @@ export default defineComponent({
       selectConversation(pubkey);
     };
 
+    const isMessengerRoute = computed(() =>
+      router.currentRoute.value.path.startsWith("/nostr-messenger"),
+    );
+
     return {
       messenger,
       conversationSearch,
@@ -179,6 +183,7 @@ export default defineComponent({
       openNewChatDialog,
       selectConversation,
       startChat,
+      isMessengerRoute,
       computedDrawerWidth,
       onResizeStart,
     };


### PR DESCRIPTION
## Summary
- expand router view to full width on `/nostr-messenger` routes

## Testing
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: 74 failed, 18 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689ef088c7ec83309b2d8099e98cb73a