### PR TITLE
fix: use ESM syntax for Tailwind config

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,5 @@
 /** @type {import('tailwindcss').Config} */
-module.exports = {
+export default {
   content: [
     "./index.html",
     "./src/**/*.{vue,js,ts,jsx,tsx}",


### PR DESCRIPTION
## Summary
- use `export default` in Tailwind config to work in ESM environment

## Testing
- `npm test` *(fails: Error: Failed to resolve import "fake-indexeddb/auto")*

------
https://chatgpt.com/codex/tasks/task_e_68ba7418b610833086a899bd8bf893e2