### PR TITLE
Center Messenger title and split nav buttons

### DIFF
--- a/src/components/ActiveChatHeader.vue
+++ b/src/components/ActiveChatHeader.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="q-pa-sm row items-center justify-between">
+  <div class="q-pa-xs row items-center justify-between">
     <div class="row items-center">
       <q-btn
         v-if="$q.screen.lt.sm"

--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -1,5 +1,5 @@
 <template>
-  <q-header class="bg-transparent z-10">
+  <q-header class="bg-transparent">
     <q-toolbar class="app-toolbar" dense>
       <div class="left-controls row items-center no-wrap">
         <template v-if="showBackButton">
@@ -18,7 +18,7 @@
             round
             icon="menu"
             color="primary"
-            aria-label="Open menu"
+            aria-label="Open main menu"
             :aria-expanded="String(ui.mainNavOpen)"
             aria-controls="app-nav"
             @click="ui.toggleMainNav"
@@ -32,28 +32,29 @@
           round
           icon="menu"
           color="primary"
-          aria-label="Open menu"
+          aria-label="Open main menu"
           :aria-expanded="String(ui.mainNavOpen)"
           aria-controls="app-nav"
           @click="ui.toggleMainNav"
           :disable="ui.globalMutexLock"
+        />
+        <!-- NEW: Chats sidebar toggle (only on Messenger) -->
+        <q-btn
+          v-if="isMessengerPage"
+          flat
+          dense
+          round
+          icon="view_sidebar"
+          color="primary"
+          aria-label="Toggle chats sidebar"
+          @click.stop="toggleMessengerDrawer"
+          class="q-ml-xs"
         />
       </div>
 
       <q-toolbar-title class="app-title">{{ currentTitle }}</q-toolbar-title>
 
       <div class="right-controls row items-center no-wrap">
-        <q-btn
-          v-if="isMessengerPage"
-          flat
-          dense
-          round
-          icon="menu"
-          color="primary"
-          aria-label="Toggle Chat Menu"
-          @click.stop="toggleMessengerDrawer"
-          class="q-mr-sm"
-        />
         <transition
           appear
           enter-active-class="animated wobble"
@@ -245,15 +246,20 @@ export default defineComponent({
 </script>
 <style scoped>
 .q-header {
-  position: sticky; /* or fixed */
+  position: sticky;
   top: 0;
-  z-index: 1000; /* ensures header stays above page content */
+  /* Keep header above Quasar drawer/scrim layers on mobile overlays */
+  z-index: 11000;
   overflow-x: hidden;
 }
 
 .app-toolbar {
   padding-inline: 8px;
   min-height: 48px;
+  /* helps the title feel centered visually */
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
 }
 
 .app-title {
@@ -261,6 +267,7 @@ export default defineComponent({
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  text-align: center; /* center the title itself */
 }
 
 .left-controls,

--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -4,19 +4,7 @@
     :class="[$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark']"
     v-touch-swipe.right="openDrawer"
   >
-    <div :class="['col column', $q.screen.gt.xs ? 'q-pa-lg' : 'q-pa-md']">
-      <q-btn
-        v-if="$q.screen.gt.xs"
-        class="q-ml-sm"
-        flat
-        dense
-        round
-        icon="menu"
-        aria-label="Open menu"
-        :aria-expanded="String(ui.mainNavOpen)"
-        aria-controls="app-nav"
-        @click="ui.toggleMainNav"
-      />
+    <div :class="['col column', $q.screen.gt.xs ? 'q-pt-sm q-px-lg q-pb-md' : 'q-pt-xs q-px-md q-pb-md']">
       <q-banner v-if="connecting && !loading" dense class="bg-grey-3">
         Connecting...
       </q-banner>
@@ -50,18 +38,6 @@
       style="bottom: 16px; left: 16px"
       @click="openDrawer"
     />
-    <q-page-sticky v-if="$q.screen.xs" position="top-left" :offset="[12, 12]">
-      <q-btn
-        round
-        dense
-        icon="menu"
-        color="primary"
-        aria-label="Open menu"
-        :aria-expanded="String(ui.mainNavOpen)"
-        aria-controls="app-nav"
-        @click="ui.toggleMainNav"
-      />
-    </q-page-sticky>
   </q-page>
   <NostrSetupWizard v-model="showSetupWizard" @complete="setupComplete" />
 </template>


### PR DESCRIPTION
## Summary
- Add dedicated chats sidebar button and center the Messenger title
- Remove page-level menu buttons and tighten top padding
- Trim active chat header spacing for a tighter layout

## Testing
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: 38 failed | 10 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c8bba6888330bf19bc3f1aa4353d