### PR TITLE
feat: clean messenger drawer mini mode

### DIFF
--- a/src/components/ConversationList.vue
+++ b/src/components/ConversationList.vue
@@ -10,7 +10,7 @@
       v-else
       :items="virtualItems"
       :virtual-scroll-sizes="virtualSizes"
-      :virtual-scroll-item-size="ITEM_HEIGHT"
+      :virtual-scroll-item-size="itemHeight"
       class="full-width conversation-vscroll"
     >
       <template v-slot="{ item }">
@@ -44,7 +44,7 @@ import { useMessengerStore } from "src/stores/messenger";
 import { useNostrStore } from "src/stores/nostr";
 import ConversationListItem from "./ConversationListItem.vue";
 
-const props = defineProps<{ selectedPubkey: string; search?: string }>();
+const props = defineProps<{ selectedPubkey: string; search?: string; mini?: boolean }>();
 
 const emit = defineEmits(["select"]);
 const messenger = useMessengerStore();
@@ -96,7 +96,7 @@ const applyFilter = (list: typeof uniqueConversations.value) => {
 const filteredPinned = computed(() => applyFilter(pinnedConversations.value));
 const filteredRegular = computed(() => applyFilter(regularConversations.value));
 
-const ITEM_HEIGHT = 72;
+const itemHeight = computed(() => (props.mini ? 60 : 72));
 const HEADER_HEIGHT = 36;
 
 interface VirtualHeader {
@@ -117,16 +117,20 @@ type VirtualEntry = VirtualHeader | VirtualItem;
 const virtualItems = computed<VirtualEntry[]>(() => {
   const items: VirtualEntry[] = [];
   if (filteredPinned.value.length) {
-    items.push({ type: "header", key: "header-pinned", label: "Pinned" });
+    if (!props.mini) {
+      items.push({ type: "header", key: "header-pinned", label: "Pinned" });
+    }
     filteredPinned.value.forEach((c) =>
       items.push({ type: "item", key: "pinned-" + c.pubkey, ...c }),
     );
   }
-  items.push({
-    type: "header",
-    key: "header-all",
-    label: "All Conversations",
-  });
+  if (!props.mini) {
+    items.push({
+      type: "header",
+      key: "header-all",
+      label: "All Conversations",
+    });
+  }
   filteredRegular.value.forEach((c) =>
     items.push({ type: "item", key: "reg-" + c.pubkey, ...c }),
   );
@@ -134,7 +138,9 @@ const virtualItems = computed<VirtualEntry[]>(() => {
 });
 
 const virtualSizes = computed(() =>
-  virtualItems.value.map((i) => (i.type === "header" ? HEADER_HEIGHT : ITEM_HEIGHT)),
+  virtualItems.value.map((i) =>
+    i.type === "header" ? HEADER_HEIGHT : itemHeight.value,
+  ),
 );
 
 const loadProfiles = async () => {

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -21,11 +21,15 @@
       ]"
     >
       <div class="column no-wrap full-height">
-        <div class="row items-center justify-between q-mb-md">
+        <div
+          v-show="!messenger.drawerMini"
+          class="row items-center justify-between q-mb-md"
+        >
           <div class="text-subtitle1">Chats</div>
           <q-btn flat dense round icon="add" @click="openNewChatDialog" />
         </div>
         <q-input
+          v-show="!messenger.drawerMini"
           dense
           rounded
           debounce="300"
@@ -41,6 +45,7 @@
           <Suspense>
             <template #default>
               <ConversationList
+                :mini="messenger.drawerMini"
                 :selected-pubkey="messenger.currentConversation"
                 :search="conversationSearch"
                 @select="selectConversation"
@@ -51,7 +56,7 @@
             </template>
           </Suspense>
         </q-scroll-area>
-        <UserInfo />
+        <UserInfo v-show="!messenger.drawerMini" />
       </div>
       <!-- Desktop resizer handle (hidden on <md and when mini) -->
       <div
@@ -205,6 +210,10 @@ export default defineComponent({
 .messenger-drawer {
   overflow: hidden;
   position: relative;
+}
+
+.messenger-drawer.drawer-collapsed {
+  padding: 8px 6px !important;
 }
 
 .messenger-drawer :deep(.column),

--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -7,14 +7,16 @@
     <div :class="['col column', $q.screen.gt.xs ? 'q-pa-lg' : 'q-pa-md']">
       <q-header elevated class="q-mb-md bg-transparent">
         <q-toolbar>
-          <q-btn
-            flat
-            round
-            dense
-            icon="menu"
-            @click="toggleDrawer"
-          />
-          <q-btn flat round dense icon="arrow_back" @click="goBack" />
+          <div class="row items-center no-wrap header-controls">
+            <q-btn
+              flat
+              round
+              dense
+              icon="menu"
+              @click="toggleDrawer"
+            />
+            <q-btn flat round dense icon="arrow_back" @click="goBack" />
+          </div>
           <q-toolbar-title class="text-h6 ellipsis">
             Nostr Messenger
             <q-badge
@@ -294,5 +296,9 @@ export default defineComponent({
 .q-toolbar {
   flex-wrap: nowrap;
 }
-  
+
+.header-controls {
+  flex-shrink: 0;
+}
+
 </style>


### PR DESCRIPTION
## Summary
- hide drawer header, search, and footer in mini mode
- drop section headers and adjust item height when drawer collapsed
- reserve header icon space to avoid title overlap

## Testing
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: multiple vitest errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a035fd16148330ae8bad297843f5b6