### PR TITLE
feat: add nav menu toggle to messenger

### DIFF
--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -2,8 +2,29 @@
   <q-header class="bg-transparent z-10">
     <q-toolbar class="app-toolbar" dense>
       <div class="left-controls header-gutter row items-center no-wrap">
+        <template v-if="showBackButton">
+          <q-btn
+            flat
+            dense
+            round
+            icon="arrow_back_ios_new"
+            :to="backRoute"
+            color="primary"
+            aria-label="Back"
+          />
+          <q-btn
+            flat
+            dense
+            round
+            icon="menu"
+            color="primary"
+            aria-label="Menu"
+            @click="toggleLeftDrawer"
+            :disable="uiStore.globalMutexLock"
+          />
+        </template>
         <q-btn
-          v-if="!showBackButton"
+          v-else
           flat
           dense
           round
@@ -12,16 +33,6 @@
           aria-label="Menu"
           @click="toggleLeftDrawer"
           :disable="uiStore.globalMutexLock"
-        />
-        <q-btn
-          v-else-if="showBackButton"
-          flat
-          dense
-          round
-          icon="arrow_back_ios_new"
-          :to="backRoute"
-          color="primary"
-          aria-label="Back"
         />
       </div>
 


### PR DESCRIPTION
## Summary
- show both back and navigation menu buttons on /nostr-messenger

## Testing
- `pnpm run lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: multiple failing tests, e.g., TypeError: Cannot spy on export "useQuasar" ...)*

------
https://chatgpt.com/codex/tasks/task_e_68a05fd8a6e08330b9859943a21ac404