### PR TITLE
feat: add multi-step onboarding

### DIFF
--- a/src/components/SettingsView.vue
+++ b/src/components/SettingsView.vue
@@ -1805,7 +1805,7 @@ import { usePRStore } from "../stores/payment-request";
 import { useRestoreStore } from "src/stores/restore";
 import { useDexieStore } from "../stores/dexie";
 import { useReceiveTokensStore } from "../stores/receiveTokensStore";
-import { useWelcomeStore } from "src/stores/welcome";
+import { useOnboardingStore } from "src/stores/onboarding";
 import { useStorageStore } from "src/stores/storage";
 import { useI18n } from "vue-i18n";
 
@@ -2115,9 +2115,9 @@ export default defineComponent({
       await this.generateNPCConnection();
     },
     showOnboarding: function () {
-      const welcomeStore = useWelcomeStore();
-      welcomeStore.resetWelcome();
-      this.$router.push("/welcome");
+      const store = useOnboardingStore();
+      store.reset();
+      this.$router.push("/onboarding");
     },
     nukeWallet: async function () {
       // create a backup just in case

--- a/src/components/onboarding/MiniDiagram.vue
+++ b/src/components/onboarding/MiniDiagram.vue
@@ -1,0 +1,10 @@
+<template>
+  <div class="row items-center justify-center q-gutter-sm" aria-hidden="true">
+    <q-icon name="account_circle" size="24px" />
+    <q-icon name="east" size="24px" />
+    <q-icon name="flash_on" size="24px" />
+    <q-icon name="east" size="24px" />
+    <q-icon name="hub" size="24px" />
+  </div>
+</template>
+<script setup lang="ts"></script>

--- a/src/components/onboarding/OnboardingCarousel.vue
+++ b/src/components/onboarding/OnboardingCarousel.vue
@@ -1,0 +1,147 @@
+<template>
+  <div class="full-width flex flex-center q-px-sm" @drop.prevent @dragover.prevent>
+    <q-card class="q-pa-none column full-width" style="max-width:768px">
+      <div class="col">
+        <OnboardingStep :step="steps[current]" />
+      </div>
+      <footer class="q-pa-sm row items-center no-wrap">
+        <div class="col-auto column items-start q-gutter-xs">
+          <q-select
+            v-model="selectedLanguage"
+            :options="languageOptions"
+            emit-value
+            map-options
+            dense
+            outlined
+            style="width:150px"
+            :label="$t('onb.footer.language')"
+            @update:model-value="changeLanguage"
+          />
+          <q-btn flat size="sm" class="q-px-none" @click="goRestore" :label="$t('onb.footer.restore')" />
+        </div>
+        <div class="col text-center">
+          <div aria-live="polite">{{ $t('onb.footer.step',{current:current+1,total}) }}</div>
+          <q-linear-progress class="q-mt-xs" color="primary" track-color="grey-3" :value="(current+1)/total" />
+        </div>
+        <div class="col-auto row items-center q-gutter-sm">
+          <q-btn flat :label="$t('onb.nav.back')" :disable="current===0" v-if="current>0" @click="back" />
+          <q-btn flat color="primary" :label="current===total-1?$t('onb.nav.next'):$t('onb.nav.next')" @click="next" />
+          <q-btn flat :label="$t('onb.nav.skip')" @click="skip" />
+        </div>
+      </footer>
+      <div class="text-caption text-center q-pb-sm">{{ $t('onb.footer.draghint') }}</div>
+    </q-card>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useRouter } from 'vue-router';
+import OnboardingStep from './OnboardingStep.vue';
+import type { OnboardingStep as Step } from './types';
+import { useOnboardingStore } from 'src/stores/onboarding';
+
+const router = useRouter();
+const { t, locale, availableLocales } = useI18n();
+const onboarding = useOnboardingStore();
+
+const steps = ref<Step[]>([
+  {
+    id: 1,
+    titleKey: 'onb.1.title',
+    subtitleKey: 'onb.1.subtitle',
+    bulletsKeys: ['onb.1.badge.private','onb.1.badge.p2p','onb.1.badge.cr','onb.1.badge.client']
+  },
+  {
+    id: 2,
+    titleKey: 'onb.2.title',
+    bodyKey: 'onb.2.body',
+    ctas: [
+      { labelKey: 'onb.2.cta.fresh', action: 'emit', eventName: 'onb_cta_fresh_key', variant:'primary' },
+      { labelKey: 'onb.2.cta.import', action: 'emit', eventName: 'onb_cta_import_key_open', variant:'secondary' },
+    ],
+  },
+  {
+    id: 3,
+    titleKey: 'onb.3.title',
+    bodyKey: 'onb.3.body',
+    ctas: [
+      { labelKey: 'onb.3.cta.recommended', action: 'emit', eventName: 'onb_cta_recommended_mint', variant:'primary' },
+      { labelKey: 'onb.3.cta.custom', action: 'emit', eventName: 'onb_cta_custom_mint_open', variant:'secondary' },
+    ],
+  },
+  {
+    id: 4,
+    titleKey: 'onb.4.title',
+    bodyKey: 'onb.4.body',
+    ctas: [
+      { labelKey: 'onb.4.cta.preset', action: 'route', to: '/wallet', params:{ amount:1000 }, variant:'primary' },
+      { labelKey: 'onb.4.cta.custom', action: 'route', to: '/wallet', variant:'secondary' },
+    ],
+  },
+  {
+    id: 5,
+    titleKey: 'onb.5.title',
+    bodyKey: 'onb.5.body',
+    ctas: [
+      { labelKey: 'onb.5.cta.testpay', action: 'route', to: '/wallet', variant:'primary' },
+      { labelKey: 'onb.5.cta.token', action: 'route', to: '/wallet', variant:'secondary' },
+    ],
+  },
+  {
+    id: 6,
+    titleKey: 'onb.6.title',
+    bodyKey: 'onb.6.body',
+    ctas: [
+      { labelKey: 'onb.6.cta.profile', action: 'route', to: '/creator-hub', variant:'primary' },
+      { labelKey: 'onb.6.cta.find', action: 'route', to: '/find-creators', variant:'secondary' },
+    ],
+  },
+  {
+    id: 7,
+    titleKey: 'onb.7.title',
+    bodyKey: 'onb.7.body',
+    ctas: [
+      { labelKey: 'onb.7.cta.backup', action: 'route', to: '/settings', variant:'primary' },
+      { labelKey: 'onb.7.cta.subs', action: 'route', to: '/subscriptions', variant:'secondary' },
+    ],
+  },
+]);
+
+const current = ref(0);
+const total = steps.value.length;
+
+const languageOptions = computed(() =>
+  availableLocales.map((l) => ({ label: l, value: l }))
+);
+const selectedLanguage = ref(locale.value);
+function changeLanguage(lang: string) {
+  locale.value = lang;
+}
+
+function goRestore() {
+  router.push('/restore');
+}
+
+function next() {
+  console.log('onb_click_next');
+  if (current.value < total - 1) {
+    current.value++;
+  } else {
+    finish();
+  }
+}
+function back() {
+  console.log('onb_click_back');
+  if (current.value > 0) current.value--;
+}
+function skip() {
+  console.log('onb_click_skip');
+  finish();
+}
+function finish() {
+  onboarding.complete();
+  router.replace('/wallet');
+}
+</script>

--- a/src/components/onboarding/OnboardingStep.vue
+++ b/src/components/onboarding/OnboardingStep.vue
@@ -1,0 +1,45 @@
+<template>
+  <div class="column items-center q-pa-lg text-center">
+    <MiniDiagram class="q-mb-lg" />
+    <h2 class="text-h5 q-mb-md">{{ $t(step.titleKey) }}</h2>
+    <div v-if="step.subtitleKey" class="q-mb-md">{{ $t(step.subtitleKey) }}</div>
+    <div v-if="step.bodyKey" class="q-mb-md">{{ $t(step.bodyKey) }}</div>
+    <div v-if="step.bulletsKeys" class="row q-gutter-sm q-mb-md">
+      <q-badge v-for="b in step.bulletsKeys" :key="b">{{ $t(b) }}</q-badge>
+    </div>
+    <div v-if="step.ctas" class="column q-gutter-sm q-mt-md">
+      <q-btn
+        v-for="cta in step.ctas"
+        :key="cta.labelKey"
+        :label="$t(cta.labelKey)"
+        :color="cta.variant === 'secondary' ? 'secondary' : 'primary'"
+        :outline="cta.variant === 'secondary'"
+        @click="handleCta(cta)"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { useRouter } from 'vue-router';
+import MiniDiagram from './MiniDiagram.vue';
+import type { OnboardingCTA, OnboardingStep as Step } from './types';
+import { useOnboardingStore } from 'src/stores/onboarding';
+
+const props = defineProps<{ step: Step }>();
+
+const router = useRouter();
+const onboarding = useOnboardingStore();
+
+function handleCta(cta: OnboardingCTA) {
+  onboarding.complete();
+  if (cta.action === 'route' && cta.to) {
+    router.push({ path: cta.to, params: cta.params });
+  } else if (cta.action === 'emit' && cta.eventName) {
+    // simple analytics emit
+    console.log(cta.eventName);
+  } else if (cta.action === 'openModal' && cta.eventName) {
+    console.log(cta.eventName);
+  }
+}
+</script>

--- a/src/components/onboarding/types.ts
+++ b/src/components/onboarding/types.ts
@@ -1,0 +1,19 @@
+export interface OnboardingCTA {
+  labelKey: string;
+  action: 'route' | 'emit' | 'openModal';
+  to?: string;
+  params?: Record<string, any>;
+  eventName?: string;
+  variant?: 'primary' | 'secondary';
+  guarded?: boolean;
+}
+
+export interface OnboardingStep {
+  id: number;
+  titleKey: string;
+  subtitleKey?: string;
+  bodyKey?: string;
+  bulletsKeys?: string[];
+  ctas?: OnboardingCTA[];
+  icon?: 'vision' | 'nostr' | 'mint' | 'deposit' | 'pay' | 'creator' | 'safety';
+}

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1983,6 +1983,79 @@ export const messages = {
       },
     },
   },
+  onb: {
+    1: {
+      title: "Private money for the open internet",
+      subtitle:
+        "You hold ecash on your device (cash-like privacy). A mint bridges you to Lightning for deposits and payments. Nostr connects you with creators and supporters—no accounts, no surveillance.",
+      badge: {
+        private: "Private",
+        p2p: "Peer-to-peer",
+        cr: "Censorship-resistant",
+        client: "Client-side",
+      },
+    },
+    2: {
+      title: "Use a Nostr key, not an account",
+      body: "Publish and subscribe with a Nostr pubkey. Generate a fresh key or import your own. Keys never leave your device.",
+      cta: {
+        fresh: "Use a fresh key",
+        import: "Import my key",
+      },
+    },
+    3: {
+      title: "Pick who bridges you to Lightning",
+      body: "The mint converts Lightning payments ↔ ecash. You can switch later.",
+      cta: {
+        recommended: "Use recommended mint",
+        custom: "Choose custom mint",
+      },
+    },
+    4: {
+      title: "Deposit via Lightning, receive as ecash",
+      body: "Scan or pay a Lightning invoice—your mint issues ecash tokens to your device instantly.",
+      cta: {
+        preset: "Deposit 1,000 sats",
+        custom: "Enter custom amount",
+      },
+    },
+    5: {
+      title: "Pay Lightning or send tokens directly",
+      body: "Paste a Lightning invoice to pay via the mint, or send ecash to a friend (QR/DM) for fast, private transfers—even offline-friendly.",
+      cta: {
+        testpay: "Try a test payment",
+        token: "Create a token to share",
+      },
+    },
+    6: {
+      title: "Publish privately, support directly",
+      body: "Creators publish a profile; supporters discover and subscribe. Payments ride over Nostr (encrypted DMs or Lightning). No platforms.",
+      cta: {
+        profile: "Create my profile",
+        find: "Find creators",
+      },
+    },
+    7: {
+      title: "Stay organized and safe",
+      body: "Manage who you support, organize funds with Buckets, and back up your wallet (export file or Nostr-based sync, if enabled).",
+      cta: {
+        backup: "Export a backup now",
+        subs: "Open Subscriptions",
+      },
+    },
+    footer: {
+      restore: "Restore from Backup",
+      draghint:
+        "You can also drag & drop a backup file anywhere on this screen.",
+      step: "Step {current} of {total}",
+      language: "Language",
+    },
+    nav: {
+      next: "Next",
+      back: "Back",
+      skip: "Skip",
+    },
+  },
 };
 
 export default {

--- a/src/pages/OnboardingPage.vue
+++ b/src/pages/OnboardingPage.vue
@@ -1,0 +1,6 @@
+<template>
+  <OnboardingCarousel />
+</template>
+<script setup lang="ts">
+import OnboardingCarousel from 'src/components/onboarding/OnboardingCarousel.vue';
+</script>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -6,6 +6,8 @@ import {
   createWebHashHistory,
 } from "vue-router";
 import routes from "./routes";
+import { useOnboardingStore } from "src/stores/onboarding";
+import { useRestoreStore } from "src/stores/restore";
 
 /*
  * If not building with SSR mode, you can
@@ -31,6 +33,22 @@ export default route(function (/* { store, ssrContext } */) {
     // quasar.conf.js -> build -> vueRouterMode
     // quasar.conf.js -> build -> publicPath
     history: createHistory(process.env.VUE_ROUTER_BASE),
+  });
+
+  Router.beforeEach((to, from, next) => {
+    const onboarding = useOnboardingStore();
+    const restore = useRestoreStore();
+    if (
+      onboarding.isNewOnboardingEnabled &&
+      !onboarding.hasCompletedOnboarding &&
+      to.path !== "/onboarding" &&
+      !restore.restoringState &&
+      to.path !== "/restore"
+    ) {
+      next("/onboarding");
+    } else {
+      next();
+    }
   });
 
   return Router;

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -111,6 +111,13 @@ const routes = [
     ],
   },
   {
+    path: "/onboarding",
+    component: () => import("layouts/BlankLayout.vue"),
+    children: [
+      { path: "", component: () => import("src/pages/OnboardingPage.vue") },
+    ],
+  },
+  {
     path: "/terms",
     component: () => import("layouts/FullscreenLayout.vue"),
     children: [

--- a/src/stores/onboarding.ts
+++ b/src/stores/onboarding.ts
@@ -1,0 +1,17 @@
+import { defineStore } from 'pinia';
+import { useLocalStorage } from '@vueuse/core';
+
+export const useOnboardingStore = defineStore('onboarding', {
+  state: () => ({
+    isNewOnboardingEnabled: true,
+    hasCompletedOnboarding: useLocalStorage<boolean>('cashu.onboarding.completed', false),
+  }),
+  actions: {
+    complete() {
+      this.hasCompletedOnboarding = true;
+    },
+    reset() {
+      this.hasCompletedOnboarding = false;
+    },
+  },
+});

--- a/test/onboarding.store.spec.ts
+++ b/test/onboarding.store.spec.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+import { useOnboardingStore } from 'src/stores/onboarding';
+
+describe('onboarding store', () => {
+  it('defaults', () => {
+    setActivePinia(createPinia());
+    const store = useOnboardingStore();
+    expect(store.isNewOnboardingEnabled).toBe(true);
+    expect(store.hasCompletedOnboarding).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add new onboarding store with feature flag and completion tracking
- introduce multi-step onboarding carousel with language selection and CTAs
- guard routes to redirect first-time users into onboarding

## Testing
- `pnpm test`
- `npx vitest run test/onboarding.store.spec.ts`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a4c602f8948330bb18833b401b4de6