### PR TITLE
fix: load SafeArea plugin dynamically for web dev

### DIFF
--- a/src/boot/base.js
+++ b/src/boot/base.js
@@ -1,6 +1,6 @@
 import { useUiStore } from "stores/ui";
 import { Clipboard } from "@capacitor/clipboard";
-import { SafeArea } from "capacitor-plugin-safe-area";
+
 
 window.LOCALE = "en";
 // window.EventHub = new Vue();
@@ -220,25 +220,33 @@ window.windowMixin = {
 
     // only for iOS
     if (window.Capacitor && Capacitor.getPlatform() === "ios") {
-      SafeArea.getStatusBarHeight().then(({ statusBarHeight }) => {
-        document.documentElement.style.setProperty(
-          `--safe-area-inset-top`,
-          `${statusBarHeight}px`
-        );
-      });
+      import(
+        /* @vite-ignore */ "capacitor-plugin-safe-area"
+      )
+        .then(({ SafeArea }) => {
+          SafeArea.getStatusBarHeight().then(({ statusBarHeight }) => {
+            document.documentElement.style.setProperty(
+              `--safe-area-inset-top`,
+              `${statusBarHeight}px`
+            );
+          });
 
-      SafeArea.removeAllListeners();
+          SafeArea.removeAllListeners();
 
-      // when safe-area changed
-      SafeArea.addListener("safeAreaChanged", (data) => {
-        const { insets } = data;
-        for (const [key, value] of Object.entries(insets)) {
-          document.documentElement.style.setProperty(
-            `--safe-area-inset-${key}`,
-            `${value}px`
-          );
-        }
-      });
+          // when safe-area changed
+          SafeArea.addListener("safeAreaChanged", (data) => {
+            const { insets } = data;
+            for (const [key, value] of Object.entries(insets)) {
+              document.documentElement.style.setProperty(
+                `--safe-area-inset-${key}`,
+                `${value}px`
+              );
+            }
+          });
+        })
+        .catch(() => {
+          // plugin not available
+        });
     }
   },
 };


### PR DESCRIPTION
## Summary
- load `capacitor-plugin-safe-area` only on iOS with dynamic import
- guard against missing plugin to prevent Vite import errors

## Testing
- `npm test` *(fails: Failed to resolve import "fake-indexeddb/auto")*
- `npx eslint src/boot/base.js` *(fails: module is not defined in ES module scope)*

------
https://chatgpt.com/codex/tasks/task_e_68ba697b28e48330b217063cc1578529