### PR TITLE
Improve Messenger header layout and drawer controls

### DIFF
--- a/src/components/ActiveChatHeader.vue
+++ b/src/components/ActiveChatHeader.vue
@@ -1,27 +1,6 @@
 <template>
-  <div class="q-pa-xs row items-center justify-between">
+  <div class="row items-center justify-between q-pt-xs q-pb-none q-px-sm">
     <div class="row items-center">
-      <q-btn
-        v-if="$q.screen.lt.sm"
-        flat
-        round
-        dense
-        icon="menu"
-        class="q-mr-sm"
-        aria-label="Open menu"
-        :aria-expanded="String(ui.mainNavOpen)"
-        aria-controls="app-nav"
-        @click="toggleMainMenu"
-      />
-      <q-btn
-        v-if="$q.screen.lt.sm"
-        flat
-        round
-        dense
-        icon="chat"
-        class="q-mr-sm"
-        @click="messenger.toggleDrawer()"
-      />
       <q-btn
         flat
         round
@@ -84,28 +63,24 @@
 
 <script lang="ts" setup>
 import { ref, watch, computed } from "vue";
-import { useQuasar } from "quasar";
 import { useNostrStore } from "src/stores/nostr";
 import { useMessengerStore } from "src/stores/messenger";
 import ChatSendTokenDialog from "./ChatSendTokenDialog.vue";
 import { nip19 } from "nostr-tools";
 import ProfileInfoDialog from "./ProfileInfoDialog.vue";
 import RelayManagerDialog from "./RelayManagerDialog.vue";
-import { useUiStore } from "src/stores/ui";
 
 const props = defineProps<{ pubkey: string }>();
 const nostr = useNostrStore();
 const messenger = useMessengerStore();
-const $q = useQuasar();
-const ui = useUiStore();
 const profile = ref<any>(null);
 
 const loadProfile = async () => {
-  if (props.pubkey) {
-    profile.value = await nostr.getProfile(props.pubkey);
-  } else {
-    profile.value = null;
-  }
+      if (props.pubkey) {
+        profile.value = await nostr.getProfile(props.pubkey);
+      } else {
+        profile.value = null;
+      }
 };
 
 watch(
@@ -147,10 +122,6 @@ const relayManagerDialogRef = ref<InstanceType<
   typeof RelayManagerDialog
 > | null>(null);
 const showProfileDialog = ref(false);
-
-function toggleMainMenu() {
-  ui.toggleMainNav();
-}
 
 function openSendTokenDialog() {
   if (!props.pubkey) return;

--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -2,31 +2,22 @@
   <q-header class="bg-transparent">
     <q-toolbar class="app-toolbar" dense>
       <div class="left-controls row items-center no-wrap">
-        <template v-if="showBackButton">
-          <q-btn
-            flat
-            dense
-            round
-            icon="arrow_back_ios_new"
-            :to="backRoute"
-            color="primary"
-            aria-label="Back"
-          />
-          <q-btn
-            flat
-            dense
-            round
-            icon="menu"
-            color="primary"
-            aria-label="Open main menu"
-            :aria-expanded="String(ui.mainNavOpen)"
-            aria-controls="app-nav"
-            @click="ui.toggleMainNav"
-            :disable="ui.globalMutexLock"
-          />
-        </template>
         <q-btn
-          v-else
+          v-if="isMessengerPage"
+          flat
+          dense
+          round
+          icon="menu"
+          color="primary"
+          aria-label="Toggle chat menu"
+          @click.stop="toggleMessengerDrawer"
+        />
+      </div>
+
+      <q-space />
+
+      <div class="title-group row items-center no-wrap">
+        <q-btn
           flat
           dense
           round
@@ -38,21 +29,10 @@
           @click="ui.toggleMainNav"
           :disable="ui.globalMutexLock"
         />
-        <!-- NEW: Chats sidebar toggle (only on Messenger) -->
-        <q-btn
-          v-if="isMessengerPage"
-          flat
-          dense
-          round
-          icon="view_sidebar"
-          color="primary"
-          aria-label="Toggle chats sidebar"
-          @click.stop="toggleMessengerDrawer"
-          class="q-ml-xs"
-        />
+        <div class="app-title q-ml-sm">{{ currentTitle }}</div>
       </div>
 
-      <q-toolbar-title class="app-title">{{ currentTitle }}</q-toolbar-title>
+      <q-space />
 
       <div class="right-controls row items-center no-wrap">
         <transition
@@ -163,10 +143,6 @@ export default defineComponent({
     const isMessengerPage = computed(() =>
       route.path.startsWith("/nostr-messenger"),
     );
-    const showBackButton = computed(
-      () => isMessengerPage.value && $q.screen.lt.md,
-    );
-    const backRoute = computed(() => "/wallet");
     const currentTitle = computed(() => {
       if (isMessengerPage.value) return "Nostr Messenger";
       if (route.path.startsWith("/wallet")) return "Wallet";
@@ -178,11 +154,14 @@ export default defineComponent({
 
 
     const toggleMessengerDrawer = () => {
-      console.log("toggleMessengerDrawer", messenger.drawerMini);
-      messenger.toggleDrawer();
-      vm?.notify(
-        messenger.drawerMini ? "Messenger collapsed" : "Messenger expanded",
-      );
+      if ($q.screen.lt.md) {
+        messenger.setDrawer(true);
+      } else {
+        messenger.toggleDrawer();
+        vm?.notify(
+          messenger.drawerMini ? "Messenger collapsed" : "Messenger expanded",
+        );
+      }
     };
 
     const isStaging = () => {
@@ -233,8 +212,6 @@ export default defineComponent({
       countdown,
       reloading,
       ui,
-      showBackButton,
-      backRoute,
       currentTitle,
       toggleMessengerDrawer,
       isMessengerPage,
@@ -256,9 +233,7 @@ export default defineComponent({
 .app-toolbar {
   padding-inline: 8px;
   min-height: 48px;
-  /* helps the title feel centered visually */
-  display: grid;
-  grid-template-columns: auto 1fr auto;
+  display: flex;
   align-items: center;
 }
 
@@ -267,7 +242,12 @@ export default defineComponent({
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  text-align: center; /* center the title itself */
+}
+
+.title-group {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
 }
 
 .left-controls,

--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -4,7 +4,7 @@
     :class="[$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark']"
     v-touch-swipe.right="openDrawer"
   >
-    <div :class="['col column', $q.screen.gt.xs ? 'q-pt-sm q-px-lg q-pb-md' : 'q-pt-xs q-px-md q-pb-md']">
+    <div :class="['col column', $q.screen.gt.xs ? 'q-pt-xs q-px-lg q-pb-md' : 'q-pt-none q-px-md q-pb-md']">
       <q-banner v-if="connecting && !loading" dense class="bg-grey-3">
         Connecting...
       </q-banner>


### PR DESCRIPTION
## Summary
- Center "Nostr Messenger" with main-nav hamburger
- Add dedicated chat sidebar toggle and tighten conversation header spacing
- Trim excess top padding on Messenger page

## Testing
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: TypeError: Cannot read properties of undefined (reading 'iconSet'))*

------
https://chatgpt.com/codex/tasks/task_e_68a0d465604883308bd9e3ab1e59d4e3