### PR TITLE
chore: expand CSP for fonts and remote APIs

### DIFF
--- a/deploy/nginx/security-headers.conf
+++ b/deploy/nginx/security-headers.conf
@@ -2,10 +2,10 @@
 add_header Content-Security-Policy-Report-Only "
   default-src 'self';
   script-src 'self';
-  style-src 'self' 'unsafe-inline';
+  style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
   img-src 'self' data: blob:;
-  font-src 'self' data:;
-  connect-src 'self' wss: https:;
+  font-src 'self' data: https://fonts.gstatic.com;
+  connect-src 'self' https://api.coinbase.com https://npub.cash https://audit.8333.space https://api.audit.8333.space https://api.nostr.band https: wss:;
   worker-src 'self' blob:;
   manifest-src 'self';
   object-src 'none';
@@ -16,10 +16,10 @@ add_header Content-Security-Policy-Report-Only "
 add_header Content-Security-Policy "
   default-src 'self';
   script-src 'self';
-  style-src 'self' 'unsafe-inline';
+  style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
   img-src 'self' data: blob:;
-  font-src 'self' data:;
-  connect-src 'self' https: wss:;
+  font-src 'self' data: https://fonts.gstatic.com;
+  connect-src 'self' https://api.coinbase.com https://npub.cash https://audit.8333.space https://api.audit.8333.space https://api.nostr.band https: wss:;
   worker-src 'self' blob:;
   manifest-src 'self';
   object-src 'none';

--- a/quasar.config.js
+++ b/quasar.config.js
@@ -14,7 +14,7 @@ import path from "path";
 export default configure(function () {
   const csp = [
     "default-src 'self'",
-    "connect-src 'self' https: wss:",
+    "connect-src 'self' https://api.coinbase.com https://npub.cash https://audit.8333.space https://api.audit.8333.space https://api.nostr.band https: wss:",
     "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
     "script-src 'self' 'unsafe-eval' 'unsafe-inline'",
     "img-src 'self' https: data:",
@@ -73,7 +73,7 @@ export default configure(function () {
             "http-equiv": "Content-Security-Policy",
             content: [
               "default-src 'self'",
-              "connect-src 'self' https: wss:",
+              "connect-src 'self' https://api.coinbase.com https://npub.cash https://audit.8333.space https://api.audit.8333.space https://api.nostr.band https: wss:",
               "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
               "script-src 'self' 'unsafe-eval' 'unsafe-inline'",
               "img-src 'self' https: data:",


### PR DESCRIPTION
## Summary
- allow Google Fonts styles and font hosts in CSP
- permit remote API endpoints so wallet can query external mints and services

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a70796308c8330a0e458af7c98a4ae