### PR TITLE
Fix header overlap and compact drawer avatar layout

### DIFF
--- a/src/components/ConversationListItem.vue
+++ b/src/components/ConversationListItem.vue
@@ -1,9 +1,10 @@
 <template>
   <q-item
     clickable
+    v-ripple
     @click="onClick"
     class="conversation-item"
-    :class="{ selected }"
+    :class="{ selected, 'is-unread': unreadCount > 0 }"
     data-test="conversation-item"
     tabindex="0"
   >
@@ -328,10 +329,6 @@ const deleteItem = () => emit('delete', nostr.resolvePubkey(props.pubkey))
   min-width: 0;
 }
 
-.drawer-collapsed .conversation-item .main-section,
-.drawer-collapsed .conversation-item .ellipsis {
-  display: none;
-}
 .status-dot {
   position: absolute;
   bottom: -2px;
@@ -452,28 +449,28 @@ const deleteItem = () => emit('delete', nostr.resolvePubkey(props.pubkey))
 }
 
 /* Mini (collapsed) drawer polish */
-.drawer-collapsed .conversation-item {
+:deep(.drawer-collapsed) .conversation-item {
   justify-content: center;
   padding: 10px 8px;
   gap: 0;
   border-left-color: transparent;
 }
-.drawer-collapsed .avatar-col,
-.drawer-collapsed .q-item__section--avatar {
+:deep(.drawer-collapsed) .avatar-col,
+:deep(.drawer-collapsed) .q-item__section--avatar {
   display: flex;
   justify-content: center;
   align-items: center;
   width: 100%;
 }
-.drawer-collapsed .conversation-item .main-section,
-.drawer-collapsed .conversation-item .snippet,
-.drawer-collapsed .conversation-item .title,
-.drawer-collapsed .conversation-item .time,
-.drawer-collapsed .conversation-item .meta-actions--overlay,
-.drawer-collapsed .conversation-item .ellipsis {
+:deep(.drawer-collapsed) .conversation-item .main-section,
+:deep(.drawer-collapsed) .conversation-item .snippet,
+:deep(.drawer-collapsed) .conversation-item .title,
+:deep(.drawer-collapsed) .conversation-item .time,
+:deep(.drawer-collapsed) .conversation-item .meta-actions--overlay,
+:deep(.drawer-collapsed) .conversation-item .ellipsis {
   display: none !important; /* avatar only */
 }
-.drawer-collapsed .conversation-item .unread-overlay {
+:deep(.drawer-collapsed) .conversation-item .unread-overlay {
   position: absolute;
   top: 6px;
   right: 6px;

--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -1,5 +1,5 @@
 <template>
-  <q-header class="bg-transparent z-10">
+  <q-header class="bg-transparent z-10" elevated>
     <q-toolbar class="main-toolbar" dense>
       <div class="left-controls row items-center no-wrap">
         <q-btn
@@ -30,13 +30,9 @@
         </q-btn>
       </div>
 
-      <q-space />
-
-      <div class="toolbar-title ellipsis">
-        <q-toolbar-title />
-      </div>
-
-      <q-space />
+      <q-toolbar-title class="toolbar-title ellipsis">
+        <slot name="title">Nostr Messenger</slot>
+      </q-toolbar-title>
 
       <div class="right-controls row items-center no-wrap">
         <q-btn


### PR DESCRIPTION
## Summary
- Prevent header title from overlapping side icons
- Show avatar-only conversation items when chat drawer is collapsed

## Testing
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: 14 failed, 60 failed tests)*

------
https://chatgpt.com/codex/tasks/task_e_689f762ed3c483309fa1fe31b0fed0bf