### PR TITLE
Handle SafeArea plugin on iOS without dynamic import

### DIFF
--- a/src/boot/base.js
+++ b/src/boot/base.js
@@ -219,34 +219,32 @@ window.windowMixin = {
     }
 
     // only for iOS
-    if (window.Capacitor && Capacitor.getPlatform() === "ios") {
-      import(
-        /* @vite-ignore */ "capacitor-plugin-safe-area"
-      )
-        .then(({ SafeArea }) => {
-          SafeArea.getStatusBarHeight().then(({ statusBarHeight }) => {
-            document.documentElement.style.setProperty(
-              `--safe-area-inset-top`,
-              `${statusBarHeight}px`
-            );
-          });
+    if (
+      window.Capacitor &&
+      Capacitor.getPlatform() === "ios" &&
+      Capacitor.isPluginAvailable("SafeArea")
+    ) {
+      const { SafeArea } = Capacitor.Plugins;
 
-          SafeArea.removeAllListeners();
+      SafeArea.getStatusBarHeight().then(({ statusBarHeight }) => {
+        document.documentElement.style.setProperty(
+          `--safe-area-inset-top`,
+          `${statusBarHeight}px`
+        );
+      });
 
-          // when safe-area changed
-          SafeArea.addListener("safeAreaChanged", (data) => {
-            const { insets } = data;
-            for (const [key, value] of Object.entries(insets)) {
-              document.documentElement.style.setProperty(
-                `--safe-area-inset-${key}`,
-                `${value}px`
-              );
-            }
-          });
-        })
-        .catch(() => {
-          // plugin not available
-        });
+      SafeArea.removeAllListeners();
+
+      // when safe-area changed
+      SafeArea.addListener("safeAreaChanged", (data) => {
+        const { insets } = data;
+        for (const [key, value] of Object.entries(insets)) {
+          document.documentElement.style.setProperty(
+            `--safe-area-inset-${key}`,
+            `${value}px`
+          );
+        }
+      });
     }
   },
 };


### PR DESCRIPTION
## Summary
- use Capacitor's SafeArea plugin directly instead of dynamic import so Vite dev no longer fails

## Testing
- `pnpm exec eslint .` *(fails: ReferenceError: module is not defined)*
- `pnpm test` *(fails: Failed to resolve import "fake-indexeddb/auto" from "test/vitest/setup-file.js")*


------
https://chatgpt.com/codex/tasks/task_e_68ba6acae96c8330a2e889a9456e82f0