### PR TITLE
refactor: streamline messenger navigation

### DIFF
--- a/src/components/ActiveChatHeader.vue
+++ b/src/components/ActiveChatHeader.vue
@@ -2,27 +2,6 @@
   <div class="q-pa-xs row items-center justify-between">
     <div class="row items-center">
       <q-btn
-        v-if="$q.screen.lt.sm"
-        flat
-        round
-        dense
-        icon="menu"
-        class="q-mr-sm"
-        aria-label="Open menu"
-        :aria-expanded="String(ui.mainNavOpen)"
-        aria-controls="app-nav"
-        @click="toggleMainMenu"
-      />
-      <q-btn
-        v-if="$q.screen.lt.sm"
-        flat
-        round
-        dense
-        icon="chat"
-        class="q-mr-sm"
-        @click="messenger.toggleDrawer()"
-      />
-      <q-btn
         flat
         round
         dense
@@ -84,20 +63,16 @@
 
 <script lang="ts" setup>
 import { ref, watch, computed } from "vue";
-import { useQuasar } from "quasar";
 import { useNostrStore } from "src/stores/nostr";
 import { useMessengerStore } from "src/stores/messenger";
 import ChatSendTokenDialog from "./ChatSendTokenDialog.vue";
 import { nip19 } from "nostr-tools";
 import ProfileInfoDialog from "./ProfileInfoDialog.vue";
 import RelayManagerDialog from "./RelayManagerDialog.vue";
-import { useUiStore } from "src/stores/ui";
 
 const props = defineProps<{ pubkey: string }>();
 const nostr = useNostrStore();
 const messenger = useMessengerStore();
-const $q = useQuasar();
-const ui = useUiStore();
 const profile = ref<any>(null);
 
 const loadProfile = async () => {
@@ -147,10 +122,6 @@ const relayManagerDialogRef = ref<InstanceType<
   typeof RelayManagerDialog
 > | null>(null);
 const showProfileDialog = ref(false);
-
-function toggleMainMenu() {
-  ui.toggleMainNav();
-}
 
 function openSendTokenDialog() {
   if (!props.pubkey) return;

--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -1,6 +1,6 @@
 <template>
   <q-header class="bg-transparent">
-    <q-toolbar class="app-toolbar" dense>
+    <q-toolbar class="app-toolbar app-toolbar--grid" dense>
       <div class="left-controls row items-center no-wrap">
         <template v-if="showBackButton">
           <q-btn
@@ -38,15 +38,14 @@
           @click="ui.toggleMainNav"
           :disable="ui.globalMutexLock"
         />
-        <!-- NEW: Chats sidebar toggle (only on Messenger) -->
         <q-btn
           v-if="isMessengerPage"
           flat
           dense
           round
-          icon="view_sidebar"
-          color="primary"
-          aria-label="Toggle chats sidebar"
+          :icon="messenger.drawerMini ? 'menu' : 'menu_open'"
+          :color="$q.dark.isActive ? 'white' : 'primary'"
+          aria-label="Toggle chat menu"
           @click.stop="toggleMessengerDrawer"
           class="q-ml-xs"
         />
@@ -256,18 +255,20 @@ export default defineComponent({
 .app-toolbar {
   padding-inline: 8px;
   min-height: 48px;
-  /* helps the title feel centered visually */
+}
+
+.app-toolbar--grid {
   display: grid;
   grid-template-columns: auto 1fr auto;
   align-items: center;
 }
 
 .app-title {
+  text-align: center;
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  text-align: center; /* center the title itself */
 }
 
 .left-controls,

--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -4,7 +4,7 @@
     :class="[$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark']"
     v-touch-swipe.right="openDrawer"
   >
-    <div :class="['col column', $q.screen.gt.xs ? 'q-pt-sm q-px-lg q-pb-md' : 'q-pt-xs q-px-md q-pb-md']">
+    <div :class="['col column', $q.screen.gt.xs ? 'q-px-lg q-pt-sm q-pb-md' : 'q-pa-md q-pt-sm']">
       <q-banner v-if="connecting && !loading" dense class="bg-grey-3">
         Connecting...
       </q-banner>


### PR DESCRIPTION
## Summary
- make app header use grid layout and center title with chat drawer toggle
- trim top padding and remove redundant nav buttons on messenger page
- drop small-screen chat/menu buttons from ActiveChatHeader

## Testing
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: 18 failed, 66 failed tests overall)*

------
https://chatgpt.com/codex/tasks/task_e_68a0cd532cd083308802190c04751774