### PR TITLE
fix: improve messenger drawer usability and wrapping

### DIFF
--- a/src/components/ConversationList.vue
+++ b/src/components/ConversationList.vue
@@ -8,7 +8,6 @@
     </div>
     <q-virtual-scroll
       v-else
-      bordered
       :items="virtualItems"
       :virtual-scroll-sizes="virtualSizes"
       :virtual-scroll-item-size="ITEM_HEIGHT"

--- a/src/components/ConversationListItem.vue
+++ b/src/components/ConversationListItem.vue
@@ -233,11 +233,11 @@ export default defineComponent({
 <style scoped>
 .conversation-item {
   border-bottom: 1px solid rgba(0, 0, 0, 0.1);
-  padding: 10px 16px;
+  padding: 10px 12px;
   border-radius: 8px;
   transition: background-color 0.2s ease;
   display: flex;
-  gap: 10px;
+  gap: 8px;
   border-left: 3px solid transparent;
   overflow-x: hidden;
   min-width: 0;
@@ -266,8 +266,8 @@ export default defineComponent({
   font-size: 0.7rem;
   line-height: 1.2;
   white-space: normal;
-  /* Allow single long "words" (tokens/npubs/URLs) to wrap within the column */
-  overflow-wrap: anywhere;
+  /* Prefer natural word boundaries; still break very long tokens/npubs/URLs */
+  overflow-wrap: break-word;
   word-break: break-word;
   /* Keep visual height predictable for virtualization: clamp to 2 lines */
   display: -webkit-box;

--- a/src/components/UserInfo.vue
+++ b/src/components/UserInfo.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="row items-center justify-between q-mt-md">
+  <div class="row items-center justify-between q-mt-md userinfo-root">
     <div class="row items-center">
       <q-avatar size="32px" class="q-mr-sm">
         <img v-if="profile?.picture" :src="profile.picture" />
@@ -70,3 +70,13 @@ function toggleDark() {
   $q.localStorage.set("cashu.darkMode", $q.dark.isActive);
 }
 </script>
+
+<style scoped>
+.userinfo-root {
+  min-width: 0;
+}
+.userinfo-root :deep(.row) {
+  min-width: 0;
+  box-sizing: border-box;
+}
+</style>

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -100,10 +100,10 @@ export default defineComponent({
     const $q = useQuasar();
 
     // Persisted width just for this layout (keep store unchanged)
-    const DEFAULT_DESKTOP = 400;
-    const DEFAULT_TABLET = 300;
-    const MIN_W = 280;
-    const MAX_W = 600;
+    const DEFAULT_DESKTOP = 440;
+    const DEFAULT_TABLET  = 320;
+    const MIN_W = 320;
+    const MAX_W = 640;
 
     const saved = LocalStorage.getItem("cashu.messenger.drawerWidth");
     const drawerWidth = ref(
@@ -116,7 +116,7 @@ export default defineComponent({
 
     const computedDrawerWidth = computed(() => {
       if ($q.screen.lt.md)
-        return Math.max(MIN_W, Math.min(drawerWidth.value, 400));
+        return Math.max(MIN_W, Math.min(drawerWidth.value, 420));
       return Math.max(MIN_W, Math.min(drawerWidth.value, MAX_W));
     });
 
@@ -127,9 +127,8 @@ export default defineComponent({
     watch(
       () => $q.screen.lt.md,
       (isLt) => {
-        if (isLt && drawerWidth.value > 400) drawerWidth.value = DEFAULT_TABLET;
-        if (!isLt && drawerWidth.value < MIN_W)
-          drawerWidth.value = DEFAULT_DESKTOP;
+        if (isLt && drawerWidth.value > 420) drawerWidth.value = DEFAULT_TABLET;
+        if (!isLt && drawerWidth.value < MIN_W) drawerWidth.value = DEFAULT_DESKTOP;
       },
     );
 


### PR DESCRIPTION
## Summary
- adjust messenger drawer default/min/max width and mobile clamp
- remove virtual scroll border and tweak conversation item spacing
- ensure user info footer and snippets wrap naturally without overflow

## Testing
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: 28 failed tests)*

------
https://chatgpt.com/codex/tasks/task_e_689ef9dbaa5c83309ba0f3c371337ed0