### PR TITLE
Improve NDK relay defaults and connection robustness

### DIFF
--- a/src/config/relays.ts
+++ b/src/config/relays.ts
@@ -2,8 +2,9 @@ export const DEFAULT_RELAYS = [
   "wss://relay.damus.io",
   "wss://relay.primal.net",
   "wss://relay.snort.social",
-  "wss://nostr.wine",
-  "wss://nos.lol",
+  // Replaced unreachable relays with active public ones
+  "wss://nostr-pub.wellorder.net",
+  "wss://relay.nostr.band",
 ];
 
 export const FREE_RELAYS = [


### PR DESCRIPTION
## Summary
- replace unreachable default relays with active public relays
- add retry/backoff logic and deduplicated relay error handling to NDK connections

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a70c6fc0d08330b7b68738bfd1b21b