### PR TITLE
fix: keep menu button accessible

### DIFF
--- a/src/components/AppNavDrawer.vue
+++ b/src/components/AppNavDrawer.vue
@@ -197,7 +197,9 @@ const essentialLinks = [
 <style scoped>
 .app-nav-drawer {
   z-index: 4000;
-  transition: transform .18s ease, opacity .18s ease;
+  top: var(--app-header-height);
+  height: calc(100vh - var(--app-header-height));
+  transition: transform 0.18s ease, opacity 0.18s ease;
   backdrop-filter: saturate(1.2);
 }
 </style>

--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -234,7 +234,8 @@ export default defineComponent({
 
 .app-toolbar {
   padding-inline: 8px;
-  min-height: 48px;
+  min-height: var(--app-header-height);
+  height: var(--app-header-height);
   display: flex;
   align-items: center;
 }

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -99,6 +99,7 @@ body,
 
 /* theme-based variables */
 :root {
+  --app-header-height: 48px;
   --icon-bg-dark: var(--q-color-grey-10);
   --icon-bg-light: var(--q-color-grey-3);
   --custom-btn-dark: var(--q-color-grey-9);


### PR DESCRIPTION
## Summary
- offset navigation drawer to sit below header so hamburger toggle stays visible
- centralize header height via CSS variable

## Testing
- `pnpm run test:ci`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a2d38c2bfc833087087bf7985e5672