### PR TITLE
Hide chat drawer outside messenger

### DIFF
--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -6,6 +6,7 @@
     <MainHeader />
     <AppNavDrawer />
     <q-drawer
+      v-if="isMessengerRoute"
       v-model="messenger.drawerOpen"
       :mini="messenger.drawerMini"
       mini-width="80"
@@ -73,7 +74,11 @@
         <router-view />
       </div>
     </q-page-container>
-    <NewChatDialog ref="newChatDialogRef" @start="startChat" />
+    <NewChatDialog
+      v-if="isMessengerRoute"
+      ref="newChatDialogRef"
+      @start="startChat"
+    />
   </q-layout>
 </template>
 


### PR DESCRIPTION
## Summary
- Only render chat drawer and new chat dialog on `/nostr-messenger`

## Testing
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: Cannot read properties of undefined (reading 'iconSet'))*

------
https://chatgpt.com/codex/tasks/task_e_68a194ff50d08330a060b8938c2287df