### PR TITLE
feat: offset header when nav drawer open

### DIFF
--- a/src/components/AppNavDrawer.vue
+++ b/src/components/AppNavDrawer.vue
@@ -4,6 +4,7 @@
     side="left"
     :overlay="$q.screen.lt.md"
     :breakpoint="1024"
+    :width="NAV_DRAWER_WIDTH"
     bordered
     behavior="mobile"
     :no-swipe-backdrop="false"
@@ -135,6 +136,7 @@ import { useNostrStore } from 'src/stores/nostr'
 import { useI18n } from 'vue-i18n'
 import { useQuasar } from 'quasar'
 import EssentialLink from 'components/EssentialLink.vue'
+import { NAV_DRAWER_WIDTH } from 'src/constants/layout'
 
 const ui = useUiStore()
 const router = useRouter()
@@ -161,7 +163,7 @@ const gotoAbout = () => goto('/about')
 const needsNostrLogin = computed(() => !nostrStore.privateKeySignerPrivateKey)
 
 const drawerContentClass = computed(() =>
-  $q.screen.lt.md ? 'main-nav-safe' : undefined,
+  $q.screen.lt.md ? 'main-nav-safe' : 'q-pt-sm',
 )
 
 const essentialLinks = [
@@ -206,9 +208,15 @@ const essentialLinks = [
 
 <style scoped>
 .app-nav-drawer {
-  z-index: 4000;
+  z-index: 1000;
   transition: transform .18s ease, opacity .18s ease;
   backdrop-filter: saturate(1.2);
+  box-shadow: 2px 0 4px rgba(0, 0, 0, 0.1);
+  border-right: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+.body--dark .app-nav-drawer {
+  border-right: 1px solid rgba(255, 255, 255, 0.24);
 }
 
 .main-nav-safe {

--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -300,6 +300,11 @@ export default defineComponent({
   gap: 6px;
 }
 
+.left-controls {
+  transition: transform 0.2s ease;
+  transform: translateX(var(--nav-offset-x, 0));
+}
+
 .mobile-nav-toggle {
   position: fixed;
   top: calc(env(safe-area-inset-top) + 8px);

--- a/src/constants/layout.ts
+++ b/src/constants/layout.ts
@@ -1,0 +1,2 @@
+export const NAV_DRAWER_WIDTH = 280;
+export const NAV_DRAWER_GUTTER = 8;

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -2,6 +2,7 @@
   <q-layout
     view="lHh Lpr lFf"
     :class="$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark'"
+    :style="navStyleVars"
   >
     <MainHeader />
     <AppNavDrawer />
@@ -94,6 +95,8 @@ import NewChatDialog from "components/NewChatDialog.vue";
 import { useNostrStore } from "src/stores/nostr";
 import { useNutzapStore } from "src/stores/nutzap";
 import { useMessengerStore } from "src/stores/messenger";
+import { useUiStore } from "src/stores/ui";
+import { NAV_DRAWER_WIDTH, NAV_DRAWER_GUTTER } from "src/constants/layout";
 
 export default defineComponent({
   name: "MainLayout",
@@ -111,6 +114,15 @@ export default defineComponent({
     const conversationSearch = ref("");
     const newChatDialogRef = ref(null);
     const $q = useQuasar();
+    const ui = useUiStore();
+
+    const navStyleVars = computed(() => ({
+      "--nav-drawer-width": `${NAV_DRAWER_WIDTH}px`,
+      "--nav-offset-x":
+        ui.mainNavOpen && $q.screen.width >= 1024
+          ? `calc(var(--nav-drawer-width) + ${NAV_DRAWER_GUTTER}px)`
+          : "0px",
+    }));
 
     // Persisted width just for this layout (keep store unchanged)
     const DEFAULT_DESKTOP = 440;
@@ -198,6 +210,7 @@ export default defineComponent({
       isMessengerRoute,
       computedDrawerWidth,
       onResizeStart,
+      navStyleVars,
     };
   },
   async mounted() {


### PR DESCRIPTION
## Summary
- shift header controls using CSS vars so hamburger clears drawer
- add subtle border and shadow to desktop nav drawer
- centralize drawer width and gutter constants

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a2e05f9b748330894ad49dfc3c27eb