### PR TITLE
fix: prevent navigation drawer overlapping with hamburger button

### DIFF
--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -1,5 +1,5 @@
 <template>
-  <q-header class="bg-transparent">
+  <q-header class="bg-transparent" :class="{ 'nav-open': ui.mainNavOpen }">
     <q-toolbar class="app-toolbar" dense>
       <div class="left-controls row items-center no-wrap">
         <q-btn
@@ -230,6 +230,11 @@ export default defineComponent({
   /* Keep header above Quasar drawer/scrim layers on mobile overlays */
   z-index: 11000;
   overflow-x: hidden;
+}
+
+.q-header.nav-open {
+  /* Let the main navigation drawer overlay the header */
+  z-index: 1;
 }
 
 .app-toolbar {


### PR DESCRIPTION
## Summary
- lower header z-index while nav drawer is open to let drawer fully cover the hamburger button

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2d0cbc1b48330ad881e3eb30a38e7