### PR TITLE
Add Creator Hub translations and dynamic NIP-07 extension suggestions

### DIFF
--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -1812,6 +1812,11 @@ export const messages = {
             "Your public storefront as seen by visitors. Great for a quick audit of how your profile appears worldwide.",
         },
 
+        creatorHub: {
+          fan: "Publish a profile; get support.",
+          creator: "Set tiers, goals and withdraw earnings.",
+        },
+
         myProfile: {
           fan: "Show off your avatar, npub link and optional NIP-05. Personal stats: total zaps sent & received, bucket balances.",
           creator:

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -1812,6 +1812,11 @@ export const messages = {
             "Your public storefront as seen by visitors. Great for a quick audit of how your profile appears worldwide.",
         },
 
+        creatorHub: {
+          fan: "Publish a profile; get support.",
+          creator: "Set tiers, goals and withdraw earnings.",
+        },
+
         myProfile: {
           fan: "Show off your avatar, npub link and optional NIP-05. Personal stats: total zaps sent & received, bucket balances.",
           creator:

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -1812,6 +1812,11 @@ export const messages = {
             "Your public storefront as seen by visitors. Great for a quick audit of how your profile appears worldwide.",
         },
 
+        creatorHub: {
+          fan: "Publish a profile; get support.",
+          creator: "Set tiers, goals and withdraw earnings.",
+        },
+
         myProfile: {
           fan: "Show off your avatar, npub link and optional NIP-05. Personal stats: total zaps sent & received, bucket balances.",
           creator:

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1804,6 +1804,11 @@ export const messages = {
             "Your public storefront as seen by visitors. Great for a quick audit of how your profile appears worldwide.",
         },
 
+        creatorHub: {
+          fan: "Publish a profile; get support.",
+          creator: "Set tiers, goals and withdraw earnings.",
+        },
+
         myProfile: {
           fan: "Show off your avatar, npub link and optional NIP-05. Personal stats: total zaps sent & received, bucket balances.",
           creator:
@@ -1918,7 +1923,8 @@ export const messages = {
       errorInvalid: "Invalid key",
       errorConnect: "Extension connection failed. Make sure a NIP-07 extension is installed and try again.",
       installHint: "Install a NIP-07 browser extension",
-      installUrl: "https://github.com/albyorg/alby-extension",
+      installBrowser: "Choose an extension for {browser}",
+      unknownBrowser: "your browser",
       backupTitle: "Backup your Nostr secret",
       backupWarning: "Anyone with this can act as you. Store it privately. We cannot recover it.",
       backupOk: "Got it",

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -1812,6 +1812,11 @@ export const messages = {
             "Your public storefront as seen by visitors. Great for a quick audit of how your profile appears worldwide.",
         },
 
+        creatorHub: {
+          fan: "Publish a profile; get support.",
+          creator: "Set tiers, goals and withdraw earnings.",
+        },
+
         myProfile: {
           fan: "Show off your avatar, npub link and optional NIP-05. Personal stats: total zaps sent & received, bucket balances.",
           creator:

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -1812,6 +1812,11 @@ export const messages = {
             "Your public storefront as seen by visitors. Great for a quick audit of how your profile appears worldwide.",
         },
 
+        creatorHub: {
+          fan: "Publish a profile; get support.",
+          creator: "Set tiers, goals and withdraw earnings.",
+        },
+
         myProfile: {
           fan: "Show off your avatar, npub link and optional NIP-05. Personal stats: total zaps sent & received, bucket balances.",
           creator:

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -1812,6 +1812,11 @@ export const messages = {
             "Your public storefront as seen by visitors. Great for a quick audit of how your profile appears worldwide.",
         },
 
+        creatorHub: {
+          fan: "Publish a profile; get support.",
+          creator: "Set tiers, goals and withdraw earnings.",
+        },
+
         myProfile: {
           fan: "Show off your avatar, npub link and optional NIP-05. Personal stats: total zaps sent & received, bucket balances.",
           creator:

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -1812,6 +1812,11 @@ export const messages = {
             "Your public storefront as seen by visitors. Great for a quick audit of how your profile appears worldwide.",
         },
 
+        creatorHub: {
+          fan: "Publish a profile; get support.",
+          creator: "Set tiers, goals and withdraw earnings.",
+        },
+
         myProfile: {
           fan: "Show off your avatar, npub link and optional NIP-05. Personal stats: total zaps sent & received, bucket balances.",
           creator:

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -1812,6 +1812,11 @@ export const messages = {
             "Your public storefront as seen by visitors. Great for a quick audit of how your profile appears worldwide.",
         },
 
+        creatorHub: {
+          fan: "Publish a profile; get support.",
+          creator: "Set tiers, goals and withdraw earnings.",
+        },
+
         myProfile: {
           fan: "Show off your avatar, npub link and optional NIP-05. Personal stats: total zaps sent & received, bucket balances.",
           creator:

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -1812,6 +1812,11 @@ export const messages = {
             "Your public storefront as seen by visitors. Great for a quick audit of how your profile appears worldwide.",
         },
 
+        creatorHub: {
+          fan: "Publish a profile; get support.",
+          creator: "Set tiers, goals and withdraw earnings.",
+        },
+
         myProfile: {
           fan: "Show off your avatar, npub link and optional NIP-05. Personal stats: total zaps sent & received, bucket balances.",
           creator:

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -1812,6 +1812,11 @@ export const messages = {
             "Your public storefront as seen by visitors. Great for a quick audit of how your profile appears worldwide.",
         },
 
+        creatorHub: {
+          fan: "Publish a profile; get support.",
+          creator: "Set tiers, goals and withdraw earnings.",
+        },
+
         myProfile: {
           fan: "Show off your avatar, npub link and optional NIP-05. Personal stats: total zaps sent & received, bucket balances.",
           creator:

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -1812,6 +1812,11 @@ export const messages = {
             "Your public storefront as seen by visitors. Great for a quick audit of how your profile appears worldwide.",
         },
 
+        creatorHub: {
+          fan: "Publish a profile; get support.",
+          creator: "Set tiers, goals and withdraw earnings.",
+        },
+
         myProfile: {
           fan: "Show off your avatar, npub link and optional NIP-05. Personal stats: total zaps sent & received, bucket balances.",
           creator:

--- a/src/pages/welcome/WelcomeSlideNostr.vue
+++ b/src/pages/welcome/WelcomeSlideNostr.vue
@@ -11,13 +11,15 @@
           @click="connectNip07"
           :disable="!hasNip07"
         />
-        <div v-if="!hasNip07" class="text-caption">
-          <a
-            :href="t('Welcome.nostr.installUrl')"
-            target="_blank"
-            class="text-primary"
-          >{{ t('Welcome.nostr.installHint') }}</a>
-        </div>
+      <div v-if="!hasNip07" class="text-caption">
+        <div>{{ t('Welcome.nostr.installHint') }}</div>
+        <div>{{ t('Welcome.nostr.installBrowser', { browser: browserLabel }) }}</div>
+        <ul class="q-mt-xs">
+          <li v-for="ext in suggestedExtensions" :key="ext.name">
+            <a :href="ext.url" target="_blank" class="text-primary">{{ ext.name }}</a>
+          </li>
+        </ul>
+      </div>
         <q-btn color="primary" :label="t('Welcome.nostr.generate')" @click="generate" />
         <q-form @submit.prevent="importKey">
           <q-input v-model="nsec" :label="t('Welcome.nostr.importPlaceholder')" autocomplete="off" />
@@ -55,6 +57,61 @@ const showBackup = ref(false)
 const backupNsec = ref('')
 
 const hasNip07 = computed(() => typeof window !== 'undefined' && !!(window as any).nostr?.getPublicKey)
+
+type BrowserKind = 'chromium' | 'firefox' | 'safari' | 'unknown'
+const browser = ref<BrowserKind>('unknown')
+
+if (typeof navigator !== 'undefined') {
+  const ua = navigator.userAgent
+  if (/firefox/i.test(ua)) browser.value = 'firefox'
+  else if (/safari/i.test(ua) && !/chrome|chromium|crios|edg/i.test(ua)) browser.value = 'safari'
+  else if (/chrome|chromium|crios|edg/i.test(ua)) browser.value = 'chromium'
+}
+
+const browserLabel = computed(() => {
+  switch (browser.value) {
+    case 'chromium':
+      return 'Chromium'
+    case 'firefox':
+      return 'Firefox'
+    case 'safari':
+      return 'Safari'
+    default:
+      return t('Welcome.nostr.unknownBrowser')
+  }
+})
+
+interface ExtensionLink {
+  name: string
+  url: string
+  browsers: BrowserKind[]
+}
+
+const extensions: ExtensionLink[] = [
+  {
+    name: 'Alby',
+    url: 'https://github.com/getAlby/lightning-browser-extension',
+    browsers: ['chromium', 'firefox'],
+  },
+  { name: 'nos2x', url: 'https://github.com/fiatjaf/nos2x', browsers: ['chromium'] },
+  { name: 'nos2x-fox', url: 'https://github.com/diegogurpegui/nos2x-fox', browsers: ['firefox'] },
+  { name: 'nostr-keyx', url: 'https://github.com/susumuota/nostr-keyx', browsers: ['chromium'] },
+  { name: 'AKA Profiles', url: 'https://github.com/neilck/aka-extension', browsers: ['chromium'] },
+  { name: 'Frost2x', url: 'https://github.com/FROSTR-ORG/frost2x', browsers: ['chromium'] },
+  { name: 'Keys.Band', url: 'https://github.com/toastr-space/keys-band', browsers: ['chromium'] },
+  { name: 'horse', url: 'https://github.com/fiatjaf/horse', browsers: ['chromium'] },
+  { name: 'Nostore', url: 'https://github.com/ursuscamp/nostore', browsers: ['safari'] },
+  {
+    name: 'Blockcore Wallet',
+    url: 'https://github.com/block-core/blockcore-wallet',
+    browsers: ['chromium', 'firefox'],
+  },
+]
+
+const suggestedExtensions = computed(() => {
+  const list = extensions.filter((e) => e.browsers.includes(browser.value))
+  return list.length ? list : extensions
+})
 
 async function connectNip07() {
   error.value = ''


### PR DESCRIPTION
## Summary
- add missing Creator Hub translations to navigation items
- detect browser on Nostr setup screen and list relevant NIP-07 extensions

## Testing
- `pnpm run lint`
- `pnpm test`
- `pnpm run check:i18n` *(fails: ReferenceError: welcome is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a6ab79c7f08330842ee7b27d7ed175