### PR TITLE
chore: expand messenger drawer width

### DIFF
--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -100,10 +100,10 @@ export default defineComponent({
     const $q = useQuasar();
 
     // Persisted width just for this layout (keep store unchanged)
-    const DEFAULT_DESKTOP = 360;
+    const DEFAULT_DESKTOP = 400;
     const DEFAULT_TABLET = 300;
     const MIN_W = 280;
-    const MAX_W = 520;
+    const MAX_W = 600;
 
     const saved = LocalStorage.getItem("cashu.messenger.drawerWidth");
     const drawerWidth = ref(


### PR DESCRIPTION
## Summary
- increase default desktop and maximum messenger drawer widths for better readability

## Testing
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: 82 failed, 44 passed)*


------
https://chatgpt.com/codex/tasks/task_e_689ef284a01083308b1bc5baed7a27f0