### PR TITLE
style: add spacing above chats list

### DIFF
--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -26,7 +26,7 @@
       <div class="column no-wrap full-height">
         <div
           v-show="!messenger.drawerMini"
-          class="row items-center justify-between q-mb-md"
+          class="row items-center justify-between q-mt-md q-mb-md"
         >
           <div class="text-subtitle1">Chats</div>
           <q-btn flat dense round icon="add" @click="openNewChatDialog" />


### PR DESCRIPTION
## Summary
- add margin above Chats header in messenger drawer

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a40c82e4a48330b15aa64e62f7e97b