### PR TITLE
Improve welcome flow onboarding and guidance

### DIFF
--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1883,10 +1883,13 @@ export const messages = {
       finish: "Finish",
       step: "Step {n} of {total}",
       language: "Language",
+      help: "Need help?",
     },
     features: {
       title: "Get to Know the App",
       lead: "Explore these key sections to start using the wallet:",
+      subtitle: "Click a feature below to see what it's for.",
+      intro: "Click on each step to learn what it's for.",
       bullets: {
         creatorHub: {
           label: "CreatorHub",
@@ -1913,7 +1916,9 @@ export const messages = {
       importPlaceholder: "nsec or hex key",
       skip: "Skip for now",
       errorInvalid: "Invalid key",
-      errorConnect: "Could not connect to extension",
+      errorConnect: "Extension connection failed. Make sure a NIP-07 extension is installed and try again.",
+      installHint: "Install a NIP-07 browser extension",
+      installUrl: "https://github.com/albyorg/alby-extension",
       backupTitle: "Backup your Nostr secret",
       backupWarning: "Anyone with this can act as you. Store it privately. We cannot recover it.",
       backupOk: "Got it",
@@ -1931,10 +1936,14 @@ export const messages = {
     mints: {
       title: "Connect to a Cashu mint",
       lead: "You must connect a mint to issue and verify ecash; you can add more later.",
+      primer: "A mint issues your ecash. Choose one to start or learn more.",
       placeholder: "https://your-mint.example",
       connect: "Connect mint",
+      browse: "Browse mints",
       addAnother: "Add another",
-      error: "Could not connect to mint",
+      errorInvalid: "Please enter a valid mint URL",
+      errorUnreachable: "Mint is unreachable",
+      errorResponse: "Mint responded with an error",
     },
     proofs: {
       title: "Proofs",

--- a/src/pages/WelcomePage.vue
+++ b/src/pages/WelcomePage.vue
@@ -1,6 +1,26 @@
 <template>
   <q-page class="q-pa-md flex flex-center">
     <div style="width:100%;max-width:600px">
+      <div class="row items-center justify-between q-mb-md">
+        <div></div>
+        <q-btn dense flat icon="checklist" @click="showChecklist = true" />
+      </div>
+      <div class="text-center q-mb-md">
+        <div class="row justify-center q-gutter-sm">
+          <q-btn
+            v-for="(_, i) in slides"
+            :key="i"
+            round
+            dense
+            :label="i + 1"
+            :color="i === welcome.currentSlide ? 'primary' : (i < welcome.currentSlide ? 'secondary' : 'grey-4')"
+            @click="jump(i)"
+            :disable="i > welcome.currentSlide && !welcome.canProceed(i - 1)"
+          />
+        </div>
+        <q-linear-progress class="q-mt-sm" :value="(welcome.currentSlide + 1) / slides.length" />
+        <div class="text-caption q-mt-xs">{{ $t('Welcome.footer.step',{n: welcome.currentSlide + 1, total: slides.length}) }}</div>
+      </div>
       <component :is="slides[welcome.currentSlide]" />
       <div class="row justify-between q-mt-lg">
         <q-btn flat :disable="welcome.currentSlide === 0" @click="prev" :label="$t('Welcome.footer.previous')" />
@@ -11,20 +31,37 @@
           @click="next"
         />
       </div>
+      <div class="text-center q-mt-md">
+        <a href="https://docs.cashu.space" target="_blank" class="text-primary">{{ $t('Welcome.footer.help') }}</a>
+      </div>
     </div>
+    <q-dialog v-model="showChecklist">
+      <TaskChecklist
+        :tasks="tasks"
+        :progress="progress"
+        :can-finish="canFinish"
+        @run="runTask"
+        @finish="showChecklist=false"
+      />
+    </q-dialog>
   </q-page>
 </template>
 
 <script setup lang="ts">
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
 import WelcomeSlideFeatures from './welcome/WelcomeSlideFeatures.vue'
 import WelcomeSlideNostr from './welcome/WelcomeSlideNostr.vue'
 import WelcomeSlidePwa from './welcome/WelcomeSlidePwa.vue'
 import WelcomeSlideBackup from './welcome/WelcomeSlideBackup.vue'
 import WelcomeSlideMints from './welcome/WelcomeSlideMints.vue'
 import WelcomeSlideTerms from './welcome/WelcomeSlideTerms.vue'
+import TaskChecklist from 'src/components/welcome/TaskChecklist.vue'
+import type { WelcomeTask } from 'src/types/welcome'
 import { useWelcomeStore, LAST_WELCOME_SLIDE } from 'src/stores/welcome'
 import { useRouter } from 'vue-router'
 
+const { t } = useI18n()
 const welcome = useWelcomeStore()
 const router = useRouter()
 
@@ -37,6 +74,36 @@ const slides = [
   WelcomeSlideTerms,
 ]
 
+const showChecklist = ref(false)
+
+const tasks = computed<WelcomeTask[]>(() => [
+  {
+    id: 'nostr',
+    icon: 'badge',
+    title: t('welcome.tasks.createKey.title'),
+    desc: t('welcome.tasks.createKey.desc'),
+    done: () => welcome.nostrSetupCompleted,
+    ctas: [{ label: t('welcome.tasks.createKey.generate'), action: 'emit', eventName: 'goto', params: { slide: 1 } }],
+  },
+  {
+    id: 'chooseMint',
+    icon: 'factory',
+    title: t('welcome.tasks.chooseMint.title'),
+    desc: t('welcome.tasks.chooseMint.desc'),
+    done: () => welcome.mintConnected,
+    ctas: [{ label: t('welcome.tasks.chooseMint.choose'), action: 'emit', eventName: 'goto', params: { slide: 4 } }],
+  },
+])
+
+const progress = computed(() => t('welcome.taskList.progress', { done: tasks.value.filter((t) => t.done()).length, total: tasks.value.length }))
+const canFinish = computed(() => tasks.value.every((t) => t.done()))
+
+function runTask(task: WelcomeTask) {
+  if (task.id === 'nostr') jump(1)
+  if (task.id === 'chooseMint') jump(4)
+  showChecklist.value = false
+}
+
 function next() {
   if (welcome.currentSlide === LAST_WELCOME_SLIDE) {
     welcome.closeWelcome()
@@ -48,5 +115,11 @@ function next() {
 
 function prev() {
   if (welcome.currentSlide > 0) welcome.currentSlide--
+}
+
+function jump(i: number) {
+  if (i <= welcome.currentSlide || welcome.canProceed(i - 1)) {
+    welcome.currentSlide = i
+  }
 }
 </script>

--- a/src/pages/welcome/WelcomeSlideFeatures.vue
+++ b/src/pages/welcome/WelcomeSlideFeatures.vue
@@ -2,37 +2,55 @@
   <section role="region" :aria-labelledby="id" class="q-pa-md flex flex-center">
     <div class="text-center">
       <q-icon name="apps" size="4em" color="primary" />
-      <h1 :id="id" tabindex="-1" class="q-mt-md">{{ $t("Welcome.features.title") }}</h1>
-      <p class="q-mt-sm">{{ $t("Welcome.features.lead") }}</p>
-      <ul class="q-mt-md text-left" style="display: inline-block">
-        <li>
-          <router-link to="/creator-hub">
-            {{ $t("Welcome.features.bullets.creatorHub.label") }}
+      <h1 :id="id" tabindex="-1" class="q-mt-md">{{ $t('Welcome.features.title') }}</h1>
+      <p class="q-mt-sm">{{ $t('Welcome.features.lead') }}</p>
+      <p class="text-caption q-mt-sm">{{ $t('Welcome.features.subtitle') }}</p>
+      <p class="text-caption q-mt-sm">{{ $t('Welcome.features.intro') }}</p>
+      <div class="q-mt-md text-left" style="display:inline-block; width:250px">
+        <div v-for="f in featureLinks" :key="f.id" class="q-mb-sm">
+          <router-link :to="f.to" @click="markVisited(f.id)">
+            <q-btn class="full-width justify-between" outline>
+              <span>{{ $t(f.label) }}</span>
+              <q-icon v-if="welcome.featuresVisited[f.id]" name="check" color="positive" />
+            </q-btn>
           </router-link>
-          - {{ $t("Welcome.features.bullets.creatorHub.desc") }}
-        </li>
-        <li>
-          <router-link to="/subscriptions">
-            {{ $t("Welcome.features.bullets.subscriptions.label") }}
-          </router-link>
-          - {{ $t("Welcome.features.bullets.subscriptions.desc") }}
-        </li>
-        <li>
-          <router-link to="/buckets">
-            {{ $t("Welcome.features.bullets.buckets.label") }}
-          </router-link>
-          - {{ $t("Welcome.features.bullets.buckets.desc") }}
-        </li>
-      </ul>
-      <p class="q-mt-md">
-        {{ $t("Welcome.features.relation") }}
-      </p>
+          <div class="text-caption q-mt-xs">{{ $t(f.desc) }}</div>
+        </div>
+      </div>
+      <p class="q-mt-md">{{ $t('Welcome.features.relation') }}</p>
     </div>
   </section>
 </template>
 
 <script setup lang="ts">
-const id = "welcome-features-title";
+import { useWelcomeStore } from 'src/stores/welcome'
+
+const id = 'welcome-features-title'
+const welcome = useWelcomeStore()
+const featureLinks = [
+  {
+    id: 'creatorHub',
+    to: '/creator-hub',
+    label: 'Welcome.features.bullets.creatorHub.label',
+    desc: 'Welcome.features.bullets.creatorHub.desc',
+  },
+  {
+    id: 'subscriptions',
+    to: '/subscriptions',
+    label: 'Welcome.features.bullets.subscriptions.label',
+    desc: 'Welcome.features.bullets.subscriptions.desc',
+  },
+  {
+    id: 'buckets',
+    to: '/buckets',
+    label: 'Welcome.features.bullets.buckets.label',
+    desc: 'Welcome.features.bullets.buckets.desc',
+  },
+]
+
+function markVisited(id: string) {
+  ;(welcome.featuresVisited as any)[id] = true
+}
 </script>
 
 <style scoped>

--- a/src/pages/welcome/WelcomeSlideMints.vue
+++ b/src/pages/welcome/WelcomeSlideMints.vue
@@ -6,7 +6,10 @@
         {{ t('Welcome.mints.title') }}
       </h1>
       <p class="q-mt-sm">{{ t('Welcome.mints.lead') }}</p>
-      <q-btn flat dense icon="info" class="q-mt-sm" @click="info = true" />
+      <p class="text-caption q-mt-sm">{{ t('Welcome.mints.primer') }}</p>
+      <div class="q-mt-sm">
+        <q-btn flat dense icon="info" @click="info = true" :label="t('Welcome.mints.browse')" />
+      </div>
       <q-form class="q-mt-md" @submit.prevent="connect">
         <q-input v-model="url" :placeholder="t('Welcome.mints.placeholder')" autocomplete="off" />
         <div v-if="error" class="text-negative text-caption q-mt-xs">{{ error }}</div>
@@ -35,7 +38,7 @@ const { t } = useI18n()
 const welcome = useWelcomeStore()
 const mints = useMintsStore()
 const id = 'welcome-mints-title'
-const url = ref('')
+const url = ref((process.env.RECOMMENDED_MINT_URL as string) || '')
 const error = ref('')
 const loading = ref(false)
 const connected = ref<any[]>([])
@@ -52,14 +55,14 @@ async function connect() {
   error.value = ''
   let input = url.value.trim()
   if (!input) {
-    error.value = t('Welcome.mints.error')
+    error.value = t('Welcome.mints.errorInvalid')
     return
   }
   if (!/^https?:\/\//i.test(input)) {
     input = 'https://' + input
   }
   if (/\s/.test(input) || !input.includes('.')) {
-    error.value = t('Welcome.mints.error')
+    error.value = t('Welcome.mints.errorInvalid')
     return
   }
   loading.value = true
@@ -67,7 +70,7 @@ async function connect() {
   try {
     await fetch(checkUrl, { method: 'GET', mode: 'no-cors' })
   } catch {
-    error.value = t('Welcome.mints.error')
+    error.value = t('Welcome.mints.errorUnreachable')
     loading.value = false
     return
   }
@@ -77,7 +80,7 @@ async function connect() {
     welcome.mintConnected = true
     url.value = ''
   } catch {
-    error.value = t('Welcome.mints.error')
+    error.value = t('Welcome.mints.errorResponse')
   } finally {
     loading.value = false
   }

--- a/src/pages/welcome/WelcomeSlideNostr.vue
+++ b/src/pages/welcome/WelcomeSlideNostr.vue
@@ -6,11 +6,18 @@
       <p class="q-mt-sm">{{ t('Welcome.nostr.lead') }}</p>
       <div class="q-gutter-y-md q-mt-md">
         <q-btn
-          v-if="hasNip07"
           color="primary"
           :label="t('Welcome.nostr.connect')"
           @click="connectNip07"
+          :disable="!hasNip07"
         />
+        <div v-if="!hasNip07" class="text-caption">
+          <a
+            :href="t('Welcome.nostr.installUrl')"
+            target="_blank"
+            class="text-primary"
+          >{{ t('Welcome.nostr.installHint') }}</a>
+        </div>
         <q-btn color="primary" :label="t('Welcome.nostr.generate')" @click="generate" />
         <q-form @submit.prevent="importKey">
           <q-input v-model="nsec" :label="t('Welcome.nostr.importPlaceholder')" autocomplete="off" />
@@ -28,6 +35,7 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { useQuasar } from 'quasar'
 import { useNostrStore } from 'src/stores/nostr'
 import { useWelcomeStore } from 'src/stores/welcome'
 import NostrBackupDialog from 'src/components/welcome/NostrBackupDialog.vue'
@@ -35,6 +43,7 @@ import { nip19 } from 'nostr-tools'
 import { hexToBytes } from '@noble/hashes/utils'
 
 const { t } = useI18n()
+const $q = useQuasar()
 const nostr = useNostrStore()
 const welcome = useWelcomeStore()
 const id = 'welcome-nostr-title'
@@ -56,7 +65,9 @@ async function connectNip07() {
     welcome.nostrSetupCompleted = true
     npub.value = nostr.npub
   } catch (e) {
-    error.value = t('Welcome.nostr.errorConnect')
+    const msg = t('Welcome.nostr.errorConnect')
+    error.value = msg
+    $q.notify({ type: 'negative', message: msg })
   }
 }
 

--- a/src/pages/welcome/WelcomeSlideTerms.vue
+++ b/src/pages/welcome/WelcomeSlideTerms.vue
@@ -50,16 +50,23 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from "vue";
-import TermsContent from "src/components/TermsContent.vue";
+import { ref, watch } from 'vue'
+import TermsContent from 'src/components/TermsContent.vue'
+import { useWelcomeStore } from 'src/stores/welcome'
 
-const id = "welcome-terms-title";
-const showTerms = ref(false);
-const accepted = ref(false);
+const id = 'welcome-terms-title'
+const showTerms = ref(false)
+const accepted = ref(false)
+const welcome = useWelcomeStore()
+
+watch(accepted, (val) => {
+  welcome.termsAccepted = val
+})
 
 function acceptAndClose() {
-  accepted.value = true;
-  showTerms.value = false;
+  accepted.value = true
+  welcome.termsAccepted = true
+  showTerms.value = false
 }
 </script>
 

--- a/src/stores/welcome.ts
+++ b/src/stores/welcome.ts
@@ -13,6 +13,11 @@ export const useWelcomeStore = defineStore('welcome', {
     termsAccepted: useLocalStorage('cashu.welcome.termsAccepted', false),
     nostrSetupCompleted: useLocalStorage('cashu.welcome.nostrSetupCompleted', false),
     mintConnected: useLocalStorage('cashu.welcome.mintConnected', false),
+    featuresVisited: useLocalStorage('cashu.welcome.featuresVisited', {
+      creatorHub: false,
+      subscriptions: false,
+      buckets: false,
+    }),
   }),
   actions: {
     walletHasAtLeastOneMint(): boolean {

--- a/test/vitest/__tests__/welcome.features.spec.ts
+++ b/test/vitest/__tests__/welcome.features.spec.ts
@@ -17,15 +17,29 @@ vi.mock('vue-i18n', async () => {
   }
 })
 
+vi.mock('quasar', () => ({
+  useQuasar: () => ({ notify: vi.fn(), platform: { has: {} } }),
+  QIcon: { template: '<i></i>' },
+  QBtn: { template: '<button @click="$emit(\'click\')"><slot/></button>' },
+  QForm: { template: '<form @submit.prevent="(e)=>$emit(\'submit\',e)"><slot/></form>' },
+  QInput: { props: ['modelValue', 'label', 'placeholder'], template: '<input />' },
+  QCheckbox: { props: ['modelValue', 'label'], template: '<input type="checkbox" />' },
+  QDialog: { template: '<div><slot/></div>' },
+  QCard: { template: '<div><slot/></div>' },
+  QCardSection: { template: '<div><slot/></div>' },
+  QSeparator: { template: '<hr />' },
+  QCardActions: { template: '<div><slot/></div>' },
+  QLinearProgress: { template: '<div></div>' },
+}))
+
 describe("WelcomeSlideFeatures", () => {
   it("renders feature links", () => {
     const wrapper = mount(WelcomeSlideFeatures, {
       global: {
         mocks: { $t: (msg: string) => msg },
         stubs: {
-          RouterLink: { props: ["to"], template: '<a :href="to"><slot/></a>' },
-          "q-icon": { template: "<i></i>" },
-        },
+          RouterLink: { props: ['to'], template: '<a :href="to"><slot/></a>' }
+        }
       },
     });
 
@@ -44,17 +58,13 @@ describe('WelcomeSlideNostr', () => {
       global: {
         mocks: { t: (msg: string) => msg },
         stubs: {
-          'q-icon': { template: '<i></i>' },
-          'q-btn': { template: '<button @click="$emit(\'click\')"><slot/></button>' },
-          'q-form': { template: '<form @submit.prevent="(e)=>$emit(\'submit\',e)"><slot/></form>' },
-          'q-input': { props:['modelValue','label'], template: '<input />' },
-          'NostrBackupDialog': { template: '<div></div>', props:['modelValue','nsec'] }
+          NostrBackupDialog: { template: '<div></div>', props: ['modelValue', 'nsec'] }
         }
       }
     })
     const welcome = useWelcomeStore()
     const btns = wrapper.findAll('button')
-    await btns[0].trigger('click')
+    await btns[1].trigger('click')
     expect(welcome.nostrSetupCompleted).toBe(true)
   })
 
@@ -67,11 +77,7 @@ describe('WelcomeSlideNostr', () => {
       global: {
         mocks: { t: (msg: string) => msg },
         stubs: {
-          'q-icon': { template: '<i></i>' },
-          'q-btn': { template: '<button @click="$emit(\'click\')"><slot/></button>' },
-          'q-form': { template: '<form @submit.prevent="(e)=>$emit(\'submit\',e)"><slot/></form>' },
-          'q-input': { props:['modelValue','label'], template: '<input />' },
-          'NostrBackupDialog': { template: '<div></div>', props:['modelValue','nsec'] }
+          NostrBackupDialog: { template: '<div></div>', props: ['modelValue', 'nsec'] }
         }
       }
     })
@@ -92,11 +98,7 @@ describe('WelcomeSlideNostr', () => {
       global: {
         mocks: { t: (msg: string) => msg },
         stubs: {
-          'q-icon': { template: '<i></i>' },
-          'q-btn': { template: '<button @click="$emit(\'click\')"><slot/></button>' },
-          'q-form': { template: '<form @submit.prevent="(e)=>$emit(\'submit\',e)"><slot/></form>' },
-          'q-input': { props:['modelValue','label'], template: '<input />' },
-          'NostrBackupDialog': { template: '<div></div>', props:['modelValue','nsec'] }
+          NostrBackupDialog: { template: '<div></div>', props: ['modelValue', 'nsec'] }
         }
       }
     })
@@ -119,11 +121,7 @@ describe('WelcomeSlideMints', () => {
       global: {
         mocks: { t: (msg: string) => msg },
         stubs: {
-          'q-icon': { template: '<i></i>' },
-          'q-input': { props:['modelValue','placeholder'], template: '<input />' },
-          'q-form': { template: '<form @submit.prevent="(e)=>$emit(\'submit\',e)"><slot/></form>' },
-          'q-btn': { template: '<button @click="$emit(\'click\')"><slot/></button>' },
-          'MintInfoDrawer': { template: '<div></div>' }
+          MintInfoDrawer: { template: '<div></div>' }
         }
       }
     })
@@ -143,11 +141,7 @@ describe('WelcomeSlideMints', () => {
       global: {
         mocks: { t: (msg: string) => msg },
         stubs: {
-          'q-icon': { template: '<i></i>' },
-          'q-input': { props:['modelValue','placeholder'], template: '<input />' },
-          'q-form': { template: '<form @submit.prevent="(e)=>$emit(\'submit\',e)"><slot/></form>' },
-          'q-btn': { template: '<button @click="$emit(\'click\')"><slot/></button>' },
-          'MintInfoDrawer': { template: '<div></div>' }
+          MintInfoDrawer: { template: '<div></div>' }
         }
       }
     })
@@ -155,6 +149,6 @@ describe('WelcomeSlideMints', () => {
     await wrapper.find('form').trigger('submit')
     const welcome = useWelcomeStore()
     expect(welcome.mintConnected).toBe(false)
-    expect(wrapper.text()).toContain('Welcome.mints.error')
+    expect(wrapper.text()).toContain('Welcome.mints.errorInvalid')
   })
 })


### PR DESCRIPTION
## Summary
- add Nostr extension guidance and error notifications
- enrich mint selection with primer, browse button, and clearer errors
- introduce welcome stepper, checklist, and feature visit tracking
- persist terms acceptance in welcome store

## Testing
- `pnpm test`
- `node --experimental-vm-modules node_modules/vitest/vitest.mjs run test/vitest/__tests__/welcome.features.spec.ts`
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68a5f0a5355c8330acfb261a6b012af1