### PR TITLE
chore: rename cashu.me references to Fundstr

### DIFF
--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='utf-8' ?>
 <resources>
-    <string name="app_name">Cashu.me</string>
-    <string name="title_activity_main">Cashu.me</string>
+    <string name="app_name">Fundstr</string>
+    <string name="title_activity_main">Fundstr</string>
     <string name="package_name">me.cashu.wallet</string>
     <string name="custom_url_scheme">me.cashu.wallet</string>
 </resources>

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -2,7 +2,7 @@ import type { CapacitorConfig } from "@capacitor/cli";
 
 const config: CapacitorConfig = {
   appId: "me.cashu.wallet",
-  appName: "Cashu.me",
+  appName: "Fundstr",
   webDir: "dist/pwa/",
 };
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,9 +1,9 @@
 version: "2"
 services:
-  cashu.me:
-    image: cashu.me
+  Fundstr:
+    image: Fundstr
     build: .
-    container_name: cashu.me
+    container_name: Fundstr
     restart: always
     ports:
       - "127.0.0.1:3000:80"

--- a/extension/embedder.html
+++ b/extension/embedder.html
@@ -4,6 +4,6 @@
     <link rel="stylesheet" type="text/css" href="style.css" />
   </head>
   <body>
-    <iframe id="iframe" src="https://wallet.cashu.me"></iframe>
+    <iframe id="iframe" src="https://wallet.Fundstr"></iframe>
   </body>
 </html>

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "Cashu.me",
+  "name": "Fundstr",
   "description": "A privacy-preserving ecash wallet for Bitcoin Lightning",
   "icons": { "128": "128.png", "32": "32.png", "16": "16.png" },
   "manifest_version": 3,
@@ -7,7 +7,7 @@
   "action": {
     "default_icon": "32.png",
     "default_popup": "embedder.html",
-    "default_title": "Cashu.me"
+    "default_title": "Fundstr"
   },
   "permissions": ["unlimitedStorage", "storage"]
 }

--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -6,7 +6,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
-	<string>Cashu.me</string>
+	<string>Fundstr</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "cashu",
   "version": "0.0.1",
-  "description": "Cashu.me Wallet",
-  "productName": "Cashu.me",
-  "author": "cashu.me",
+  "description": "Fundstr Wallet",
+  "productName": "Fundstr",
+  "author": "Fundstr",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src-pwa/manifest.json
+++ b/src-pwa/manifest.json
@@ -1,6 +1,6 @@
 {
-  "name": "Cashu.me",
-  "short_name": "Cashu.me",
+  "name": "Fundstr",
+  "short_name": "Fundstr",
   "description": "A Cashu Ecash wallet for the web.",
   "display": "standalone",
   "orientation": "portrait",

--- a/src/components/AddTierDialog.vue
+++ b/src/components/AddTierDialog.vue
@@ -91,7 +91,7 @@
                 :close-label="$t('global.actions.close.label')"
               />
               <a
-                href="https://github.com/cashu-community/cashu.me/blob/main/README.md#media-previews-for-tiers"
+                href="https://github.com/cashu-community/Fundstr/blob/main/README.md#media-previews-for-tiers"
                 target="_blank"
                 class="text-primary text-caption q-ml-sm"
                 >Learn more</a

--- a/src/components/AppNavDrawer.vue
+++ b/src/components/AppNavDrawer.vue
@@ -225,7 +225,7 @@ const essentialLinks = [
     title: t("MainHeader.menu.links.github.title"),
     caption: t("MainHeader.menu.links.github.caption"),
     icon: "code",
-    link: "https://github.com/cashubtc/cashu.me",
+    link: "https://github.com/cashubtc/Fundstr",
   },
   {
     title: t("MainHeader.menu.links.telegram.title"),

--- a/src/components/MainHeader.vue
+++ b/src/components/MainHeader.vue
@@ -185,7 +185,7 @@ export default defineComponent({
       route.path.startsWith("/nostr-messenger"),
     );
     const isWelcomePage = computed(() => route.path.startsWith("/welcome"));
-    const appName = "Cashu.me";
+    const appName = "Fundstr";
     const currentTitle = computed(() => {
       if (isMessengerPage.value) return "Nostr Messenger";
       if (route.path.startsWith("/wallet")) return "Wallet";

--- a/src/pages/ErrorNotFound.vue
+++ b/src/pages/ErrorNotFound.vue
@@ -14,13 +14,13 @@
         <div class="q-mt-md">
           <a
             class="q-pr-md"
-            href="https://docs.cashu.me"
+            href="https://docs.Fundstr"
             target="_blank"
             rel="noopener"
           >
             {{ $t("ErrorNotFound.links.docs") }}
           </a>
-          <a href="https://cashu.me" target="_blank" rel="noopener">
+          <a href="https://Fundstr" target="_blank" rel="noopener">
             {{ $t("ErrorNotFound.links.tips") }}
           </a>
         </div>

--- a/src/stores/nwc.ts
+++ b/src/stores/nwc.ts
@@ -100,7 +100,7 @@ export const useNWCStore = defineStore("nwc", {
       return {
         result_type: "get_info",
         result: {
-          alias: "Cashu.me",
+          alias: "Fundstr",
           color: "#FF0000",
           pubkey: this.connections[0].walletPublicKey,
           network: "mainnet",


### PR DESCRIPTION
## Summary
- replace `cashu.me` name with `Fundstr` in app metadata, manifests, and UI components
- update user-facing links and docker service names accordingly

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a42e8fe9e88330a7c9ad572a996623