### PR TITLE
refactor: unify overlay navigation drawer

### DIFF
--- a/src/components/AppNavDrawer.vue
+++ b/src/components/AppNavDrawer.vue
@@ -2,16 +2,16 @@
   <q-drawer
     v-model="ui.mainNavOpen"
     side="left"
-    :overlay="$q.screen.lt.md"
-    :breakpoint="1024"
-    :width="NAV_DRAWER_WIDTH"
+    overlay
+    elevated
     bordered
-    behavior="mobile"
+    :width="NAV_DRAWER_WIDTH"
+    :breakpoint="NAV_DRAWER_BREAKPOINT"
+    behavior="desktop"
     :no-swipe-backdrop="false"
     :no-swipe-open="false"
     class="app-nav-drawer"
     id="app-nav"
-    elevated
     tabindex="0"
     :content-class="drawerContentClass"
     @hide="ui.closeMainNav()"
@@ -178,7 +178,10 @@ import { useNostrStore } from "src/stores/nostr";
 import { useI18n } from "vue-i18n";
 import { useQuasar } from "quasar";
 import EssentialLink from "components/EssentialLink.vue";
-import { NAV_DRAWER_WIDTH } from "src/constants/layout";
+import {
+  NAV_DRAWER_WIDTH,
+  NAV_DRAWER_BREAKPOINT,
+} from "src/constants/layout";
 
 const ui = useUiStore();
 const router = useRouter();
@@ -204,8 +207,9 @@ const gotoAbout = () => goto("/about");
 
 const needsNostrLogin = computed(() => !nostrStore.privateKeySignerPrivateKey);
 
+// Keep the safe-area padding for small screens only
 const drawerContentClass = computed(() =>
-  $q.screen.lt.md ? "main-nav-safe" : "q-pt-sm",
+  $q.screen.lt.md ? "main-nav-safe" : "q-pt-sm"
 );
 
 const essentialLinks = [
@@ -251,7 +255,9 @@ const essentialLinks = [
 <style scoped>
 .app-nav-drawer {
   z-index: 1000;
-  transition: transform 0.18s ease, opacity 0.18s ease;
+  /* unify motion across pages */
+  transition: transform var(--nav-anim, 220ms) var(--nav-ease, cubic-bezier(.2,.8,.2,1)),
+              opacity   var(--nav-anim, 220ms) var(--nav-ease, cubic-bezier(.2,.8,.2,1));
   backdrop-filter: saturate(1.2);
   box-shadow: 2px 0 4px rgba(0, 0, 0, 0.1);
   border-right: 1px solid rgba(0, 0, 0, 0.12);

--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -303,8 +303,8 @@ export default defineComponent({
 }
 
 .left-controls {
-  transition: transform 0.2s ease;
-  transform: translateX(var(--nav-offset-x, 0));
+  /* No layout shifting; drawer overlays content */
+  transition: none;
 }
 
 .mobile-nav-toggle {

--- a/src/constants/layout.ts
+++ b/src/constants/layout.ts
@@ -1,2 +1,5 @@
 export const NAV_DRAWER_WIDTH = 280;
 export const NAV_DRAWER_GUTTER = 8;
+export const NAV_DRAWER_BREAKPOINT = 1024;
+export const NAV_ANIM_MS = 220;
+export const NAV_EASING = 'cubic-bezier(.2, .8, .2, 1)';

--- a/src/css/app.scss
+++ b/src/css/app.scss
@@ -329,3 +329,16 @@ body.body--dark .received {
   grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
   gap: 1.5rem;
 }
+
+/* Nav drawer motion tokens */
+:root {
+  --nav-anim: 220ms;
+  --nav-ease: cubic-bezier(.2, .8, .2, 1);
+}
+
+/* Ensure drawer & its scrim share the same feel */
+.q-drawer,
+.q-drawer__backdrop {
+  transition-duration: var(--nav-anim) !important;
+  transition-timing-function: var(--nav-ease) !important;
+}

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -2,7 +2,6 @@
   <q-layout
     view="lHh Lpr lFf"
     :class="$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark'"
-    :style="navStyleVars"
   >
     <MainHeader />
     <AppNavDrawer />
@@ -95,8 +94,6 @@ import NewChatDialog from "components/NewChatDialog.vue";
 import { useNostrStore } from "src/stores/nostr";
 import { useNutzapStore } from "src/stores/nutzap";
 import { useMessengerStore } from "src/stores/messenger";
-import { useUiStore } from "src/stores/ui";
-import { NAV_DRAWER_WIDTH, NAV_DRAWER_GUTTER } from "src/constants/layout";
 
 export default defineComponent({
   name: "MainLayout",
@@ -114,15 +111,6 @@ export default defineComponent({
     const conversationSearch = ref("");
     const newChatDialogRef = ref(null);
     const $q = useQuasar();
-    const ui = useUiStore();
-
-    const navStyleVars = computed(() => ({
-      "--nav-drawer-width": `${NAV_DRAWER_WIDTH}px`,
-      "--nav-offset-x":
-        ui.mainNavOpen && $q.screen.width >= 1024
-          ? `calc(var(--nav-drawer-width) + ${NAV_DRAWER_GUTTER}px)`
-          : "0px",
-    }));
 
     // Persisted width just for this layout (keep store unchanged)
     const DEFAULT_DESKTOP = 440;
@@ -211,7 +199,6 @@ export default defineComponent({
       isMessengerRoute,
       computedDrawerWidth,
       onResizeStart,
-      navStyleVars,
     };
   },
   async mounted() {

--- a/src/pages/WalletBucketsPage.vue
+++ b/src/pages/WalletBucketsPage.vue
@@ -6,7 +6,6 @@
       'wallet-layout',
     ]"
   >
-    <Sidebar />
     <HeaderBar />
     <q-page-container class="q-pa-md">
       <BucketManager />
@@ -25,7 +24,6 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import { storeToRefs } from "pinia";
-import Sidebar from "components/Sidebar.vue";
 import HeaderBar from "components/HeaderBar.vue";
 import BucketManager from "components/BucketManager.vue";
 import { useBucketsStore } from "stores/buckets";


### PR DESCRIPTION
## Summary
- standardize AppNavDrawer to always overlay with shared width, breakpoint, and animations
- remove layout offsets and header transforms now that nav doesn't push content
- drop legacy Sidebar usage and add nav motion tokens

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a37949eff88330869bb9d0c00bcbb9