### PR TITLE
Expose global nav drawer across layouts

### DIFF
--- a/src/layouts/BlankLayout.vue
+++ b/src/layouts/BlankLayout.vue
@@ -4,7 +4,7 @@
     :class="$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark'"
   >
     <MainHeader />
-    <AppNavDrawer />
+    <AppNavDrawer v-model="ui.mainNavOpen" />
     <q-page-container class="text-body1">
       <div class="max-w-7xl mx-auto">
         <router-view />

--- a/src/layouts/FullscreenLayout.vue
+++ b/src/layouts/FullscreenLayout.vue
@@ -4,7 +4,7 @@
     :class="$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark'"
   >
     <MainHeader />
-    <AppNavDrawer />
+    <AppNavDrawer v-model="ui.mainNavOpen" />
     <q-page-container class="text-body1">
       <router-view />
     </q-page-container>
@@ -23,6 +23,7 @@ import MainHeader from "components/MainHeader.vue";
 import AppNavDrawer from "components/AppNavDrawer.vue";
 import PublishBar from "components/PublishBar.vue";
 import { useCreatorHub } from "src/composables/useCreatorHub";
+import { useUiStore } from "src/stores/ui";
 
 export default defineComponent({
   name: "FullscreenLayout",
@@ -36,7 +37,8 @@ export default defineComponent({
     const { loggedIn, publishFullProfile, publishing } = useCreatorHub();
     const route = useRoute();
     const showPublishBar = computed(() => route.path === "/creator-hub");
-    return { loggedIn, publishFullProfile, publishing, showPublishBar };
+    const ui = useUiStore();
+    return { loggedIn, publishFullProfile, publishing, showPublishBar, ui };
   },
 });
 </script>

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -5,7 +5,7 @@
     :style="navStyleVars"
   >
     <MainHeader />
-    <AppNavDrawer />
+    <AppNavDrawer v-model="ui.mainNavOpen" />
     <q-drawer
       v-if="isMessengerRoute"
       v-model="messenger.drawerOpen"
@@ -203,6 +203,7 @@ export default defineComponent({
 
     return {
       messenger,
+      ui,
       conversationSearch,
       newChatDialogRef,
       openNewChatDialog,


### PR DESCRIPTION
## Summary
- Wire `AppNavDrawer` with `ui.mainNavOpen` in all layouts
- Import `useUiStore` in fullscreen layout and return to template
- Ensure layouts used by routes already reference these components

## Testing
- `pnpm lint`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3832ef9fc8330a2a68e1165d50a89