### PR TITLE
Improve mint discovery and connection on welcome page

### DIFF
--- a/src/components/welcome/MintGallery.vue
+++ b/src/components/welcome/MintGallery.vue
@@ -20,7 +20,7 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
 import { useMintsStore } from 'src/stores/mints'
-import { MINTS, type MintInfo } from 'src/data/mints'
+import { loadMintCatalog, type MintInfo } from 'src/data/mints'
 import MintCard from './MintCard.vue'
 import MintInfoDrawer from './MintInfoDrawer.vue'
 
@@ -29,7 +29,7 @@ interface MintState extends MintInfo {
   latencyMs: number | null
 }
 
-const mints = ref<MintState[]>(MINTS.map(m => ({ ...m, status: 'pending', latencyMs: null })))
+const mints = ref<MintState[]>([])
 const sort = ref<'latency' | 'alpha'>('latency')
 const region = ref<string | null>(null)
 const info = ref(false)
@@ -40,7 +40,7 @@ const sortOptions = [
   { label: 'Alphabetical', value: 'alpha' },
 ]
 const regionOptions = computed(() => {
-  const regions = Array.from(new Set(MINTS.map(m => m.region).filter(Boolean))) as string[]
+  const regions = Array.from(new Set(mints.value.map(m => m.region).filter(Boolean))) as string[]
   return regions.map(r => ({ label: r, value: r }))
 })
 
@@ -54,14 +54,17 @@ const sortedMints = computed(() => {
   return arr
 })
 
-onMounted(() => {
+onMounted(async () => {
+  const catalog = await loadMintCatalog()
+  mints.value = catalog.map(m => ({ ...m, status: 'pending', latencyMs: null }))
   mints.value.forEach(m => pingMint(m))
 })
 
 async function pingMint(m: MintState) {
   const start = performance.now()
   try {
-    await fetch(m.url + '/info', { method: 'GET', mode: 'no-cors' })
+    const resp = await fetch(m.url + '/info')
+    if (!resp.ok) throw new Error('network')
     m.latencyMs = Math.round(performance.now() - start)
     m.status = 'ok'
   } catch (e) {

--- a/src/data/mints.ts
+++ b/src/data/mints.ts
@@ -6,8 +6,22 @@ export interface MintInfo {
   feeNote?: string
   notes?: string[]
 }
-
-export const MINTS: MintInfo[] = [
-  { name: 'Mint A', url: 'https://mint-a.example', unit: 'sat', region: 'EU', feeNote: 'Standard' },
-  { name: 'Mint B', url: 'https://mint-b.example', unit: 'sat', region: 'US', feeNote: 'Low fee' },
-]
+export async function loadMintCatalog(): Promise<MintInfo[]> {
+  try {
+    const base = new URL(import.meta.env.BASE_URL, window.location.origin)
+    const resp = await fetch(new URL('mints.json', base).toString())
+    if (!resp.ok) throw new Error('network')
+    const data = await resp.json()
+    return (Array.isArray(data) ? data : []).map((m: any) => ({
+      name: m.label || m.name || m.url,
+      url: m.url,
+      unit: m.unit,
+      region: m.region,
+      feeNote: m.feeNote,
+      notes: m.notes,
+    }))
+  } catch (e) {
+    console.error('Failed to load mint catalog', e)
+    return []
+  }
+}


### PR DESCRIPTION
## Summary
- Load mint catalog from the app base path and log failures
- Reuse MintGallery for browsing mints on the welcome screen
- Validate mint connections directly via the store

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a603fd20448330a4f3e09f6782e5b7