### PR TITLE
fix: remove duplicate messenger title

### DIFF
--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -1,6 +1,6 @@
 <template>
   <q-header class="bg-transparent z-10">
-    <q-toolbar class="main-toolbar" dense>
+    <q-toolbar class="app-toolbar" dense>
       <div class="left-controls header-gutter row items-center no-wrap">
         <q-btn
           v-if="!showBackButton"
@@ -14,7 +14,7 @@
           :disable="uiStore.globalMutexLock"
         />
         <q-btn
-          v-else
+          v-else-if="showBackButton"
           flat
           dense
           round
@@ -510,18 +510,35 @@ export default defineComponent({
   overflow-x: hidden;
 }
 
-.main-toolbar { padding-inline: 8px; min-height: 48px; min-width: 0; }
-.header-gutter { flex: 0 0 96px; }
-.left-controls { gap: 4px; }
-.right-controls { gap: 4px; justify-content: flex-end; }
+.app-toolbar {
+  padding-inline: 8px;
+  min-height: 48px;
+}
+
+.app-toolbar,
+.toolbar-title {
+  min-width: 0;
+}
+
+.header-gutter {
+  flex: 0 0 96px;
+}
+
+.left-controls {
+  gap: 4px;
+}
+
+.right-controls {
+  gap: 4px;
+  justify-content: flex-end;
+}
+
 /* CRITICAL: let the middle title shrink and ellipsis instead of overflowing */
 .toolbar-title {
   flex: 1;
-  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   text-align: center;
-  font-weight: 600;
 }
 </style>

--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -5,32 +5,6 @@
     v-touch-swipe.right="openDrawer"
   >
     <div :class="['col column', $q.screen.gt.xs ? 'q-pa-lg' : 'q-pa-md']">
-      <q-header elevated class="q-mb-md bg-transparent">
-        <div class="page-toolbar q-pa-sm">
-          <div class="header-controls">
-            <q-btn
-              flat
-              round
-              dense
-              icon="menu"
-              @click="toggleDrawer"
-            />
-            <q-btn flat round dense icon="arrow_back" @click="goBack" />
-          </div>
-
-          <div class="toolbar-title">
-            Nostr Messenger
-            <q-badge
-              :color="messenger.connected ? 'positive' : 'negative'"
-              class="q-ml-sm"
-            >
-              {{ messenger.connected ? "Online" : "Offline" }}
-            </q-badge>
-          </div>
-
-          <div class="toolbar-right-ghost" aria-hidden="true"></div>
-        </div>
-      </q-header>
       <q-banner v-if="connecting && !loading" dense class="bg-grey-3">
         Connecting...
       </q-banner>
@@ -77,7 +51,7 @@ import {
   onUnmounted,
   watch,
 } from "vue";
-import { useRouter, useRoute } from "vue-router";
+import { useRoute } from "vue-router";
 import { useMessengerStore } from "src/stores/messenger";
 import { useNdk } from "src/composables/useNdk";
 import { useNostrStore } from "src/stores/nostr";
@@ -164,28 +138,11 @@ export default defineComponent({
       if (timer) clearInterval(timer);
     });
 
-    const router = useRouter();
     const route = useRoute();
-
-    const goBack = () => {
-      if (window.history.length > 1) {
-        router.back();
-      } else {
-        router.push("/wallet");
-      }
-    };
 
     const openDrawer = () => {
       if ($q.screen.lt.md) {
         messenger.setDrawer(true);
-      }
-    };
-
-    const toggleDrawer = () => {
-      if ($q.screen.lt.md) {
-        messenger.setDrawer(true);
-      } else {
-        messenger.toggleDrawer();
       }
     };
 
@@ -283,40 +240,13 @@ export default defineComponent({
       showSetupWizard,
       sendMessage,
       openSendTokenDialog,
-      goBack,
       reconnectAll,
       connectedCount,
       totalRelays,
       nextReconnectIn,
       setupComplete,
       openDrawer,
-      toggleDrawer,
     };
   },
 });
 </script>
-<style scoped>
-.page-toolbar {
-  display: grid;
-  grid-template-columns: auto 1fr auto; /* left / title / right */
-  align-items: center;
-  column-gap: 8px;
-}
-
-.header-controls {
-  display: flex;
-  gap: 4px;
-}
-
-.toolbar-title {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  text-align: center;
-}
-
-.toolbar-right-ghost {
-  width: 72px;
-}
-</style>


### PR DESCRIPTION
## Summary
- remove page header from NostrMessenger so only global header sets title
- harden MainHeader layout and ensure single burger/back button

## Testing
- `pnpm run lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm run test` *(fails: 60 failed tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a04979ebec8330abd5e9a17e5bb5b7