### PR TITLE
feat(onboarding): harden nostr identity and mint connection steps

### DIFF
--- a/src/components/welcome/NostrBackupDialog.vue
+++ b/src/components/welcome/NostrBackupDialog.vue
@@ -1,0 +1,44 @@
+<template>
+  <q-dialog v-model="model">
+    <q-card style="max-width:400px">
+      <q-card-section class="text-h6">
+        {{ t('Welcome.nostr.backupTitle') }}
+      </q-card-section>
+      <q-card-section>
+        <q-input :model-value="nsec" readonly dense>
+          <template #append>
+            <q-btn flat icon="content_copy" @click="copy" :aria-label="t('global.actions.copy.label')" />
+          </template>
+        </q-input>
+        <p class="text-caption q-mt-sm">
+          {{ t('Welcome.nostr.backupWarning') }}
+        </p>
+      </q-card-section>
+      <q-card-actions align="right">
+        <q-btn flat color="primary" :label="t('Welcome.nostr.backupOk')" @click="model = false" />
+      </q-card-actions>
+    </q-card>
+  </q-dialog>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { copyToClipboard } from 'quasar'
+
+const props = defineProps<{ modelValue: boolean; nsec: string }>()
+const emit = defineEmits<{ (e: 'update:modelValue', v: boolean): void }>()
+const { t } = useI18n()
+
+const model = ref(props.modelValue)
+watch(() => props.modelValue, v => (model.value = v))
+watch(model, v => emit('update:modelValue', v))
+
+async function copy() {
+  try {
+    await copyToClipboard(props.nsec)
+  } catch {
+    // ignore copy errors
+  }
+}
+</script>

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1914,6 +1914,9 @@ export const messages = {
       skip: "Skip for now",
       errorInvalid: "Invalid key",
       errorConnect: "Could not connect to extension",
+      backupTitle: "Backup your Nostr secret",
+      backupWarning: "Anyone with this can act as you. Store it privately. We cannot recover it.",
+      backupOk: "Got it",
     },
     privacy: {
       title: "Cashu & Privacy",
@@ -1927,7 +1930,7 @@ export const messages = {
     },
     mints: {
       title: "Connect to a Cashu mint",
-      lead: "Cashu requires a mint to issue and verify ecash. Choose a mint you trust. You can add more later.",
+      lead: "You must connect a mint to issue and verify ecash; you can add more later.",
       placeholder: "https://your-mint.example",
       connect: "Connect mint",
       addAnother: "Add another",

--- a/test/vitest/__tests__/welcome.features.spec.ts
+++ b/test/vitest/__tests__/welcome.features.spec.ts
@@ -36,13 +36,20 @@ describe("WelcomeSlideFeatures", () => {
 
 describe('WelcomeSlideNostr', () => {
   it('marks setup completion on generate', async () => {
+    localStorage.clear()
     setActivePinia(createPinia())
     const nostr = useNostrStore()
     nostr.initWalletSeedPrivateKeySigner = async () => {}
     const wrapper = mount(WelcomeSlideNostr, {
       global: {
         mocks: { t: (msg: string) => msg },
-        stubs: { 'q-icon': { template: '<i></i>' }, 'q-btn': { template: '<button @click="$emit(\'click\')"><slot/></button>' }, 'q-form': { template: '<form @submit.prevent="(e)=>$emit(\'submit\',e)"><slot/></form>' }, 'q-input': { props:['modelValue','label'], template: '<input />' } }
+        stubs: {
+          'q-icon': { template: '<i></i>' },
+          'q-btn': { template: '<button @click="$emit(\'click\')"><slot/></button>' },
+          'q-form': { template: '<form @submit.prevent="(e)=>$emit(\'submit\',e)"><slot/></form>' },
+          'q-input': { props:['modelValue','label'], template: '<input />' },
+          'NostrBackupDialog': { template: '<div></div>', props:['modelValue','nsec'] }
+        }
       }
     })
     const welcome = useWelcomeStore()
@@ -50,13 +57,64 @@ describe('WelcomeSlideNostr', () => {
     await btns[0].trigger('click')
     expect(welcome.nostrSetupCompleted).toBe(true)
   })
+
+  it('import invalid key shows error and flag remains false', async () => {
+    localStorage.clear()
+    setActivePinia(createPinia())
+    const nostr = useNostrStore()
+    nostr.initPrivateKeySigner = vi.fn().mockRejectedValue(new Error('bad'))
+    const wrapper = mount(WelcomeSlideNostr, {
+      global: {
+        mocks: { t: (msg: string) => msg },
+        stubs: {
+          'q-icon': { template: '<i></i>' },
+          'q-btn': { template: '<button @click="$emit(\'click\')"><slot/></button>' },
+          'q-form': { template: '<form @submit.prevent="(e)=>$emit(\'submit\',e)"><slot/></form>' },
+          'q-input': { props:['modelValue','label'], template: '<input />' },
+          'NostrBackupDialog': { template: '<div></div>', props:['modelValue','nsec'] }
+        }
+      }
+    })
+    ;(wrapper.vm as any).nsec = 'a'.repeat(64)
+    await wrapper.find('form').trigger('submit')
+    const welcome = useWelcomeStore()
+    expect(welcome.nostrSetupCompleted).toBe(false)
+    expect(wrapper.text()).toContain('Welcome.nostr.errorInvalid')
+  })
+
+  it('connect extension path', async () => {
+    localStorage.clear()
+    setActivePinia(createPinia())
+    const nostr = useNostrStore()
+    nostr.connectBrowserSigner = vi.fn().mockResolvedValue(undefined)
+    window.nostr = { getPublicKey: vi.fn().mockResolvedValue('a'.repeat(64)) } as any
+    const wrapper = mount(WelcomeSlideNostr, {
+      global: {
+        mocks: { t: (msg: string) => msg },
+        stubs: {
+          'q-icon': { template: '<i></i>' },
+          'q-btn': { template: '<button @click="$emit(\'click\')"><slot/></button>' },
+          'q-form': { template: '<form @submit.prevent="(e)=>$emit(\'submit\',e)"><slot/></form>' },
+          'q-input': { props:['modelValue','label'], template: '<input />' },
+          'NostrBackupDialog': { template: '<div></div>', props:['modelValue','nsec'] }
+        }
+      }
+    })
+    const btns = wrapper.findAll('button')
+    await btns[0].trigger('click')
+    const welcome = useWelcomeStore()
+    expect(welcome.nostrSetupCompleted).toBe(true)
+    delete (window as any).nostr
+  })
 })
 
 describe('WelcomeSlideMints', () => {
   it('sets mintConnected when adding mint', async () => {
+    localStorage.clear()
     setActivePinia(createPinia())
     const mints = useMintsStore()
     mints.addMint = async (d: any) => ({ url: d.url }) as any
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({}))
     const wrapper = mount(WelcomeSlideMints, {
       global: {
         mocks: { t: (msg: string) => msg },
@@ -64,12 +122,39 @@ describe('WelcomeSlideMints', () => {
           'q-icon': { template: '<i></i>' },
           'q-input': { props:['modelValue','placeholder'], template: '<input />' },
           'q-form': { template: '<form @submit.prevent="(e)=>$emit(\'submit\',e)"><slot/></form>' },
-          'q-btn': { template: '<button @click="$emit(\'click\')"><slot/></button>' }
+          'q-btn': { template: '<button @click="$emit(\'click\')"><slot/></button>' },
+          'MintInfoDrawer': { template: '<div></div>' }
         }
       }
     })
+    ;(wrapper.vm as any).url = 'example.com'
     await wrapper.find('form').trigger('submit')
     const welcome = useWelcomeStore()
     expect(welcome.mintConnected).toBe(true)
+  })
+
+  it('bad URL shows error and does not set flag', async () => {
+    localStorage.clear()
+    setActivePinia(createPinia())
+    const mints = useMintsStore()
+    mints.addMint = vi.fn()
+    vi.stubGlobal('fetch', vi.fn())
+    const wrapper = mount(WelcomeSlideMints, {
+      global: {
+        mocks: { t: (msg: string) => msg },
+        stubs: {
+          'q-icon': { template: '<i></i>' },
+          'q-input': { props:['modelValue','placeholder'], template: '<input />' },
+          'q-form': { template: '<form @submit.prevent="(e)=>$emit(\'submit\',e)"><slot/></form>' },
+          'q-btn': { template: '<button @click="$emit(\'click\')"><slot/></button>' },
+          'MintInfoDrawer': { template: '<div></div>' }
+        }
+      }
+    })
+    ;(wrapper.vm as any).url = 'badurl'
+    await wrapper.find('form').trigger('submit')
+    const welcome = useWelcomeStore()
+    expect(welcome.mintConnected).toBe(false)
+    expect(wrapper.text()).toContain('Welcome.mints.error')
   })
 })


### PR DESCRIPTION
## Summary
- add backup dialog and robust NIP-07/seed/import flows on Nostr step
- validate and ping mint URLs before connecting; require at least one mint
- extend onboarding tests for Nostr and mint slides

## Testing
- `pnpm vitest run test/vitest/__tests__/welcome.store.spec.ts test/vitest/__tests__/welcome.features.spec.ts`

------
https://chatgpt.com/codex/tasks/task_e_68a5e9bb4f408330b5b24a18c62d23e1