### PR TITLE
Improve Nostr onboarding text and connection feedback

### DIFF
--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1914,8 +1914,9 @@ export const messages = {
     },
     nostr: {
       title: "Set up your Nostr identity (optional)",
-      lead: "Nostr is an open identity protocol. Connecting a Nostr key lets Cashu create a Lightning address for tips and back up your mint list. You can skip this.",
+      lead: "Nostr is a decentralized, censorship-resistant identity protocol. Connecting a Nostr key lets Cashu create a Lightning address for tips and back up your mint list. You can skip this.",
       connect: "Connect Nostr extension",
+      connected: "Connected",
       generate: "Generate new key",
       import: "Import existing key",
       importPlaceholder: "nsec or hex key",

--- a/src/pages/welcome/WelcomeSlideNostr.vue
+++ b/src/pages/welcome/WelcomeSlideNostr.vue
@@ -6,11 +6,13 @@
       <p class="q-mt-sm">{{ t('Welcome.nostr.lead') }}</p>
       <div class="q-gutter-y-md q-mt-md">
         <q-btn
-          color="primary"
-          :label="t('Welcome.nostr.connect')"
-          @click="connectNip07"
-          :disable="!hasNip07"
-        />
+            color="primary"
+            :label="connected ? t('Welcome.nostr.connected') : t('Welcome.nostr.connect')"
+            @click="connectNip07"
+            :disable="!hasNip07 || connected"
+            :loading="connecting"
+            :icon="connected ? 'check' : undefined"
+          />
       <div v-if="!hasNip07" class="text-caption">
         <div>{{ t('Welcome.nostr.installHint') }}</div>
         <div>{{ t('Welcome.nostr.installBrowser', { browser: browserLabel }) }}</div>
@@ -55,6 +57,8 @@ const error = ref('')
 const npub = ref('')
 const showBackup = ref(false)
 const backupNsec = ref('')
+const connecting = ref(false)
+const connected = ref(false)
 
 const hasNip07 = computed(() => typeof window !== 'undefined' && !!(window as any).nostr?.getPublicKey)
 
@@ -115,16 +119,21 @@ const suggestedExtensions = computed(() => {
 
 async function connectNip07() {
   error.value = ''
+  connecting.value = true
   try {
     const pk = await (window as any).nostr.getPublicKey()
     await nostr.connectBrowserSigner()
     nostr.setPubkey(pk)
     welcome.nostrSetupCompleted = true
     npub.value = nostr.npub
+    connected.value = true
+    $q.notify({ type: 'positive', message: t('Welcome.nostr.connected') })
   } catch (e) {
     const msg = t('Welcome.nostr.errorConnect')
     error.value = msg
     $q.notify({ type: 'negative', message: msg })
+  } finally {
+    connecting.value = false
   }
 }
 
@@ -177,6 +186,7 @@ function skip() {
   nsec.value = ''
   error.value = ''
   npub.value = ''
+  connected.value = false
 }
 </script>
 


### PR DESCRIPTION
## Summary
- Clarify Nostr's decentralized, censorship-resistant identity in welcome copy
- Show loading state and success feedback when connecting a Nostr extension

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm run check:i18n` *(fails: ReferenceError: welcome is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a6b09fc3f88330a9563eaeebcb69c5