### PR TITLE
Add feature overview slide to welcome carousel

### DIFF
--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -1892,6 +1892,26 @@ export const messages = {
       step: "Step {n} of {total}",
       language: "Language",
     },
+    features: {
+      title: "Get to Know the App",
+      lead: "Explore these key sections to start using the wallet:",
+      bullets: {
+        creatorHub: {
+          label: "CreatorHub",
+          desc: "Publish your profile and find creators.",
+        },
+        subscriptions: {
+          label: "Subscriptions",
+          desc: "Manage creators you support.",
+        },
+        buckets: {
+          label: "Buckets",
+          desc: "Organize your tokens.",
+        },
+      },
+      relation:
+        "Browse creators in CreatorHub and subscribe to them in Subscriptions.",
+    },
     privacy: {
       title: "Cashu & Privacy",
       lead: "Cashu uses blinded tokens so mints can’t see who you are or what you pay.",

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -1892,6 +1892,26 @@ export const messages = {
       step: "Step {n} of {total}",
       language: "Language",
     },
+    features: {
+      title: "Get to Know the App",
+      lead: "Explore these key sections to start using the wallet:",
+      bullets: {
+        creatorHub: {
+          label: "CreatorHub",
+          desc: "Publish your profile and find creators.",
+        },
+        subscriptions: {
+          label: "Subscriptions",
+          desc: "Manage creators you support.",
+        },
+        buckets: {
+          label: "Buckets",
+          desc: "Organize your tokens.",
+        },
+      },
+      relation:
+        "Browse creators in CreatorHub and subscribe to them in Subscriptions.",
+    },
     privacy: {
       title: "Cashu & Privacy",
       lead: "Cashu uses blinded tokens so mints can’t see who you are or what you pay.",

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -1892,6 +1892,26 @@ export const messages = {
       step: "Step {n} of {total}",
       language: "Language",
     },
+    features: {
+      title: "Get to Know the App",
+      lead: "Explore these key sections to start using the wallet:",
+      bullets: {
+        creatorHub: {
+          label: "CreatorHub",
+          desc: "Publish your profile and find creators.",
+        },
+        subscriptions: {
+          label: "Subscriptions",
+          desc: "Manage creators you support.",
+        },
+        buckets: {
+          label: "Buckets",
+          desc: "Organize your tokens.",
+        },
+      },
+      relation:
+        "Browse creators in CreatorHub and subscribe to them in Subscriptions.",
+    },
     privacy: {
       title: "Cashu & Privacy",
       lead: "Cashu uses blinded tokens so mints can’t see who you are or what you pay.",

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1883,6 +1883,26 @@ export const messages = {
       step: "Step {n} of {total}",
       language: "Language",
     },
+    features: {
+      title: "Get to Know the App",
+      lead: "Explore these key sections to start using the wallet:",
+      bullets: {
+        creatorHub: {
+          label: "CreatorHub",
+          desc: "Publish your profile and find creators.",
+        },
+        subscriptions: {
+          label: "Subscriptions",
+          desc: "Manage creators you support.",
+        },
+        buckets: {
+          label: "Buckets",
+          desc: "Organize your tokens.",
+        },
+      },
+      relation:
+        "Browse creators in CreatorHub and subscribe to them in Subscriptions.",
+    },
     privacy: {
       title: "Cashu & Privacy",
       lead: "Cashu uses blinded tokens so mints can’t see who you are or what you pay.",

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -1892,6 +1892,26 @@ export const messages = {
       step: "Step {n} of {total}",
       language: "Language",
     },
+    features: {
+      title: "Get to Know the App",
+      lead: "Explore these key sections to start using the wallet:",
+      bullets: {
+        creatorHub: {
+          label: "CreatorHub",
+          desc: "Publish your profile and find creators.",
+        },
+        subscriptions: {
+          label: "Subscriptions",
+          desc: "Manage creators you support.",
+        },
+        buckets: {
+          label: "Buckets",
+          desc: "Organize your tokens.",
+        },
+      },
+      relation:
+        "Browse creators in CreatorHub and subscribe to them in Subscriptions.",
+    },
     privacy: {
       title: "Cashu & Privacy",
       lead: "Cashu uses blinded tokens so mints can’t see who you are or what you pay.",

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -1892,6 +1892,26 @@ export const messages = {
       step: "Step {n} of {total}",
       language: "Language",
     },
+    features: {
+      title: "Get to Know the App",
+      lead: "Explore these key sections to start using the wallet:",
+      bullets: {
+        creatorHub: {
+          label: "CreatorHub",
+          desc: "Publish your profile and find creators.",
+        },
+        subscriptions: {
+          label: "Subscriptions",
+          desc: "Manage creators you support.",
+        },
+        buckets: {
+          label: "Buckets",
+          desc: "Organize your tokens.",
+        },
+      },
+      relation:
+        "Browse creators in CreatorHub and subscribe to them in Subscriptions.",
+    },
     privacy: {
       title: "Cashu & Privacy",
       lead: "Cashu uses blinded tokens so mints can’t see who you are or what you pay.",

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -1892,6 +1892,26 @@ export const messages = {
       step: "Step {n} of {total}",
       language: "Language",
     },
+    features: {
+      title: "Get to Know the App",
+      lead: "Explore these key sections to start using the wallet:",
+      bullets: {
+        creatorHub: {
+          label: "CreatorHub",
+          desc: "Publish your profile and find creators.",
+        },
+        subscriptions: {
+          label: "Subscriptions",
+          desc: "Manage creators you support.",
+        },
+        buckets: {
+          label: "Buckets",
+          desc: "Organize your tokens.",
+        },
+      },
+      relation:
+        "Browse creators in CreatorHub and subscribe to them in Subscriptions.",
+    },
     privacy: {
       title: "Cashu & Privacy",
       lead: "Cashu uses blinded tokens so mints can’t see who you are or what you pay.",

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -1892,6 +1892,26 @@ export const messages = {
       step: "Step {n} of {total}",
       language: "Language",
     },
+    features: {
+      title: "Get to Know the App",
+      lead: "Explore these key sections to start using the wallet:",
+      bullets: {
+        creatorHub: {
+          label: "CreatorHub",
+          desc: "Publish your profile and find creators.",
+        },
+        subscriptions: {
+          label: "Subscriptions",
+          desc: "Manage creators you support.",
+        },
+        buckets: {
+          label: "Buckets",
+          desc: "Organize your tokens.",
+        },
+      },
+      relation:
+        "Browse creators in CreatorHub and subscribe to them in Subscriptions.",
+    },
     privacy: {
       title: "Cashu & Privacy",
       lead: "Cashu uses blinded tokens so mints can’t see who you are or what you pay.",

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -1892,6 +1892,26 @@ export const messages = {
       step: "Step {n} of {total}",
       language: "Language",
     },
+    features: {
+      title: "Get to Know the App",
+      lead: "Explore these key sections to start using the wallet:",
+      bullets: {
+        creatorHub: {
+          label: "CreatorHub",
+          desc: "Publish your profile and find creators.",
+        },
+        subscriptions: {
+          label: "Subscriptions",
+          desc: "Manage creators you support.",
+        },
+        buckets: {
+          label: "Buckets",
+          desc: "Organize your tokens.",
+        },
+      },
+      relation:
+        "Browse creators in CreatorHub and subscribe to them in Subscriptions.",
+    },
     privacy: {
       title: "Cashu & Privacy",
       lead: "Cashu uses blinded tokens so mints can’t see who you are or what you pay.",

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -1892,6 +1892,26 @@ export const messages = {
       step: "Step {n} of {total}",
       language: "Language",
     },
+    features: {
+      title: "Get to Know the App",
+      lead: "Explore these key sections to start using the wallet:",
+      bullets: {
+        creatorHub: {
+          label: "CreatorHub",
+          desc: "Publish your profile and find creators.",
+        },
+        subscriptions: {
+          label: "Subscriptions",
+          desc: "Manage creators you support.",
+        },
+        buckets: {
+          label: "Buckets",
+          desc: "Organize your tokens.",
+        },
+      },
+      relation:
+        "Browse creators in CreatorHub and subscribe to them in Subscriptions.",
+    },
     privacy: {
       title: "Cashu & Privacy",
       lead: "Cashu uses blinded tokens so mints can’t see who you are or what you pay.",

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -1892,6 +1892,26 @@ export const messages = {
       step: "Step {n} of {total}",
       language: "Language",
     },
+    features: {
+      title: "Get to Know the App",
+      lead: "Explore these key sections to start using the wallet:",
+      bullets: {
+        creatorHub: {
+          label: "CreatorHub",
+          desc: "Publish your profile and find creators.",
+        },
+        subscriptions: {
+          label: "Subscriptions",
+          desc: "Manage creators you support.",
+        },
+        buckets: {
+          label: "Buckets",
+          desc: "Organize your tokens.",
+        },
+      },
+      relation:
+        "Browse creators in CreatorHub and subscribe to them in Subscriptions.",
+    },
     privacy: {
       title: "Cashu & Privacy",
       lead: "Cashu uses blinded tokens so mints can’t see who you are or what you pay.",

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -1892,6 +1892,26 @@ export const messages = {
       step: "Step {n} of {total}",
       language: "Language",
     },
+    features: {
+      title: "Get to Know the App",
+      lead: "Explore these key sections to start using the wallet:",
+      bullets: {
+        creatorHub: {
+          label: "CreatorHub",
+          desc: "Publish your profile and find creators.",
+        },
+        subscriptions: {
+          label: "Subscriptions",
+          desc: "Manage creators you support.",
+        },
+        buckets: {
+          label: "Buckets",
+          desc: "Organize your tokens.",
+        },
+      },
+      relation:
+        "Browse creators in CreatorHub and subscribe to them in Subscriptions.",
+    },
     privacy: {
       title: "Cashu & Privacy",
       lead: "Cashu uses blinded tokens so mints can’t see who you are or what you pay.",

--- a/src/pages/WelcomePage.vue
+++ b/src/pages/WelcomePage.vue
@@ -108,6 +108,7 @@ import { useMintsStore } from "src/stores/mints";
 import { useBucketsStore } from "src/stores/buckets";
 import { useMnemonicStore } from "src/stores/mnemonic";
 import WelcomeSlidePrivacy from "./welcome/WelcomeSlidePrivacy.vue";
+import WelcomeSlideFeatures from "./welcome/WelcomeSlideFeatures.vue";
 // Mints & Buckets are now optional actions on the Finish slide.
 // import WelcomeSlideMints from "./welcome/WelcomeSlideMints.vue";
 import WelcomeSlideProofs from "./welcome/WelcomeSlideProofs.vue";
@@ -147,6 +148,7 @@ const slides = ref<{ key: string; component: any; props?: any }[]>([]);
 
 function buildSlides() {
   const arr = [
+    { key: "features", component: WelcomeSlideFeatures },
     { key: "privacy", component: WelcomeSlidePrivacy },
     { key: "proofs", component: WelcomeSlideProofs },
     {

--- a/src/pages/welcome/WelcomeSlideFeatures.vue
+++ b/src/pages/welcome/WelcomeSlideFeatures.vue
@@ -1,0 +1,42 @@
+<template>
+  <section role="region" :aria-labelledby="id" class="q-pa-md flex flex-center">
+    <div class="text-center">
+      <q-icon name="apps" size="4em" color="primary" />
+      <h1 :id="id" tabindex="-1" class="q-mt-md">{{ $t("Welcome.features.title") }}</h1>
+      <p class="q-mt-sm">{{ $t("Welcome.features.lead") }}</p>
+      <ul class="q-mt-md text-left" style="display: inline-block">
+        <li>
+          <router-link to="/creator-hub">
+            {{ $t("Welcome.features.bullets.creatorHub.label") }}
+          </router-link>
+          - {{ $t("Welcome.features.bullets.creatorHub.desc") }}
+        </li>
+        <li>
+          <router-link to="/subscriptions">
+            {{ $t("Welcome.features.bullets.subscriptions.label") }}
+          </router-link>
+          - {{ $t("Welcome.features.bullets.subscriptions.desc") }}
+        </li>
+        <li>
+          <router-link to="/buckets">
+            {{ $t("Welcome.features.bullets.buckets.label") }}
+          </router-link>
+          - {{ $t("Welcome.features.bullets.buckets.desc") }}
+        </li>
+      </ul>
+      <p class="q-mt-md">
+        {{ $t("Welcome.features.relation") }}
+      </p>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+const id = "welcome-features-title";
+</script>
+
+<style scoped>
+h1 {
+  font-weight: bold;
+}
+</style>

--- a/test/vitest/__tests__/welcome.features.spec.ts
+++ b/test/vitest/__tests__/welcome.features.spec.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { mount } from "@vue/test-utils";
+import WelcomeSlideFeatures from "../../../src/pages/welcome/WelcomeSlideFeatures.vue";
+
+describe("WelcomeSlideFeatures", () => {
+  it("renders feature links", () => {
+    const wrapper = mount(WelcomeSlideFeatures, {
+      global: {
+        mocks: { $t: (msg: string) => msg },
+        stubs: {
+          RouterLink: { props: ["to"], template: '<a :href="to"><slot/></a>' },
+          "q-icon": { template: "<i></i>" },
+        },
+      },
+    });
+
+    const hrefs = wrapper.findAll("a").map((a) => a.attributes("href"));
+    expect(hrefs).toEqual(["/creator-hub", "/subscriptions", "/buckets"]);
+  });
+});


### PR DESCRIPTION
## Summary
- add new WelcomeSlideFeatures component introducing CreatorHub, Subscriptions and Buckets
- register feature slide early in welcome carousel
- provide translations for the slide across all locales and test coverage for links

## Testing
- `pnpm lint`
- `pnpm run check:i18n`
- `pnpm test`
- `npx vitest run test/vitest/__tests__/welcome.features.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a4b56677808330892cc779a2d47a7e