### PR TITLE
feat: add nostr mint list and make mint optional

### DIFF
--- a/public/mints.json
+++ b/public/mints.json
@@ -1,4 +1,24 @@
 [
-  { "label": "Mutiny Mint", "url": "https://mint.mutinywallet.com" },
-  { "label": "LNbits Mint", "url": "https://pay.cashu.me" }
+  { "url": "https://mint.cubabitcoin.org" },
+  { "url": "https://mint.minibits.cash/Bitcoin" },
+  { "url": "https://21mint.me" },
+  { "url": "https://stablenut.umint.cash" },
+  { "url": "https://mint.lnvoltz.com" },
+  { "url": "https://mint.coinos.io" },
+  { "url": "https://mint.lnwallet.app" },
+  { "url": "https://bitcointxoko.com/cashu/api/v1/dMk78c5aR7uhHzcqH3Bwqp" },
+  { "url": "https://mint.lnfast.com" },
+  { "url": "https://mint.lnserver.com" },
+  { "url": "https://mint.0xchat.com" },
+  { "url": "https://mint.nutmix.cash" },
+  { "url": "https://mint.belgianbitcoinembassy.org" },
+  { "url": "https://mint.fredix.xyz" },
+  { "url": "https://mint.westernbtc.com" },
+  { "url": "https://mint2.nutmix.cash" },
+  { "url": "https://mint.lnw.cash" },
+  { "url": "https://mint.103100.xyz" },
+  { "url": "https://mint.lnwasanee.com" },
+  { "url": "https://mint.agorist.space" },
+  { "url": "https://cashu.boats" },
+  { "url": "https://kashu.me" }
 ]

--- a/src/pages/WelcomePage.vue
+++ b/src/pages/WelcomePage.vue
@@ -108,14 +108,6 @@ const tasks = computed<WelcomeTask[]>(() => [
     done: () => welcome.nostrSetupCompleted,
     ctas: [{ label: t('welcome.tasks.createKey.generate'), action: 'emit', eventName: 'goto', params: { slide: 1 } }],
   },
-  {
-    id: 'chooseMint',
-    icon: 'factory',
-    title: t('welcome.tasks.chooseMint.title'),
-    desc: t('welcome.tasks.chooseMint.desc'),
-    done: () => welcome.mintConnected,
-    ctas: [{ label: t('welcome.tasks.chooseMint.choose'), action: 'emit', eventName: 'goto', params: { slide: 4 } }],
-  },
 ])
 
 const progress = computed(() => t('welcome.taskList.progress', { done: tasks.value.filter((t) => t.done()).length, total: tasks.value.length }))
@@ -123,7 +115,6 @@ const canFinish = computed(() => tasks.value.every((t) => t.done()))
 
 function runTask(task: WelcomeTask) {
   if (task.id === 'nostr') jump(1)
-  if (task.id === 'chooseMint') jump(4)
   showChecklist.value = false
 }
 

--- a/src/pages/welcome/WelcomeSlideMints.vue
+++ b/src/pages/welcome/WelcomeSlideMints.vue
@@ -7,13 +7,24 @@
       </h1>
       <p class="q-mt-sm">{{ t('Welcome.mints.lead') }}</p>
       <p class="text-caption q-mt-sm">{{ t('Welcome.mints.primer') }}</p>
+      <p class="text-caption q-mt-sm">
+        These mints were recommended by other Nostr users.
+        Read reviews at
+        <a
+          href="https://bitcoinmints.com"
+          target="_blank"
+          rel="noopener"
+          >bitcoinmints.com</a
+        >.
+        Be careful and do your own research before using a mint.
+      </p>
       <div class="q-mt-sm">
         <q-btn
           flat
           dense
           icon="factory"
           @click="showCatalog = true"
-          :label="t('Welcome.mints.browse')"
+          label="Click to browse mints"
           :disable="!recommendedMints.length"
         />
       </div>

--- a/src/stores/welcome.ts
+++ b/src/stores/welcome.ts
@@ -1,6 +1,5 @@
 import { defineStore } from 'pinia'
 import { useLocalStorage } from '@vueuse/core'
-import { useMintsStore } from './mints'
 
 export const LAST_WELCOME_SLIDE = 5
 
@@ -20,10 +19,6 @@ export const useWelcomeStore = defineStore('welcome', {
     }),
   }),
   actions: {
-    walletHasAtLeastOneMint(): boolean {
-      const mints = useMintsStore()
-      return mints.mints.length > 0
-    },
     canProceed(slide: number): boolean {
       switch (slide) {
         case 0:
@@ -33,7 +28,7 @@ export const useWelcomeStore = defineStore('welcome', {
         case 3:
           return this.seedPhraseValidated || this.walletRestored
         case 4:
-          return this.mintConnected || this.walletHasAtLeastOneMint()
+          return true
         case 5:
           return this.termsAccepted
         default:

--- a/test/vitest/__tests__/welcome.store.spec.ts
+++ b/test/vitest/__tests__/welcome.store.spec.ts
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 import { useWelcomeStore } from '../../../src/stores/welcome'
-import { useMintsStore } from '../../../src/stores/mints'
 
 beforeEach(() => {
   setActivePinia(createPinia())
@@ -10,7 +9,6 @@ beforeEach(() => {
 describe('welcome store gating', () => {
   it('enforces slide requirements', () => {
     const w = useWelcomeStore()
-    const mints = useMintsStore()
     expect(w.canProceed(0)).toBe(true)
     expect(w.canProceed(1)).toBe(true)
     expect(w.canProceed(2)).toBe(true)
@@ -21,13 +19,7 @@ describe('welcome store gating', () => {
     w.walletRestored = true
     expect(w.canProceed(3)).toBe(true)
     w.walletRestored = false
-    expect(w.canProceed(4)).toBe(false)
-    w.mintConnected = true
     expect(w.canProceed(4)).toBe(true)
-    w.mintConnected = false
-    mints.mints = [{ url: 'https://mint' } as any]
-    expect(w.canProceed(4)).toBe(true)
-    mints.mints = []
     expect(w.canProceed(5)).toBe(false)
     w.termsAccepted = true
     expect(w.canProceed(5)).toBe(true)


### PR DESCRIPTION
## Summary
- list community recommended mints on the welcome page
- show warning and link to bitcoinmints.com
- allow progressing past welcome without connecting a mint

## Testing
- `pnpm test`
- `node --experimental-vm-modules node_modules/vitest/vitest.mjs run test/vitest/__tests__/welcome.store.spec.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a61b712d108330b547a28e60b1e98e