### PR TITLE
Guard against undefined mint hosts

### DIFF
--- a/src/stores/mints.ts
+++ b/src/stores/mints.ts
@@ -138,6 +138,10 @@ export const useMintsStore = defineStore("mints", {
       }
       try {
         const parsed = new URL(url);
+        if (parsed.hostname === "undefined") {
+          activeMintUrl.value = "";
+          return false;
+        }
         return parsed.protocol === "https:";
       } catch {
         return false;


### PR DESCRIPTION
## Summary
- Reject mint URLs whose hostname is `undefined` and clear any stored `activeMintUrl`

## Testing
- `pnpm lint src/stores/mints.ts`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a72b184d7c8330aa2d004949dd97ba