### PR TITLE
feat: actionable welcome checklist and learn cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ The app includes a built-in Nostr messenger for private chat.
 
 Fundstr is currently in Alpha/Beta.
 
+## Welcome onboarding
+
+- The `/welcome` page now includes an actionable checklist for setting up a Nostr identity and selecting a mint, with state stored in `useWelcomeStore`.
+- Informational learn cards explain the main app sections without leaving the page.
+- To change the default mint suggested during onboarding, set the `RECOMMENDED_MINT_URL` environment variable.
+
 **What's Working**
 
 - Core Cashu wallet functionality (send, receive, mint management)

--- a/src/components/welcome/LearnCards.vue
+++ b/src/components/welcome/LearnCards.vue
@@ -1,0 +1,83 @@
+<template>
+  <div class="column q-gutter-md">
+    <q-card v-for="card in cards" :key="card.title" flat bordered>
+      <q-card-section>
+        <div class="text-h6">{{ card.title }}</div>
+        <p class="q-mt-xs">{{ card.text }}</p>
+        <ul class="q-pl-md q-mt-sm">
+          <li v-for="(b, i) in card.bullets" :key="i">{{ b }}</li>
+        </ul>
+      </q-card-section>
+    </q-card>
+  </div>
+</template>
+
+<script setup lang="ts">
+interface Card { title: string; text: string; bullets: string[] }
+
+const cards: Card[] = [
+  {
+    title: 'Wallet',
+    text: 'Home for send/receive.',
+    bullets: [
+      'Receive via Lightning invoice or token',
+      'Send tokens or pay invoices',
+      'Works offline for token handoff',
+    ],
+  },
+  {
+    title: 'Buckets',
+    text: 'Organize your sats by goal.',
+    bullets: [
+      'Create buckets (rent, tips, savings)',
+      'Move tokens between buckets',
+      'Optional—power users',
+    ],
+  },
+  {
+    title: 'Creator Hub',
+    text: 'Publish a profile; get support.',
+    bullets: [
+      'Set display name and tiers',
+      'Share your subscribe link',
+      'No platform middleman',
+    ],
+  },
+  {
+    title: 'Subscriptions',
+    text: 'Manage creators you support.',
+    bullets: [
+      'See active supports',
+      'Edit amounts or cancel',
+      'Track history',
+    ],
+  },
+  {
+    title: 'Messenger',
+    text: 'Private DMs; send tokens.',
+    bullets: [
+      'Chat over Nostr',
+      'Drop a token in chat',
+      'End-to-end encrypted',
+    ],
+  },
+  {
+    title: 'Settings',
+    text: 'Toggles & advanced.',
+    bullets: [
+      'Add/change mints',
+      'Lightning Address & NWC',
+      'Backup & appearance',
+    ],
+  },
+  {
+    title: 'Restore',
+    text: 'Recover your wallet.',
+    bullets: [
+      'Import backup',
+      'Reconcile tokens',
+      'Continue where you left off',
+    ],
+  },
+]
+</script>

--- a/src/components/welcome/TaskModalAddSats.vue
+++ b/src/components/welcome/TaskModalAddSats.vue
@@ -1,0 +1,62 @@
+<template>
+  <q-dialog v-model="model">
+    <q-card style="min-width:320px">
+      <q-card-section class="text-h6">Add sats</q-card-section>
+      <q-separator />
+      <q-card-section class="q-gutter-sm">
+        <q-btn
+          unelevated
+          color="primary"
+          class="full-width"
+          label="Deposit via Lightning"
+          @click="deposit"
+        />
+        <q-btn
+          unelevated
+          color="primary"
+          class="full-width"
+          label="Paste Token"
+          @click="paste"
+        />
+      </q-card-section>
+    </q-card>
+  </q-dialog>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import { useUiStore } from 'src/stores/ui'
+import { useWalletStore } from 'src/stores/wallet'
+import { useReceiveTokensStore } from 'src/stores/receiveTokensStore'
+
+const props = defineProps<{ modelValue: boolean }>()
+const emit = defineEmits<{ (e: 'update:modelValue', v: boolean): void; (e: 'done'): void }>()
+
+const model = ref(props.modelValue)
+watch(() => props.modelValue, v => (model.value = v))
+watch(model, v => emit('update:modelValue', v))
+
+const ui = useUiStore()
+const wallet = useWalletStore()
+const receive = useReceiveTokensStore()
+
+function deposit() {
+  wallet.invoiceData.amount = '' as any
+  wallet.invoiceData.bolt11 = '' as any
+  wallet.invoiceData.hash = '' as any
+  wallet.invoiceData.memo = '' as any
+  ui.showInvoiceDetails = true
+  close()
+}
+
+function paste() {
+  receive.receiveData.tokensBase64 = ''
+  ui.showReceiveEcashDrawer = true
+  close()
+}
+
+function close() {
+  emit('done')
+  model.value = false
+}
+</script>

--- a/src/components/welcome/TaskModalIdentity.vue
+++ b/src/components/welcome/TaskModalIdentity.vue
@@ -1,0 +1,93 @@
+<template>
+  <q-dialog v-model="model">
+    <q-card style="min-width:320px">
+      <q-card-section class="text-h6">Nostr Identity</q-card-section>
+      <q-separator />
+      <q-card-section class="q-gutter-sm">
+        <q-btn
+          v-if="hasNip07"
+          unelevated
+          color="primary"
+          class="full-width"
+          label="Use NIP-07"
+          @click="connectNip07"
+        />
+        <q-btn
+          unelevated
+          color="primary"
+          class="full-width"
+          label="Generate new key"
+          @click="generateKey"
+        />
+        <q-form @submit.prevent="importKey" class="full-width">
+          <q-input v-model="nsec" label="Import nsec" autocomplete="off" />
+          <q-btn
+            unelevated
+            color="primary"
+            class="full-width q-mt-sm"
+            :disable="!nsec"
+            label="Import"
+            type="submit"
+          />
+        </q-form>
+      </q-card-section>
+    </q-card>
+  </q-dialog>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue'
+import { useNostrStore, SignerType } from 'src/stores/nostr'
+
+const props = defineProps<{ modelValue: boolean }>()
+const emit = defineEmits<{ (e: 'update:modelValue', v: boolean): void; (e: 'done'): void }>()
+
+const model = ref(props.modelValue)
+watch(() => props.modelValue, v => (model.value = v))
+watch(model, v => emit('update:modelValue', v))
+
+const nostr = useNostrStore()
+const nsec = ref('')
+
+const hasNip07 = computed(
+  () => typeof window !== 'undefined' && !!(window as any).nostr?.getPublicKey,
+)
+
+async function connectNip07() {
+  try {
+    const pk = await (window as any).nostr.getPublicKey()
+    const test = {
+      kind: 1,
+      created_at: Math.floor(Date.now() / 1000),
+      tags: [],
+      content: 'test',
+    }
+    await (window as any).nostr.signEvent(test)
+    await nostr.connectBrowserSigner()
+    nostr.setPubkey(pk)
+    nostr.signerType = SignerType.NIP07
+    close()
+  } catch (e) {
+    console.error(e)
+  }
+}
+
+async function generateKey() {
+  await nostr.initWalletSeedPrivateKeySigner()
+  close()
+}
+
+async function importKey() {
+  try {
+    await nostr.initPrivateKeySigner(nsec.value.trim())
+    close()
+  } catch (e) {
+    console.error(e)
+  }
+}
+
+function close() {
+  emit('done')
+  model.value = false
+}
+</script>

--- a/src/components/welcome/TaskModalMint.vue
+++ b/src/components/welcome/TaskModalMint.vue
@@ -1,0 +1,66 @@
+<template>
+  <q-dialog v-model="model">
+    <q-card style="min-width:320px">
+      <q-card-section class="text-h6">Choose a Mint</q-card-section>
+      <q-separator />
+      <q-card-section class="q-gutter-sm">
+        <q-btn
+          unelevated
+          color="primary"
+          class="full-width"
+          label="Use Recommended Mint"
+          @click="useRecommended"
+        />
+        <q-input v-model="customUrl" label="Custom Mint URL" />
+        <q-btn
+          unelevated
+          color="primary"
+          class="full-width q-mt-sm"
+          :disable="!customUrl"
+          label="Add Mint"
+          @click="useCustom"
+        />
+      </q-card-section>
+    </q-card>
+  </q-dialog>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import { useMintsStore } from 'src/stores/mints'
+import { useWelcomeStore } from 'src/stores/welcome'
+
+const DEFAULT_MINT_URL = 'https://mint.example.com'
+
+const props = defineProps<{ modelValue: boolean }>()
+const emit = defineEmits<{ (e: 'update:modelValue', v: boolean): void; (e: 'done'): void }>()
+
+const model = ref(props.modelValue)
+watch(() => props.modelValue, v => (model.value = v))
+watch(model, v => emit('update:modelValue', v))
+
+const customUrl = ref('')
+
+async function useRecommended() {
+  const welcome = useWelcomeStore()
+  const mints = useMintsStore()
+  const url = welcome.recommendedMintUrl || DEFAULT_MINT_URL
+  await mints.addMint(url)
+  await mints.activateMintUrl(url)
+  close()
+}
+
+async function useCustom() {
+  const mints = useMintsStore()
+  const url = customUrl.value.trim()
+  if (!url) return
+  await mints.addMint(url)
+  await mints.activateMintUrl(url)
+  close()
+}
+
+function close() {
+  emit('done')
+  model.value = false
+}
+</script>

--- a/src/pages/WalletPage.vue
+++ b/src/pages/WalletPage.vue
@@ -516,7 +516,7 @@ export default {
     },
     showWelcomePage: function () {
       const store = useWelcomeStore();
-      if (!store.hasKey || !store.welcomeCompleted) {
+      if (!store.welcomeCompleted) {
         const currentQuery = window.location.search;
         const currentHash = window.location.hash;
         this.$router.push("/welcome" + currentQuery + currentHash);

--- a/src/pages/WelcomePage.vue
+++ b/src/pages/WelcomePage.vue
@@ -5,167 +5,83 @@
         <TaskChecklist
           :tasks="tasks"
           :progress="progressLabel"
-          :can-finish="canFinish"
+          :can-finish="welcome.canFinish"
           @run="runTask"
           @finish="finish"
         />
       </div>
       <div class="col-12 col-md-8">
-        <WelcomeSlides />
+        <LearnCards />
       </div>
     </div>
-
-    <CreateKeyDialog v-model="showCreateKey" @done="onKeyCreated" />
-    <BackupDialog v-model="showBackup" @done="onBackupDone" />
-    <ChooseMintDrawer v-model="showChooseMint" @done="onMintChosen" />
-    <DepositDialog v-model="showDeposit" @done="onDepositPaid" />
-    <TestSendDialog v-model="showTestSend" @done="onTestSendOk" />
-    <RoleDialog v-model="showRole" @selected="onRoleSelected" />
-    <CreatorSetupDialog v-if="welcome.role === 'creator'" v-model="showCreator" @done="onCreatorDone" />
-    <BucketQuickstartDialog v-model="showBucketIntro" @done="onBucketDone" />
+    <TaskModalIdentity v-model="showIdentity" />
+    <TaskModalMint v-model="showMint" />
+    <TaskModalAddSats v-model="showAddSats" />
   </q-page>
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { ref, computed } from 'vue'
 import { useRouter } from 'vue-router'
-import { useI18n } from 'vue-i18n'
+import TaskChecklist from 'src/components/welcome/TaskChecklist.vue'
+import LearnCards from 'src/components/welcome/LearnCards.vue'
+import TaskModalIdentity from 'src/components/welcome/TaskModalIdentity.vue'
+import TaskModalMint from 'src/components/welcome/TaskModalMint.vue'
+import TaskModalAddSats from 'src/components/welcome/TaskModalAddSats.vue'
 import { useWelcomeStore } from 'src/stores/welcome'
 import type { WelcomeTask } from 'src/types/welcome'
 
-import TaskChecklist from 'src/components/welcome/TaskChecklist.vue'
-import WelcomeSlides from 'src/components/welcome/WelcomeSlides.vue'
-import PlaceholderDialog from 'src/components/welcome/PlaceholderDialog.vue'
-
-const CreateKeyDialog = PlaceholderDialog
-const BackupDialog = PlaceholderDialog
-const ChooseMintDrawer = PlaceholderDialog
-const DepositDialog = PlaceholderDialog
-const TestSendDialog = PlaceholderDialog
-const RoleDialog = PlaceholderDialog
-const CreatorSetupDialog = PlaceholderDialog
-const BucketQuickstartDialog = PlaceholderDialog
-
 const router = useRouter()
-const { t } = useI18n()
 const welcome = useWelcomeStore()
 
-const testSendDone = ref(false)
-const bucketDone = ref(false)
+const showIdentity = ref(false)
+const showMint = ref(false)
+const showAddSats = ref(false)
 
-function buildTasks(store: ReturnType<typeof useWelcomeStore>): WelcomeTask[] {
-  return [
-    {
-      id: 'create-key',
-      icon: 'vpn_key',
-      title: t('welcome.tasks.createKey.title'),
-      desc: t('welcome.tasks.createKey.desc'),
-      done: () => store.hasKey,
-      ctas: [],
-    },
-    {
-      id: 'backup',
-      icon: 'save',
-      title: t('welcome.tasks.backup.title'),
-      desc: t('welcome.tasks.backup.desc'),
-      requires: ['create-key'],
-      done: () => store.hasBackup,
-      ctas: [],
-    },
-    {
-      id: 'pick-mint',
-      icon: 'account_balance',
-      title: t('welcome.tasks.chooseMint.title'),
-      desc: t('welcome.tasks.chooseMint.desc'),
-      done: () => store.hasMint,
-      ctas: [],
-    },
-    {
-      id: 'deposit',
-      icon: 'add_circle',
-      title: t('welcome.tasks.deposit.title'),
-      desc: t('welcome.tasks.deposit.desc'),
-      optional: true,
-      requires: ['pick-mint'],
-      done: () => store.hasBalance,
-      ctas: [],
-    },
-    {
-      id: 'test-send',
-      icon: 'send',
-      title: t('welcome.tasks.testSend.title'),
-      desc: t('welcome.tasks.testSend.desc'),
-      done: () => testSendDone.value,
-      ctas: [],
-    },
-    {
-      id: 'choose-role',
-      icon: 'person_search',
-      title: t('welcome.tasks.role.title'),
-      desc: t('welcome.tasks.role.desc'),
-      done: () => store.role !== null,
-      ctas: [],
-    },
-    {
-      id: 'creator-setup',
-      icon: 'badge',
-      title: t('welcome.tasks.creatorSetup.title'),
-      desc: t('welcome.tasks.creatorSetup.desc'),
-      requires: ['choose-role'],
-      done: () => store.hasProfile,
-      ctas: [],
-      optional: false,
-    },
-    {
-      id: 'bucket-quickstart',
-      icon: 'inventory_2',
-      title: t('welcome.tasks.buckets.title'),
-      desc: t('welcome.tasks.buckets.desc'),
-      optional: true,
-      done: () => bucketDone.value,
-      ctas: [],
-    },
-  ].filter((t) => (store.role === 'creator' ? true : t.id !== 'creator-setup'))
-}
-
-const tasks = computed<WelcomeTask[]>(() => buildTasks(welcome))
+const tasks = computed<WelcomeTask[]>(() => [
+  {
+    id: 'identity',
+    icon: 'badge',
+    title: 'Set up your Nostr Identity',
+    desc: 'Use NIP-07, generate a new key, or import nsec.',
+    done: () => welcome.hasIdentity,
+    ctas: [],
+  },
+  {
+    id: 'mint',
+    icon: 'account_balance',
+    title: 'Pick a Mint',
+    desc: 'A mint bridges Lightning ↔ ecash. You can switch anytime.',
+    done: () => welcome.hasMint,
+    ctas: [],
+  },
+  {
+    id: 'sats',
+    icon: 'add_circle',
+    title: 'Add sats (optional)',
+    desc: 'Deposit via Lightning or paste a token.',
+    optional: true,
+    done: () => welcome.balanceSats > 0,
+    ctas: [],
+  },
+])
 
 const progressLabel = computed(() => {
-  const required = tasks.value.filter((t) => !t.optional)
-  const done = required.filter((t) => t.done()).length
-  return t('welcome.taskList.progress', { done, total: required.length })
-})
-
-const canFinish = computed(() => {
-  const required = tasks.value.filter((t) => !t.optional)
-  return required.every((t) => t.done())
+  const required = tasks.value.filter(t => !t.optional)
+  const done = required.filter(t => t.done()).length
+  return `${done}/${required.length} required steps`
 })
 
 function runTask(task: WelcomeTask) {
   switch (task.id) {
-    case 'create-key':
-      showCreateKey.value = true
+    case 'identity':
+      showIdentity.value = true
       break
-    case 'backup':
-      showBackup.value = true
+    case 'mint':
+      showMint.value = true
       break
-    case 'pick-mint':
-      showChooseMint.value = true
-      break
-    case 'deposit':
-      showDeposit.value = true
-      break
-    case 'test-send':
-      showTestSend.value = true
-      break
-    case 'choose-role':
-      showRole.value = true
-      break
-    case 'creator-setup':
-      showCreator.value = true
-      break
-    case 'bucket-quickstart':
-      showBucketIntro.value = true
+    case 'sats':
+      showAddSats.value = true
       break
   }
 }
@@ -173,43 +89,5 @@ function runTask(task: WelcomeTask) {
 function finish() {
   welcome.markWelcomeCompleted()
   router.push('/wallet')
-}
-
-const showCreateKey = ref(false)
-const showBackup = ref(false)
-const showChooseMint = ref(false)
-const showDeposit = ref(false)
-const showTestSend = ref(false)
-const showRole = ref(false)
-const showCreator = ref(false)
-const showBucketIntro = ref(false)
-
-function onKeyCreated() {
-  showCreateKey.value = false
-  showBackup.value = true
-}
-function onBackupDone() {
-  showBackup.value = false
-}
-function onMintChosen() {
-  showChooseMint.value = false
-}
-function onDepositPaid() {
-  showDeposit.value = false
-}
-function onTestSendOk() {
-  testSendDone.value = true
-  showTestSend.value = false
-}
-function onRoleSelected(role?: any) {
-  if (role) welcome.setRole(role)
-  showRole.value = false
-}
-function onCreatorDone() {
-  showCreator.value = false
-}
-function onBucketDone() {
-  bucketDone.value = true
-  showBucketIntro.value = false
 }
 </script>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -39,12 +39,12 @@ export default route(function (/* { store, ssrContext } */) {
     const welcome = useWelcomeStore();
     const restore = useRestoreStore();
     if (
-      to.path !== "/welcome" &&
-      ( !welcome.hasKey || !welcome.welcomeCompleted ) &&
+      to.path !== '/welcome' &&
+      !welcome.welcomeCompleted &&
       !restore.restoringState &&
-      to.path !== "/restore"
+      to.path !== '/restore'
     ) {
-      next("/welcome?first=1");
+      next('/welcome?first=1');
       return;
     }
     next();

--- a/test/vitest/__tests__/welcome.store.spec.ts
+++ b/test/vitest/__tests__/welcome.store.spec.ts
@@ -1,56 +1,22 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 import { useWelcomeStore } from '../../../src/stores/welcome'
-import { useSignerStore } from '../../../src/stores/signer'
+import { useNostrStore } from '../../../src/stores/nostr'
 import { useMintsStore } from '../../../src/stores/mints'
-import { useProofsStore } from '../../../src/stores/proofs'
-import { useCreatorProfileStore } from '../../../src/stores/creatorProfile'
 
 beforeEach(() => {
   setActivePinia(createPinia())
 })
 
 describe('welcome store', () => {
-  it('hasKey reflects signer state', () => {
-    const signer = useSignerStore()
-    const store = useWelcomeStore()
-    expect(store.hasKey).toBe(false)
-    signer.method = 'local'
-    expect(store.hasKey).toBe(true)
-  })
-
-  it('hasBackup reads from localStorage', () => {
-    localStorage.setItem('cashu.backup.completed', 'true')
-    const store = useWelcomeStore()
-    expect(store.hasBackup).toBe(true)
-  })
-
-  it('hasMint detects configured mints', () => {
+  it('canFinish reacts to identity and mint', () => {
+    const welcome = useWelcomeStore()
+    const nostr = useNostrStore()
     const mints = useMintsStore()
-    mints.mints.push({ url: 'https://mint', keys: [], keysets: [] } as any)
-    const store = useWelcomeStore()
-    expect(store.hasMint).toBe(true)
-  })
-
-  it('hasBalance checks proofs', () => {
-    const proofs = useProofsStore()
-    proofs.proofs.push({ amount: 1 } as any)
-    const store = useWelcomeStore()
-    expect(store.hasBalance).toBe(true)
-  })
-
-  it('hasProfile detects creator profile', () => {
-    const profile = useCreatorProfileStore()
-    profile.display_name = 'Alice'
-    const store = useWelcomeStore()
-    expect(store.hasProfile).toBe(true)
-  })
-
-  it('setRole and markWelcomeCompleted update state', () => {
-    const store = useWelcomeStore()
-    store.setRole('supporter')
-    expect(store.role).toBe('supporter')
-    store.markWelcomeCompleted()
-    expect(store.welcomeCompleted).toBe(true)
+    expect(welcome.canFinish).toBe(false)
+    nostr.pubkey = 'pk'
+    expect(welcome.canFinish).toBe(false)
+    mints.activeMintUrl = 'https://mint'
+    expect(welcome.canFinish).toBe(true)
   })
 })


### PR DESCRIPTION
## Summary
- add welcome store with identity and mint completion
- implement onboarding modals for identity, mint, and sats
- replace welcome slides with inline learn cards and progress gating

## Testing
- `pnpm test`
- `node --experimental-vm-modules node_modules/vitest/vitest.mjs run test/vitest/__tests__/welcome.store.spec.ts`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a58a6fb6d083308119c8d3aa543635