### PR TITLE
feat: add nostr messenger nav toggle

### DIFF
--- a/src/components/ActiveChatHeader.vue
+++ b/src/components/ActiveChatHeader.vue
@@ -89,12 +89,14 @@ import ChatSendTokenDialog from "./ChatSendTokenDialog.vue";
 import { nip19 } from "nostr-tools";
 import ProfileInfoDialog from "./ProfileInfoDialog.vue";
 import RelayManagerDialog from "./RelayManagerDialog.vue";
+import { useUiStore } from "src/stores/ui";
 
 const props = defineProps<{ pubkey: string }>();
 const nostr = useNostrStore();
 const messenger = useMessengerStore();
 const $q = useQuasar();
 const profile = ref<any>(null);
+const ui = useUiStore();
 
 const loadProfile = async () => {
   if (props.pubkey) {
@@ -145,7 +147,7 @@ const relayManagerDialogRef = ref<InstanceType<
 const showProfileDialog = ref(false);
 
 function toggleMainMenu() {
-  window.dispatchEvent(new CustomEvent("toggle-left-drawer"));
+  ui.toggleMainNav();
 }
 
 function openSendTokenDialog() {

--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -1,7 +1,7 @@
 <template>
   <q-header class="bg-transparent z-10">
     <q-toolbar class="app-toolbar" dense>
-      <div class="left-controls header-gutter row items-center no-wrap">
+      <div class="left-controls">
         <template v-if="showBackButton">
           <q-btn
             flat
@@ -19,8 +19,8 @@
             icon="menu"
             color="primary"
             aria-label="Menu"
-            @click="toggleLeftDrawer"
-            :disable="uiStore.globalMutexLock"
+            @click="ui.toggleMainNav"
+            :disable="ui.globalMutexLock"
           />
         </template>
         <q-btn
@@ -31,14 +31,14 @@
           icon="menu"
           color="primary"
           aria-label="Menu"
-          @click="toggleLeftDrawer"
-          :disable="uiStore.globalMutexLock"
+          @click="ui.toggleMainNav"
+          :disable="ui.globalMutexLock"
         />
       </div>
 
-      <q-toolbar-title class="toolbar-title">{{ currentTitle }}</q-toolbar-title>
+      <q-toolbar-title class="app-title">{{ currentTitle }}</q-toolbar-title>
 
-      <div class="right-controls header-gutter row items-center no-wrap">
+      <div class="right-controls">
         <q-btn
           v-if="isMessengerPage"
           flat
@@ -104,7 +104,7 @@
           aria-label="Refresh"
           @click.stop="reload"
           :loading="reloading"
-          :disable="uiStore.globalMutexLock && countdown === 0"
+          :disable="ui.globalMutexLock && countdown === 0"
         >
           <q-tooltip>{{ $t("MainHeader.reload.tooltip") }}</q-tooltip>
           <template v-slot:loading>
@@ -127,7 +127,14 @@
   </q-header>
 
   <!-- Drawer positioned on the left for main navigation -->
-  <q-drawer v-model="leftDrawerOpen" side="left" bordered>
+  <q-drawer
+    v-model="ui.mainNavOpen"
+    side="left"
+    show-if-above
+    :overlay="$q.screen.lt.md"
+    :breakpoint="1024"
+    bordered
+  >
     <q-list>
       <q-item-label header>{{
         $t("MainHeader.menu.settings.title")
@@ -281,14 +288,7 @@
 </template>
 
 <script>
-import {
-  defineComponent,
-  ref,
-  computed,
-  onMounted,
-  onUnmounted,
-  getCurrentInstance,
-} from "vue";
+import { defineComponent, ref, computed, getCurrentInstance } from "vue";
 import { useRouter, useRoute } from "vue-router";
 import EssentialLink from "components/EssentialLink.vue";
 import { useUiStore } from "src/stores/ui";
@@ -305,8 +305,7 @@ export default defineComponent({
   },
   setup() {
     const vm = getCurrentInstance()?.proxy;
-    const leftDrawerOpen = ref(false);
-    const uiStore = useUiStore();
+    const ui = useUiStore();
     const { t } = useI18n();
     const router = useRouter();
     const route = useRoute();
@@ -382,17 +381,7 @@ export default defineComponent({
       },
     ];
 
-    const toggleLeftDrawer = () => {
-      leftDrawerOpen.value = !leftDrawerOpen.value;
-    };
-
-    onMounted(() => {
-      window.addEventListener("toggle-left-drawer", toggleLeftDrawer);
-    });
-
-    onUnmounted(() => {
-      window.removeEventListener("toggle-left-drawer", toggleLeftDrawer);
-    });
+    
 
     const toggleMessengerDrawer = () => {
       console.log("toggleMessengerDrawer", messenger.drawerMini);
@@ -412,7 +401,7 @@ export default defineComponent({
         "countdown:",
         countdown.value,
         "mutex:",
-        uiStore.globalMutexLock,
+        ui.globalMutexLock,
       );
       if (countdown.value > 0) {
         try {
@@ -421,12 +410,12 @@ export default defineComponent({
           reloading.value = false;
           vm?.notifyWarning("Reload cancelled");
         } finally {
-          uiStore.unlockMutex();
+          ui.unlockMutex();
         }
         return;
       }
-      if (uiStore.globalMutexLock) return;
-      uiStore.lockMutex();
+      if (ui.globalMutexLock) return;
+      ui.lockMutex();
       reloading.value = true;
       countdown.value = 3;
       vm?.notify("Reloading in 3 seconds…");
@@ -438,7 +427,7 @@ export default defineComponent({
           try {
             location.reload();
           } finally {
-            uiStore.unlockMutex();
+            ui.unlockMutex();
           }
         }
       }, 1000);
@@ -446,53 +435,51 @@ export default defineComponent({
 
     const gotoBuckets = () => {
       router.push("/buckets");
-      leftDrawerOpen.value = false;
+      ui.closeMainNav();
     };
 
     const gotoFindCreators = () => {
       router.push("/find-creators");
-      leftDrawerOpen.value = false;
+      ui.closeMainNav();
     };
 
     const gotoCreatorHub = () => {
       router.push("/creator-hub");
-      leftDrawerOpen.value = false;
+      ui.closeMainNav();
     };
 
     const gotoMyProfile = () => {
       router.push("/my-profile");
-      leftDrawerOpen.value = false;
+      ui.closeMainNav();
     };
 
     const gotoSubscriptions = () => {
       router.push("/subscriptions");
-      leftDrawerOpen.value = false;
+      ui.closeMainNav();
     };
 
     const gotoChats = () => {
       router.push("/nostr-messenger");
-      leftDrawerOpen.value = false;
+      ui.closeMainNav();
     };
 
     const gotoNostrLogin = () => {
       router.push("/nostr-login");
-      leftDrawerOpen.value = false;
+      ui.closeMainNav();
     };
 
     const gotoWallet = () => {
       router.push("/wallet");
-      leftDrawerOpen.value = false;
+      ui.closeMainNav();
     };
 
     return {
       essentialLinks,
-      leftDrawerOpen,
-      toggleLeftDrawer,
       isStaging,
       reload,
       countdown,
       reloading,
-      uiStore,
+      ui,
       gotoBuckets,
       gotoFindCreators,
       gotoCreatorHub,
@@ -526,30 +513,23 @@ export default defineComponent({
   min-height: 48px;
 }
 
-.app-toolbar,
-.toolbar-title {
+.app-title {
   min-width: 0;
-}
-
-.header-gutter {
-  flex: 0 0 96px;
-}
-
-.left-controls {
-  gap: 4px;
-}
-
-.right-controls {
-  gap: 4px;
-  justify-content: flex-end;
-}
-
-/* CRITICAL: let the middle title shrink and ellipsis instead of overflowing */
-.toolbar-title {
-  flex: 1;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   text-align: center;
+}
+
+.left-controls,
+.right-controls {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.right-controls {
+  justify-content: flex-end;
 }
 </style>

--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -5,6 +5,17 @@
     v-touch-swipe.right="openDrawer"
   >
     <div :class="['col column', $q.screen.gt.xs ? 'q-pa-lg' : 'q-pa-md']">
+      <!-- Top-left menu button within the page so Messenger has a nav entry point -->
+      <q-btn
+        v-if="$q.screen.gt.xs"
+        class="q-ml-sm q-mb-sm"
+        flat
+        dense
+        round
+        icon="menu"
+        aria-label="Open menu"
+        @click="ui.toggleMainNav"
+      />
       <q-banner v-if="connecting && !loading" dense class="bg-grey-3">
         Connecting...
       </q-banner>
@@ -38,16 +49,16 @@
       style="bottom: 16px; left: 16px"
       @click="openDrawer"
     />
-    <q-btn
-      v-if="$q.screen.lt.md && !$q.screen.lt.sm"
-      fab
-      icon="menu"
-      color="primary"
-      class="fixed bottom-right"
-      style="bottom: 16px; right: 16px"
-      aria-label="Menu"
-      @click="toggleMainMenu"
-    />
+    <q-page-sticky v-if="$q.screen.xs" position="top-left" :offset="[12, 12]">
+      <q-btn
+        round
+        dense
+        icon="menu"
+        color="primary"
+        aria-label="Open menu"
+        @click="ui.toggleMainNav"
+      />
+    </q-page-sticky>
   </q-page>
   <NostrSetupWizard v-model="showSetupWizard" @complete="setupComplete" />
 </template>
@@ -73,6 +84,7 @@ import MessageInput from "components/MessageInput.vue";
 import ChatSendTokenDialog from "components/ChatSendTokenDialog.vue";
 import NostrSetupWizard from "components/NostrSetupWizard.vue";
 import { useQuasar, TouchSwipe } from "quasar";
+import { useUiStore } from "src/stores/ui";
 
 export default defineComponent({
   name: "NostrMessenger",
@@ -91,6 +103,7 @@ export default defineComponent({
     const nostr = useNostrStore();
     const showSetupWizard = ref(false);
     const $q = useQuasar();
+    const ui = useUiStore();
 
     const ndkRef = ref<NDK | null>(null);
     const now = ref(Date.now());
@@ -154,10 +167,6 @@ export default defineComponent({
       if ($q.screen.lt.md) {
         messenger.setDrawer(true);
       }
-    };
-
-    const toggleMainMenu = () => {
-      window.dispatchEvent(new CustomEvent("toggle-left-drawer"));
     };
 
     const selected = computed(() => messenger.currentConversation);
@@ -260,7 +269,7 @@ export default defineComponent({
       nextReconnectIn,
       setupComplete,
       openDrawer,
-      toggleMainMenu,
+      ui,
     };
   },
 });

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -46,6 +46,7 @@ export const useUiStore = defineStore("ui", {
     globalMutexLock: false,
     showDebugConsole: useLocalStorage("cashu.ui.showDebugConsole", false),
     lastBalanceCached: useLocalStorage("cashu.ui.lastBalanceCached", 0),
+    mainNavOpen: false,
   }),
   actions: {
     closeDialogs() {
@@ -156,6 +157,15 @@ export const useUiStore = defineStore("ui", {
       } else {
         navigator.vibrate(200);
       }
+    },
+    toggleMainNav() {
+      this.mainNavOpen = !this.mainNavOpen;
+    },
+    openMainNav() {
+      this.mainNavOpen = true;
+    },
+    closeMainNav() {
+      this.mainNavOpen = false;
     },
   },
   getters: {


### PR DESCRIPTION
## Summary
- centralize main navigation drawer state in `useUiStore`
- wire `MainHeader` and `NostrMessenger` to shared nav state
- add responsive hamburger menu and sticky fallback on messenger page

## Testing
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: 82 failed, 44 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a07794bebc833088da48d1e3f34178