### PR TITLE
refactor: tweak messenger layout

### DIFF
--- a/src/components/ActiveChatHeader.vue
+++ b/src/components/ActiveChatHeader.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="q-pa-sm row items-center justify-between">
+  <div class="q-px-sm q-py-xs row items-center justify-between">
     <div class="row items-center">
       <q-btn
         v-if="$q.screen.lt.sm"

--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -1,7 +1,18 @@
 <template>
   <q-header class="bg-transparent z-10">
-    <q-toolbar class="app-toolbar" dense>
+    <q-toolbar class="app-toolbar toolbar-grid" dense>
       <div class="left-controls row items-center no-wrap">
+        <q-btn
+          v-if="isMessengerPage"
+          flat
+          dense
+          round
+          icon="menu"
+          color="white"
+          aria-label="Toggle Conversations"
+          @click.stop="toggleMessengerDrawer"
+          class="q-mr-xs"
+        />
         <template v-if="showBackButton">
           <q-btn
             flat
@@ -43,17 +54,6 @@
       <q-toolbar-title class="app-title">{{ currentTitle }}</q-toolbar-title>
 
       <div class="right-controls row items-center no-wrap">
-        <q-btn
-          v-if="isMessengerPage"
-          flat
-          dense
-          round
-          icon="menu"
-          color="primary"
-          aria-label="Toggle Chat Menu"
-          @click.stop="toggleMessengerDrawer"
-          class="q-mr-sm"
-        />
         <transition
           appear
           enter-active-class="animated wobble"
@@ -256,16 +256,23 @@ export default defineComponent({
   min-height: 48px;
 }
 
+.toolbar-grid {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+}
+
 .app-title {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  text-align: center;
+  justify-self: center;
 }
 
 .left-controls,
 .right-controls {
-  flex: 0 0 auto;
   display: inline-flex;
   align-items: center;
   gap: 6px;

--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -4,7 +4,7 @@
     :class="[$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark']"
     v-touch-swipe.right="openDrawer"
   >
-    <div :class="['col column', $q.screen.gt.xs ? 'q-pa-lg' : 'q-pa-md']">
+    <div class="col column q-px-md q-pt-xs q-pb-md">
       <q-btn
         v-if="$q.screen.gt.xs"
         class="q-ml-sm"


### PR DESCRIPTION
## Summary
- tighten messenger page and header padding
- center main header title using grid layout
- add left-aligned chat drawer toggle on messenger pages

## Testing
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: multiple Vitest errors, e.g. ReferenceError and TypeError)*


------
https://chatgpt.com/codex/tasks/task_e_68a0c4330c448330b810233ca0b431d3