### PR TITLE
feat: add messenger menu toggle

### DIFF
--- a/src/components/ActiveChatHeader.vue
+++ b/src/components/ActiveChatHeader.vue
@@ -8,6 +8,7 @@
         dense
         icon="menu"
         class="q-mr-sm"
+        aria-label="Menu"
         @click="toggleMainMenu"
       />
       <q-btn

--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -39,12 +39,13 @@
       @click="openDrawer"
     />
     <q-btn
-      v-if="$q.screen.lt.md"
+      v-if="$q.screen.lt.md && !$q.screen.lt.sm"
       fab
       icon="menu"
       color="primary"
       class="fixed bottom-right"
       style="bottom: 16px; right: 16px"
+      aria-label="Menu"
       @click="toggleMainMenu"
     />
   </q-page>


### PR DESCRIPTION
## Summary
- show accessible menu button in active chat header on small screens
- only display menu FAB on sm+ screens and add aria-label

## Testing
- `pnpm lint` (fails: Cannot find module './.eslintrc.js')
- `pnpm test` (fails: 82 failed | 44 passed)


------
https://chatgpt.com/codex/tasks/task_e_68a06d46c30c8330a5989fa08aae7f28