### PR TITLE
Fix header layout and mini drawer rail

### DIFF
--- a/src/components/ConversationList.vue
+++ b/src/components/ConversationList.vue
@@ -96,7 +96,7 @@ const applyFilter = (list: typeof uniqueConversations.value) => {
 const filteredPinned = computed(() => applyFilter(pinnedConversations.value));
 const filteredRegular = computed(() => applyFilter(regularConversations.value));
 
-const itemHeight = computed(() => (props.mini ? 60 : 72));
+const itemHeight = computed(() => (messenger.drawerMini ? 60 : 72));
 const HEADER_HEIGHT = 36;
 
 interface VirtualHeader {

--- a/src/components/ConversationListItem.vue
+++ b/src/components/ConversationListItem.vue
@@ -6,6 +6,7 @@
     :class="{ selected }"
     data-test="conversation-item"
     tabindex="0"
+    :aria-label="isMini ? displayName : undefined"
   >
     <q-item-section avatar class="avatar-col">
       <q-avatar size="40px" class="relative-position">
@@ -31,13 +32,18 @@
           rounded
         />
       </q-avatar>
-      <q-tooltip v-if="$q.screen.gt.xs && messenger.drawerMini" anchor="top middle" self="bottom middle" class="mini-tooltip">
+      <q-tooltip
+        v-if="$q.screen.gt.xs && isMini"
+        anchor="top middle"
+        self="bottom middle"
+        class="mini-tooltip"
+      >
         {{ displayName }}
       </q-tooltip>
     </q-item-section>
 
     <!-- Main text column: name + time (top row), snippet (bottom row) -->
-    <q-item-section class="main-section">
+    <q-item-section v-if="!isMini" class="main-section">
       <template v-if="loaded">
         <div class="list-head row no-wrap items-center">
           <q-item-label
@@ -45,7 +51,13 @@
             :class="{ 'text-weight-bold': unreadCount > 0 }"
             :title="displayName"
           >
-            <q-icon v-if="isPinned" name="star" size="xs" color="warning" class="q-mr-xs" />
+            <q-icon
+              v-if="isPinned"
+              name="star"
+              size="xs"
+              color="warning"
+              class="q-mr-xs"
+            />
             {{ displayName }}
           </q-item-label>
           <span class="time text-caption">{{ timeExact }}</span>
@@ -67,10 +79,12 @@
       </template>
     </q-item-section>
 
-    <!-- (timestamp-section removed; time now lives next to the title) -->
-
     <!-- Meta actions: overlayed; does not reserve width when hidden -->
-    <q-item-section side class="items-center meta-actions meta-actions--overlay">
+    <q-item-section
+      v-if="!isMini"
+      side
+      class="items-center meta-actions meta-actions--overlay"
+    >
       <q-btn
         flat
         dense
@@ -210,6 +224,7 @@ const isOnline = computed(() => messenger.connected)
 const isPinned = computed(() => messenger.pinned[props.pubkey])
 const unreadCount = computed(() => messenger.unreadCounts[props.pubkey] || 0)
 const selected = computed(() => props.selected)
+const isMini = computed(() => messenger.drawerMini)
 
 const profile = computed(() => {
   const entry: any = (nostr.profiles as any)[props.pubkey]
@@ -328,10 +343,6 @@ const deleteItem = () => emit('delete', nostr.resolvePubkey(props.pubkey))
   min-width: 0;
 }
 
-.drawer-collapsed .conversation-item .main-section,
-.drawer-collapsed .conversation-item .ellipsis {
-  display: none;
-}
 .status-dot {
   position: absolute;
   bottom: -2px;
@@ -454,10 +465,12 @@ const deleteItem = () => emit('delete', nostr.resolvePubkey(props.pubkey))
 /* Mini (collapsed) drawer polish */
 .drawer-collapsed .conversation-item {
   justify-content: center;
-  padding: 10px 6px;
+  align-items: center;
+  height: 60px;
+  padding: 0;
   gap: 0;
+  border: none;
   border-left-color: transparent;
-  border-bottom: none;
 }
 .drawer-collapsed .avatar-col,
 .drawer-collapsed .q-item__section--avatar {
@@ -465,14 +478,6 @@ const deleteItem = () => emit('delete', nostr.resolvePubkey(props.pubkey))
   justify-content: center;
   align-items: center;
   width: 100%;
-}
-.drawer-collapsed .conversation-item .main-section,
-.drawer-collapsed .conversation-item .snippet,
-.drawer-collapsed .conversation-item .title,
-.drawer-collapsed .conversation-item .time,
-.drawer-collapsed .conversation-item .meta-actions--overlay,
-.drawer-collapsed .conversation-item .ellipsis {
-  display: none !important; /* avatar only */
 }
 .drawer-collapsed .conversation-item .unread-overlay {
   position: absolute;

--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -1,8 +1,9 @@
 <template>
   <q-header class="bg-transparent z-10">
     <q-toolbar class="main-toolbar" dense>
-      <div class="left-controls row items-center no-wrap">
+      <div class="left-controls header-gutter row items-center no-wrap">
         <q-btn
+          v-if="!showBackButton"
           flat
           dense
           round
@@ -13,32 +14,20 @@
           :disable="uiStore.globalMutexLock"
         />
         <q-btn
-          v-if="showBackButton"
+          v-else
           flat
           dense
-          rounded
+          round
           icon="arrow_back_ios_new"
           :to="backRoute"
           color="primary"
           aria-label="Back"
-          no-caps
-          class="q-ml-sm"
-        >
-          <span class="q-mx-md text-weight-bold">
-            {{ $t("FullscreenHeader.actions.back.label") }}
-          </span>
-        </q-btn>
+        />
       </div>
 
-      <q-space />
+      <q-toolbar-title class="toolbar-title">{{ currentTitle }}</q-toolbar-title>
 
-      <div class="toolbar-title ellipsis">
-        <q-toolbar-title />
-      </div>
-
-      <q-space />
-
-      <div class="right-controls row items-center no-wrap">
+      <div class="right-controls header-gutter row items-center no-wrap">
         <q-btn
           v-if="isMessengerPage"
           flat
@@ -330,8 +319,15 @@ export default defineComponent({
     const isMessengerPage = computed(() =>
       route.path.startsWith("/nostr-messenger"),
     );
-    const showBackButton = computed(() => isMessengerPage.value);
+    const showBackButton = computed(
+      () => isMessengerPage.value && $q.screen.lt.md,
+    );
     const backRoute = computed(() => "/wallet");
+    const currentTitle = computed(() => {
+      if (isMessengerPage.value) return "Nostr Messenger";
+      if (route.path.startsWith("/wallet")) return "Wallet";
+      return "Cashu";
+    });
     const countdown = ref(0);
     const reloading = ref(false);
     let countdownInterval;
@@ -496,6 +492,7 @@ export default defineComponent({
       gotoWallet,
       showBackButton,
       backRoute,
+      currentTitle,
       needsNostrLogin,
       toggleMessengerDrawer,
       isMessengerPage,
@@ -513,10 +510,18 @@ export default defineComponent({
   overflow-x: hidden;
 }
 
-.main-toolbar { padding-inline: 8px; min-height: 48px; }
-/* Reserve space for left controls so title never collides on click/ripple */
-.left-controls { gap: 4px; flex: 0 0 auto; }
-.right-controls { gap: 4px; flex: 0 0 auto; }
+.main-toolbar { padding-inline: 8px; min-height: 48px; min-width: 0; }
+.header-gutter { flex: 0 0 96px; }
+.left-controls { gap: 4px; }
+.right-controls { gap: 4px; justify-content: flex-end; }
 /* CRITICAL: let the middle title shrink and ellipsis instead of overflowing */
-.toolbar-title { min-width: 0; max-width: min(56vw, 640px); text-align: center; font-weight: 600; }
+.toolbar-title {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: center;
+  font-weight: 600;
+}
 </style>


### PR DESCRIPTION
## Summary
- Prevent header icon clusters from overlapping the title by using fixed-width gutters and exclusive burger/back buttons
- Render a centered avatar rail when the drawer is collapsed with dynamic virtual scroll item heights

## Testing
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: multiple failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a0430593bc8330b03534a3600767f9