### PR TITLE
fix: handle invalid mint url

### DIFF
--- a/src/boot/cashu.js
+++ b/src/boot/cashu.js
@@ -8,8 +8,18 @@ export default boot(async () => {
   const walletStore = useWalletStore();
   const wallet = walletStore.wallet;
   const mints = useMintsStore();
-  if (mints.activeMintUrl) {
-    const ok = await verifyMint(mints.activeMintUrl);
+  const mintUrl = mints.activeMintUrl;
+  let valid = false;
+  if (mintUrl && mintUrl !== "undefined") {
+    try {
+      const parsed = new URL(mintUrl);
+      valid = parsed.protocol === "https:";
+    } catch {
+      valid = false;
+    }
+  }
+  if (valid) {
+    const ok = await verifyMint(mintUrl);
     if (!ok) {
       Notify.create({
         type: "negative",

--- a/src/stores/mints.ts
+++ b/src/stores/mints.ts
@@ -132,6 +132,24 @@ export const useMintsStore = defineStore("mints", {
       await proofsStore.updateActiveProofs();
     });
 
+    const isValidUrl = (url: string): boolean => {
+      if (!url || url === "undefined") {
+        return false;
+      }
+      try {
+        const parsed = new URL(url);
+        return parsed.protocol === "https:";
+      } catch {
+        return false;
+      }
+    };
+
+    if (!isValidUrl(activeMintUrl.value)) {
+      activeMintUrl.value = "";
+      uiStoreGlobal.setTab("mints");
+      showAddMintDialog.value = true;
+    }
+
     return {
       t,
       activeProofs,


### PR DESCRIPTION
## Summary
- sanitize stored mint URL, prompting user if invalid
- skip mint verification when URL is malformed

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a70a1705c483309d92293f7d859611