### PR TITLE
Propagate nav drawer offset vars to all layouts

### DIFF
--- a/src/components/AppNavDrawer.vue
+++ b/src/components/AppNavDrawer.vue
@@ -205,7 +205,7 @@ const gotoAbout = () => goto("/about");
 const needsNostrLogin = computed(() => !nostrStore.privateKeySignerPrivateKey);
 
 const drawerContentClass = computed(() =>
-  $q.screen.lt.md ? "main-nav-safe" : "q-pt-sm",
+  $q.screen.lt.md ? "main-nav-safe" : "q-pt-sm"
 );
 
 const essentialLinks = [

--- a/src/layouts/BlankLayout.vue
+++ b/src/layouts/BlankLayout.vue
@@ -2,6 +2,7 @@
   <q-layout
     view="lHh Lpr lFf"
     :class="$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark'"
+    :style="navStyleVars"
   >
     <MainHeader />
     <AppNavDrawer />
@@ -14,10 +15,12 @@
 </template>
 
 <script>
-import { defineComponent } from "vue";
+import { defineComponent, computed } from "vue";
 import MainHeader from "components/MainHeader.vue";
 import AppNavDrawer from "components/AppNavDrawer.vue";
 import { useUiStore } from "src/stores/ui";
+import { useQuasar } from "quasar";
+import { NAV_DRAWER_WIDTH, NAV_DRAWER_GUTTER } from "src/constants/layout";
 
 export default defineComponent({
   name: "BlankLayout",
@@ -28,7 +31,16 @@ export default defineComponent({
   },
   setup() {
     const ui = useUiStore();
-    return { ui };
+    const $q = useQuasar();
+    const navStyleVars = computed(() => ({
+      "--nav-drawer-width": `${NAV_DRAWER_WIDTH}px`,
+      "--nav-offset-x":
+        ui.mainNavOpen && $q.screen.width >= 1024
+          ? `calc(var(--nav-drawer-width) + ${NAV_DRAWER_GUTTER}px)`
+          : "0px",
+    }));
+
+    return { ui, navStyleVars };
   },
 });
 </script>

--- a/src/layouts/FullscreenLayout.vue
+++ b/src/layouts/FullscreenLayout.vue
@@ -2,6 +2,7 @@
   <q-layout
     view="lHh Lpr lFf"
     :class="$q.dark.isActive ? 'bg-dark text-white' : 'bg-white text-dark'"
+    :style="navStyleVars"
   >
     <MainHeader />
     <AppNavDrawer />
@@ -23,6 +24,9 @@ import MainHeader from "components/MainHeader.vue";
 import AppNavDrawer from "components/AppNavDrawer.vue";
 import PublishBar from "components/PublishBar.vue";
 import { useCreatorHub } from "src/composables/useCreatorHub";
+import { useQuasar } from "quasar";
+import { useUiStore } from "src/stores/ui";
+import { NAV_DRAWER_WIDTH, NAV_DRAWER_GUTTER } from "src/constants/layout";
 
 export default defineComponent({
   name: "FullscreenLayout",
@@ -36,7 +40,24 @@ export default defineComponent({
     const { loggedIn, publishFullProfile, publishing } = useCreatorHub();
     const route = useRoute();
     const showPublishBar = computed(() => route.path === "/creator-hub");
-    return { loggedIn, publishFullProfile, publishing, showPublishBar };
+
+    const $q = useQuasar();
+    const ui = useUiStore();
+    const navStyleVars = computed(() => ({
+      "--nav-drawer-width": `${NAV_DRAWER_WIDTH}px`,
+      "--nav-offset-x":
+        ui.mainNavOpen && $q.screen.width >= 1024
+          ? `calc(var(--nav-drawer-width) + ${NAV_DRAWER_GUTTER}px)`
+          : "0px",
+    }));
+
+    return {
+      loggedIn,
+      publishFullProfile,
+      publishing,
+      showPublishBar,
+      navStyleVars,
+    };
   },
 });
 </script>


### PR DESCRIPTION
## Summary
- expose shared nav drawer width and offset CSS vars in all layouts
- compute drawer padding class

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a386a9c94883308bfcd060d0dd8649