### PR TITLE
fix: skip problematic deps in Vite optimizer

### DIFF
--- a/quasar.config.js
+++ b/quasar.config.js
@@ -65,6 +65,19 @@ export default configure(function (/* ctx */) {
           ...(viteConf.resolve.alias || {}),
           "@cashu/cashu-ts": path.resolve(__dirname, "src/lib/cashu-ts/src/index.ts"),
         };
+
+        // Some dependencies like nostr-tools and noble crypto libraries
+        // don't play well with Vite's dependency optimizer. Exclude them
+        // from the optimization step so they are loaded directly from
+        // node_modules at runtime.
+        viteConf.optimizeDeps = viteConf.optimizeDeps || {};
+        viteConf.optimizeDeps.exclude = [
+          ...(viteConf.optimizeDeps.exclude || []),
+          "nostr-tools",
+          "@noble/curves",
+          "@noble/hashes",
+          "@noble/secp256k1",
+        ];
       },
       // viteVuePluginOptions: {},
 


### PR DESCRIPTION
## Summary
- exclude nostr-tools and noble crypto libs from Vite dep optimization

## Testing
- `pnpm lint` *(fails: Invalid option '--ext')*
- `npx eslint` *(fails: ReferenceError: module is not defined in ES module scope)*
- `pnpm test` *(fails: Failed to resolve import "fake-indexeddb/auto")*

------
https://chatgpt.com/codex/tasks/task_e_68ba6807322c8330beb72c9cdc1f64a1