### PR TITLE
Ensure navigation drawer available across layouts

### DIFF
--- a/src/layouts/BlankLayout.vue
+++ b/src/layouts/BlankLayout.vue
@@ -4,6 +4,7 @@
     :class="$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark'"
   >
     <MainHeader />
+    <AppNavDrawer />
     <q-page-container class="text-body1">
       <div class="max-w-7xl mx-auto">
         <router-view />
@@ -15,12 +16,19 @@
 <script>
 import { defineComponent } from "vue";
 import MainHeader from "components/MainHeader.vue";
+import AppNavDrawer from "components/AppNavDrawer.vue";
+import { useUiStore } from "src/stores/ui";
 
 export default defineComponent({
   name: "BlankLayout",
   mixins: [windowMixin],
   components: {
     MainHeader,
+    AppNavDrawer,
+  },
+  setup() {
+    const ui = useUiStore();
+    return { ui };
   },
 });
 </script>

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -51,8 +51,14 @@ const routes = [
   },
   {
     path: "/creator/:npub",
-    name: "PublicCreatorProfile",
-    component: () => import("src/pages/PublicCreatorProfilePage.vue"),
+    component: () => import("layouts/FullscreenLayout.vue"),
+    children: [
+      {
+        path: "",
+        name: "PublicCreatorProfile",
+        component: () => import("src/pages/PublicCreatorProfilePage.vue"),
+      },
+    ],
   },
   {
     path: "/buckets",


### PR DESCRIPTION
## Summary
- include `AppNavDrawer` and `useUiStore` in `BlankLayout` so nav menu works on welcome/already-running pages
- wrap public creator profile route with `FullscreenLayout` for consistent header and drawer

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a36649eb9483308ee209a09c25652d