### PR TITLE
feat: guided welcome flow with mint gallery

### DIFF
--- a/src/components/welcome/Coachmark.vue
+++ b/src/components/welcome/Coachmark.vue
@@ -1,0 +1,11 @@
+<template>
+  <q-expansion-item dense expand-separator :label="title" icon="info">
+    <div class="text-body2 q-mt-sm">
+      <slot />
+    </div>
+  </q-expansion-item>
+</template>
+
+<script setup lang="ts">
+defineProps<{ title: string }>()
+</script>

--- a/src/components/welcome/MintCard.vue
+++ b/src/components/welcome/MintCard.vue
@@ -1,0 +1,33 @@
+<template>
+  <q-card class="q-pa-md">
+    <div class="text-subtitle1">{{ mint.name }}</div>
+    <div class="text-caption">{{ mint.url }}</div>
+    <div class="text-caption q-mt-sm">
+      <q-icon name="lens" size="8px" :color="statusColor" class="q-mr-xs" />
+      <span v-if="mint.latencyMs !== null">{{ mint.latencyMs }}ms</span>
+      <span v-else>unreachable</span>
+    </div>
+    <div class="text-caption q-mt-sm">
+      <span v-if="mint.unit">Unit: {{ mint.unit }}</span>
+      <span v-if="mint.region" class="q-ml-sm">Region: {{ mint.region }}</span>
+    </div>
+    <q-card-actions class="q-pt-md">
+      <q-btn unelevated color="primary" class="full-width" label="Select" @click="emit('select', mint.url)" />
+    </q-card-actions>
+  </q-card>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+
+const props = defineProps<{ mint: any }>()
+const emit = defineEmits<{ (e: 'select', url: string): void }>()
+
+const statusColor = computed(() =>
+  props.mint.status === 'ok'
+    ? 'positive'
+    : props.mint.status === 'pending'
+    ? 'warning'
+    : 'negative',
+)
+</script>

--- a/src/components/welcome/MintGallery.vue
+++ b/src/components/welcome/MintGallery.vue
@@ -1,0 +1,90 @@
+<template>
+  <div>
+    <div class="row items-center q-gutter-md q-mb-md">
+      <q-select v-model="sort" :options="sortOptions" label="Sort" dense outlined style="min-width:140px" />
+      <q-select v-model="region" :options="regionOptions" label="Region" dense outlined clearable style="min-width:140px" />
+      <q-space />
+      <q-input v-model="customUrl" label="Custom URL" dense outlined class="col" />
+      <q-btn color="primary" :disable="!customUrl" label="Add" @click="addCustom" />
+      <q-btn dense flat icon="info" @click="info = true" />
+    </div>
+    <div class="row q-col-gutter-md">
+      <div v-for="m in sortedMints" :key="m.url" class="col-12 col-sm-6 col-md-4">
+        <MintCard :mint="m" @select="selectMint" />
+      </div>
+    </div>
+    <MintInfoDrawer v-model="info" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { useMintsStore } from 'src/stores/mints'
+import { MINTS, type MintInfo } from 'src/data/mints'
+import MintCard from './MintCard.vue'
+import MintInfoDrawer from './MintInfoDrawer.vue'
+
+interface MintState extends MintInfo {
+  status: 'pending' | 'ok' | 'fail'
+  latencyMs: number | null
+}
+
+const mints = ref<MintState[]>(MINTS.map(m => ({ ...m, status: 'pending', latencyMs: null })))
+const sort = ref<'latency' | 'alpha'>('latency')
+const region = ref<string | null>(null)
+const info = ref(false)
+const customUrl = ref('')
+
+const sortOptions = [
+  { label: 'Latency', value: 'latency' },
+  { label: 'Alphabetical', value: 'alpha' },
+]
+const regionOptions = computed(() => {
+  const regions = Array.from(new Set(MINTS.map(m => m.region).filter(Boolean))) as string[]
+  return regions.map(r => ({ label: r, value: r }))
+})
+
+const sortedMints = computed(() => {
+  let arr = mints.value.filter(m => !region.value || m.region === region.value)
+  if (sort.value === 'alpha') {
+    arr = [...arr].sort((a, b) => a.name.localeCompare(b.name))
+  } else {
+    arr = [...arr].sort((a, b) => (a.latencyMs ?? Infinity) - (b.latencyMs ?? Infinity))
+  }
+  return arr
+})
+
+onMounted(() => {
+  mints.value.forEach(m => pingMint(m))
+})
+
+async function pingMint(m: MintState) {
+  const start = performance.now()
+  try {
+    await fetch(m.url + '/info', { method: 'GET', mode: 'no-cors' })
+    m.latencyMs = Math.round(performance.now() - start)
+    m.status = 'ok'
+  } catch (e) {
+    m.latencyMs = null
+    m.status = 'fail'
+  }
+}
+
+const store = useMintsStore()
+const emit = defineEmits<{ (e: 'selected'): void }>()
+
+async function selectMint(url: string) {
+  await store.addMint(url)
+  await store.activateMintUrl(url)
+  emit('selected')
+}
+
+async function addCustom() {
+  const url = customUrl.value.trim()
+  if (!url) return
+  await store.addMint(url)
+  await store.activateMintUrl(url)
+  customUrl.value = ''
+  emit('selected')
+}
+</script>

--- a/src/components/welcome/MintInfoDrawer.vue
+++ b/src/components/welcome/MintInfoDrawer.vue
@@ -1,0 +1,26 @@
+<template>
+  <q-dialog v-model="model">
+    <q-card style="max-width:400px">
+      <q-card-section class="text-h6">What is a mint?</q-card-section>
+      <q-card-section class="text-body2">
+        <p>A mint exchanges Lightning payments for private ecash. When you deposit, the mint issues unlinkable proofs to your device.</p>
+        <p>When you spend, the mint swaps your proofs for new ones so payments stay private.</p>
+        <p>You can change mints anytime.</p>
+      </q-card-section>
+      <q-card-actions align="right">
+        <q-btn flat label="Close" color="primary" v-close-popup />
+      </q-card-actions>
+    </q-card>
+  </q-dialog>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+
+const props = defineProps<{ modelValue: boolean }>()
+const emit = defineEmits<{ (e: 'update:modelValue', v: boolean): void }>()
+
+const model = ref(props.modelValue)
+watch(() => props.modelValue, v => (model.value = v))
+watch(model, v => emit('update:modelValue', v))
+</script>

--- a/src/components/welcome/TaskModalAddSats.vue
+++ b/src/components/welcome/TaskModalAddSats.vue
@@ -1,5 +1,5 @@
 <template>
-  <q-dialog v-model="model">
+  <q-dialog v-if="!inline" v-model="model">
     <q-card style="min-width:320px">
       <q-card-section class="text-h6">Add sats</q-card-section>
       <q-separator />
@@ -21,20 +21,44 @@
       </q-card-section>
     </q-card>
   </q-dialog>
+  <div v-else>
+    <q-card flat>
+      <q-card-section class="text-h6">Add sats</q-card-section>
+      <q-separator />
+      <q-card-section class="q-gutter-sm">
+        <q-btn
+          unelevated
+          color="primary"
+          class="full-width"
+          label="Deposit via Lightning"
+          @click="deposit"
+        />
+        <q-btn
+          unelevated
+          color="primary"
+          class="full-width"
+          label="Paste Token"
+          @click="paste"
+        />
+      </q-card-section>
+    </q-card>
+  </div>
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { ref, watch, computed } from 'vue'
 import { useUiStore } from 'src/stores/ui'
 import { useWalletStore } from 'src/stores/wallet'
 import { useReceiveTokensStore } from 'src/stores/receiveTokensStore'
 
-const props = defineProps<{ modelValue: boolean }>()
+const props = defineProps<{ modelValue?: boolean; inline?: boolean }>()
 const emit = defineEmits<{ (e: 'update:modelValue', v: boolean): void; (e: 'done'): void }>()
 
-const model = ref(props.modelValue)
-watch(() => props.modelValue, v => (model.value = v))
+const model = ref(props.modelValue ?? false)
+watch(() => props.modelValue, v => (model.value = v ?? false))
 watch(model, v => emit('update:modelValue', v))
+
+const inline = computed(() => !!props.inline)
 
 const ui = useUiStore()
 const wallet = useWalletStore()
@@ -57,6 +81,6 @@ function paste() {
 
 function close() {
   emit('done')
-  model.value = false
+  if (!inline.value) model.value = false
 }
 </script>

--- a/src/components/welcome/TaskModalIdentity.vue
+++ b/src/components/welcome/TaskModalIdentity.vue
@@ -1,5 +1,5 @@
 <template>
-  <q-dialog v-model="model">
+  <q-dialog v-if="!inline" v-model="model">
     <q-card style="min-width:320px">
       <q-card-section class="text-h6">Nostr Identity</q-card-section>
       <q-separator />
@@ -33,18 +33,54 @@
       </q-card-section>
     </q-card>
   </q-dialog>
+  <div v-else>
+    <q-card flat>
+      <q-card-section class="text-h6">Nostr Identity</q-card-section>
+      <q-separator />
+      <q-card-section class="q-gutter-sm">
+        <q-btn
+          v-if="hasNip07"
+          unelevated
+          color="primary"
+          class="full-width"
+          label="Use NIP-07"
+          @click="connectNip07"
+        />
+        <q-btn
+          unelevated
+          color="primary"
+          class="full-width"
+          label="Generate new key"
+          @click="generateKey"
+        />
+        <q-form @submit.prevent="importKey" class="full-width">
+          <q-input v-model="nsec" label="Import nsec" autocomplete="off" />
+          <q-btn
+            unelevated
+            color="primary"
+            class="full-width q-mt-sm"
+            :disable="!nsec"
+            label="Import"
+            type="submit"
+          />
+        </q-form>
+      </q-card-section>
+    </q-card>
+  </div>
 </template>
 
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
 import { useNostrStore, SignerType } from 'src/stores/nostr'
 
-const props = defineProps<{ modelValue: boolean }>()
+const props = defineProps<{ modelValue?: boolean; inline?: boolean }>()
 const emit = defineEmits<{ (e: 'update:modelValue', v: boolean): void; (e: 'done'): void }>()
 
-const model = ref(props.modelValue)
-watch(() => props.modelValue, v => (model.value = v))
+const model = ref(props.modelValue ?? false)
+watch(() => props.modelValue, v => (model.value = v ?? false))
 watch(model, v => emit('update:modelValue', v))
+
+const inline = computed(() => !!props.inline)
 
 const nostr = useNostrStore()
 const nsec = ref('')
@@ -88,6 +124,6 @@ async function importKey() {
 
 function close() {
   emit('done')
-  model.value = false
+  if (!inline.value) model.value = false
 }
 </script>

--- a/src/components/welcome/TaskModalMint.vue
+++ b/src/components/welcome/TaskModalMint.vue
@@ -1,66 +1,29 @@
 <template>
-  <q-dialog v-model="model">
+  <q-dialog v-if="!inline" v-model="model">
     <q-card style="min-width:320px">
-      <q-card-section class="text-h6">Choose a Mint</q-card-section>
-      <q-separator />
-      <q-card-section class="q-gutter-sm">
-        <q-btn
-          unelevated
-          color="primary"
-          class="full-width"
-          label="Use Recommended Mint"
-          @click="useRecommended"
-        />
-        <q-input v-model="customUrl" label="Custom Mint URL" />
-        <q-btn
-          unelevated
-          color="primary"
-          class="full-width q-mt-sm"
-          :disable="!customUrl"
-          label="Add Mint"
-          @click="useCustom"
-        />
-      </q-card-section>
+      <MintGallery @selected="close" />
     </q-card>
   </q-dialog>
+  <div v-else>
+    <MintGallery @selected="close" />
+  </div>
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from 'vue'
-import { useMintsStore } from 'src/stores/mints'
-import { useWelcomeStore } from 'src/stores/welcome'
+import { ref, watch, computed } from 'vue'
+import MintGallery from './MintGallery.vue'
 
-const DEFAULT_MINT_URL = 'https://mint.example.com'
-
-const props = defineProps<{ modelValue: boolean }>()
+const props = defineProps<{ modelValue?: boolean; inline?: boolean }>()
 const emit = defineEmits<{ (e: 'update:modelValue', v: boolean): void; (e: 'done'): void }>()
 
-const model = ref(props.modelValue)
-watch(() => props.modelValue, v => (model.value = v))
+const model = ref(props.modelValue ?? false)
+watch(() => props.modelValue, v => (model.value = v ?? false))
 watch(model, v => emit('update:modelValue', v))
 
-const customUrl = ref('')
-
-async function useRecommended() {
-  const welcome = useWelcomeStore()
-  const mints = useMintsStore()
-  const url = welcome.recommendedMintUrl || DEFAULT_MINT_URL
-  await mints.addMint(url)
-  await mints.activateMintUrl(url)
-  close()
-}
-
-async function useCustom() {
-  const mints = useMintsStore()
-  const url = customUrl.value.trim()
-  if (!url) return
-  await mints.addMint(url)
-  await mints.activateMintUrl(url)
-  close()
-}
+const inline = computed(() => !!props.inline)
 
 function close() {
   emit('done')
-  model.value = false
+  if (!inline.value) model.value = false
 }
 </script>

--- a/src/components/welcome/WelcomeStepper.vue
+++ b/src/components/welcome/WelcomeStepper.vue
@@ -1,0 +1,65 @@
+<template>
+  <q-stepper v-model="step" flat animated>
+    <q-step :name="1" title="Nostr Identity" :done="welcome.hasIdentity">
+      <div class="q-pa-md">
+        <div class="text-h4 text-weight-bold q-mb-md">Set up your Nostr identity</div>
+        <TaskModalIdentity inline @done="nextIf(welcome.hasIdentity)" />
+        <Coachmark title="What is Nostr?">
+          Your npub is a pseudonymous identity used for tips, DMs, and Lightning Address. Keys never leave this device unless you opt in with NIP-07.
+        </Coachmark>
+        <div class="row justify-end q-mt-md">
+          <q-btn color="primary" label="Next" :disable="!welcome.hasIdentity" @click="step = 2" />
+        </div>
+      </div>
+    </q-step>
+    <q-step :name="2" title="Choose a Mint" :done="welcome.hasMint">
+      <div class="q-pa-md">
+        <div class="text-h4 text-weight-bold q-mb-md">Choose a mint</div>
+        <TaskModalMint inline @done="nextIf(welcome.hasMint)" />
+        <Coachmark title="How mints work">
+          You pay a Lightning invoice, the mint issues private ecash proofs to your device. On spend, proofs are swapped for new ones.
+        </Coachmark>
+        <div class="row justify-between q-mt-md">
+          <q-btn flat label="Back" @click="step = 1" />
+          <q-btn color="primary" label="Next" :disable="!welcome.hasMint" @click="step = 3" />
+        </div>
+      </div>
+    </q-step>
+    <q-step :name="3" title="Add sats (optional)" :done="welcome.balanceSats > 0">
+      <div class="q-pa-md">
+        <div class="text-h4 text-weight-bold q-mb-md">Add sats</div>
+        <TaskModalAddSats inline />
+        <Coachmark title="Optional">
+          You can also skip now and fund later from the Wallet page.
+        </Coachmark>
+        <div class="row justify-between q-mt-md">
+          <q-btn flat label="Back" @click="step = 2" />
+          <q-btn color="primary" label="Finish" :disable="!welcome.canFinish" @click="finish" />
+        </div>
+      </div>
+    </q-step>
+  </q-stepper>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { useWelcomeStore } from 'src/stores/welcome'
+import TaskModalIdentity from './TaskModalIdentity.vue'
+import TaskModalMint from './TaskModalMint.vue'
+import TaskModalAddSats from './TaskModalAddSats.vue'
+import Coachmark from './Coachmark.vue'
+
+const welcome = useWelcomeStore()
+const router = useRouter()
+const step = ref(1)
+
+function nextIf(cond: boolean) {
+  if (cond) step.value++
+}
+
+function finish() {
+  welcome.markWelcomeCompleted()
+  router.push('/wallet')
+}
+</script>

--- a/src/data/mints.ts
+++ b/src/data/mints.ts
@@ -1,0 +1,13 @@
+export interface MintInfo {
+  name: string
+  url: string
+  unit?: 'sat' | 'msat'
+  region?: string
+  feeNote?: string
+  notes?: string[]
+}
+
+export const MINTS: MintInfo[] = [
+  { name: 'Mint A', url: 'https://mint-a.example', unit: 'sat', region: 'EU', feeNote: 'Standard' },
+  { name: 'Mint B', url: 'https://mint-b.example', unit: 'sat', region: 'US', feeNote: 'Low fee' },
+]

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -2004,7 +2004,7 @@ export const messages = {
       title: "Pick who bridges you to Lightning",
       body: "The mint converts Lightning payments ↔ ecash. You can switch later.",
       cta: {
-        recommended: "Use recommended mint",
+        recommended: "Browse mints",
         custom: "Choose custom mint",
       },
     },

--- a/src/i18n/en-US/welcome.json
+++ b/src/i18n/en-US/welcome.json
@@ -21,7 +21,7 @@
     "chooseMint": {
       "title": "Pick a mint",
       "desc": "Mints convert Lightning ↔ ecash. You can switch anytime.",
-      "recommended": "Use recommended mint",
+      "recommended": "Browse mints",
       "choose": "Choose a mint"
     },
     "deposit": {

--- a/src/pages/WelcomePage.vue
+++ b/src/pages/WelcomePage.vue
@@ -1,6 +1,12 @@
 <template>
   <q-page class="q-pa-md welcome">
-    <div class="row q-col-gutter-md">
+    <div class="q-mb-md">
+      <q-toggle v-model="guided" label="Guided setup" />
+    </div>
+    <div v-if="guided">
+      <WelcomeStepper />
+    </div>
+    <div v-else class="row q-col-gutter-md">
       <div class="col-12 col-md-4">
         <TaskChecklist
           :tasks="tasks"
@@ -14,20 +20,21 @@
         <LearnCards />
       </div>
     </div>
-    <TaskModalIdentity v-model="showIdentity" />
-    <TaskModalMint v-model="showMint" />
-    <TaskModalAddSats v-model="showAddSats" />
+    <TaskModalIdentity v-if="!guided" v-model="showIdentity" />
+    <TaskModalMint v-if="!guided" v-model="showMint" />
+    <TaskModalAddSats v-if="!guided" v-model="showAddSats" />
   </q-page>
 </template>
 
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { ref, computed, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import TaskChecklist from 'src/components/welcome/TaskChecklist.vue'
 import LearnCards from 'src/components/welcome/LearnCards.vue'
 import TaskModalIdentity from 'src/components/welcome/TaskModalIdentity.vue'
 import TaskModalMint from 'src/components/welcome/TaskModalMint.vue'
 import TaskModalAddSats from 'src/components/welcome/TaskModalAddSats.vue'
+import WelcomeStepper from 'src/components/welcome/WelcomeStepper.vue'
 import { useWelcomeStore } from 'src/stores/welcome'
 import type { WelcomeTask } from 'src/types/welcome'
 
@@ -37,6 +44,8 @@ const welcome = useWelcomeStore()
 const showIdentity = ref(false)
 const showMint = ref(false)
 const showAddSats = ref(false)
+const guided = ref(localStorage.getItem('cashu.welcome.guided') === 'true')
+watch(guided, v => localStorage.setItem('cashu.welcome.guided', String(v)))
 
 const tasks = computed<WelcomeTask[]>(() => [
   {


### PR DESCRIPTION
## Summary
- add guided setup toggle and stepper for onboarding
- introduce neutral mint gallery with sorting and custom URLs
- remove biased recommended mint wording

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a592f3453c8330b5ede6a31602f096