### PR TITLE
Preload NIP-07 signer and widen welcome titles

### DIFF
--- a/src/pages/WelcomePage.vue
+++ b/src/pages/WelcomePage.vue
@@ -52,7 +52,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import { useQuasar } from 'quasar'
@@ -69,6 +69,8 @@ import type { WelcomeTask } from 'src/types/welcome'
 import { useWelcomeStore, LAST_WELCOME_SLIDE } from 'src/stores/welcome'
 import { useMnemonicStore } from 'src/stores/mnemonic'
 import { useStorageStore } from 'src/stores/storage'
+import { useNostrStore } from 'src/stores/nostr'
+import { useNdk } from 'src/composables/useNdk'
 
 const { t } = useI18n()
 const welcome = useWelcomeStore()
@@ -76,6 +78,7 @@ const router = useRouter()
 const $q = useQuasar()
 const mnemonicStore = useMnemonicStore()
 const storageStore = useStorageStore()
+const nostr = useNostrStore()
 const showSeedDialog = ref(false)
 const showChecklist = ref(false)
 
@@ -142,4 +145,15 @@ function jump(i: number) {
     welcome.currentSlide = i
   }
 }
+
+onMounted(() => {
+  nostr
+    .initNip07Signer()
+    .then(() => {
+      if (nostr.signer) {
+        useNdk({ requireSigner: true }).catch(() => {})
+      }
+    })
+    .catch(() => {})
+})
 </script>

--- a/src/pages/welcome/WelcomeSlideMints.vue
+++ b/src/pages/welcome/WelcomeSlideMints.vue
@@ -1,6 +1,6 @@
 <template>
   <section role="region" :aria-labelledby="id" class="q-pa-md flex flex-center">
-    <div class="text-center" style="max-width: 400px">
+    <div class="text-center q-mx-auto" style="max-width: 600px">
       <q-icon name="factory" size="4em" color="primary" />
       <h1 :id="id" tabindex="-1" class="q-mt-md">
         {{ t('Welcome.mints.title') }}

--- a/src/pages/welcome/WelcomeSlideNostr.vue
+++ b/src/pages/welcome/WelcomeSlideNostr.vue
@@ -1,6 +1,6 @@
 <template>
   <section role="region" :aria-labelledby="id" class="q-pa-md flex flex-center">
-    <div class="text-center" style="max-width:400px">
+    <div class="text-center q-mx-auto" style="max-width:600px">
       <q-icon name="badge" size="4em" color="primary" />
       <h1 :id="id" tabindex="-1" class="q-mt-md">{{ t('Welcome.nostr.title') }}</h1>
       <p class="q-mt-sm">{{ t('Welcome.nostr.lead') }}</p>
@@ -121,9 +121,9 @@ async function connectNip07() {
   error.value = ''
   connecting.value = true
   try {
-    const pk = await (window as any).nostr.getPublicKey()
-    await nostr.connectBrowserSigner()
-    nostr.setPubkey(pk)
+    if (!nostr.signer) {
+      await nostr.connectBrowserSigner()
+    }
     welcome.nostrSetupCompleted = true
     npub.value = nostr.npub
     connected.value = true

--- a/src/stores/nostr.ts
+++ b/src/stores/nostr.ts
@@ -663,10 +663,11 @@ export const useNostrStore = defineStore("nostr", {
     async connectBrowserSigner() {
       const nip07 = new NDKNip07Signer();
       try {
-        await nip07.user();
+        const user = await nip07.user();
         this.signer = nip07;
         this.signerType = SignerType.NIP07;
-        await useNdk({ requireSigner: true });
+        this.setPubkey(user.pubkey);
+        useNdk({ requireSigner: true }).catch(() => {});
       } catch (e) {
         throw new Error("The signer request was rejected or blocked.");
       }


### PR DESCRIPTION
## Summary
- Warm up NIP-07 signer and fire off NDK connection when the welcome page mounts
- Defer relay connection in NDK until after Nostr extension handshake
- Expand Nostr and Mint slide heading containers for better readability

## Testing
- `pnpm lint`
- `pnpm test`
- `pnpm format:check` *(fails: Code style issues found in 53 files)*

------
https://chatgpt.com/codex/tasks/task_e_68a6b9f8e7408330b14ce723e3a790b9