### PR TITLE
Allow HTTPS CSP requests and slow redeem worker polling

### DIFF
--- a/deploy/nginx/security-headers.conf
+++ b/deploy/nginx/security-headers.conf
@@ -1,4 +1,18 @@
 # ---- Strict CSP tuned for Vue/Quasar PWA ----
+add_header Content-Security-Policy-Report-Only "
+  default-src 'self';
+  script-src 'self';
+  style-src 'self' 'unsafe-inline';
+  img-src 'self' data: blob:;
+  font-src 'self' data:;
+  connect-src 'self' wss: https:;
+  worker-src 'self' blob:;
+  manifest-src 'self';
+  object-src 'none';
+  base-uri 'self';
+  form-action 'self';
+  frame-ancestors 'none'
+" always;
 add_header Content-Security-Policy "
   default-src 'self';
   script-src 'self';

--- a/src/stores/lockedTokensRedeemWorker.ts
+++ b/src/stores/lockedTokensRedeemWorker.ts
@@ -15,7 +15,7 @@ export const useLockedTokensRedeemWorker = defineStore(
   "lockedTokensRedeemWorker",
   {
     state: () => ({
-      checkInterval: 5000,
+      checkInterval: 60 * 1000,
       worker: null as NodeJS.Timeout | null,
       redeemChain: Promise.resolve() as Promise<void>,
     }),


### PR DESCRIPTION
## Summary
- permit HTTPS connections in report-only Content Security Policy
- poll locked token redemption only once per minute

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6eb7d3a3c8330a2c8c278bcca7ec7