### PR TITLE
Fix chip overflow in chat bubbles

### DIFF
--- a/src/components/ChatMessageBubble.vue
+++ b/src/components/ChatMessageBubble.vue
@@ -12,56 +12,58 @@
       :class="message.outgoing ? 'items-end' : 'items-start'"
     >
       <div class="bubble" :class="message.outgoing ? 'bubble-outgoing' : 'bubble-incoming'">
-        <template v-if="message.subscriptionPayment">
-          <TokenCarousel
-            :payments="message.subscriptionPayment"
-            :creator="!message.outgoing"
-            :message="message"
-            @redeem="redeemPayment"
-          />
-          <div v-if="unlockTime && remaining > 0" class="text-caption q-mt-xs">
-            Unlocks in {{ countdown }}
-          </div>
-          <q-toggle
-            v-if="!message.outgoing"
-            v-model="autoRedeem"
-            label="Auto-redeem"
-            class="q-mt-sm"
-            @update:model-value="updateAutoRedeem"
-          />
-        </template>
-        <template v-else-if="message.tokenPayload">
-          <div class="token-wrapper">
-            <TokenInformation
-              :encodedToken="message.tokenPayload.token"
-              :showAmount="true"
+        <div class="bubble-content">
+          <template v-if="message.subscriptionPayment">
+            <TokenCarousel
+              :payments="message.subscriptionPayment"
+              :creator="!message.outgoing"
+              :message="message"
+              @redeem="redeemPayment"
             />
-            <div v-if="message.tokenPayload.memo" class="q-mt-sm">
-              <span class="text-weight-bold">Memo:</span>
-              {{ message.tokenPayload.memo }}
+            <div v-if="unlockTime && remaining > 0" class="text-caption q-mt-xs">
+              Unlocks in {{ countdown }}
             </div>
-          </div>
-        </template>
-        <template v-else>
-          <q-img
-            v-if="imageSrc"
-            :src="imageSrc"
-            style="max-width: 300px; max-height: 300px"
-            class="q-mb-sm"
-          />
-          <template v-else-if="isFile">
-            <a
-              :href="message.content"
-              target="_blank"
-              :download="attachmentName"
-            >
-              {{ attachmentName }}
-            </a>
+            <q-toggle
+              v-if="!message.outgoing"
+              v-model="autoRedeem"
+              label="Auto-redeem"
+              class="q-mt-sm"
+              @update:model-value="updateAutoRedeem"
+            />
+          </template>
+          <template v-else-if="message.tokenPayload">
+            <div class="token-wrapper">
+              <TokenInformation
+                :encodedToken="message.tokenPayload.token"
+                :showAmount="true"
+              />
+              <div v-if="message.tokenPayload.memo" class="q-mt-sm">
+                <span class="text-weight-bold">Memo:</span>
+                {{ message.tokenPayload.memo }}
+              </div>
+            </div>
           </template>
           <template v-else>
-            {{ message.content }}
+            <q-img
+              v-if="imageSrc"
+              :src="imageSrc"
+              style="max-width: 300px; max-height: 300px"
+              class="q-mb-sm"
+            />
+            <template v-else-if="isFile">
+              <a
+                :href="message.content"
+                target="_blank"
+                :download="attachmentName"
+              >
+                {{ attachmentName }}
+              </a>
+            </template>
+            <template v-else>
+              {{ message.content }}
+            </template>
           </template>
-        </template>
+        </div>
       </div>
       <div
         class="text-caption q-mt-xs row items-center"
@@ -289,11 +291,25 @@ async function updateAutoRedeem(val: boolean) {
 }
 
 .bubble {
-  padding: 16px;
+  padding: 18px;
   max-width: 70%;
   word-break: break-word;
   margin: 2px 0;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+/* Constrain content to the bubble’s width & allow natural wrapping */
+.bubble-content {
+  min-width: 0;
+  max-width: 100%;
+  overflow-wrap: break-word;
+  word-break: break-word;
+  white-space: normal;
+}
+/* Ensure any immediate child block respects width */
+.bubble-content > * {
+  min-width: 0;
+  max-width: 100%;
 }
 
 .bubble-outgoing {
@@ -315,11 +331,8 @@ async function updateAutoRedeem(val: boolean) {
   margin-top: 4px;
 }
 
-.token-wrapper .q-chip {
-  white-space: normal;
-  word-break: break-word;
+.token-wrapper .chip {
   max-width: 100%;
-  display: block; /* optional: stack chips vertically */
   margin-bottom: 4px; /* spacing between chips */
 }
 </style>

--- a/src/components/TokenInformation.vue
+++ b/src/components/TokenInformation.vue
@@ -1,51 +1,58 @@
 <template>
-  <div class="row text-left q-py-none q-my-none">
+  <div class="token-information row text-left q-py-none q-my-none">
     <div class="col-12 q-px-none">
-      <q-chip
-        v-if="showAmount"
-        outline
-        class="q-pa-md"
-        style="border-width: 2px"
-      >
-        <q-icon name="toll" size="xs" class="q-mr-sm" />
-        <strong>{{ displayUnit }} </strong>
-      </q-chip>
-      <q-chip
-        outline
-        class="q-pa-md"
-        style="height: 36px; font-family: monospace"
-      >
-        <q-icon name="account_balance" size="xs" class="q-mr-xs" />
-        {{ tokenMintUrl }}
-        <q-spinner-hourglass v-if="addMintBlocking" size="sm" class="q-ml-sm" />
-        <q-icon
-          v-if="
-            showMintCheck && mintKnownToUs(proofsToShow) && !addMintBlocking
-          "
-          name="check"
-          size="sm"
-          color="green"
-          class="q-ml-xs"
-        />
-      </q-chip>
-      <q-chip
-        v-if="isPureP2PK(proofsToShow)"
-        outline
-        icon="lock"
-        class="q-pa-md"
-      >
-        P2PK
-        <q-icon
-          v-if="showP2PKCheck || isLockedToUs(proofsToShow)"
-          :name="isLockedToUs(proofsToShow) ? 'check' : 'close'"
-          size="sm"
-          :color="isLockedToUs(proofsToShow) ? 'green' : 'red'"
-          class="q-ml-xs"
-        />
-      </q-chip>
-      <q-chip v-if="isHTLC(proofsToShow)" outline icon="link" class="q-pa-md">
-        HTLC
-      </q-chip>
+      <div class="chip-row">
+        <q-chip
+          v-if="showAmount"
+          outline
+          class="q-pa-md chip amount-chip"
+          style="border-width: 2px"
+        >
+          <q-icon name="toll" size="xs" class="q-mr-sm" />
+          <strong>{{ displayUnit }} </strong>
+        </q-chip>
+        <q-chip
+          outline
+          class="q-pa-md chip mint-chip"
+          style="height: 36px; font-family: monospace"
+        >
+          <q-icon name="account_balance" size="xs" class="q-mr-xs" />
+          {{ tokenMintUrl }}
+          <q-spinner-hourglass v-if="addMintBlocking" size="sm" class="q-ml-sm" />
+          <q-icon
+            v-if="
+              showMintCheck && mintKnownToUs(proofsToShow) && !addMintBlocking
+            "
+            name="check"
+            size="sm"
+            color="green"
+            class="q-ml-xs"
+          />
+        </q-chip>
+        <q-chip
+          v-if="isPureP2PK(proofsToShow)"
+          outline
+          icon="lock"
+          class="q-pa-md chip"
+        >
+          P2PK
+          <q-icon
+            v-if="showP2PKCheck || isLockedToUs(proofsToShow)"
+            :name="isLockedToUs(proofsToShow) ? 'check' : 'close'"
+            size="sm"
+            :color="isLockedToUs(proofsToShow) ? 'green' : 'red'"
+            class="q-ml-xs"
+          />
+        </q-chip>
+        <q-chip
+          v-if="isHTLC(proofsToShow)"
+          outline
+          icon="link"
+          class="q-pa-md chip"
+        >
+          HTLC
+        </q-chip>
+      </div>
       <div v-if="displayMemo" class="q-my-md">
         <q-icon name="chat" size="xs" color="grey" class="q-mr-sm" />
         <span>{{ displayMemo }}</span>
@@ -170,3 +177,30 @@ export default defineComponent({
   },
 });
 </script>
+
+<style scoped>
+.token-information {
+  min-width: 0;
+  max-width: 100%;
+}
+
+/* Row that holds the pills: wrap and gap */
+.chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  min-width: 0;
+  max-width: 100%;
+}
+
+/* Chips respect container width; long content ellipsizes */
+.chip {
+  max-width: 100%;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: inline-flex;
+  align-items: center;
+}
+</style>


### PR DESCRIPTION
## Summary
- constrain chat bubble content and bump padding
- wrap token info chips and ellipsis long text

## Testing
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: 38 failed | 10 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689f64d32c7c8330b2c2911a5523c8b0