### PR TITLE
feat: adjust conversation list row heights

### DIFF
--- a/src/components/ConversationList.vue
+++ b/src/components/ConversationList.vue
@@ -10,7 +10,7 @@
       v-else
       :items="virtualItems"
       :virtual-scroll-sizes="virtualSizes"
-      :virtual-scroll-item-size="ITEM_HEIGHT"
+      :virtual-scroll-item-size="itemHeight"
       class="full-width conversation-vscroll"
     >
       <template v-slot="{ item }">
@@ -96,7 +96,7 @@ const applyFilter = (list: typeof uniqueConversations.value) => {
 const filteredPinned = computed(() => applyFilter(pinnedConversations.value));
 const filteredRegular = computed(() => applyFilter(regularConversations.value));
 
-const ITEM_HEIGHT = 72;
+const itemHeight = computed(() => (messenger.drawerMini ? 60 : 72));
 const HEADER_HEIGHT = 36;
 
 interface VirtualHeader {
@@ -134,7 +134,7 @@ const virtualItems = computed<VirtualEntry[]>(() => {
 });
 
 const virtualSizes = computed(() =>
-  virtualItems.value.map((i) => (i.type === "header" ? HEADER_HEIGHT : ITEM_HEIGHT)),
+  virtualItems.value.map((i) => (i.type === "header" ? HEADER_HEIGHT : itemHeight.value)),
 );
 
 const loadProfiles = async () => {

--- a/src/components/ConversationListItem.vue
+++ b/src/components/ConversationListItem.vue
@@ -262,7 +262,7 @@ const deleteItem = () => emit('delete', nostr.resolvePubkey(props.pubkey))
 <style scoped>
 .conversation-item {
   border-bottom: 1px solid rgba(0, 0, 0, 0.1);
-  padding: 10px 12px;
+  padding: 16px 12px;
   border-radius: 8px;
   display: flex;
   gap: 8px;
@@ -273,6 +273,11 @@ const deleteItem = () => emit('delete', nostr.resolvePubkey(props.pubkey))
   position: relative; /* enable overlay positioning for actions */
   /* Let each row respond to its own inline size (tracks drawer width) */
   container-type: inline-size;
+}
+
+.drawer-collapsed .conversation-item {
+  padding-top: 10px;
+  padding-bottom: 10px;
 }
 
 /* Unread badge overlay on avatar (top-right) */


### PR DESCRIPTION
## Summary
- adjust virtual scroll item height based on drawer size
- align conversation list row CSS with new heights

## Testing
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: many tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_689f84095de08330a4695f485346327a