### PR TITLE
fix(favicon): root-absolute micro-favicons with cache-bust

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,16 +30,20 @@
       };
     </script>
 
+    <link rel="icon" href="/favicon.ico?v=3" sizes="any" />
     <link
       rel="icon"
       type="image/png"
-      sizes="128x128"
-      href="icons/128x128.png"
+      sizes="32x32"
+      href="/icons/favicon-32x32.png?v=3"
     />
-    <link rel="icon" type="image/png" sizes="96x96" href="icons/96x96.png" />
-    <link rel="icon" type="image/png" sizes="32x32" href="icons/32x32.png" />
-    <link rel="icon" type="image/png" sizes="16x16" href="icons/16x16.png" />
-    <link rel="icon" type="image/ico" href="favicon.ico" />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="/icons/favicon-16x16.png?v=3"
+    />
+    <link rel="shortcut icon" href="/favicon.ico?v=3" />
   </head>
   <body>
     <!-- quasar:entry-point -->


### PR DESCRIPTION
## Summary
- use root-absolute favicon links with ?v=3 cache-bust
- keep micro 16x16 and 32x32 PNG favicons

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a43ed03e0883309392e7bf2c3c0876