### PR TITLE
feat: improve mint onboarding

### DIFF
--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1944,6 +1944,9 @@ export const messages = {
       errorInvalid: "Please enter a valid mint URL",
       errorUnreachable: "Mint is unreachable",
       errorResponse: "Mint responded with an error",
+      errorNoName: "Mint metadata missing name",
+      errorNoVersion: "Mint metadata missing version",
+      errorMetadata: "Mint info could not be retrieved",
     },
     proofs: {
       title: "Proofs",

--- a/src/pages/welcome/WelcomeSlideMints.vue
+++ b/src/pages/welcome/WelcomeSlideMints.vue
@@ -18,16 +18,40 @@
         />
       </div>
       <q-form class="q-mt-md" @submit.prevent="connect">
-        <q-input v-model="url" :placeholder="t('Welcome.mints.placeholder')" autocomplete="off" />
+        <q-select
+          v-model="url"
+          :options="recommendedMints"
+          :option-label="(opt) => opt.label || opt.url"
+          option-value="url"
+          emit-value
+          map-options
+          use-input
+          input-debounce="0"
+          @new-value="onNewValue"
+          :placeholder="t('Welcome.mints.placeholder')"
+        />
         <div v-if="error" class="text-negative text-caption q-mt-xs">{{ error }}</div>
         <q-btn color="primary" class="q-mt-md" :loading="loading" type="submit" :label="t('Welcome.mints.connect')" />
       </q-form>
       <div v-if="connected.length" class="q-mt-md">
-        <div v-for="m in connected" :key="m.url" class="row items-center justify-center q-my-xs">
-          <q-icon name="check" color="positive" class="q-mr-sm" />
-          <span>{{ m.nickname || m.url }}</span>
+        <div
+          v-for="m in connected"
+          :key="m.url"
+          class="row items-center justify-between q-my-xs"
+        >
+          <div class="row items-center">
+            <q-icon name="check" color="positive" class="q-mr-sm" />
+            <span>{{ m.nickname || m.url }}</span>
+          </div>
+          <q-btn flat dense icon="delete" color="negative" @click="remove(m.url)" />
         </div>
-        <q-btn flat color="primary" class="q-mt-sm" @click="addAnother" :label="t('Welcome.mints.addAnother')" />
+        <q-btn
+          flat
+          color="primary"
+          class="q-mt-sm"
+          @click="addAnother"
+          :label="t('Welcome.mints.addAnother')"
+        />
       </div>
       <q-dialog v-model="showCatalog">
         <q-card style="min-width:300px">
@@ -70,29 +94,37 @@ const error = ref('')
 const loading = ref(false)
 const connected = ref<any[]>([])
 const showCatalog = ref(false)
-const recommendedMints = ref<{ label?: string; url: string }[]>([])
+const recommendedMints = ref<{ label: string; url: string }[]>([])
 
 async function loadRecommendedMints() {
   try {
     const resp = await fetch('/mints.json')
     if (!resp.ok) throw new Error('network')
     const data = await resp.json()
-    recommendedMints.value = Array.isArray(data) ? data : []
+    recommendedMints.value = Array.isArray(data)
+      ? data.map((m: any) => ({ url: m.url, label: m.label || m.url }))
+      : []
     if (!recommendedMints.value.length && process.env.RECOMMENDED_MINTS) {
       recommendedMints.value = (process.env.RECOMMENDED_MINTS as string)
         .split(',')
-        .map((u) => ({ url: u.trim() }))
+        .map((u) => ({ url: u.trim(), label: u.trim() }))
     }
     if (!recommendedMints.value.length && process.env.RECOMMENDED_MINT_URL) {
-      recommendedMints.value.push({ url: process.env.RECOMMENDED_MINT_URL as string })
+      recommendedMints.value.push({
+        url: process.env.RECOMMENDED_MINT_URL as string,
+        label: process.env.RECOMMENDED_MINT_URL as string,
+      })
     }
   } catch {
     if (process.env.RECOMMENDED_MINTS) {
       recommendedMints.value = (process.env.RECOMMENDED_MINTS as string)
         .split(',')
-        .map((u) => ({ url: u.trim() }))
+        .map((u) => ({ url: u.trim(), label: u.trim() }))
     } else if (process.env.RECOMMENDED_MINT_URL) {
-      recommendedMints.value.push({ url: process.env.RECOMMENDED_MINT_URL as string })
+      recommendedMints.value.push({
+        url: process.env.RECOMMENDED_MINT_URL as string,
+        label: process.env.RECOMMENDED_MINT_URL as string,
+      })
     } else {
       $q.notify({ type: 'negative', message: t('Welcome.mints.errorLoad') })
     }
@@ -122,18 +154,32 @@ async function connect() {
     return
   }
   loading.value = true
-  const checkUrl = input.replace(/\/$/, '') + '/keys'
+  const base = input.replace(/\/$/, '')
   try {
-    await fetch(checkUrl, { method: 'GET', mode: 'no-cors' })
-  } catch {
-    error.value = t('Welcome.mints.errorUnreachable')
+    await fetch(base + '/keys', { method: 'GET', mode: 'no-cors' })
+    const infoResp = await fetch(base + '/info')
+    const info = await infoResp.json()
+    if (!info?.name) {
+      throw new Error('noname')
+    }
+    if (!info?.version) {
+      throw new Error('noversion')
+    }
+  } catch (e: any) {
+    if (e.message === 'noname') {
+      error.value = t('Welcome.mints.errorNoName')
+    } else if (e.message === 'noversion') {
+      error.value = t('Welcome.mints.errorNoVersion')
+    } else {
+      error.value = t('Welcome.mints.errorUnreachable')
+    }
     loading.value = false
     return
   }
   try {
     const mint = await mints.addMint({ url: input }, true)
     connected.value.push(mint)
-    welcome.mintConnected = true
+    welcome.mintConnected = mints.mints.length > 0
     url.value = ''
   } catch {
     error.value = t('Welcome.mints.errorResponse')
@@ -151,6 +197,17 @@ function selectMint(mintUrl: string) {
   showCatalog.value = false
   url.value = mintUrl
   connect()
+}
+
+function onNewValue(val: string, done: (val: any, mode?: string) => void) {
+  const opt = { url: val, label: val }
+  done(opt, 'add-unique')
+}
+
+async function remove(mintUrl: string) {
+  await mints.removeMint(mintUrl)
+  connected.value = connected.value.filter((m) => m.url !== mintUrl)
+  welcome.mintConnected = mints.mints.length > 0
 }
 </script>
 


### PR DESCRIPTION
## Summary
- use selectable list for mint URLs with optional custom entry
- validate mint metadata before connection
- allow deleting and persisting multiple mints during onboarding

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm run check:i18n` *(fails: ReferenceError: welcome is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a61849c1a483309f9de1ab6056f7e8