### PR TITLE
Gate messenger UI on messenger routes

### DIFF
--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -57,6 +57,17 @@
         </q-badge>
       </transition-group>
       <q-btn
+        v-if="route.meta.messengerUI"
+        flat
+        dense
+        round
+        icon="menu"
+        color="primary"
+        aria-label="Toggle Chat Menu"
+        @click="uiStore.showMessengerDrawer = !uiStore.showMessengerDrawer"
+        :disable="uiStore.globalMutexLock"
+      />
+      <q-btn
         flat
         dense
         round
@@ -132,6 +143,7 @@ import { defineComponent, ref } from "vue";
 import EssentialLink from "components/EssentialLink.vue";
 import { useUiStore } from "src/stores/ui";
 import { useI18n } from "vue-i18n";
+import { useRoute } from "vue-router";
 
 export default defineComponent({
   name: "MainHeader",
@@ -143,6 +155,7 @@ export default defineComponent({
     const leftDrawerOpen = ref(false);
     const uiStore = useUiStore();
     const { t } = useI18n();
+    const route = useRoute();
     const countdown = ref(0);
     let countdownInterval;
 
@@ -215,6 +228,7 @@ export default defineComponent({
       reload,
       countdown,
       uiStore,
+      route,
     };
   },
 });

--- a/src/components/MessengerDrawer.vue
+++ b/src/components/MessengerDrawer.vue
@@ -1,0 +1,29 @@
+<template>
+  <q-drawer
+    side="right"
+    overlay
+    :model-value="modelValue"
+    @update:model-value="$emit('update:modelValue', $event)"
+  >
+    <q-list>
+      <q-item>
+        <q-item-section>Messenger</q-item-section>
+      </q-item>
+    </q-list>
+  </q-drawer>
+</template>
+
+<script lang="ts">
+import { defineComponent } from "vue";
+
+export default defineComponent({
+  name: "MessengerDrawer",
+  props: {
+    modelValue: {
+      type: Boolean,
+      required: true,
+    },
+  },
+  emits: ["update:modelValue"],
+});
+</script>

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -1,6 +1,10 @@
 <template>
   <q-layout view="lHh Lpr lFf">
     <MainHeader />
+    <MessengerDrawer
+      v-if="route.meta.messengerUI"
+      v-model="uiStore.showMessengerDrawer"
+    />
     <q-page-container>
       <router-view />
     </q-page-container>
@@ -8,14 +12,23 @@
 </template>
 
 <script>
-import { defineComponent, ref } from "vue";
+import { defineComponent } from "vue";
+import { useRoute } from "vue-router";
 import MainHeader from "components/MainHeader.vue";
+import MessengerDrawer from "components/MessengerDrawer.vue";
+import { useUiStore } from "src/stores/ui";
 
 export default defineComponent({
   name: "MainLayout",
   mixins: [windowMixin],
   components: {
     MainHeader,
+    MessengerDrawer,
+  },
+  setup() {
+    const route = useRoute();
+    const uiStore = useUiStore();
+    return { route, uiStore };
   },
 });
 </script>

--- a/src/pages/NostrMessenger.vue
+++ b/src/pages/NostrMessenger.vue
@@ -1,0 +1,7 @@
+<template>
+  <q-page padding>
+    <div class="text-h5">Nostr Messenger</div>
+  </q-page>
+</template>
+
+<script setup lang="ts"></script>

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -42,6 +42,17 @@ const routes = [
     component: () => import("layouts/FullscreenLayout.vue"),
     children: [{ path: "", component: () => import("src/pages/AboutPage.vue") }],
   },
+  {
+    path: "/nostr-messenger",
+    component: () => import("layouts/MainLayout.vue"),
+    meta: { messengerUI: true },
+    children: [
+      {
+        path: "",
+        component: () => import("src/pages/NostrMessenger.vue"),
+      },
+    ],
+  },
 
   // Always leave this as last one,
   // but you can also remove it

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -30,6 +30,7 @@ export const useUiStore = defineStore("ui", {
     showReceiveEcashDrawer: false,
     showNumericKeyboard: false,
     activityOrb: false,
+    showMessengerDrawer: false,
     tab: useLocalStorage("cashu.ui.tab", "history" as string),
     expandHistory: useLocalStorage("cashu.ui.expandHistory", true as boolean),
     globalMutexLock: false,


### PR DESCRIPTION
## Summary
- show chat menu button only on routes tagged with `messengerUI`
- mount messenger drawer only when `messengerUI` meta is present
- add placeholder Nostr messenger page and drawer components

## Testing
- `npm run lint`
- `npm test` *(fails: [🍍]: "getActivePinia()" was called but there was no active Pinia)*

------
https://chatgpt.com/codex/tasks/task_e_68a19f9b13f48330a307a3bdff3795b3