### PR TITLE
fix: keep main nav hamburger accessible on mobile

### DIFF
--- a/src/components/AppNavDrawer.vue
+++ b/src/components/AppNavDrawer.vue
@@ -2,7 +2,8 @@
   <q-drawer
     v-model="ui.mainNavOpen"
     side="left"
-    overlay
+    :overlay="$q.screen.lt.md"
+    :breakpoint="1024"
     bordered
     behavior="mobile"
     :no-swipe-backdrop="false"
@@ -10,7 +11,10 @@
     class="app-nav-drawer"
     id="app-nav"
     elevated
+    tabindex="0"
+    :content-class="drawerContentClass"
     @hide="ui.closeMainNav()"
+    @keyup.esc="ui.closeMainNav()"
   >
     <q-list>
       <q-item-label header>{{ $t('MainHeader.menu.settings.title') }}</q-item-label>
@@ -129,12 +133,14 @@ import { useRouter } from 'vue-router'
 import { useUiStore } from 'src/stores/ui'
 import { useNostrStore } from 'src/stores/nostr'
 import { useI18n } from 'vue-i18n'
+import { useQuasar } from 'quasar'
 import EssentialLink from 'components/EssentialLink.vue'
 
 const ui = useUiStore()
 const router = useRouter()
 const nostrStore = useNostrStore()
 const { t } = useI18n()
+const $q = useQuasar()
 
 function goto(path: string) {
   router.push(path)
@@ -153,6 +159,10 @@ const gotoTerms = () => goto('/terms')
 const gotoAbout = () => goto('/about')
 
 const needsNostrLogin = computed(() => !nostrStore.privateKeySignerPrivateKey)
+
+const drawerContentClass = computed(() =>
+  $q.screen.lt.md ? 'main-nav-safe' : undefined,
+)
 
 const essentialLinks = [
   {
@@ -199,5 +209,10 @@ const essentialLinks = [
   z-index: 4000;
   transition: transform .18s ease, opacity .18s ease;
   backdrop-filter: saturate(1.2);
+}
+
+.main-nav-safe {
+  padding-left: calc(env(safe-area-inset-left) + 60px);
+  padding-top: calc(env(safe-area-inset-top) + 8px);
 }
 </style>

--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -24,6 +24,7 @@
           :aria-expanded="String(ui.mainNavOpen)"
           aria-controls="app-nav"
           @click="ui.toggleMainNav"
+          ref="mainNavBtn"
           :disable="ui.globalMutexLock"
         >
           <q-tooltip>Menu</q-tooltip>
@@ -110,10 +111,35 @@
       </div>
     </q-toolbar>
   </q-header>
+  <div
+    v-if="$q.screen.lt.md"
+    class="mobile-nav-toggle"
+  >
+    <q-btn
+      ref="mobileNavBtn"
+      round
+      flat
+      :icon="ui.mainNavOpen ? 'close' : 'menu'"
+      color="primary"
+      class="mobile-nav-btn"
+      aria-label="Toggle main menu"
+      aria-controls="app-nav"
+      :aria-expanded="String(ui.mainNavOpen)"
+      @click="ui.toggleMainNav"
+    />
+  </div>
 </template>
 
 <script>
-import { defineComponent, ref, computed, getCurrentInstance } from "vue";
+import {
+  defineComponent,
+  ref,
+  computed,
+  getCurrentInstance,
+  onMounted,
+  onBeforeUnmount,
+  nextTick,
+} from "vue";
 import { useRoute } from "vue-router";
 import { useUiStore } from "src/stores/ui";
 import { useMessengerStore } from "src/stores/messenger";
@@ -128,6 +154,24 @@ export default defineComponent({
     const route = useRoute();
     const messenger = useMessengerStore();
     const $q = useQuasar();
+    const mainNavBtn = ref(null);
+    const mobileNavBtn = ref(null);
+
+    const focusNavBtn = () => {
+      (mobileNavBtn.value || mainNavBtn.value)?.focus();
+    };
+    const onKeydown = (e) => {
+      if (e.key === "Escape" && ui.mainNavOpen) {
+        ui.closeMainNav();
+        nextTick(focusNavBtn);
+      }
+    };
+
+    onMounted(() => window.addEventListener("keydown", onKeydown));
+    onBeforeUnmount(() =>
+      window.removeEventListener("keydown", onKeydown),
+    );
+
     const toggleDarkMode = () => {
       console.log("toggleDarkMode", $q.dark.isActive);
       $q.dark.toggle();
@@ -219,6 +263,8 @@ export default defineComponent({
       toggleDarkMode,
       darkIcon,
       chatButtonColor,
+      mainNavBtn,
+      mobileNavBtn,
     };
   },
 });
@@ -252,5 +298,17 @@ export default defineComponent({
   display: inline-flex;
   align-items: center;
   gap: 6px;
+}
+
+.mobile-nav-toggle {
+  position: fixed;
+  top: calc(env(safe-area-inset-top) + 8px);
+  left: calc(env(safe-area-inset-left) + 8px);
+  z-index: 12000;
+}
+
+.mobile-nav-btn {
+  width: 44px;
+  height: 44px;
 }
 </style>


### PR DESCRIPTION
## Summary
- add fixed mobile nav toggle that stays above drawers and reflects nav state
- pad nav drawer content on small screens and close on Esc

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a2d8f8a6c48330a9a4ae2eebf470cf