### PR TITLE
Fix welcome flow completion and cleanup onboarding text

### DIFF
--- a/src/i18n/ar-SA/index.ts
+++ b/src/i18n/ar-SA/index.ts
@@ -1913,9 +1913,7 @@ export const messages = {
           label: "Buckets",
           desc: "Organize your tokens.",
         },
-      },
-      relation:
-        "Browse creators in CreatorHub and subscribe to them in Subscriptions.",
+      }
     },
     privacy: {
       title: "Cashu & Privacy",

--- a/src/i18n/de-DE/index.ts
+++ b/src/i18n/de-DE/index.ts
@@ -1913,9 +1913,7 @@ export const messages = {
           label: "Buckets",
           desc: "Organize your tokens.",
         },
-      },
-      relation:
-        "Browse creators in CreatorHub and subscribe to them in Subscriptions.",
+      }
     },
     privacy: {
       title: "Cashu & Privacy",

--- a/src/i18n/el-GR/index.ts
+++ b/src/i18n/el-GR/index.ts
@@ -1913,9 +1913,7 @@ export const messages = {
           label: "Buckets",
           desc: "Organize your tokens.",
         },
-      },
-      relation:
-        "Browse creators in CreatorHub and subscribe to them in Subscriptions.",
+      }
     },
     privacy: {
       title: "Cashu & Privacy",

--- a/src/i18n/en-US/index.ts
+++ b/src/i18n/en-US/index.ts
@@ -1893,8 +1893,6 @@ export const messages = {
     features: {
       title: "Get to Know the App",
       lead: "Explore these key sections to start using the wallet:",
-      subtitle: "Click a feature below to see what it's for.",
-      intro: "Click on each step to learn what it's for.",
       bullets: {
         creatorHub: {
           label: "CreatorHub",
@@ -1908,9 +1906,7 @@ export const messages = {
           label: "Buckets",
           desc: "Organize your tokens.",
         },
-      },
-      relation:
-        "Browse creators in CreatorHub and subscribe to them in Subscriptions.",
+      }
     },
     nostr: {
       title: "Set up your Nostr identity (optional)",

--- a/src/i18n/es-ES/index.ts
+++ b/src/i18n/es-ES/index.ts
@@ -1913,9 +1913,7 @@ export const messages = {
           label: "Buckets",
           desc: "Organize your tokens.",
         },
-      },
-      relation:
-        "Browse creators in CreatorHub and subscribe to them in Subscriptions.",
+      }
     },
     privacy: {
       title: "Cashu & Privacy",

--- a/src/i18n/fr-FR/index.ts
+++ b/src/i18n/fr-FR/index.ts
@@ -1913,9 +1913,7 @@ export const messages = {
           label: "Buckets",
           desc: "Organize your tokens.",
         },
-      },
-      relation:
-        "Browse creators in CreatorHub and subscribe to them in Subscriptions.",
+      }
     },
     privacy: {
       title: "Cashu & Privacy",

--- a/src/i18n/it-IT/index.ts
+++ b/src/i18n/it-IT/index.ts
@@ -1913,9 +1913,7 @@ export const messages = {
           label: "Buckets",
           desc: "Organize your tokens.",
         },
-      },
-      relation:
-        "Browse creators in CreatorHub and subscribe to them in Subscriptions.",
+      }
     },
     privacy: {
       title: "Cashu & Privacy",

--- a/src/i18n/ja-JP/index.ts
+++ b/src/i18n/ja-JP/index.ts
@@ -1913,9 +1913,7 @@ export const messages = {
           label: "Buckets",
           desc: "Organize your tokens.",
         },
-      },
-      relation:
-        "Browse creators in CreatorHub and subscribe to them in Subscriptions.",
+      }
     },
     privacy: {
       title: "Cashu & Privacy",

--- a/src/i18n/sv-SE/index.ts
+++ b/src/i18n/sv-SE/index.ts
@@ -1913,9 +1913,7 @@ export const messages = {
           label: "Buckets",
           desc: "Organize your tokens.",
         },
-      },
-      relation:
-        "Browse creators in CreatorHub and subscribe to them in Subscriptions.",
+      }
     },
     privacy: {
       title: "Cashu & Privacy",

--- a/src/i18n/th-TH/index.ts
+++ b/src/i18n/th-TH/index.ts
@@ -1913,9 +1913,7 @@ export const messages = {
           label: "Buckets",
           desc: "Organize your tokens.",
         },
-      },
-      relation:
-        "Browse creators in CreatorHub and subscribe to them in Subscriptions.",
+      }
     },
     privacy: {
       title: "Cashu & Privacy",

--- a/src/i18n/tr-TR/index.ts
+++ b/src/i18n/tr-TR/index.ts
@@ -1913,9 +1913,7 @@ export const messages = {
           label: "Buckets",
           desc: "Organize your tokens.",
         },
-      },
-      relation:
-        "Browse creators in CreatorHub and subscribe to them in Subscriptions.",
+      }
     },
     privacy: {
       title: "Cashu & Privacy",

--- a/src/i18n/zh-CN/index.ts
+++ b/src/i18n/zh-CN/index.ts
@@ -1913,9 +1913,7 @@ export const messages = {
           label: "Buckets",
           desc: "Organize your tokens.",
         },
-      },
-      relation:
-        "Browse creators in CreatorHub and subscribe to them in Subscriptions.",
+      }
     },
     privacy: {
       title: "Cashu & Privacy",

--- a/src/pages/WelcomePage.vue
+++ b/src/pages/WelcomePage.vue
@@ -44,7 +44,7 @@
         :progress="progress"
         :can-finish="canFinish"
         @run="runTask"
-        @finish="showChecklist=false"
+        @finish="finishOnboarding"
       />
     </q-dialog>
     <RevealSeedDialog v-model="showSeedDialog" :seed="mnemonicStore.mnemonic" />
@@ -62,6 +62,7 @@ import WelcomeSlidePwa from './welcome/WelcomeSlidePwa.vue'
 import WelcomeSlideBackup from './welcome/WelcomeSlideBackup.vue'
 import WelcomeSlideMints from './welcome/WelcomeSlideMints.vue'
 import WelcomeSlideTerms from './welcome/WelcomeSlideTerms.vue'
+import WelcomeSlideFinish from './welcome/WelcomeSlideFinish.vue'
 import TaskChecklist from 'src/components/welcome/TaskChecklist.vue'
 import RevealSeedDialog from 'src/components/welcome/RevealSeedDialog.vue'
 import type { WelcomeTask } from 'src/types/welcome'
@@ -76,6 +77,7 @@ const $q = useQuasar()
 const mnemonicStore = useMnemonicStore()
 const storageStore = useStorageStore()
 const showSeedDialog = ref(false)
+const showChecklist = ref(false)
 
 function revealSeed() {
   showSeedDialog.value = true
@@ -83,6 +85,12 @@ function revealSeed() {
 
 function downloadBackup() {
   storageStore.exportWalletState()
+}
+
+function finishOnboarding() {
+  showChecklist.value = false
+  welcome.closeWelcome()
+  router.push('/')
 }
 
 const slides = [
@@ -95,9 +103,8 @@ const slides = [
   },
   { component: WelcomeSlideMints },
   { component: WelcomeSlideTerms },
+  { component: WelcomeSlideFinish, props: { onOpenWallet: finishOnboarding } },
 ]
-
-const showChecklist = ref(false)
 
 const tasks = computed<WelcomeTask[]>(() => [
   {
@@ -120,8 +127,7 @@ function runTask(task: WelcomeTask) {
 
 function next() {
   if (welcome.currentSlide === LAST_WELCOME_SLIDE) {
-    welcome.closeWelcome()
-    router.push('/')
+    finishOnboarding()
   } else if (welcome.canProceed(welcome.currentSlide)) {
     welcome.currentSlide++
   }

--- a/src/pages/welcome/WelcomeSlideFeatures.vue
+++ b/src/pages/welcome/WelcomeSlideFeatures.vue
@@ -4,10 +4,7 @@
       <q-icon name="apps" size="4em" color="primary" />
       <h1 :id="id" tabindex="-1" class="q-mt-md">{{ $t('Welcome.features.title') }}</h1>
       <p class="q-mt-sm">{{ $t('Welcome.features.lead') }}</p>
-      <p class="text-caption q-mt-sm">{{ $t('Welcome.features.subtitle') }}</p>
-      <p class="text-caption q-mt-sm">{{ $t('Welcome.features.intro') }}</p>
       <NavigationMap :items="navigationItems" @opened="markVisited" />
-      <p class="q-mt-md">{{ $t('Welcome.features.relation') }}</p>
     </div>
   </section>
 </template>

--- a/src/pages/welcome/WelcomeSlideFinish.vue
+++ b/src/pages/welcome/WelcomeSlideFinish.vue
@@ -43,6 +43,7 @@ const props = defineProps<{
   onCreateBuckets?: () => void;
   onRestore?: () => void;
 }>();
+const emit = defineEmits<{ (e: 'open-wallet'): void }>();
 
 function addMint() {
   props.onAddMint?.();
@@ -57,7 +58,7 @@ function restore() {
 }
 
 function openWallet() {
-  /* handled by main welcome page */
+  emit('open-wallet');
 }
 </script>
 

--- a/src/stores/welcome.ts
+++ b/src/stores/welcome.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia'
 import { useLocalStorage } from '@vueuse/core'
 
-export const LAST_WELCOME_SLIDE = 5
+export const LAST_WELCOME_SLIDE = 6
 
 export const useWelcomeStore = defineStore('welcome', {
   state: () => ({
@@ -17,6 +17,7 @@ export const useWelcomeStore = defineStore('welcome', {
       subscriptions: false,
       buckets: false,
     }),
+    welcomeCompleted: useLocalStorage('cashu.welcome.completed', false),
   }),
   actions: {
     canProceed(slide: number): boolean {
@@ -31,6 +32,8 @@ export const useWelcomeStore = defineStore('welcome', {
           return true
         case 5:
           return this.termsAccepted
+        case 6:
+          return true
         default:
           return false
       }
@@ -38,6 +41,8 @@ export const useWelcomeStore = defineStore('welcome', {
     closeWelcome() {
       this.showWelcome = false
       this.currentSlide = 0
+      this.featuresVisited = { creatorHub: false, subscriptions: false, buckets: false }
+      this.welcomeCompleted = true
     },
   },
 })


### PR DESCRIPTION
## Summary
- remove redundant copy from Get to Know the App slide and translations
- persist onboarding completion in store and handle final slide navigation
- add finish slide "Open Wallet" handler to exit onboarding

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm run check:i18n` *(fails: ReferenceError: welcome is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a6b4c957188330be39db12ec142555