### PR TITLE
Fix About tiles: remove link underline, stop translating icons, add i18n fallbacks

### DIFF
--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1740,57 +1740,48 @@ export const messages = {
       title: "Site Overview",
       wallet: {
         description: "Manage your ecash balance.",
-        icon: "account_balance_wallet",
       },
       findCreators: {
         description: "Discover creators to support.",
-        icon: "img:icons/find-creators.svg",
       },
-
+      creatorHub: {
+        description:
+          "Post, track goals, and withdraw—your creator tools.",
+      },
       myProfile: {
         description: "View and edit your profile.",
-        icon: "person",
       },
       buckets: {
         description: "Organize funds into buckets.",
-        icon: "inventory_2",
       },
       subscriptions: {
         description: "Manage your subscriptions.",
-        icon: "auto_awesome_motion",
       },
       nostrMessengerTitle: "Nostr Messenger",
       nostrMessenger: {
         description: "Chat privately with Nostr.",
-        icon: "chat",
       },
       settings: {
         description: "Configure the app.",
-        icon: "settings",
       },
       restoreTitle: "Restore",
       restore: {
         description: "Recover your wallet from a backup.",
-        icon: "settings_backup_restore",
       },
       alreadyRunningTitle: "Already Running",
       alreadyRunning: {
         description: "Warning when another session is active.",
-        icon: "warning",
       },
       welcomeTitle: "Welcome",
       welcome: {
         description: "Introductory guide to Fundstr.",
-        icon: "info",
       },
       terms: {
         description: "Review the terms of service.",
-        icon: "gavel",
       },
       nostrLoginTitle: "Nostr Login",
       nostrLogin: {
         description: "Authenticate using your Nostr keys.",
-        icon: "vpn_key",
       },
     },
     navigation: {

--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -52,18 +52,19 @@
             v-for="card in siteOverviewCards"
             :key="card.route"
             :to="card.route"
-            class="interactive-card p-6 md:p-8 flex flex-col cursor-pointer"
+            class="interactive-card block no-underline p-6 md:p-8 flex flex-col cursor-pointer"
+            :aria-label="$t(card.titleKey)"
           >
             <q-icon
-              :name="$t(card.iconKey)"
+              :name="card.icon"
               size="2.5rem"
               class="text-white mb-4"
             />
             <p class="text-accent font-semibold">
-              {{ $t(card.titleKey) }}
+              {{ tOr(card.titleKey) }}
             </p>
             <p class="text-sm mt-2">
-              {{ $t(card.descriptionKey) }}
+              {{ tOr(card.descriptionKey) }}
             </p>
           </router-link>
         </div>
@@ -826,12 +827,16 @@ const dialogStep2 = ref(false);
 const dialogStep3 = ref(false);
 
 const { t } = useI18n();
+const tOr = (key: string, fallback = "") => {
+  const val = t(key) as string;
+  return val && val !== key ? val : fallback;
+};
 
 interface SiteOverviewCard {
   route: string;
   titleKey: string;
   descriptionKey: string;
-  iconKey: string;
+  icon: string;
 }
 
 const siteOverviewCards: SiteOverviewCard[] = [
@@ -839,79 +844,79 @@ const siteOverviewCards: SiteOverviewCard[] = [
     route: "/wallet",
     titleKey: "MainHeader.menu.wallet.title",
     descriptionKey: "AboutPage.siteOverview.wallet.description",
-    iconKey: "AboutPage.siteOverview.wallet.icon",
+    icon: "account_balance_wallet",
   },
   {
     route: "/find-creators",
     titleKey: "MainHeader.menu.findCreators.title",
     descriptionKey: "AboutPage.siteOverview.findCreators.description",
-    iconKey: "AboutPage.siteOverview.findCreators.icon",
+    icon: "img:icons/find-creators.svg",
   },
   {
     route: "/creator-hub",
     titleKey: "MainHeader.menu.creatorHub.title",
     descriptionKey: "AboutPage.siteOverview.creatorHub.description",
-    iconKey: "AboutPage.siteOverview.creatorHub.icon",
+    icon: "img:icons/creator-hub.svg",
   },
   {
     route: "/my-profile",
     titleKey: "MainHeader.menu.myProfile.title",
     descriptionKey: "AboutPage.siteOverview.myProfile.description",
-    iconKey: "AboutPage.siteOverview.myProfile.icon",
+    icon: "person",
   },
   {
     route: "/buckets",
     titleKey: "MainHeader.menu.buckets.title",
     descriptionKey: "AboutPage.siteOverview.buckets.description",
-    iconKey: "AboutPage.siteOverview.buckets.icon",
+    icon: "inventory_2",
   },
   {
     route: "/subscriptions",
     titleKey: "MainHeader.menu.subscriptions.title",
     descriptionKey: "AboutPage.siteOverview.subscriptions.description",
-    iconKey: "AboutPage.siteOverview.subscriptions.icon",
+    icon: "auto_awesome_motion",
   },
   {
     route: "/nostr-messenger",
     titleKey: "MainHeader.menu.nostrMessenger.title",
     descriptionKey: "AboutPage.siteOverview.nostrMessenger.description",
-    iconKey: "AboutPage.siteOverview.nostrMessenger.icon",
+    icon: "chat",
   },
   {
     route: "/settings",
     titleKey: "MainHeader.menu.settings.title",
     descriptionKey: "AboutPage.siteOverview.settings.description",
-    iconKey: "AboutPage.siteOverview.settings.icon",
+    icon: "settings",
   },
   {
     route: "/restore",
     titleKey: "MainHeader.menu.restore.title",
     descriptionKey: "AboutPage.siteOverview.restore.description",
-    iconKey: "AboutPage.siteOverview.restore.icon",
+    icon: "settings_backup_restore",
   },
   {
     route: "/already-running",
     titleKey: "MainHeader.menu.alreadyRunning.title",
     descriptionKey: "AboutPage.siteOverview.alreadyRunning.description",
-    iconKey: "AboutPage.siteOverview.alreadyRunning.icon",
+    icon: "warning",
   },
   {
     route: "/welcome",
     titleKey: "MainHeader.menu.welcome.title",
     descriptionKey: "AboutPage.siteOverview.welcome.description",
-    iconKey: "AboutPage.siteOverview.welcome.icon",
+    icon: "info",
   },
   {
     route: "/terms",
     titleKey: "MainHeader.menu.terms.title",
     descriptionKey: "AboutPage.siteOverview.terms.description",
-    iconKey: "AboutPage.siteOverview.terms.icon",
+    icon: "gavel",
   },
   {
     route: "/nostr-login",
     titleKey: "MainHeader.menu.nostrLogin.title",
     descriptionKey: "AboutPage.siteOverview.nostrLogin.description",
-    iconKey: "AboutPage.siteOverview.nostrLogin.icon",
+    icon: "vpn_key",
   },
 ];
 
@@ -1074,12 +1079,19 @@ onMounted(() => {
   border: 1px solid #1e293b;
   border-radius: 0.75rem;
   transition: all 0.3s ease;
+  text-decoration: none;
 }
 
 .interactive-card:hover {
   transform: translateY(-5px);
   box-shadow: 0 0 25px rgba(var(--color-accent-rgb), 0.2);
   border-color: rgba(var(--color-accent-rgb), 0.4);
+  text-decoration: none;
+}
+
+.interactive-card p {
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .accordion-item {


### PR DESCRIPTION
## Summary
- Stop translating About page card icons and add fallback helper to avoid raw i18n keys
- Make About page cards block-level links with no underline and safe text wrapping
- Fill missing creator hub description and drop unused icon entries in en-US locale

## Testing
- `pnpm run lint`
- `pnpm run types` *(fails: Property 'trustedTypes' does not exist, unknown type errors in creatorSubscribers, safe-markdown overload issues)*
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a33b5ae6c4833095833b30136d5854