### PR TITLE
test: add URL sanitization tests

### DIFF
--- a/src/components/ChatMessageBubble.vue
+++ b/src/components/ChatMessageBubble.vue
@@ -52,8 +52,9 @@
             />
             <template v-else-if="isFile">
               <a
-                :href="message.content"
+                :href="attachmentUrl"
                 target="_blank"
+                rel="noopener noreferrer"
                 :download="attachmentName"
               >
                 {{ attachmentName }}
@@ -169,6 +170,9 @@ const deliveryColor = computed(() =>
 );
 
 const isDataUrl = computed(() => props.message.content.startsWith("data:"));
+const isSafeDataUrl = computed(() =>
+  /^data:(image|audio|video)\//i.test(props.message.content),
+);
 const isImageDataUrl = computed(() =>
   props.message.content.startsWith("data:image"),
 );
@@ -181,7 +185,10 @@ const isImageLink = computed(
 const imageSrc = computed(() =>
   isImageDataUrl.value || isImageLink.value ? props.message.content : "",
 );
-const isFile = computed(() => isDataUrl.value || isHttpUrl.value);
+const isFile = computed(() => isSafeDataUrl.value || isHttpUrl.value);
+const attachmentUrl = computed(() =>
+  isFile.value ? props.message.content : "#",
+);
 const attachmentName = computed(
   () =>
     props.message.attachment?.name ||

--- a/src/components/EssentialLink.vue
+++ b/src/components/EssentialLink.vue
@@ -1,5 +1,11 @@
 <template>
-  <q-item clickable tag="a" target="_blank" :href="link">
+  <q-item
+    clickable
+    tag="a"
+    target="_blank"
+    :href="safeLink"
+    rel="noopener noreferrer"
+  >
     <q-item-section v-if="icon" avatar>
       <q-icon :name="icon" />
     </q-item-section>
@@ -13,6 +19,7 @@
 
 <script>
 import { defineComponent } from "vue";
+import { isTrustedUrl } from "src/utils/sanitize-url";
 
 export default defineComponent({
   name: "EssentialLink",
@@ -35,6 +42,11 @@ export default defineComponent({
     icon: {
       type: String,
       default: "",
+    },
+  },
+  computed: {
+    safeLink() {
+      return isTrustedUrl(this.link) ? this.link : "#";
     },
   },
 });

--- a/src/components/MintAuditInfo.vue
+++ b/src/components/MintAuditInfo.vue
@@ -16,7 +16,7 @@
       <br />
       <span class="text-caption">
         To learn more about the auditor or support a future audit, visit
-        <a :href="auditUrl">audit.8333.space</a> or click
+        <a :href="auditUrl" rel="noopener noreferrer">audit.8333.space</a> or click
         <span
           class="text-bold cursor-pointer text-primary"
           @click="getAuditorPaymentRequestsAndHandle"
@@ -78,8 +78,8 @@
       <!-- Donate ecash to the auditor -->
       <div class="q-mt-md text-grey-6 text-caption">
         Audit information is made available by
-        <a :href="auditUrl">{{ auditUrlShort }}</a
-        >. The current balance held by the auditor for this mint is
+        <a :href="auditUrl" rel="noopener noreferrer">{{ auditUrlShort }}</a>
+        . The current balance held by the auditor for this mint is
         <span class="text-bold">{{ mintInfo.balance }} sats</span>, with a total
         of
         <span class="text-bold">{{ mintInfo.sum_donations }} sats</span>
@@ -134,6 +134,7 @@ import { useWalletStore } from "../stores/wallet";
 import { useMintsStore } from "../stores/mints";
 import { useSettingsStore } from "../stores/settings";
 import { getShortUrl } from "../js/wallet-helpers";
+import { isTrustedUrl } from "src/utils/sanitize-url";
 
 export default {
   name: "MintAuditInfo",
@@ -151,7 +152,9 @@ export default {
     const settingsStore = useSettingsStore();
     return {
       auditorApiUrl: settingsStore.auditorApiUrl,
-      auditUrl: settingsStore.auditorUrl,
+      auditUrl: isTrustedUrl(settingsStore.auditorUrl)
+        ? settingsStore.auditorUrl
+        : "#",
       auditUrlShort: getShortUrl(settingsStore.auditorUrl),
       mintNotAudited: false,
       loading: true,

--- a/src/components/NWCDialog.vue
+++ b/src/components/NWCDialog.vue
@@ -9,7 +9,7 @@
       class="q-px-lg q-pt-md q-pb-md qcard"
     >
       <div class="text-center q-mb-md q-mt-none q-pt-none">
-        <a :href="showNWCData.connectionString">
+        <a :href="safeConnectionString" rel="noopener noreferrer">
           <q-responsive :ratio="1" class="q-mx-md q-mt-none q-pt-none">
             <vue-qrcode
               :value="showNWCData.connectionString"
@@ -86,6 +86,10 @@ export default defineComponent({
   computed: {
     ...mapState(useNWCStore, ["showNWCData"]),
     ...mapWritableState(useNWCStore, ["showNWCDialog"]),
+    safeConnectionString() {
+      const url = this.showNWCData.connectionString || "";
+      return /^(nostr\+walletconnect:|https?:)/i.test(url) ? url : "#";
+    },
   },
   methods: {},
 });

--- a/test/chat-message-bubble.sanitize.spec.ts
+++ b/test/chat-message-bubble.sanitize.spec.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { createTestingPinia } from '@pinia/testing';
+import { useNostrStore } from 'src/stores/nostr';
+
+describe('ChatMessageBubble', () => {
+  it('blocks HTML data URLs', async () => {
+    (window as any).windowMixin = {};
+    const ChatMessageBubble = (await import('src/components/ChatMessageBubble.vue')).default;
+    const pinia = createTestingPinia({ createSpy: vi.fn });
+    const nostr = useNostrStore();
+    nostr.pubkey = 'pk';
+    nostr.getProfile = vi.fn().mockResolvedValue(null);
+    const message = {
+      id: '1',
+      pubkey: 'pk',
+      content: 'data:text/html,<script>console.log(1)</script>',
+      created_at: 0,
+      outgoing: true,
+    };
+    const wrapper = shallowMount(ChatMessageBubble, {
+      props: { message },
+      global: { plugins: [pinia] },
+    });
+    expect(wrapper.find('a').exists()).toBe(false);
+  });
+});

--- a/test/essential-link.sanitize.spec.ts
+++ b/test/essential-link.sanitize.spec.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { defineComponent, h } from 'vue';
+import EssentialLink from 'src/components/EssentialLink.vue';
+
+const QItemStub = defineComponent({
+  props: ['href', 'target', 'rel', 'tag'],
+  setup(props, { slots }) {
+    return () =>
+      h(
+        props.tag || 'div',
+        { href: props.href, target: props.target, rel: props.rel },
+        slots.default ? slots.default() : [],
+      );
+  },
+});
+
+describe('EssentialLink', () => {
+  it('sanitizes malicious link', () => {
+    const wrapper = mount(EssentialLink, {
+      props: { title: 't', link: 'javascript:console.log(1)' },
+      global: {
+        stubs: {
+          'q-item': QItemStub,
+          'q-item-section': { template: '<div><slot/></div>' },
+          'q-item-label': { template: '<div><slot/></div>' },
+          'q-icon': { template: '<i />' },
+        },
+      },
+    });
+    const a = wrapper.get('a');
+    expect(a.attributes('href')).toBe('#');
+    expect(a.attributes('rel')).toBe('noopener noreferrer');
+  });
+});

--- a/test/mint-audit-info.sanitize.spec.ts
+++ b/test/mint-audit-info.sanitize.spec.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { createTestingPinia } from '@pinia/testing';
+describe('MintAuditInfo', () => {
+  it('sanitizes auditor URL', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, json: async () => ({}) })));
+    const pinia = createTestingPinia({
+      createSpy: vi.fn,
+      initialState: {
+        settings: {
+          auditorUrl: 'javascript:1',
+          auditorApiUrl: '',
+          defaultNostrRelays: [],
+        },
+      },
+    });
+    const MintAuditInfo = (await import('src/components/MintAuditInfo.vue')).default;
+    const wrapper = shallowMount(MintAuditInfo, {
+      props: { mintUrl: 'm' },
+      global: {
+        plugins: [pinia],
+        stubs: {
+          'q-spinner-hourglass': true,
+          'q-icon': true,
+          MintAuditWarningBox: true,
+          MintAuditSwapsBarChart: true,
+        },
+      },
+    });
+    await wrapper.setData({ loading: false, mintNotAudited: true });
+    const a = wrapper.get('a');
+    expect(a.attributes('href')).toBe('#');
+    expect(a.attributes('rel')).toBe('noopener noreferrer');
+  });
+});

--- a/test/nwc-dialog.sanitize.spec.ts
+++ b/test/nwc-dialog.sanitize.spec.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+import { createTestingPinia } from '@pinia/testing';
+import { useNWCStore } from 'src/stores/nwc';
+
+vi.mock('src/composables/useClipboard', () => ({ useClipboard: () => ({ copy: vi.fn() }) }));
+
+describe('NWCDialog', () => {
+  it('rejects javascript protocol', async () => {
+    (window as any).windowMixin = {};
+    const NWCDialog = (await import('src/components/NWCDialog.vue')).default;
+    const pinia = createTestingPinia({ createSpy: vi.fn });
+    const nwcStore = useNWCStore();
+    nwcStore.showNWCData.connectionString = 'javascript:alert(1)';
+    nwcStore.showNWCDialog = true;
+    const wrapper = shallowMount(NWCDialog, {
+      global: {
+        plugins: [pinia],
+        mocks: { $t: (s: string) => s },
+        stubs: {
+          'q-dialog': { template: '<div><slot /></div>' },
+          'q-card': { template: '<div><slot /></div>' },
+          'q-responsive': { template: '<div><slot /></div>' },
+          'q-card-section': { template: '<div><slot /></div>' },
+          'q-item-label': { template: '<div><slot /></div>' },
+          'q-btn': { template: '<button><slot /></button>' },
+          'vue-qrcode': { template: '<div />' },
+        },
+      },
+    });
+    const a = wrapper.get('a');
+    expect(a.attributes('href')).toBe('#');
+    expect(a.attributes('rel')).toBe('noopener noreferrer');
+  });
+});


### PR DESCRIPTION
## Summary
- sanitize external links with `isTrustedUrl` and enforce `rel="noopener noreferrer"`
- whitelist NWC connection protocols and harden chat attachment handling
- validate auditor URL before rendering
- add regression tests covering malicious link and data URL cases

## Testing
- `pnpm test`
- `pnpm vitest run test/essential-link.sanitize.spec.ts test/nwc-dialog.sanitize.spec.ts test/chat-message-bubble.sanitize.spec.ts test/mint-audit-info.sanitize.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a216a451208330b5271489a58158c8