### PR TITLE
Hide chat toggle button outside messenger page

### DIFF
--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -3,6 +3,7 @@
     <q-toolbar class="app-toolbar" dense>
       <div class="left-controls row items-center no-wrap">
         <q-btn
+          v-if="isMessengerPage"
           flat
           dense
           round
@@ -213,6 +214,7 @@ export default defineComponent({
       reloading,
       ui,
       currentTitle,
+      isMessengerPage,
       toggleMessengerDrawer,
       toggleDarkMode,
       darkIcon,


### PR DESCRIPTION
## Summary
- show chat drawer toggle only on /nostr-messenger route

## Testing
- `pnpm lint` *(fails: Cannot find module './.eslintrc.js')*
- `pnpm test` *(fails: failing suites and module errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a1a37d75bc8330996d5cef9336bfa3