### PR TITLE
Center messenger header and tighten chat spacing

### DIFF
--- a/src/components/ActiveChatHeader.vue
+++ b/src/components/ActiveChatHeader.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="q-pa-sm row items-center justify-between">
+  <div class="q-px-sm q-py-xs row items-center justify-between">
     <div class="row items-center">
       <q-btn
         v-if="$q.screen.lt.sm"

--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -1,38 +1,36 @@
 <template>
   <q-header class="bg-transparent z-10">
-    <q-toolbar class="app-toolbar" dense>
+    <q-toolbar class="app-toolbar toolbar-grid" dense>
       <div class="left-controls row items-center no-wrap">
-        <template v-if="showBackButton">
-          <q-btn
-            flat
-            dense
-            round
-            icon="arrow_back_ios_new"
-            :to="backRoute"
-            color="primary"
-            aria-label="Back"
-          />
-          <q-btn
-            flat
-            dense
-            round
-            icon="menu"
-            color="primary"
-            aria-label="Open menu"
-            :aria-expanded="String(ui.mainNavOpen)"
-            aria-controls="app-nav"
-            @click="ui.toggleMainNav"
-            :disable="ui.globalMutexLock"
-          />
-        </template>
+        <!-- NEW: chat drawer toggle first when on Messenger -->
         <q-btn
-          v-else
+          v-if="isMessengerPage"
+          flat
+          dense
+          round
+          icon="menu"
+          color="white"
+          aria-label="Toggle Conversations"
+          @click.stop="toggleMessengerDrawer"
+          class="q-mr-xs"
+        />
+        <q-btn
+          v-if="showBackButton"
+          flat
+          dense
+          round
+          icon="arrow_back_ios_new"
+          :to="backRoute"
+          color="primary"
+          aria-label="Back"
+        />
+        <q-btn
           flat
           dense
           round
           icon="menu"
           color="primary"
-          aria-label="Open menu"
+          aria-label="Open Main Menu"
           :aria-expanded="String(ui.mainNavOpen)"
           aria-controls="app-nav"
           @click="ui.toggleMainNav"
@@ -43,17 +41,6 @@
       <q-toolbar-title class="app-title">{{ currentTitle }}</q-toolbar-title>
 
       <div class="right-controls row items-center no-wrap">
-        <q-btn
-          v-if="isMessengerPage"
-          flat
-          dense
-          round
-          icon="menu"
-          color="primary"
-          aria-label="Toggle Chat Menu"
-          @click.stop="toggleMessengerDrawer"
-          class="q-mr-sm"
-        />
         <transition
           appear
           enter-active-class="animated wobble"
@@ -256,16 +243,23 @@ export default defineComponent({
   min-height: 48px;
 }
 
+.toolbar-grid {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+}
+
 .app-title {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  text-align: center;
+  justify-self: center;
 }
 
 .left-controls,
 .right-controls {
-  flex: 0 0 auto;
   display: inline-flex;
   align-items: center;
   gap: 6px;

--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -4,7 +4,7 @@
     :class="[$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark']"
     v-touch-swipe.right="openDrawer"
   >
-    <div :class="['col column', $q.screen.gt.xs ? 'q-pa-lg' : 'q-pa-md']">
+    <div class="col column q-px-md q-pt-xs q-pb-md">
       <q-btn
         v-if="$q.screen.gt.xs"
         class="q-ml-sm"


### PR DESCRIPTION
## Summary
- Reduce outer and header padding in Nostr Messenger for tighter top spacing
- Rework MainHeader into a 3-column grid with left-aligned chat drawer toggle

## Testing
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: 9 failed test files, 47 failed tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c4330c448330b810233ca0b431d3