### PR TITLE
refactor: clean mini drawer

### DIFF
--- a/src/components/ConversationList.vue
+++ b/src/components/ConversationList.vue
@@ -10,7 +10,7 @@
       v-else
       :items="virtualItems"
       :virtual-scroll-sizes="virtualSizes"
-      :virtual-scroll-item-size="ITEM_HEIGHT"
+      :virtual-scroll-item-size="itemHeight"
       class="full-width conversation-vscroll"
     >
       <template v-slot="{ item }">
@@ -96,8 +96,8 @@ const applyFilter = (list: typeof uniqueConversations.value) => {
 const filteredPinned = computed(() => applyFilter(pinnedConversations.value));
 const filteredRegular = computed(() => applyFilter(regularConversations.value));
 
-const ITEM_HEIGHT = 72;
 const HEADER_HEIGHT = 36;
+const itemHeight = computed(() => (messenger.drawerMini ? 60 : 72));
 
 interface VirtualHeader {
   type: "header";
@@ -116,17 +116,20 @@ type VirtualEntry = VirtualHeader | VirtualItem;
 
 const virtualItems = computed<VirtualEntry[]>(() => {
   const items: VirtualEntry[] = [];
+  const mini = messenger.drawerMini;
   if (filteredPinned.value.length) {
-    items.push({ type: "header", key: "header-pinned", label: "Pinned" });
+    if (!mini)
+      items.push({ type: "header", key: "header-pinned", label: "Pinned" });
     filteredPinned.value.forEach((c) =>
       items.push({ type: "item", key: "pinned-" + c.pubkey, ...c }),
     );
   }
-  items.push({
-    type: "header",
-    key: "header-all",
-    label: "All Conversations",
-  });
+  if (!mini)
+    items.push({
+      type: "header",
+      key: "header-all",
+      label: "All Conversations",
+    });
   filteredRegular.value.forEach((c) =>
     items.push({ type: "item", key: "reg-" + c.pubkey, ...c }),
   );
@@ -134,7 +137,7 @@ const virtualItems = computed<VirtualEntry[]>(() => {
 });
 
 const virtualSizes = computed(() =>
-  virtualItems.value.map((i) => (i.type === "header" ? HEADER_HEIGHT : ITEM_HEIGHT)),
+  virtualItems.value.map((i) => (i.type === "header" ? HEADER_HEIGHT : itemHeight.value)),
 );
 
 const loadProfiles = async () => {

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -21,22 +21,24 @@
       ]"
     >
       <div class="column no-wrap full-height">
-        <div class="row items-center justify-between q-mb-md">
-          <div class="text-subtitle1">Chats</div>
-          <q-btn flat dense round icon="add" @click="openNewChatDialog" />
+        <div v-show="!messenger.drawerMini">
+          <div class="row items-center justify-between q-mb-md">
+            <div class="text-subtitle1">Chats</div>
+            <q-btn flat dense round icon="add" @click="openNewChatDialog" />
+          </div>
+          <q-input
+            dense
+            rounded
+            debounce="300"
+            v-model="conversationSearch"
+            placeholder="Search"
+            class="q-mb-md"
+          >
+            <template #prepend>
+              <q-icon name="search" />
+            </template>
+          </q-input>
         </div>
-        <q-input
-          dense
-          rounded
-          debounce="300"
-          v-model="conversationSearch"
-          placeholder="Search"
-          class="q-mb-md"
-        >
-          <template #prepend>
-            <q-icon name="search" />
-          </template>
-        </q-input>
         <q-scroll-area class="col" style="min-height: 0; min-width: 0">
           <Suspense>
             <template #default>
@@ -51,7 +53,7 @@
             </template>
           </Suspense>
         </q-scroll-area>
-        <UserInfo />
+        <UserInfo v-show="!messenger.drawerMini" />
       </div>
       <!-- Desktop resizer handle (hidden on <md and when mini) -->
       <div
@@ -205,6 +207,10 @@ export default defineComponent({
 .messenger-drawer {
   overflow: hidden;
   position: relative;
+}
+
+.messenger-drawer.drawer-collapsed {
+  padding: 8px 6px !important;
 }
 
 .messenger-drawer :deep(.column),


### PR DESCRIPTION
## Summary
- hide drawer chrome in mini mode
- drop list headers for mini drawer and adjust virtual scroll height

## Testing
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: tests & Vue warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a035fd16148330ae8bad297843f5b6