### PR TITLE
Humanize drawer snippets and quiet conversation headers

### DIFF
--- a/src/components/ConversationList.vue
+++ b/src/components/ConversationList.vue
@@ -18,8 +18,7 @@
           v-if="item.type === 'header'"
           :key="item.key"
           header
-          class="q-px-md q-pt-sm q-pb-xs bg-white dark:bg-dark"
-          style="position: sticky; top: 0; z-index: 1"
+          class="conversation-header q-px-md q-pt-sm q-pb-xs"
         >
           {{ item.label }}
         </q-item-label>
@@ -173,5 +172,27 @@ const deleteConversation = (pubkey: string) => {
 /* Safety if a flex wrapper is around */
 :host {
   min-width: 0;
+}
+
+.conversation-header {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  /* Inherit drawer bg – no bright fill */
+  background: transparent;
+  /* Quiet label aesthetics */
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-weight: 600;
+  font-size: 0.72rem;
+  opacity: 0.7;
+  /* Subtle divider that adapts to theme */
+  --sep: rgba(0, 0, 0, 0.12);
+  border-bottom: 1px solid var(--sep);
+}
+@media (prefers-color-scheme: dark) {
+  .conversation-header {
+    --sep: rgba(255, 255, 255, 0.08);
+  }
 }
 </style>


### PR DESCRIPTION
## Summary
- Humanize conversation snippets to avoid raw JSON and highlight tokens, subscriptions, and long links
- Bump snippet typography for readability and subtle contrast
- Restyle conversation section headers as quiet sticky labels with theme-aware divider

## Testing
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: multiple failing tests such as missing IndexedDB API)*

------
https://chatgpt.com/codex/tasks/task_e_689f253ffbb8833098176d8421f336dd